### PR TITLE
Default routes #131

### DIFF
--- a/config.go
+++ b/config.go
@@ -56,7 +56,7 @@ func LoadConfig() (*Config, error) {
 
 	if _, err := os.Stat("/var/lib/lxd/unix.socket"); err == nil {
 		//lxd is present on local machine.
-		defaultRemotes["local"] = RemoteConfig{"http+lxd://var/lib/lxd/unix.socket"}
+		defaultRemotes["local"] = RemoteConfig{"http+lxd://unix.socket"}
 	}
 	//Create a default config setting.
 	defaultConfig := &Config{TestOption: "",

--- a/config.go
+++ b/config.go
@@ -50,10 +50,24 @@ func ServerCertPath(name string) string {
 
 // LoadConfig reads the configuration from the config path.
 func LoadConfig() (*Config, error) {
+	defaultRemotes := map[string]RemoteConfig{
+		"images": RemoteConfig{"https+registry://registry.linuxcontainers.org"},
+	}
+
+	if _, err := os.Stat("/var/lib/lxd/unix.socket"); err == nil {
+		//lxd is present on local machine.
+		defaultRemotes["local"] = RemoteConfig{"http+lxd://var/lib/lxd/unix.socket"}
+	}
+	//Create a default config setting.
+	defaultConfig := &Config{TestOption: "",
+		DefaultRemote: "",
+		Remotes:       defaultRemotes,
+		ListenAddr:    ""}
+
 	data, err := ioutil.ReadFile(configPath(configFileName))
 	if os.IsNotExist(err) {
 		// A missing file is equivalent to the default configuration.
-		return &Config{}, nil
+		return defaultConfig, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot read config file: %v", err)


### PR DESCRIPTION
Default routes added for LXD.

For previous discussion please refer https://github.com/lxc/lxd/pull/131

Test fails in last condition. This is expected as already local route exists.

error: remote local exists as <http+lxd://unix.socket>
Test result: failure

