### PR TITLE
store certs in memory by hostname

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -53,8 +53,7 @@ func certificatesGet(d *Daemon, r *http.Request) Response {
 	body := lxd.Jmap{}
 	for host, cert := range d.clientCerts {
 		fingerprint := lxd.GenerateFingerprint(&cert)
-		hostname, _ := lxd.SplitExt(host)
-		body[hostname] = fingerprint
+		body[host] = fingerprint
 	}
 
 	return SyncResponse(true, body)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -70,6 +70,7 @@ func readSavedClientCAList(d *Daemon) {
 		if err != nil {
 			continue
 		}
+		n, _ = lxd.SplitExt(n)
 		d.clientCerts[n] = *cert
 		lxd.Debugf("Loaded cert %s", fnam)
 	}


### PR DESCRIPTION
Instead of retroactively chopping off the extension, we should just store
certs initially by hostname instead of by file name. When we got a new cert,
we would compare it against a cert without the extension, and thus end up
adding duplicate certs in memory (but not on disk, since we appended the
filename there). Instead, we should just store and look up everything by
hostname.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>