### PR TITLE
websocket: don't set unixDial for non-unix-sock connections

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,7 +167,6 @@ func NewClient(config *Config, remote string) (*Client, error) {
 	c.keyf = keyf
 	c.cert = cert
 	c.websocketDialer = websocket.Dialer{
-		NetDial:         unixDial,
 		TLSClientConfig: tlsconfig,
 	}
 
@@ -178,9 +177,11 @@ func NewClient(config *Config, remote string) (*Client, error) {
 	if remote == "" {
 		c.baseURL = "http://unix.socket"
 		c.http.Transport = &unixTransport
+		c.websocketDialer.NetDial = unixDial
 	} else if len(remote) > 6 && remote[0:5] == "unix:" {
 		c.baseURL = "http://unix.socket"
 		c.http.Transport = &unixTransport
+		c.websocketDialer.NetDial = unixDial
 	} else if r, ok := config.Remotes[remote]; ok {
 		c.baseURL = "https://" + r.Addr
 		c.Remote = &r


### PR DESCRIPTION
This doesn't actually fix attach over https connections but brings
us a step closer.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>