### PR TITLE
Only notify on lxc/lxd travis builds in irc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script: "make check"
 notifications:
   irc:
     channels:
-      - "chat.freenode.net#lxcontainers"
+      - secure: "ttPu6Gd8AzVc0jWG1FNobE13ImbfMdSovLXA8IZ2YEeJO/LAG+EpurUWtOq2rrTZ6iCF+Id1S3muFl8ycQMQdLffmTflSQxosZYI2yEHfDhGkmrcW6LqeUAQo3gGGhsHb2WyOdR5XLjsPNmgy1WnJpt1862pocA/iwyOoRfgpV4="
     use_notice: true


### PR DESCRIPTION
This didn't notify when it built on my repo, but I have no real proof that I didn't break anything. Apparently travis doesn't notify for PRs so I'm not sure there's actually a way to test this besides merging it :(