### PR TITLE
UserAuthServerCert: don't ask user to validate already-stored server cer...

### DIFF
--- a/client.go
+++ b/client.go
@@ -433,6 +433,11 @@ func (c *Client) UserAuthServerCert() error {
 		return fmt.Errorf("No certificate on this connection")
 	}
 
+	if c.scert != nil {
+		fmt.Printf("Certificate already stored.\n")
+		return nil
+	}
+
 	fmt.Printf("Certificate fingerprint: % x\n", c.scertDigest)
 	fmt.Printf("ok (y/n)? ")
 	line, err := ReadStdin()


### PR DESCRIPTION
...t

This way we can pre-store the server certificate and do a
noninteractive lxc remote add.  If the existing certificate
were not valid, the connection should have been refused, so
my understanding is that this should be safe.  Please do check
my understanding.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>