### PR TITLE
Add wait-for-websocket parameter to exec

### DIFF
--- a/client.go
+++ b/client.go
@@ -539,7 +539,8 @@ func (c *Client) Create(name string) (*Response, error) {
 }
 
 func (c *Client) Exec(name string, cmd []string, stdin io.ReadCloser, stdout io.WriteCloser, stderr io.WriteCloser) error {
-	resp, err := c.post(fmt.Sprintf("containers/%s/exec", name), Jmap{"command": cmd})
+	body := Jmap{"command": cmd, "wait-for-websocket": true}
+	resp, err := c.post(fmt.Sprintf("containers/%s/exec", name), body)
 	if err != nil {
 		return err
 	}

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -42,5 +42,7 @@ func (c *execCmd) run(config *lxd.Config, args []string) error {
 		defer terminal.Restore(cfd, oldttystate)
 	}
 
+	// TODO: we should exit with the same exit code as the command in the
+	// container.
 	return d.Exec(name, args[1:], os.Stdin, os.Stdout, os.Stderr)
 }

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -544,7 +544,7 @@ func runCommand(container *lxc.Container, command []string, fd uintptr) lxd.Oper
 		return lxd.OperationError(err)
 	}
 
-	metadata, err := json.Marshal(lxd.Jmap{"status": status})
+	metadata, err := json.Marshal(lxd.Jmap{"return": status})
 	if err != nil {
 		return lxd.OperationError(err)
 	}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -112,7 +112,7 @@ func containersPost(d *Daemon, r *http.Request) Response {
 	/*
 	 * Actually create the container
 	 */
-	return AsyncResponse(func() error { return c.Create(opts) }, nil)
+	return AsyncResponse(lxd.OperationWrap(func() error { return c.Create(opts) }), nil)
 }
 
 var containersCmd = Command{"containers", false, false, nil, nil, containersPost, nil}
@@ -142,7 +142,7 @@ func containerDelete(d *Daemon, r *http.Request) Response {
 		return NotFound
 	}
 
-	return AsyncResponse(c.Destroy, nil)
+	return AsyncResponse(lxd.OperationWrap(c.Destroy), nil)
 }
 
 var containerCmd = Command{"containers/{name}", false, false, containerGet, nil, nil, containerDelete}
@@ -213,7 +213,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("unknown action %s", action))
 	}
 
-	return AsyncResponse(do, nil)
+	return AsyncResponse(lxd.OperationWrap(do), nil)
 }
 
 var containerStateCmd = Command{"containers/{name}/state", false, false, containerStateGet, containerStatePut, nil, nil}
@@ -438,7 +438,7 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		return c.Clone(snapshotName, opts)
 	}
 
-	return AsyncResponse(snapshot, nil)
+	return AsyncResponse(lxd.OperationWrap(snapshot), nil)
 }
 
 var containerSnapshotsCmd = Command{"containers/{name}/snapshots", false, false, containerSnapshotsGet, nil, containerSnapshotsPost, nil}
@@ -507,27 +507,65 @@ func snapshotPost(r *http.Request, c *lxc.Container, oldName string) Response {
 	 * out from under criu will cause it to fail, but it may be useful to
 	 * do something for stateless ones.
 	 */
-	return AsyncResponse(func() error { return os.Rename(oldDir, newDir) }, nil)
+	rename := func() error { return os.Rename(oldDir, newDir) }
+	return AsyncResponse(lxd.OperationWrap(rename), nil)
 }
 
 func snapshotDelete(c *lxc.Container, name string) Response {
 	dir := snapshotDir(c, name)
-	return AsyncResponse(func() error { return os.RemoveAll(dir) }, nil)
+	remove := func() error { return os.RemoveAll(dir) }
+	return AsyncResponse(lxd.OperationWrap(remove), nil)
 }
 
 var containerSnapshotCmd = Command{"containers/{name}/snapshots/{snapshotName}", false, false, snapshotHandler, nil, snapshotHandler, snapshotHandler}
 
 type execWs struct {
-	PTY    *os.File
-	TTY    *os.File
-	secret string
+	command   []string
+	container *lxc.Container
+	secret    string
+	done      chan lxd.OperationResult
 }
 
 func (s *execWs) Secret() string {
 	return s.secret
 }
 
+func runCommand(container *lxc.Container, command []string, fd uintptr) lxd.OperationResult {
+
+	options := lxc.DefaultAttachOptions
+	options.StdinFd = fd
+	options.StdoutFd = fd
+	options.StderrFd = fd
+	options.ClearEnv = true
+
+	status, err := container.RunCommandStatus(command, options)
+	if err != nil {
+		lxd.Debugf("Failed running command: %q", err.Error())
+		return lxd.OperationError(err)
+	}
+
+	metadata, err := json.Marshal(lxd.Jmap{"status": status})
+	if err != nil {
+		return lxd.OperationError(err)
+	}
+
+	return lxd.OperationResult{Metadata: metadata, Error: nil}
+}
+
 func (s *execWs) Do(conn *websocket.Conn) {
+	pty, tty, err := pty.Open()
+	if err != nil {
+		s.done <- lxd.OperationError(err)
+		return
+	}
+
+	go func() {
+		result := runCommand(s.container, s.command, tty.Fd())
+		pty.Close()
+		tty.Close()
+		s.done <- result
+	}()
+
 	/*
 	 * The pty will be passed to the container's Attach.  The two
 	 * below goroutines will copy output from the socket to the
@@ -536,11 +574,12 @@ func (s *execWs) Do(conn *websocket.Conn) {
 	 * the copy-goroutines to exit.  If the connection closes, we
 	 * also want to exit
 	 */
-	lxd.WebsocketMirror(conn, s.PTY, s.PTY)
+	lxd.WebsocketMirror(conn, pty, pty)
 }
 
 type commandPostContent struct {
-	Command []string `json:"command"`
+	Command   []string `json:"command"`
+	WaitForWS bool     `json:"wait-for-websocket"`
 }
 
 func containerExecPost(d *Daemon, r *http.Request) Response {
@@ -564,36 +603,34 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	ws := &execWs{}
-	ws.PTY, ws.TTY, err = pty.Open()
-	ws.secret, err = lxd.RandomCryptoString()
-	if err != nil {
-		return InternalError(err)
-	}
-
-	run := func() error {
-		options := lxc.DefaultAttachOptions
-		defer ws.TTY.Close()
-		defer ws.PTY.Close()
-
-		options.StdinFd = ws.TTY.Fd()
-		options.StdoutFd = ws.TTY.Fd()
-		options.StderrFd = ws.TTY.Fd()
-
-		options.ClearEnv = true
-
-		_, err = c.RunCommand(post.Command, options)
+	if post.WaitForWS {
+		ws := &execWs{}
+		ws.secret, err = lxd.RandomCryptoString()
 		if err != nil {
-			lxd.Debugf("Failed starting shell in %q: %q", name, err.Error())
-			return err
+			return InternalError(err)
+		}
+		ws.command = post.Command
+		ws.container = c
+		ws.done = make(chan (lxd.OperationResult))
+
+		run := func() lxd.OperationResult {
+			return <-ws.done
 		}
 
-		lxd.Debugf("done running command")
+		return AsyncResponseWithWs(run, nil, ws)
+	} else {
+		run := func() lxd.OperationResult {
 
-		return nil
+			nullDev, err := os.OpenFile(os.DevNull, os.O_RDWR, 0666)
+			if err != nil {
+				return lxd.OperationError(err)
+			}
+			defer nullDev.Close()
+
+			return runCommand(c, post.Command, nullDev.Fd())
+		}
+		return AsyncResponse(run, nil)
 	}
-
-	return AsyncResponseWithWs(run, nil, ws)
 }
 
 var containerExecCmd = Command{"containers/{name}/exec", false, false, nil, nil, containerExecPost, nil}

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -53,7 +53,7 @@ func SyncResponse(success bool, metadata interface{}) Response {
 var EmptySyncResponse = &syncResponse{true, make(map[string]interface{})}
 
 type asyncResponse struct {
-	run    func() error
+	run    func() lxd.OperationResult
 	cancel func() error
 	ws     lxd.OperationSocket
 }
@@ -79,11 +79,11 @@ func (r *asyncResponse) Render(w http.ResponseWriter) error {
 	return json.NewEncoder(w).Encode(body)
 }
 
-func AsyncResponse(run func() error, cancel func() error) Response {
+func AsyncResponse(run func() lxd.OperationResult, cancel func() error) Response {
 	return AsyncResponseWithWs(run, cancel, nil)
 }
 
-func AsyncResponseWithWs(run func() error, cancel func() error, ws lxd.OperationSocket) Response {
+func AsyncResponseWithWs(run func() lxd.OperationResult, cancel func() error, ws lxd.OperationSocket) Response {
 	return &asyncResponse{run, cancel, ws}
 }
 

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -435,12 +435,24 @@ HTTP code for this should be 202 (Accepted).
  * Description: run a remote command
  * Authentication: trusted
  * Operation: async
- * Return: background operation + websocket information or standard error
+ * Return: background operation + optional websocket information or standard error
 
 Input (run bash):
 
     {
-        'command': ["/bin/bash"]
+        'command': ["/bin/bash"],
+        'wait-for-websocket': false
+    }
+
+`wait-for-websocket` indicates whether the operation should block and wait for
+a websocket connection to start (so that users can pass stdin and read
+stdout), or simply run to completion with /dev/null as stdin and stdout.
+
+When the exec command finishes, its exit status is avaialabe from the
+operation's metadata:
+
+    {
+        'status': 0
     }
 
 ## /1.0/images

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -452,7 +452,7 @@ When the exec command finishes, its exit status is avaialabe from the
 operation's metadata:
 
     {
-        'status': 0
+        'return': 0
     }
 
 ## /1.0/images


### PR DESCRIPTION
The problem here was a race: if we didn't wait for the user to connect to the
websocket before running the command, the command could finish before the user
even connected, and we wouldn't send it any input or receive any output.
However, sometimes it would be nice to run a command without having to connect
to the websocket interface, so we support that as well.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>

This depends on https://github.com/lxc/go-lxc/pull/31