### PR TITLE
Add support for internationalization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ dist:
 	git archive --output=../$(ARCHIVE) HEAD
 	tar -uf ../$(ARCHIVE) --exclude-vcs ./dist
 	gzip ../$(ARCHIVE)
+
+.PHONY: i18n
+i18n:
+	xgettext -d lxd -s client.go lxc/*.go -o po/lxd.pot -L c++ -i --keyword=Gettext

--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 
 	"github.com/gorilla/websocket"
+	"github.com/gosexy/gettext"
 )
 
 // Client can talk to a lxd daemon.
@@ -127,7 +128,7 @@ func readMyCert() (string, string, error) {
 func (c *Client) loadServerCert() {
 	cert, err := ReadCert(ServerCertPath(c.name))
 	if err != nil {
-		fmt.Printf("Error reading the server certificate for %s\n", c.name)
+		fmt.Printf(gettext.Gettext("Error reading the server certificate for %s\n"), c.name)
 		return
 	}
 
@@ -434,12 +435,12 @@ func (c *Client) UserAuthServerCert() error {
 	}
 
 	if c.scert != nil {
-		fmt.Printf("Certificate already stored.\n")
+		fmt.Printf(gettext.Gettext("Certificate already stored.\n"))
 		return nil
 	}
 
-	fmt.Printf("Certificate fingerprint: % x\n", c.scertDigest)
-	fmt.Printf("ok (y/n)? ")
+	fmt.Printf(gettext.Gettext("Certificate fingerprint: % x\n"), c.scertDigest)
+	fmt.Printf(gettext.Gettext("ok (y/n)? "))
 	line, err := ReadStdin()
 	if err != nil {
 		return err

--- a/lxc/action.go
+++ b/lxc/action.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
@@ -11,11 +12,10 @@ type actionCmd struct {
 }
 
 func (c *actionCmd) usage() string {
-	return fmt.Sprintf(`
-Changes a containers state to %s.
-
-lxd %s <name>
-`, c.action, c.action)
+	return fmt.Sprintf(gettext.Gettext(
+		"Changes a containers state to %s.\n"+
+			"\n"+
+			"lxd %s <name>\n"), c.action, c.action)
 }
 
 func (c *actionCmd) flags() {}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
@@ -10,14 +11,11 @@ type configCmd struct {
 	httpAddr string
 }
 
-const configUsage = `
-Manage configuration.
-
-lxc config set [remote] password <newpwd>        Set admin password
-`
-
 func (c *configCmd) usage() string {
-	return configUsage
+	return gettext.Gettext(
+		"Manage configuration.\n" +
+			"\n" +
+			"lxc config set [remote] password <newpwd>        Set admin password\n")
 }
 
 func (c *configCmd) flags() {}
@@ -46,7 +44,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		return fmt.Errorf("Only 'password' can be set currently")
+		return fmt.Errorf(gettext.Gettext("Only 'password' can be set currently"))
 	case "trust":
 		switch args[1] {
 		case "list":
@@ -75,7 +73,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 		case "add":
 			var remote string
 			if len(args) < 3 {
-				return fmt.Errorf("No cert provided to add")
+				return fmt.Errorf(gettext.Gettext("No cert provided to add"))
 			} else if len(args) == 4 {
 				remote = config.ParseRemote(args[2])
 			} else {
@@ -98,7 +96,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 		case "remove":
 			var remote string
 			if len(args) < 3 {
-				return fmt.Errorf("No fingerprint specified.")
+				return fmt.Errorf(gettext.Gettext("No fingerprint specified."))
 			} else if len(args) == 4 {
 				remote = config.ParseRemote(args[2])
 			} else {
@@ -125,9 +123,9 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 
 			return d.CertificateRemove(args[len(args)-1])
 		default:
-			return fmt.Errorf("Unkonwn config trust command %s", args[1])
+			return fmt.Errorf(gettext.Gettext("Unkonwn config trust command %s"), args[1])
 		}
 	default:
-		return fmt.Errorf("Unknown config command %s", args[0])
+		return fmt.Errorf(gettext.Gettext("Unknown config command %s"), args[0])
 	}
 }

--- a/lxc/create.go
+++ b/lxc/create.go
@@ -3,19 +3,17 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
 type createCmd struct{}
 
-const createUsage = `
-lxc create images:ubuntu <name>
-
-Creates a container using the specified image and name
-`
-
 func (c *createCmd) usage() string {
-	return createUsage
+	return gettext.Gettext(
+		"lxc create images:ubuntu <name>\n" +
+			"\n" +
+			"Creates a container using the specified image and name\n")
 }
 
 func (c *createCmd) flags() {}
@@ -30,7 +28,7 @@ func (c *createCmd) run(config *lxd.Config, args []string) error {
 	}
 
 	if args[0] != "images:ubuntu" {
-		return fmt.Errorf("Only the default ubuntu image is supported. Try `lxc create images:ubuntu foo`.")
+		return fmt.Errorf(gettext.Gettext("Only the default ubuntu image is supported. Try `lxc create images:ubuntu foo`."))
 	}
 
 	var name string

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -3,21 +3,19 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"gopkg.in/lxc/go-lxc.v2"
 )
 
 type deleteCmd struct{}
 
-const deleteUsage = `
-lxc delete <resource>
-
-Destroy a resource (e.g. container) and any attached data (configuration,
-snapshots, ...).
-`
-
 func (c *deleteCmd) usage() string {
-	return deleteUsage
+	return gettext.Gettext(
+		"lxc delete <resource>\n" +
+			"\n" +
+			"Destroy a resource (e.g. container) and any attached data (configuration,\n" +
+			"snapshots, ...).\n")
 }
 
 func (c *deleteCmd) flags() {}
@@ -52,7 +50,7 @@ func (c *deleteCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		if op.StatusCode == lxd.Failure {
-			return fmt.Errorf("Stopping container failed!")
+			return fmt.Errorf(gettext.Gettext("Stopping container failed!"))
 		}
 	}
 
@@ -69,6 +67,6 @@ func (c *deleteCmd) run(config *lxd.Config, args []string) error {
 	if op.StatusCode == lxd.Success {
 		return nil
 	} else {
-		return fmt.Errorf("Operation %s", op.Status)
+		return fmt.Errorf(gettext.Gettext("Operation %s"), op.Status)
 	}
 }

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -4,20 +4,18 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"golang.org/x/crypto/ssh/terminal"
 )
 
 type execCmd struct{}
 
-const execUsage = `
-exec specified command in a container.
-
-lxc exec container [command]
-`
-
 func (c *execCmd) usage() string {
-	return execUsage
+	return gettext.Gettext(
+		"exec specified command in a container.\n" +
+			"\n" +
+			"lxc exec container [command]\n")
 }
 
 func (c *execCmd) flags() {}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/internal/gnuflag"
 )
@@ -18,21 +19,18 @@ type fileCmd struct {
 	mode string
 }
 
-const fileUsage = `
-Manage files on a container.
-
-lxc file push [--uid=UID] [--gid=GID] [--mode=MODE] <source> [<source>...] <target>
-lxc file pull <source> [<source>...] <target>
-`
-
 func (c *fileCmd) usage() string {
-	return fileUsage
+	return gettext.Gettext(
+		"Manage files on a container.\n" +
+			"\n" +
+			"lxc file push [--uid=UID] [--gid=GID] [--mode=MODE] <source> [<source>...] <target>\n" +
+			"lxc file pull <source> [<source>...] <target>\n")
 }
 
 func (c *fileCmd) flags() {
-	gnuflag.IntVar(&c.uid, "uid", -1, "Set the file's uid on push")
-	gnuflag.IntVar(&c.gid, "gid", -1, "Set the file's gid on push")
-	gnuflag.StringVar(&c.mode, "mode", "0644", "Set the file's perms on push")
+	gnuflag.IntVar(&c.uid, "uid", -1, gettext.Gettext("Set the file's uid on push"))
+	gnuflag.IntVar(&c.gid, "gid", -1, gettext.Gettext("Set the file's gid on push"))
+	gnuflag.StringVar(&c.mode, "mode", "0644", gettext.Gettext("Set the file's perms on push"))
 }
 
 func (c *fileCmd) push(config *lxd.Config, args []string) error {
@@ -44,7 +42,7 @@ func (c *fileCmd) push(config *lxd.Config, args []string) error {
 	pathSpec := strings.SplitAfterN(target, "/", 2)
 
 	if len(pathSpec) != 2 {
-		return fmt.Errorf("Invalid target %s", target)
+		return fmt.Errorf(gettext.Gettext("Invalid target %s"), target)
 	}
 
 	targetPath := pathSpec[1]
@@ -122,7 +120,7 @@ func (c *fileCmd) pull(config *lxd.Config, args []string) error {
 
 		targetIsDir = sb.IsDir()
 		if !targetIsDir && len(args)-1 > 1 {
-			return fmt.Errorf("More than one file to download, but target is not a directory")
+			return fmt.Errorf(gettext.Gettext("More than one file to download, but target is not a directory"))
 		}
 
 	} else if strings.HasSuffix(target, string(os.PathSeparator)) || len(args)-1 > 1 {
@@ -136,7 +134,7 @@ func (c *fileCmd) pull(config *lxd.Config, args []string) error {
 	for _, f := range args[:len(args)-1] {
 		pathSpec := strings.SplitN(f, "/", 2)
 		if len(pathSpec) != 2 {
-			return fmt.Errorf("Invalid source %s", f)
+			return fmt.Errorf(gettext.Gettext("Invalid source %s"), f)
 		}
 
 		remote, container := config.ParseRemoteAndContainer(pathSpec[0])
@@ -183,6 +181,6 @@ func (c *fileCmd) run(config *lxd.Config, args []string) error {
 	case "pull":
 		return c.pull(config, args[1:])
 	default:
-		return fmt.Errorf("invalid argument %s", args[0])
+		return fmt.Errorf(gettext.Gettext("invalid argument %s"), args[0])
 	}
 }

--- a/lxc/finger.go
+++ b/lxc/finger.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
@@ -8,14 +9,11 @@ type fingerCmd struct {
 	httpAddr string
 }
 
-const fingerUsage = `
-Fingers the lxd instance to check if it is up and working.
-
-lxc finger <remote>
-`
-
 func (c *fingerCmd) usage() string {
-	return fingerUsage
+	return gettext.Gettext(
+		"Fingers the lxd instance to check if it is up and working.\n" +
+			"\n" +
+			"lxc finger <remote>\n")
 }
 
 func (c *fingerCmd) flags() {}

--- a/lxc/help.go
+++ b/lxc/help.go
@@ -6,22 +6,19 @@ import (
 	"fmt"
 	"os"
 	"sort"
-
 	"strings"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
 type helpCmd struct{}
 
-const helpUsage = `
-Presents details on how to use lxd.
-
-lxd help
-`
-
 func (c *helpCmd) usage() string {
-	return helpUsage
+	return gettext.Gettext(
+		"Presents details on how to use lxd.\n" +
+			"\n" +
+			"lxd help\n")
 }
 
 func (c *helpCmd) flags() {}
@@ -31,7 +28,7 @@ func (c *helpCmd) run(_ *lxd.Config, args []string) error {
 		for _, name := range args {
 			cmd, ok := commands[name]
 			if !ok {
-				fmt.Fprintf(os.Stderr, "error: unknown command: %s\n", name)
+				fmt.Fprintf(os.Stderr, gettext.Gettext("error: unknown command: %s\n"), name)
 			} else {
 				fmt.Fprintf(os.Stderr, cmd.usage())
 			}
@@ -39,8 +36,7 @@ func (c *helpCmd) run(_ *lxd.Config, args []string) error {
 		return nil
 	}
 
-	fmt.Println("Usage: lxc [subcommand] [options]")
-	fmt.Println("Available commands:")
+	fmt.Println(gettext.Gettext("Usage: lxc [subcommand] [options]\nAvailable commands:\n"))
 	var names []string
 	for name := range commands {
 		names = append(names, name)
@@ -65,5 +61,5 @@ func summaryLine(usage string) string {
 			return s.Text()
 		}
 	}
-	return "Missing summary."
+	return gettext.Gettext("Missing summary.")
 }

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -3,22 +3,21 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
 type listCmd struct{}
 
-const listUsage = `
-Lists the available resources.
-
-lxc list [resource]
-
-Currently resource must be a defined remote, and list only lists
-the defined containers.
-`
-
 func (c *listCmd) usage() string {
-	return listUsage
+	return gettext.Gettext(
+		"Lists the available resources.\n" +
+			"\n" +
+			"lxc list [resource]\n" +
+			"\n" +
+			"Currently resource must be a defined remote, and list only lists\n" +
+			"the defined containers.\n")
+
 }
 
 func (c *listCmd) flags() {}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -6,22 +6,26 @@ import (
 	"os"
 	"strings"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/internal/gnuflag"
 )
 
 func main() {
 	if err := run(); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		fmt.Fprintf(os.Stderr, gettext.Gettext("error: %v\n"), err)
 		os.Exit(1)
 	}
 }
 
-var verbose = gnuflag.Bool("v", false, "Enables verbose mode.")
-var debug = gnuflag.Bool("debug", false, "Enables debug mode.")
-
 func run() error {
-	gnuflag.StringVar(&lxd.ConfigDir, "config", lxd.ConfigDir, "Alternate config directory.")
+	gettext.BindTextdomain("lxd", "")
+	gettext.Textdomain("lxd")
+
+	verbose := gnuflag.Bool("v", false, gettext.Gettext("Enables verbose mode."))
+	debug := gnuflag.Bool("debug", false, gettext.Gettext("Enables debug mode."))
+
+	gnuflag.StringVar(&lxd.ConfigDir, "config", lxd.ConfigDir, gettext.Gettext("Alternate config directory."))
 
 	if len(os.Args) == 2 && (os.Args[1] == "-h" || os.Args[1] == "--help") {
 		os.Args[1] = "help"
@@ -33,13 +37,13 @@ func run() error {
 	name := os.Args[1]
 	cmd, ok := commands[name]
 	if !ok {
-		fmt.Fprintf(os.Stderr, "error: unknown command: %s\n", name)
+		fmt.Fprintf(os.Stderr, gettext.Gettext("error: unknown command: %s\n"), name)
 		commands["help"].run(nil, nil)
 		os.Exit(1)
 	}
 	cmd.flags()
 	gnuflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: %s\n\nOptions:\n\n", strings.TrimSpace(cmd.usage()))
+		fmt.Fprintf(os.Stderr, gettext.Gettext("Usage: %s\n\nOptions:\n\n"), strings.TrimSpace(cmd.usage()))
 		gnuflag.PrintDefaults()
 	}
 
@@ -58,7 +62,7 @@ func run() error {
 
 	err = cmd.run(config, gnuflag.Args())
 	if err == errArgs {
-		fmt.Fprintf(os.Stderr, "error: %v\n%s", err, cmd.usage())
+		fmt.Fprintf(os.Stderr, gettext.Gettext("error: %v\n%s"), err, cmd.usage())
 		os.Exit(1)
 	}
 	return err
@@ -89,4 +93,4 @@ var commands = map[string]command{
 	"exec":     &execCmd{},
 }
 
-var errArgs = fmt.Errorf("wrong number of subcommand arguments")
+var errArgs = fmt.Errorf(gettext.Gettext("wrong number of subcommand arguments"))

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -12,20 +13,17 @@ type remoteCmd struct {
 	httpAddr string
 }
 
-const remoteUsage = `
-Manage remote lxc servers.
-
-lxc remote add <name> <url>        Add the remote <name> at <url>.
-lxc remote remove <name>           Remove the remote <name>.
-lxc remote list                    List all remotes.
-lxc remote rename <old> <new>      Rename remote <old> to <new>.
-lxc remote set-url <name> <url>    Update <name>'s url to <url>.
-lxc remote set-default <name>      Set the default remote.
-lxc remote get-default             Print the default remote.
-`
-
 func (c *remoteCmd) usage() string {
-	return remoteUsage
+	return gettext.Gettext(
+		"Manage remote lxc servers.\n" +
+			"\n" +
+			"lxc remote add <name> <url>        Add the remote <name> at <url>.\n" +
+			"lxc remote remove <name>           Remove the remote <name>.\n" +
+			"lxc remote list                    List all remotes.\n" +
+			"lxc remote rename <old> <new>      Rename remote <old> to <new>.\n" +
+			"lxc remote set-url <name> <url>    Update <name>'s url to <url>.\n" +
+			"lxc remote set-default <name>      Set the default remote.\n" +
+			"lxc remote get-default             Print the default remote.\n")
 }
 
 func (c *remoteCmd) flags() {}
@@ -47,7 +45,7 @@ func addServer(config *lxd.Config, server string) error {
 		return nil
 	}
 
-	fmt.Printf("Admin password for %s: ", server)
+	fmt.Printf(gettext.Gettext("Admin password for %s: "), server)
 	pwd, err := terminal.ReadPassword(0)
 	if err != nil {
 		/* We got an error, maybe this isn't a terminal, let's try to
@@ -65,10 +63,10 @@ func addServer(config *lxd.Config, server string) error {
 	}
 
 	if !c.AmTrusted() {
-		return fmt.Errorf("Server doesn't trust us after adding our cert")
+		return fmt.Errorf(gettext.Gettext("Server doesn't trust us after adding our cert"))
 	}
 
-	fmt.Println("Client certificate stored at server: ", server)
+	fmt.Println(gettext.Gettext("Client certificate stored at server: "), server)
 	return nil
 }
 
@@ -91,7 +89,7 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		if rc, ok := config.Remotes[args[1]]; ok {
-			return fmt.Errorf("remote %s exists as <%s>", args[1], rc.Addr)
+			return fmt.Errorf(gettext.Gettext("remote %s exists as <%s>"), args[1], rc.Addr)
 		}
 
 		if config.Remotes == nil {
@@ -111,7 +109,7 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		if _, ok := config.Remotes[args[1]]; !ok {
-			return fmt.Errorf("remote %s doesn't exist", args[1])
+			return fmt.Errorf(gettext.Gettext("remote %s doesn't exist"), args[1])
 		}
 
 		if config.DefaultRemote == args[1] {
@@ -137,11 +135,11 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 
 		rc, ok := config.Remotes[args[1]]
 		if !ok {
-			return fmt.Errorf("remote %s doesn't exist", args[1])
+			return fmt.Errorf(gettext.Gettext("remote %s doesn't exist"), args[1])
 		}
 
 		if _, ok := config.Remotes[args[2]]; ok {
-			return fmt.Errorf("remote %s already exists", args[2])
+			return fmt.Errorf(gettext.Gettext("remote %s already exists"), args[2])
 		}
 
 		config.Remotes[args[2]] = rc
@@ -157,7 +155,7 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 		}
 		_, ok := config.Remotes[args[1]]
 		if !ok {
-			return fmt.Errorf("remote %s doesn't exist", args[1])
+			return fmt.Errorf(gettext.Gettext("remote %s doesn't exist"), args[1])
 		}
 		config.Remotes[args[1]] = lxd.RemoteConfig{Addr: args[2]}
 
@@ -168,7 +166,7 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 
 		_, ok := config.Remotes[args[1]]
 		if !ok {
-			return fmt.Errorf("remote %s doesn't exist", args[1])
+			return fmt.Errorf(gettext.Gettext("remote %s doesn't exist"), args[1])
 		}
 		config.DefaultRemote = args[1]
 
@@ -179,7 +177,7 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 		fmt.Println(config.DefaultRemote)
 		return nil
 	default:
-		return fmt.Errorf("Unknown remote subcommand %s", args[0])
+		return fmt.Errorf(gettext.Gettext("Unknown remote subcommand %s"), args[0])
 	}
 
 	return lxd.SaveConfig(config)

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/internal/gnuflag"
 )
@@ -9,18 +10,15 @@ type snapshotCmd struct {
 	stateful bool
 }
 
-const snapshotUsage = `
-Create a read-only snapshot of a container.
-
-lxc snapshot <source> <snapshot name> [--stateful]
-`
-
 func (c *snapshotCmd) usage() string {
-	return snapshotUsage
+	return gettext.Gettext(
+		"Create a read-only snapshot of a container.\n" +
+			"\n" +
+			"lxc snapshot <source> <snapshot name> [--stateful]\n")
 }
 
 func (c *snapshotCmd) flags() {
-	gnuflag.BoolVar(&c.stateful, "stateful", false, "Whether or not to snapshot the container's running state")
+	gnuflag.BoolVar(&c.stateful, "stateful", false, gettext.Gettext("Whether or not to snapshot the container's running state"))
 }
 
 func (c *snapshotCmd) run(config *lxd.Config, args []string) error {

--- a/lxc/version.go
+++ b/lxc/version.go
@@ -3,19 +3,17 @@ package main
 import (
 	"fmt"
 
+	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 )
 
 type versionCmd struct{}
 
-const versionUsage = `
-Prints the version number of lxd.
-
-lxd version
-`
-
 func (c *versionCmd) usage() string {
-	return versionUsage
+	return gettext.Gettext(
+		"Prints the version number of lxd.\n" +
+			"\n" +
+			"lxd version\n")
 }
 
 func (c *versionCmd) flags() {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -1,0 +1,230 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid   ""
+msgstr  "Project-Id-Version: PACKAGE VERSION\n"
+        "Report-Msgid-Bugs-To: \n"
+        "POT-Creation-Date: 2015-01-29 11:45+0100\n"
+        "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+        "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+        "Language-Team: LANGUAGE <LL@li.org>\n"
+        "Language: \n"
+        "MIME-Version: 1.0\n"
+        "Content-Type: text/plain; charset=CHARSET\n"
+        "Content-Transfer-Encoding: 8bit\n"
+
+#: lxc/remote.go:48
+#, c-format
+msgid   "Admin password for %s: "
+msgstr  ""
+
+#: lxc/main.go:28
+msgid   "Alternate config directory."
+msgstr  ""
+
+#: client.go:438
+msgid   "Certificate already stored.\n"
+msgstr  ""
+
+#: client.go:442
+#, c-format
+msgid   "Certificate fingerprint: % x\n"
+msgstr  ""
+
+#: lxc/remote.go:69
+msgid   "Client certificate stored at server: "
+msgstr  ""
+
+#: lxc/snapshot.go:15
+msgid   "Create a read-only snapshot of a container.\n"
+msgstr  ""
+
+#: lxc/main.go:26
+msgid   "Enables debug mode."
+msgstr  ""
+
+#: lxc/main.go:25
+msgid   "Enables verbose mode."
+msgstr  ""
+
+#: client.go:131
+#, c-format
+msgid   "Error reading the server certificate for %s\n"
+msgstr  ""
+
+#: lxc/finger.go:17
+msgid   "Fingers the lxd instance to check if it is up and working.\n"
+msgstr  ""
+
+#: lxc/file.go:137
+#, c-format
+msgid   "Invalid source %s"
+msgstr  ""
+
+#: lxc/file.go:45
+#, c-format
+msgid   "Invalid target %s"
+msgstr  ""
+
+#: lxc/list.go:14
+msgid   "Lists the available resources.\n"
+msgstr  ""
+
+#: lxc/config.go:20
+msgid   "Manage configuration.\n"
+msgstr  ""
+
+#: lxc/file.go:24
+msgid   "Manage files on a container.\n"
+msgstr  ""
+
+#: lxc/remote.go:18
+msgid   "Manage remote lxc servers.\n"
+msgstr  ""
+
+#: lxc/help.go:67
+msgid   "Missing summary."
+msgstr  ""
+
+#: lxc/file.go:123
+msgid   "More than one file to download, but target is not a directory"
+msgstr  ""
+
+#: lxc/config.go:80
+msgid   "No cert provided to add"
+msgstr  ""
+
+#: lxc/config.go:103
+msgid   "No fingerprint specified."
+msgstr  ""
+
+#: lxc/config.go:51
+msgid   "Only 'password' can be set currently"
+msgstr  ""
+
+#: lxc/create.go:31
+msgid   "Only the default ubuntu image is supported. Try `lxc create images:"
+        "ubuntu foo`."
+msgstr  ""
+
+#: lxc/delete.go:73
+#, c-format
+msgid   "Operation %s"
+msgstr  ""
+
+#: lxc/help.go:22
+msgid   "Presents details on how to use lxd.\n"
+msgstr  ""
+
+#: lxc/version.go:14
+msgid   "Prints the version number of lxd.\n"
+msgstr  ""
+
+#: lxc/remote.go:66
+msgid   "Server doesn't trust us after adding our cert"
+msgstr  ""
+
+#: lxc/file.go:32
+msgid   "Set the file's gid on push"
+msgstr  ""
+
+#: lxc/file.go:33
+msgid   "Set the file's perms on push"
+msgstr  ""
+
+#: lxc/file.go:31
+msgid   "Set the file's uid on push"
+msgstr  ""
+
+#: lxc/delete.go:56
+msgid   "Stopping container failed!"
+msgstr  ""
+
+#: lxc/config.go:133
+#, c-format
+msgid   "Unknown config command %s"
+msgstr  ""
+
+#: lxc/remote.go:180
+#, c-format
+msgid   "Unknown remote subcommand %s"
+msgstr  ""
+
+#: lxc/config.go:130
+#, c-format
+msgid   "Unkonwn config trust command %s"
+msgstr  ""
+
+#: lxc/main.go:46
+#, c-format
+msgid   "Usage: %s\n"
+        "\n"
+        "Options:\n"
+        "\n"
+msgstr  ""
+
+#: lxc/help.go:42
+msgid   "Usage: lxc [subcommand] [options]\n"
+        "Available commands:\n"
+msgstr  ""
+
+#: lxc/snapshot.go:21
+msgid   "Whether or not to snapshot the container's running state"
+msgstr  ""
+
+#: lxc/main.go:16
+msgid   "error: %v\n"
+msgstr  ""
+
+#: lxc/main.go:65
+msgid   "error: %v\n"
+        "%s"
+msgstr  ""
+
+#: lxc/help.go:34 lxc/main.go:40
+#, c-format
+msgid   "error: unknown command: %s\n"
+msgstr  ""
+
+#: lxc/exec.go:16
+msgid   "exec specified command in a container.\n"
+msgstr  ""
+
+#: lxc/file.go:184
+#, c-format
+msgid   "invalid argument %s"
+msgstr  ""
+
+#: lxc/create.go:14
+msgid   "lxc create images:ubuntu <name>\n"
+msgstr  ""
+
+#: lxc/delete.go:18
+msgid   "lxc delete <resource>\n"
+msgstr  ""
+
+#: client.go:443
+msgid   "ok (y/n)? "
+msgstr  ""
+
+#: lxc/remote.go:142
+#, c-format
+msgid   "remote %s already exists"
+msgstr  ""
+
+#: lxc/remote.go:112 lxc/remote.go:138 lxc/remote.go:158 lxc/remote.go:169
+#, c-format
+msgid   "remote %s doesn't exist"
+msgstr  ""
+
+#: lxc/remote.go:92
+#, c-format
+msgid   "remote %s exists as <%s>"
+msgstr  ""
+
+#: lxc/main.go:96
+msgid   "wrong number of subcommand arguments"
+msgstr  ""


### PR DESCRIPTION
On small caveat here is that xgettext doesn't actually support golang at the
moment, so we are hacking it by using C++ as the language. Unfortunately, this
means we have to mangle our multiline strings into single line strings, which
is rather ugly.

Additionally, we've decided for now not to i18n lxd itself (in favor of just
the client). There are several problems here: 1. how do we determine what
locale to render messages in? (Accept-Encoding is probably the answer here),
and 2. how do we do the translation with gettext in go in multithreaded land?
I'm not sure on #2, so we've punted for now.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>