### PR TITLE
exec calls exit with the same status as the process

### DIFF
--- a/operation.go
+++ b/operation.go
@@ -110,6 +110,14 @@ func (o *Operation) GetError() error {
 	return nil
 }
 
+func (r *Operation) MetadataAsMap() (*Jmap, error) {
+	ret := Jmap{}
+	if err := json.Unmarshal(r.Metadata, &ret); err != nil {
+		return nil, err
+	}
+	return &ret, nil
+}
+
 func (o *Operation) SetStatus(status OperationStatus) {
 	o.Status = status.String()
 	o.StatusCode = status


### PR DESCRIPTION
`lxc exec foo /bin/false` exits with the same code as the in-container process
does.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>