### PR TITLE
Don't print a non-error

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ func readMyCert() (string, string, error) {
 func (c *Client) loadServerCert() {
 	cert, err := ReadCert(ServerCertPath(c.name))
 	if err != nil {
-		fmt.Printf(gettext.Gettext("Error reading the server certificate for %s\n"), c.name)
+		Debugf("Error reading the server certificate for %s: %v\n", c.name, err)
 		return
 	}
 


### PR DESCRIPTION
This isn't really an error (it happens when the user hasn't ever talked to the
server before). It seems like bad UX to print "error" when something is
expected. However, it may still be useful for debugging, so I just switched it
to that.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>