### PR TITLE
implement uid shifting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 
 lxd/lxd
 lxc/lxc
+fuidshift/fuidshift

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 default:
 	make -C lxc
 	make -C lxd
+	make -C fuidshift
 
 .PHONY: check
 check: default

--- a/fuidshift/Makefile
+++ b/fuidshift/Makefile
@@ -1,0 +1,7 @@
+# we let go build figure out dependency changes
+.PHONY: fuidmap
+lxc:
+	go build
+
+clean:
+	-rm -f fuidshift

--- a/fuidshift/idmap.go
+++ b/fuidshift/idmap.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+	"strconv"
+)
+
+/*
+ * One entry in id mapping set - a single range of either
+ * uid or gid mappings.
+ */
+type idmapEntry struct {
+	isuid bool
+	isgid bool
+	srcid int
+	destid int
+	maprange int
+}
+
+func (e *idmapEntry) parse(s string) error {
+	split := strings.Split(s, ":")
+	var err error
+	if len(split) != 4 {
+		return fmt.Errorf("Bad idmap: %q", s)
+	}
+	switch split[0] {
+	case "u":
+		e.isuid = true
+	case "g":
+		e.isgid = true
+	case "b":
+		e.isuid = true
+		e.isgid = true
+	default:
+		return fmt.Errorf("Bad idmap type in %q", s)
+	}
+	e.srcid, err = strconv.Atoi(split[1])
+	if err != nil {
+		return err
+	}
+	e.destid, err = strconv.Atoi(split[2])
+	if err != nil {
+		return err
+	}
+	e.maprange, err = strconv.Atoi(split[3])
+	if err != nil {
+		return err
+	}
+
+	// wraparound
+	if e.srcid + e.maprange < e.srcid || e.destid + e.maprange < e.destid {
+		return fmt.Errorf("Bad mapping: id wraparound")
+	}
+
+	return nil
+}
+
+/*
+ * Convert an id from host id to mapped container id
+ */
+func (i *idmapEntry) shift_into_ns(id int) (int, error) {
+	if id < i.srcid || id >= i.srcid + i.maprange {
+		// this mapping doesn't apply
+		return 0, fmt.Errorf("N/A")
+	}
+
+	return id - i.srcid + i.destid, nil
+}
+
+/* taken from http://blog.golang.org/slices (which is under BSD licence) */
+func extend(slice []idmapEntry, element idmapEntry) []idmapEntry {
+	n := len(slice)
+	if n == cap(slice) {
+		// Slice is full; must grow.
+		// We double its size and add 1, so if the size is zero we still grow.
+		newSlice := make([]idmapEntry, len(slice), 2*len(slice)+1)
+		copy(newSlice, slice)
+		slice = newSlice
+	}
+	slice = slice[0 : n+1]
+	slice[n] = element
+	return slice
+}
+
+
+type Idmap struct {
+	idmap []idmapEntry
+}
+
+func (m Idmap) Len() int {
+	return len(m.idmap)
+}
+
+func (m Idmap) Append(s string) (Idmap, error) {
+	e := idmapEntry{}
+	err := e.parse(s)
+	if err != nil {
+		return m, err
+	}
+	m.idmap = extend(m.idmap, e)
+	return m, nil
+}
+
+func (m Idmap) Shift_into_ns(uid int, gid int) (int, int) {
+	u := -1
+	g := -1
+	for _, e := range m.idmap {
+		if e.isuid && u == -1 {
+			tmpu, err := e.shift_into_ns(uid)
+			if err == nil {
+				u = tmpu
+			}
+		}
+		if e.isgid && g == -1 {
+			tmpg, err := e.shift_into_ns(gid)
+			if err == nil {
+				g = tmpg
+			}
+		}
+	}
+
+	return u, g
+}

--- a/fuidshift/main.go
+++ b/fuidshift/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"path/filepath"
+	"fmt"
+	"os"
+	"syscall"
+)
+
+func help(me string, status int) {
+	fmt.Printf("Usage: %s directory [-t] <range1> [<range2> ...]\n", me)
+	fmt.Printf("  -t implies test mode.  No file ownerships will be changed.\n")
+	fmt.Printf("  A range is [u|b|g]:<first_container_id:first_host_id:range>.\n")
+	fmt.Printf("  where u means shift uids, g means shift gids, b means shift both.\n")
+	fmt.Printf("  For example: %s directory b:0:100000:65536 u:10000:1000:1\n", me)
+	os.Exit(status)
+}
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Printf("Error: %q\n", err)
+		help(os.Args[0], 1)
+	}
+}
+
+func run() error {
+	if len(os.Args) < 4 {
+		if len(os.Args) > 1 && (os.Args[1] == "-h" || os.Args[1] == "--help" || os.Args[1] == "help") {
+			help(os.Args[0], 0)
+		} else {
+			help(os.Args[0], 1)
+		}
+	}
+
+	directory := os.Args[1]
+	idmap := Idmap{}
+	testmode := false
+
+	for pos := 2; pos < len(os.Args); pos += 1 {
+
+		switch os.Args[pos] {
+		case "t", "-t", "--test", "test":
+			testmode = true
+		default:
+			var err error
+			idmap, err = idmap.Append(os.Args[pos])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if idmap.Len() == 0 {
+		fmt.Printf("No idmaps given\n")
+		help(os.Args[0], 1)
+	}
+
+	if !testmode && os.Geteuid() != 0 {
+		fmt.Printf("This must be run as root\n")
+		os.Exit(1)
+	}
+
+	return Uidshift(directory, idmap, testmode)
+}
+
+func getOwner(path string) (int, int, error) {
+	var stat syscall.Stat_t
+	err := syscall.Lstat(path, &stat)
+	if err != nil {
+		return 0, 0, err
+	}
+	uid := int(stat.Uid)
+	gid := int(stat.Gid)
+	return uid, gid, nil
+}
+
+func fileExists(p string) bool {
+	_, err := os.Lstat(p)
+	if err != nil && os.IsNotExist(err) {
+		return false
+	}
+	return true
+}
+
+func Uidshift(dir string, idmap Idmap, testmode bool) error {
+	convert := func (path string, fi os.FileInfo, err error) (e error) {
+		uid, gid, err := getOwner(path)
+		if err != nil {
+			return err
+		}
+		newuid, newgid := idmap.Shift_into_ns(uid, gid)
+		if testmode {
+			fmt.Printf("I would shift %q to %d %d\n", path, newuid, newgid)
+		} else {
+			err = os.Chown(path, int(newuid), int(newgid))
+			if err == nil {
+				m := fi.Mode()
+				if m&os.ModeSymlink == 0 {
+					err = os.Chmod(path, m)
+					if err != nil {
+						fmt.Printf("Error resetting mode on %q, continuing\n", path)
+					}
+				}
+			}
+		}
+		return nil
+	}
+
+	if ! fileExists(dir) {
+		return fmt.Errorf("No such file or directory: %q", dir)
+	}
+	return filepath.Walk(dir, convert)
+}

--- a/test/fuidshift.sh
+++ b/test/fuidshift.sh
@@ -1,0 +1,44 @@
+test_common_fuidshift() {
+	# test some bad arguments
+	fail=0
+	fuidshift > /dev/null 2>&1 && fail=1
+	fuidshift -t > /dev/null 2>&1 && fail=1
+	fuidshift /tmp -t b:0 > /dev/null 2>&1 && fail=1
+	fuidshift /tmp -t x:0:0:0 > /dev/null 2>&1 && fail=1
+	[ $fail -ne 1 ]
+}
+
+test_nonroot_fuidshift() {
+	test_common_fuidshift
+
+	u=$(id -u)
+	g=$(id -g)
+	u1=$((u+1))
+	g1=$((g+1))
+
+	touch ${LXD_FUIDMAP_DIR}/x1
+	fuidshift ${LXD_FUIDMAP_DIR}/x1 -t u:$u:100000:1 g:$g:100000:1 | tee /dev/stderr | grep "to 100000 100000" > /dev/null || fail=1
+	if [ $fail -eq 1 ]; then
+		echo "failed to shift own uid to container root"
+		false
+	fi
+	fuidshift ${LXD_FUIDMAP_DIR}/x1 -t u:$u1:10000:1 g:$g1:100000:1 | tee /dev/stderr | grep "to -1 -1" > /dev/null || fail=1
+	if [ $fail -eq 1 ]; then
+		echo "wrongly shifted invalid uid to container root"
+		false
+	fi
+}
+
+test_root_fuidshift() {
+	test_nonroot_fuidshift
+
+	# Todo - test ranges
+}
+
+test_fuidshift() {
+	if [ $(id -u) -ne 0 ]; then
+		test_nonroot_fuidshift
+	else
+		test_root_fuidshift
+	fi
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
-export PATH=../lxd:$PATH
+export PATH=../lxd:../fuidshift:$PATH
 
 # /tmp isn't moutned exec on most systems, so we can't actually start
 # containers that are created there.
 export LXD_DIR=$(mktemp -d -p $(pwd))
 chmod 777 "${LXD_DIR}"
 export LXD_CONF=$(mktemp -d)
+export LXD_FUIDMAP_DIR=${LXD_DIR}/fuidmap
+mkdir -p ${LXD_FUIDMAP_DIR}
 RESULT=failure
 lxd_pid=0
 
@@ -29,6 +31,7 @@ trap cleanup EXIT HUP INT TERM
 . ./signoff.sh
 . ./basic.sh
 . ./snapshots.sh
+. ./fuidshift.sh
 
 if [ -n "$LXD_DEBUG" ]; then
     debug=--debug
@@ -79,5 +82,8 @@ test_basic_usage
 
 echo "TEST: snapshots"
 test_snapshots
+
+echo "TEST: uidshift"
+test_fuidshift
 
 RESULT=success


### PR DESCRIPTION
The Idmap type is used by a new program fuidshift, which can shift
the userids on disk from host into container.  The same class can
later be used by the lxd container creation code.

The program must be called by root to shift uids, but has a test
mode which can be called by non-root users to show what uid/gid
conversions would be done.

add a fuidshift test

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>