### PR TITLE
Fix the lxd help message

### DIFF
--- a/internal/gnuflag/flag.go
+++ b/internal/gnuflag/flag.go
@@ -871,6 +871,11 @@ func Parsed() bool {
 // The default set of command-line flags, parsed from os.Args.
 var commandLine = NewFlagSet(os.Args[0], ExitOnError)
 
+// SetOut sets the output writer for the default FlagSet.
+func SetOut(w io.Writer) {
+	commandLine.output = w
+}
+
 // NewFlagSet returns a new, empty flag set with the specified name and
 // error handling property.
 func NewFlagSet(name string, errorHandling ErrorHandling) *FlagSet {

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -22,6 +22,7 @@ var verbose = gnuflag.Bool("v", false, "Enables verbose mode.")
 var debug = gnuflag.Bool("debug", false, "Enables debug mode.")
 var listenAddr = gnuflag.String("tcp", "", "TCP address <addr:port> to listen on in addition to the unix socket (e.g., 127.0.0.1:8443)")
 var group = gnuflag.String("group", "", "Group which owns the shared socket")
+var help = gnuflag.Bool("help", false, "Print this help message.")
 
 func init() {
 	myGroup, err := shared.GroupName(os.Getgid())
@@ -33,11 +34,18 @@ func init() {
 
 func run() error {
 	gnuflag.Usage = func() {
-		fmt.Fprintf(os.Stderr, "Usage: shared [options]\n\nOptions:\n\n")
+		fmt.Printf("Usage: lxd [options]\n\nOptions:\n")
 		gnuflag.PrintDefaults()
 	}
 
 	gnuflag.Parse(true)
+	if *help {
+		// The user asked for help via --help, so we shouldn't print to
+		// stderr.
+		gnuflag.SetOut(os.Stdout)
+		gnuflag.Usage()
+		return nil
+	}
 
 	if *verbose || *debug {
 		shared.SetLogger(log.New(os.Stderr, "", log.LstdFlags))


### PR DESCRIPTION
1. it should print to stdout and exit 0 if user requested --help
2. it should still print to stderr and exit 2 if user gave an invalid cli
   option

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>