### PR TITLE
Make BTRFS constant arch specific

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -34,11 +34,10 @@ var api10 = []Command{
 
 /* Some interesting filesystems */
 const (
-	BTRFS_SUPER_MAGIC = 0x9123683E
-	TMPFS_MAGIC       = 0x01021994
-	EXT4_SUPER_MAGIC  = 0xEF53
-	XFS_SUPER_MAGIC   = 0x58465342
-	NFS_SUPER_MAGIC   = 0x6969
+	tmpfsSuperMagic = 0x01021994
+	ext4SuperMagic  = 0xEF53
+	xfsSuperMagic   = 0x58465342
+	nfsSuperMagic   = 0x6969
 )
 
 /*
@@ -76,15 +75,15 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		env := shared.Jmap{"lxc_version": lxc.Version(), "driver": "lxc"}
 
 		switch fs.Type {
-		case BTRFS_SUPER_MAGIC:
+		case btrfsSuperMagic:
 			env["backing_fs"] = "btrfs"
-		case TMPFS_MAGIC:
+		case tmpfsSuperMagic:
 			env["backing_fs"] = "tmpfs"
-		case EXT4_SUPER_MAGIC:
+		case ext4SuperMagic:
 			env["backing_fs"] = "ext4"
-		case XFS_SUPER_MAGIC:
+		case xfsSuperMagic:
 			env["backing_fs"] = "xfs"
-		case NFS_SUPER_MAGIC:
+		case nfsSuperMagic:
 			env["backing_fs"] = "nfs"
 		default:
 			env["backing_fs"] = fs.Type

--- a/lxd/api10_386.go
+++ b/lxd/api10_386.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	/* This is really 0x9123683E, go wants us to give it in signed form
+	 * since we use it as a signed constant. */
+	btrfsSuperMagic = -1859950530
+)

--- a/lxd/api10_amd64.go
+++ b/lxd/api10_amd64.go
@@ -1,0 +1,5 @@
+package main
+
+const (
+	btrfsSuperMagic = 0x9123683E
+)

--- a/lxd/api10_arm.go
+++ b/lxd/api10_arm.go
@@ -1,0 +1,7 @@
+package main
+
+const (
+	/* This is really 0x9123683E, go wants us to give it in signed form
+	 * since we use it as a signed constant. */
+	btrfsSuperMagic = -1859950530
+)


### PR DESCRIPTION
This works around the int32/int64 problem.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>