### PR TITLE
fix `go test ./...` and run it in travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ default:
 
 .PHONY: check
 check: default
+	go test ./...
 	cd test && ./main.sh
 
 # dist is primarily for use when packaging; for development we still manage

--- a/internal/gnuflag/flag_test.go
+++ b/internal/gnuflag/flag_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	. "launchpad.net/gnuflag"
+	. "github.com/lxc/lxd/internal/gnuflag"
 )
 
 var (
@@ -103,8 +103,8 @@ func TestUsage(t *testing.T) {
 	if f.Parse(true, []string{"-x"}) == nil {
 		t.Error("parse did not fail for unknown flag")
 	}
-	if !called {
-		t.Error("did not call Usage for unknown flag")
+	if called {
+		t.Error("called Usage for unknown flag")
 	}
 }
 
@@ -535,14 +535,14 @@ func TestPrintDefaults(t *testing.T) {
 	f.SetOutput(nullWriter{})
 
 	expect :=
-		`-b, -x, --bal, --balalaika  (= false)
-    b usage
--c, --trapclap  (= 99)
-    c usage
--d (= "d default")
-    d usage
---elephant  (= 3.14)
-    elephant usage
+		`    -b, -x, --bal, --balalaika  (= false)
+        b usage
+    -c, --trapclap  (= 99)
+        c usage
+    -d (= "d default")
+        d usage
+    --elephant  (= 3.14)
+        elephant usage
 `
 	if buf.String() != expect {
 		t.Errorf("expect %q got %q", expect, buf.String())


### PR DESCRIPTION
In preparation for migration, for which I'm writing some unit tests, fix up the
tests everywhere else (i.e. gnuflag). This involved:

* fixing up the expected pretty printing of options
* fixing a small logic error (Usage() isn't called on bad flags, we have to do
  it explicitly)

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>