### PR TITLE
Cleanup snapshots

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -27,23 +27,7 @@ func (c *listCmd) usage() string {
 
 func (c *listCmd) flags() {}
 
-func (c *listCmd) run(config *lxd.Config, args []string) error {
-	if len(args) > 1 {
-		return errArgs
-	}
-
-	var remote string
-	if len(args) == 1 {
-		remote = config.ParseRemote(args[0])
-	} else {
-		remote = config.DefaultRemote
-	}
-
-	d, err := lxd.NewClient(config, remote)
-	if err != nil {
-		return err
-	}
-
+func listContainers(d *lxd.Client) error {
 	cts, err := d.ListContainers()
 	if err != nil {
 		return err
@@ -59,4 +43,54 @@ func (c *listCmd) run(config *lxd.Config, args []string) error {
 		}
 	}
 	return nil
+}
+
+func listContainer(d *lxd.Client, name string) error {
+	status, err := d.ContainerStatus(name)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Name: %s\n", name)
+	fmt.Printf("State: %s\n", status.Status.State)
+
+	// List snapshots
+	first_snapshot := true
+	snaps, err := d.ListSnapshots(name)
+	if err != nil {
+		return nil
+	}
+	for _, snap := range snaps {
+		if first_snapshot {
+			fmt.Printf("Snapshots:\n")
+		}
+		fmt.Printf("  %s\n", snap)
+		first_snapshot = false
+	}
+	return nil
+}
+
+func (c *listCmd) run(config *lxd.Config, args []string) error {
+	if len(args) > 1 {
+		return errArgs
+	}
+
+	var remote string
+	var name string
+	if len(args) == 1 {
+		remote, name = config.ParseRemoteAndContainer(args[0])
+	} else {
+		remote = config.DefaultRemote
+		name = ""
+	}
+
+	d, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	if name == "" {
+		return listContainers(d)
+	}
+
+	return listContainer(d, name)
 }

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/internal/gnuflag"
@@ -26,8 +28,15 @@ func (c *snapshotCmd) flags() {
 }
 
 func (c *snapshotCmd) run(config *lxd.Config, args []string) error {
-	if len(args) < 2 {
+	if len(args) < 1 {
 		return errArgs
+	}
+
+	var snapname string
+	if len(args) < 2 {
+		snapname = ""
+	} else {
+		snapname = args[1]
 	}
 
 	remote, name := config.ParseRemoteAndContainer(args[0])
@@ -36,7 +45,12 @@ func (c *snapshotCmd) run(config *lxd.Config, args []string) error {
 		return err
 	}
 
-	resp, err := d.Snapshot(name, args[1], c.stateful)
+	// we don't allow '/' in snapshot names
+	if lxd.IsSnapshot(snapname) {
+		return fmt.Errorf(gettext.Gettext("'/' not allowed in snapshot name\n"))
+	}
+
+	resp, err := d.Snapshot(name, snapname, c.stateful)
 	if err != nil {
 		return err
 	}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -283,6 +283,33 @@ func containerGet(d *Daemon, r *http.Request) Response {
 	return SyncResponse(true, shared.CtoD(c.c))
 }
 
+func containerDeleteSnapshots(d *Daemon, cname string) []string {
+	prefix := fmt.Sprintf("%s/", cname)
+	length := len(prefix)
+	rows, err := d.db.Query("SELECT name, id FROM containers WHERE type=? AND SUBSTR(name,1,?)=?",
+		cTypeSnapshot, length, prefix)
+	if err != nil {
+		return nil
+	}
+
+	var results []string
+	var ids []int
+
+	for rows.Next() {
+		var id int
+		var sname string
+		rows.Scan(&sname, &id)
+		ids = append(ids, id)
+		cdir := shared.VarPath("lxc", cname, "snapshots", sname)
+		results = append(results, cdir)
+	}
+	rows.Close()
+	for _, id := range ids {
+		_, _ = d.db.Exec("DELETE FROM containers WHERE id=?", id)
+	}
+	return results
+}
+
 func containerDelete(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 	fmt.Printf("delete: called with name %s\n", name)
@@ -291,9 +318,16 @@ func containerDelete(d *Daemon, r *http.Request) Response {
 		fmt.Printf("Delete: container %s not known", name)
 		// rootfs may still exist though, so try to delete it
 	}
+	dirsToDelete := containerDeleteSnapshots(d, name)
 	dbRemoveContainer(d, name)
+	dirsToDelete = append(dirsToDelete, shared.VarPath("lxc", name))
 	rmdir := func() error {
-		removeContainerPath(d, name)
+		for _, dir := range dirsToDelete {
+			err := os.RemoveAll(dir)
+			if err != nil {
+				shared.Debugf("Error cleaning up %s: %s\n", dir, err)
+			}
+		}
 		return nil
 	}
 	fmt.Printf("running rmdir\n")
@@ -629,12 +663,12 @@ func snapshotRootfsDir(c *lxdContainer, name string) string {
 
 func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 
-	name := mux.Vars(r)["name"]
+	cname := mux.Vars(r)["name"]
 
-	regexp := fmt.Sprintf("%s/", name)
+	regexp := fmt.Sprintf("%s/", cname)
 	length := len(regexp)
-	rows, err := d.db.Query("SELECT name FROM containers WHERE type=1 AND SUBSTR(name,1,%d)=%s*",
-		length, regexp)
+	rows, err := d.db.Query("SELECT name FROM containers WHERE type=? AND SUBSTR(name,1,?)=?",
+		cTypeSnapshot, length, regexp)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -645,7 +679,7 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 	for rows.Next() {
 		var name string
 		rows.Scan(&name)
-		url := fmt.Sprintf("/1.0/containers/%s", name)
+		url := fmt.Sprintf("/1.0/containers/%s/snapshots/%s", cname, name)
 		body = append(body, url)
 	}
 
@@ -657,21 +691,29 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
  * To do that, we'll need to weed out based on # slashes in names
  */
 func nextSnapshot(d *Daemon, name string) int {
-	base := fmt.Sprintf("%s/", name)
+	base := fmt.Sprintf("%s/snap", name)
 	length := len(base)
-	q := fmt.Sprintf("SELECT MAX(id) FROM containers WHERE type=1 AND SUBSTR(name,1,%d)=%s",
-		length, base)
-	rows, err := d.db.Query(q)
+	q := fmt.Sprintf("SELECT MAX(name) FROM containers WHERE type=? AND SUBSTR(name,1,?)=?")
+	rows, err := d.db.Query(q, cTypeSnapshot, length, base)
 	if err != nil {
 		return 0
 	}
 	defer rows.Close()
+	max := 0
 	for rows.Next() {
-		var tmp int
+		var tmp string
+		var num int
 		rows.Scan(&tmp)
-		return tmp
+		tmp2 := tmp[length:]
+		count, err := fmt.Sscanf(tmp2, "%d", &num)
+		if err != nil || count != 1 {
+			continue
+		}
+		if num >= max {
+			max = num + 1
+		}
 	}
-	return 0
+	return max
 }
 
 func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
@@ -694,10 +736,10 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 	}
 
 	snapshotName, err := raw.GetString("name")
-	if err != nil {
+	if err != nil || snapshotName == "" {
 		// come up with a name
 		i := nextSnapshot(d, name)
-		snapshotName = fmt.Sprintf("%s/snap%d", name, i)
+		snapshotName = fmt.Sprintf("snap%d", i)
 	}
 
 	stateful, err := raw.GetBool("stateful")
@@ -705,18 +747,20 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = os.MkdirAll(snapshotDir(c, snapshotName), 0700)
+	fullName := fmt.Sprintf("%s/%s", name, snapshotName)
+	snapDir := snapshotDir(c, snapshotName)
+	err = os.MkdirAll(snapDir, 0700)
 	if err != nil {
 		return InternalError(err)
 	}
 
 	snapshot := func() error {
 
-		snapDir := snapshotStateDir(c, snapshotName)
-		if shared.PathExists(snapDir) {
+		StateDir := snapshotStateDir(c, snapshotName)
+		if shared.PathExists(StateDir) {
 			return fmt.Errorf("Snapshot directory exists")
 		}
-		err = os.MkdirAll(snapDir, 0700)
+		err = os.MkdirAll(StateDir, 0700)
 		if err != nil {
 			return fmt.Errorf("Error creating rootfs directory")
 		}
@@ -725,7 +769,7 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 			if !c.c.Running() {
 				return fmt.Errorf("Container not running\n")
 			}
-			opts := lxc.CheckpointOptions{Directory: snapDir, Stop: true, Verbose: true}
+			opts := lxc.CheckpointOptions{Directory: StateDir, Stop: true, Verbose: true}
 			if err := c.c.Checkpoint(opts); err != nil {
 				return err
 			}
@@ -733,14 +777,15 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 
 		/* Create the db info */
 		//cId, err := dbCreateContainer(d, snapshotName, cTypeSnapshot)
-		_, err := dbCreateContainer(d, snapshotName, cTypeSnapshot)
+		_, err := dbCreateContainer(d, fullName, cTypeSnapshot)
 
 		/* todo - copy over the container_config items */
 
 		/* Create the directory and rootfs, set perms */
 		/* Copy the rootfs */
-		oldPath := shared.VarPath("lxc", name, "rootfs")
-		newPath := fmt.Sprintf("%s/%s", snapDir, "rootfs")
+		oldPath := fmt.Sprintf("%s/", shared.VarPath("lxc", name, "rootfs"))
+		newPath := snapshotRootfsDir(c, snapshotName)
+		fmt.Printf("Running rsync -a --devices %s %s\n", oldPath, newPath)
 		err = exec.Command("rsync", "-a", "--devices", oldPath, newPath).Run()
 		return err
 	}
@@ -749,6 +794,11 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 }
 
 var containerSnapshotsCmd = Command{name: "containers/{name}/snapshots", get: containerSnapshotsGet, post: containerSnapshotsPost}
+
+func dbRemoveSnapshot(d *Daemon, cname string, sname string) {
+	name := fmt.Sprintf("%s/%s", cname, sname)
+	_, _ = d.db.Exec("DELETE FROM containers WHERE type=? AND name=?", cTypeSnapshot, name)
+}
 
 func snapshotHandler(d *Daemon, r *http.Request) Response {
 	containerName := mux.Vars(r)["name"]
@@ -771,7 +821,7 @@ func snapshotHandler(d *Daemon, r *http.Request) Response {
 	case "POST":
 		return snapshotPost(r, c, snapshotName)
 	case "DELETE":
-		return snapshotDelete(c, snapshotName)
+		return snapshotDelete(d, c, snapshotName)
 	default:
 		return NotFound
 	}
@@ -814,7 +864,8 @@ func snapshotPost(r *http.Request, c *lxdContainer, oldName string) Response {
 	return AsyncResponse(shared.OperationWrap(rename), nil)
 }
 
-func snapshotDelete(c *lxdContainer, name string) Response {
+func snapshotDelete(d *Daemon, c *lxdContainer, name string) Response {
+	dbRemoveSnapshot(d, c.name, name)
 	dir := snapshotDir(c, name)
 	remove := func() error { return os.RemoveAll(dir) }
 	return AsyncResponse(shared.OperationWrap(remove), nil)

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-02-25 13:40-0600\n"
+        "POT-Creation-Date: 2015-02-26 02:05-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,6 +15,10 @@ msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "MIME-Version: 1.0\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
+
+#: lxc/snapshot.go:50
+msgid   "'/' not allowed in snapshot name\n"
+msgstr  ""
 
 #: lxc/image.go:59
 #, c-format
@@ -35,11 +39,11 @@ msgstr  ""
 msgid   "Alternate config directory."
 msgstr  ""
 
-#: client.go:557
+#: client.go:566
 msgid   "Certificate already stored.\n"
 msgstr  ""
 
-#: client.go:561
+#: client.go:570
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -53,11 +57,11 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: client.go:575
+#: client.go:584
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/snapshot.go:19
+#: lxc/snapshot.go:21
 msgid   "Create a read-only snapshot of a container.\n"
 msgstr  ""
 
@@ -135,7 +139,7 @@ msgstr  ""
 msgid   "No cert provided to add"
 msgstr  ""
 
-#: client.go:553
+#: client.go:562
 msgid   "No certificate on this connection"
 msgstr  ""
 
@@ -143,11 +147,11 @@ msgstr  ""
 msgid   "No fingerprint specified."
 msgstr  ""
 
-#: client.go:655
+#: client.go:664
 msgid   "Non-async response from create!"
 msgstr  ""
 
-#: client.go:882
+#: client.go:928
 msgid   "Non-async response from snapshot!"
 msgstr  ""
 
@@ -155,7 +159,7 @@ msgstr  ""
 msgid   "Only 'password' can be set currently"
 msgstr  ""
 
-#: lxc/delete.go:75
+#: lxc/delete.go:42
 #, c-format
 msgid   "Operation %s"
 msgstr  ""
@@ -168,11 +172,11 @@ msgstr  ""
 msgid   "Prints the version number of lxd.\n"
 msgstr  ""
 
-#: client.go:568
+#: client.go:577
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: client.go:227
+#: client.go:236
 msgid   "Server certificate has changed"
 msgstr  ""
 
@@ -196,7 +200,7 @@ msgstr  ""
 msgid   "Show all commands (not just interesting ones)"
 msgstr  ""
 
-#: lxc/delete.go:58
+#: lxc/delete.go:76
 msgid   "Stopping container failed!"
 msgstr  ""
 
@@ -237,15 +241,15 @@ msgid   "Usage: lxc [subcommand] [options]\n"
         "Available commands:\n"
 msgstr  ""
 
-#: lxc/snapshot.go:25
+#: lxc/snapshot.go:27
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: client.go:386
+#: client.go:395
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:444
+#: client.go:453 client.go:960 client.go:967
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -254,11 +258,11 @@ msgstr  ""
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:540
+#: client.go:549
 msgid   "bad response type from image list!"
 msgstr  ""
 
-#: client.go:424 client.go:501
+#: client.go:433 client.go:510 client.go:946
 msgid   "bad response type from list!"
 msgstr  ""
 
@@ -266,11 +270,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:448
+#: client.go:457 client.go:971
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:340 client.go:345
+#: client.go:349 client.go:354
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
@@ -292,12 +296,12 @@ msgstr  ""
 msgid   "error: unknown command: %s\n"
 msgstr  ""
 
-#: client.go:702
+#: client.go:741
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
 
-#: client.go:673
+#: client.go:686
 msgid   "got bad response type from exec"
 msgstr  ""
 
@@ -305,11 +309,11 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: client.go:738
+#: client.go:784
 msgid   "got non-async response from delete!"
 msgstr  ""
 
-#: client.go:757
+#: client.go:803
 msgid   "got non-sync response from containers get!"
 msgstr  ""
 
@@ -318,7 +322,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:836
+#: client.go:882
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -336,11 +340,11 @@ msgstr  ""
 msgid   "lxc launch ubuntu [<name>]\n"
 msgstr  ""
 
-#: client.go:93
+#: client.go:102
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:562
+#: client.go:571
 msgid   "ok (y/n)? "
 msgstr  ""
 
@@ -359,7 +363,7 @@ msgstr  ""
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: client.go:204
+#: client.go:213
 msgid   "unknown remote name: %q"
 msgstr  ""
 

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -1,10 +1,17 @@
 test_snapshots() {
-  shasum=`sha256sum ubuntu*.xz | awk '{ print $1 }'`
+  lxc init ubuntu foo
 
-  lxc init $shasum foo
+  lxc snapshot foo
+  [ -d "$LXD_DIR/lxc/foo/snapshots/snap0" ]
+
+  lxc snapshot foo
+  [ -d "$LXD_DIR/lxc/foo/snapshots/snap1" ]
 
   lxc snapshot foo tester
   [ -d "$LXD_DIR/lxc/foo/snapshots/tester" ]
+
+  lxc delete foo/snap0
+  [ ! -d "$LXD_DIR/lxc/foo/snapshots/snap0" ]
 
   # no CLI for this, so we use the API directly
   wait_for my_curl -X POST $BASEURL/1.0/containers/foo/snapshots/tester -d "{\"name\":\"tester2\"}"
@@ -13,4 +20,7 @@ test_snapshots() {
   # no CLI for this, so we use the API directly
   wait_for my_curl -X DELETE $BASEURL/1.0/containers/foo/snapshots/tester2
   [ ! -d "$LXD_DIR/lxc/foo/snapshots/tester2" ]
+
+  lxc delete foo
+  [ ! -d "$LXD_DIR/lxc/foo" ]
 }


### PR DESCRIPTION
containerSnapshotsGet:
	First, the return urls should include the original container
	name.
	Second, the sql container %s and %d instead of ?.

	implement ListSnapshots in client

	implement 'lxc list <container>'

	implement snapshot delete

	fix rootfs on snapshot creation

	update snapshot testcase

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>