### PR TITLE
nextSnapshot: avoid a lxd crash

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -775,6 +775,9 @@ func nextSnapshot(d *Daemon, name string) int {
 		var tmp string
 		var num int
 		rows.Scan(&tmp)
+		if len(tmp) <= length {
+			continue
+		}
 		tmp2 := tmp[length:]
 		count, err := fmt.Sscanf(tmp2, "%d", &num)
 		if err != nil || count != 1 {


### PR DESCRIPTION
don't take substring starting past the string's length.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>