### PR TITLE
build fuidmap

### DIFF
--- a/fuidshift/main.go
+++ b/fuidshift/main.go
@@ -1,10 +1,8 @@
-package fuidshift
+package main
 
 import (
 	"fmt"
 	"os"
-	"path/filepath"
-	"syscall"
 
 	"github.com/lxc/lxd/shared"
 )
@@ -35,7 +33,7 @@ func run() error {
 	}
 
 	directory := os.Args[1]
-	idmap := IdmapSet{}
+	idmap := shared.IdmapSet{}
 	testmode := false
 
 	for pos := 2; pos < len(os.Args); pos++ {
@@ -62,46 +60,5 @@ func run() error {
 		os.Exit(1)
 	}
 
-	return Uidshift(directory, idmap, testmode)
-}
-
-func getOwner(path string) (int, int, error) {
-	var stat syscall.Stat_t
-	err := syscall.Lstat(path, &stat)
-	if err != nil {
-		return 0, 0, err
-	}
-	uid := int(stat.Uid)
-	gid := int(stat.Gid)
-	return uid, gid, nil
-}
-
-func Uidshift(dir string, idmap IdmapSet, testmode bool) error {
-	convert := func(path string, fi os.FileInfo, err error) (e error) {
-		uid, gid, err := getOwner(path)
-		if err != nil {
-			return err
-		}
-		newuid, newgid := idmap.ShiftIntoNs(uid, gid)
-		if testmode {
-			fmt.Printf("I would shift %q to %d %d\n", path, newuid, newgid)
-		} else {
-			err = os.Chown(path, int(newuid), int(newgid))
-			if err == nil {
-				m := fi.Mode()
-				if m&os.ModeSymlink == 0 {
-					err = os.Chmod(path, m)
-					if err != nil {
-						fmt.Printf("Error resetting mode on %q, continuing\n", path)
-					}
-				}
-			}
-		}
-		return nil
-	}
-
-	if !shared.PathExists(dir) {
-		return fmt.Errorf("No such file or directory: %q", dir)
-	}
-	return filepath.Walk(dir, convert)
+	return shared.Uidshift(directory, idmap, testmode)
 }

--- a/lxd/idmap.go
+++ b/lxd/idmap.go
@@ -9,7 +9,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lxc/lxd/fuidshift"
+	"github.com/lxc/lxd/shared"
 )
 
 /*
@@ -107,7 +107,7 @@ func NewIdmap() (*Idmap, error) {
 }
 
 func (i *Idmap) ShiftRootfs(p string) error {
-	set := fuidshift.IdmapSet{}
+	set := shared.IdmapSet{}
 	uidstr := fmt.Sprintf("u:0:%d:%d", i.Uidmin, i.Uidrange)
 	gidstr := fmt.Sprintf("g:0:%d:%d", i.Gidmin, i.Gidrange)
 	set, err := set.Append(uidstr)
@@ -118,5 +118,5 @@ func (i *Idmap) ShiftRootfs(p string) error {
 	if err != nil {
 		return err
 	}
-	return fuidshift.Uidshift(p, set, false)
+	return shared.Uidshift(p, set, false)
 }


### PR DESCRIPTION
make fuidmap/main.go package main, and move fuidmap/idmap.go into
package shared as uidmapset.go.

We should clean this stuff up so that there is a uidmapEntry and a
uidmapSet, where uidmapSet is a set of uidmapEntry's and the
uidmaapSet.ShiftUid() and uidmapSet.ShiftTree() are the helpers
which do the work.  Hopefully I'll get to that soon, but this
at least gives us a fuidmap binary again.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>