### PR TITLE
tests: Make things a bit more readable

### DIFF
--- a/test/fuidshift.sh
+++ b/test/fuidshift.sh
@@ -19,12 +19,12 @@ test_nonroot_fuidshift() {
 	touch ${LXD_FUIDMAP_DIR}/x1
 	fuidshift ${LXD_FUIDMAP_DIR}/x1 -t u:$u:100000:1 g:$g:100000:1 | tee /dev/stderr | grep "to 100000 100000" > /dev/null || fail=1
 	if [ $fail -eq 1 ]; then
-		echo "failed to shift own uid to container root"
+		echo "==> Failed to shift own uid to container root"
 		false
 	fi
 	fuidshift ${LXD_FUIDMAP_DIR}/x1 -t u:$u1:10000:1 g:$g1:100000:1 | tee /dev/stderr | grep "to -1 -1" > /dev/null || fail=1
 	if [ $fail -eq 1 ]; then
-		echo "wrongly shifted invalid uid to container root"
+		echo "==> Wrongly shifted invalid uid to container root"
 		false
 	fi
 }

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -11,13 +11,13 @@ gen_second_cert() {
 
 test_remote() {
   bad=0
-  (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:8443 --debug || true
+  (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:8443 $debug || true
   lxc list badpass && bad=1 || true
   if [ "$bad" -eq 1 ]; then
       echo "bad password accepted" && false
   fi
 
-  (echo y;  sleep 3;  echo foo) |  lxc remote add local 127.0.0.1:8443 --debug
+  (echo y;  sleep 3;  echo foo) |  lxc remote add local 127.0.0.1:8443 $debug
   lxc remote list | grep 'local'
 
   lxc remote set-default local
@@ -33,7 +33,7 @@ test_remote() {
 
   # This is a test for #91, we expect this to hang asking for a password if we
   # tried to re-add our cert.
-  echo y | lxc remote add local 127.0.0.1:8443 --debug
+  echo y | lxc remote add local 127.0.0.1:8443 $debug
 
   # we just re-add our cert under a different name to test the cert
   # manipulation mechanism.

--- a/test/signoff.sh
+++ b/test/signoff.sh
@@ -9,6 +9,6 @@ test_commits_signed_off() {
   git fetch lxc master
   for i in $(git cherry lxc/master | grep '^+' | cut -d' ' -f2); do
     git show "$i" | grep -q 'Signed-off-by' || \
-        ( echo "Commit without sign-off:" ; git show "$i" ; false )
+        ( echo "==> Commit without sign-off:" ; git show "$i" ; false )
   done
 }

--- a/test/static_analysis.sh
+++ b/test/static_analysis.sh
@@ -13,10 +13,10 @@ static_analysis() {
   # make sure the .pot is updated
   cp $toplevel/po/lxd.pot $toplevel/po/lxd.pot.bak
   hash1=$(safe_pot_hash)
-  (cd $toplevel && make i18n)
+  (cd $toplevel && make i18n -s)
   hash2=$(safe_pot_hash)
   mv $toplevel/po/lxd.pot.bak $toplevel/po/lxd.pot
   if [ "$hash1" != "$hash2" ]; then
-    echo "please update the .pot file in your commit (make i18n)" && false
+    echo "==> Please update the .pot file in your commit (make i18n)" && false
   fi
 }


### PR DESCRIPTION
 - Always prefix status output so it can be distinguished from commands.
 - Make everything respect LXD_DEBUG

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>