### PR TITLE
Don't fail to create a nonetype

### DIFF
--- a/test/basic.sh
+++ b/test/basic.sh
@@ -41,9 +41,7 @@ test_basic_usage() {
   lxc delete foo
 
   # now, make sure create type 'none' works
-  mkdir -p "${LXD_DIR}/lxc/nonetype"
-  wait_for my_curl -X POST $BASEURL/1.0/containers -d '{"name": "nonetype", "source": {"type": "none"}}'
-  rm -rf "${LXD_DIR}/lxc/nonetype"
+  wait_for my_curl -X POST $BASEURL/1.0/containers -d "{\"name\":\"nonetype\",\"source\":{\"type\":\"none\"}}"
 
   # and creating with a config
   wait_for my_curl -X POST $BASEURL/1.0/containers -d "{\"name\":\"configtest\",\"config\":{\"raw.lxc\":\"lxc.hook.clone=/bin/true\"},\"source\":{\"type\":\"none\"}}"


### PR DESCRIPTION
Yay shell escaping.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>