### PR TITLE
sleep in tests while waiting for lxd

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -84,6 +84,7 @@ alive=0
 while [ $alive -eq 0 ]; do
   [ -e "${LXD_DIR}/unix.socket" ] || continue
   lxc finger && alive=1 || true
+  sleep 1s
 done
 
 echo "==> Setting trust password"


### PR DESCRIPTION
Now that lxc doesn't itself use a whole lot of CPU, you end up spinning the
bash script (or if you have LXD_DEBUG on, X) with spew. Don't do that.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>