### PR TITLE
Try to guess tar format

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -191,6 +191,7 @@ func extractShiftRootfs(uuid string, name string, d *Daemon) error {
 		return cleanup(err)
 	}
 
+fmt.Println(compression)
 	args := []string{"-C", dpath, "--numeric-owner"}
 	switch compression {
 	case COMPRESSION_TAR:
@@ -205,7 +206,7 @@ func extractShiftRootfs(uuid string, name string, d *Daemon) error {
 		args = append(args, "-Jxf")
 	}
 	args = append(args, imagefile, "rootfs")
-
+fmt.Println(args)
 	output, err := exec.Command("tar", args...).Output()
 	if err != nil {
 		fmt.Printf("Untar of image: Output %s\nError %s\n", output, err)

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -191,7 +191,6 @@ func extractShiftRootfs(uuid string, name string, d *Daemon) error {
 		return cleanup(err)
 	}
 
-fmt.Println(compression)
 	args := []string{"-C", dpath, "--numeric-owner"}
 	switch compression {
 	case COMPRESSION_TAR:
@@ -206,7 +205,7 @@ fmt.Println(compression)
 		args = append(args, "-Jxf")
 	}
 	args = append(args, imagefile, "rootfs")
-fmt.Println(args)
+
 	output, err := exec.Command("tar", args...).Output()
 	if err != nil {
 		fmt.Printf("Untar of image: Output %s\nError %s\n", output, err)


### PR DESCRIPTION
Maybe I got it wrong, but gave it a try today to resolve the tar compression format and get the architecture out of metadata.yaml. 

I just have a few questions. In the spec it says, it is recommended to use xz. That means I can use gzip, bz2 etc. as well? 

I'm sure you have tested everything regarding the compression and the compression rate of XZ is really good. But looking at the speed & memory, it is not very impressive. I tested  the different compressions with the ubuntu 64bit rootfs on a virtualbox 4gig, 2 cpu. XZ and LZMA took more than 2 minutes to compress and used more than 90MB doing it. I'm assuming when you "live move" containers you compress them in the actual state (haven't looked at the code yet). Wouldn't that be too slow and would use too much memory if you move a few containers at a time?

GZIP and BZ2 performance was almost equal. LZ4 was of course lightening fast, but you would end up with a lot of i/o. But the decompress took 0.5s. But compression rate was poor. Around the 50% mark.

I used exec.Command in this solution, but if you use lzma instead of xz, you could end up without it, I guess. Again, if I got it wrong and you are looking at XZ compression only, ignore this pull request :) Not a compression expert.




