### PR TITLE
Checksum for image uploads and yaml fix

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -136,7 +136,7 @@ func imagesPost(d *Daemon, r *http.Request) Response {
 	uuidfname := shared.VarPath("images", uuid)
 
 	if shared.PathExists(uuidfname) {
-		return InternalError(fmt.Errorf("Image exists"))
+		return cleanup(fmt.Errorf("Image exists already."), fname)
 	}
 
 	err = os.Rename(fname, uuidfname)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -14,6 +14,7 @@ import (
 	"bytes"
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/shared"
+	"gopkg.in/yaml.v2"
 	"hash"
 )
 
@@ -268,9 +269,10 @@ func getImageMetadata(fname string) (*imageMetadata, error) {
 	}
 
 	metadata := new(imageMetadata)
-	err = json.Unmarshal(output, &metadata)
+	err = yaml.Unmarshal(output, &metadata)
 
 	if err != nil {
+		fmt.Println(err)
 		return nil, fmt.Errorf("Could not get image metadata: %v", err)
 	}
 


### PR DESCRIPTION
Yesterday I was a bit overexcited. I used the standard JSON parser for metadata.yaml parsing. Doesn't work with pure YAML of course. 

I added a struct which generates the checksum on the fly while copying from the request body to the temp file.

I added a cleanup function if something fails during upload. Slightly changed your container cleanup function.sisatech
