### PR TITLE
Add live migration support to LXD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,4 @@
 *.swp
-
-lxd/lxd
-lxc/lxc
-fuidshift/fuidshift
 po/*.mo
-
 lxd-*.tar.gz
+*.pb.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,10 @@ before_install:
   - sudo apt-add-repository -y ppa:ubuntu-lxc/lxd-daily
   - sudo apt-get update
   - sudo apt-get install -y libssl1.0.0 libssl-dev libssl-doc curl libcurl3 libcurl3-gnutls libcurl4-openssl-dev
-  - sudo apt-get install -y acl lxc lxc-dev sqlite3 jq busybox-static
+  - sudo apt-get install -y acl lxc lxc-dev sqlite3 jq busybox-static protobuf-compiler
 
 install:
+  - go get -v code.google.com/p/goprotobuf/...
   - go get golang.org/x/tools/cmd/vet
   - mkdir -p $GOPATH/github.com/lxc
   - go get -v -d ./...
@@ -19,6 +20,7 @@ install:
   - echo "root:100000:65536" | sudo tee /etc/subuid
   - echo "root:100000:65536" | sudo tee /etc/subgid
   - sudo stop cgmanager
+  - sudo -E env PATH=$PATH env
 
 script: "sudo -E env PATH=$PATH make check"
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ARCHIVE=lxd-$(VERSION).tar
 
 .PHONY: default
 default:
+	protoc --go_out=. ./lxd/migration/migrate.proto
 	go install -v ./...
 
 .PHONY: check

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ After you've got LXD installed, you can take your [first steps](#first-steps).
 ## Building from source
 
 We have exeperienced some problems using gccgo, so for now we recommend using
-the golang compiler. We also require that a 1.0+ version of lxc and lxc-dev be
+the golang compiler. We also require that a 1.1+ version of lxc and lxc-dev be
 installed. Additionally, some of LXD's dependencies are grabbed from `go get`
 via mercurial, so you'll need to have `hg` in your path as well. You can get
 these on Ubuntu via:
 
-    sudo apt-get install lxc lxc-dev mercurial git pkg-config
+    sudo apt-get install lxc lxc-dev mercurial git pkg-config protobuf-compiler golang-goprotobuf-dev
 
 ### Installing Go
 

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -108,6 +108,7 @@ var commands = map[string]command{
 	"init":     &initCmd{},
 	"launch":   &launchCmd{},
 	"list":     &listCmd{},
+	"move":     &moveCmd{},
 	"remote":   &remoteCmd{},
 	"restart":  &actionCmd{shared.Restart, true},
 	"snapshot": &snapshotCmd{},

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"fmt"
 	"path"
 
 	"github.com/gosexy/gettext"
@@ -33,6 +34,10 @@ func (c *moveCmd) run(config *lxd.Config, args []string) error {
 
 	sourceRemote, sourceName := config.ParseRemoteAndContainer(args[0])
 	destRemote, destName := config.ParseRemoteAndContainer(args[1])
+
+	if sourceRemote == "" || destRemote == "" {
+		return fmt.Errorf("non-http remotes are not supported for migration right now")
+	}
 
 	source, err := lxd.NewClient(config, sourceRemote)
 	if err != nil {

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -39,6 +39,10 @@ func (c *moveCmd) run(config *lxd.Config, args []string) error {
 		return fmt.Errorf("non-http remotes are not supported for migration right now")
 	}
 
+	if sourceName == "" || destName == "" {
+		return fmt.Errorf("you must specify both a source and a destination container name")
+	}
+
 	source, err := lxd.NewClient(config, sourceRemote)
 	if err != nil {
 		return err

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -1,0 +1,64 @@
+package main
+
+import (
+	"encoding/json"
+	"path"
+
+	"github.com/gosexy/gettext"
+	"github.com/lxc/lxd"
+)
+
+type moveCmd struct {
+	httpAddr string
+}
+
+func (c *moveCmd) showByDefault() bool {
+	return false
+}
+
+func (c *moveCmd) usage() string {
+	return gettext.Gettext(
+		"Move containers within or in between lxd instances.\n" +
+			"\n" +
+			"(currently only live migration is supported)\n" +
+			"lxc move <source container> <destination container>\n")
+}
+
+func (c *moveCmd) flags() {}
+
+func (c *moveCmd) run(config *lxd.Config, args []string) error {
+	if len(args) != 2 {
+		return errArgs
+	}
+
+	sourceRemote, sourceName := config.ParseRemoteAndContainer(args[0])
+	destRemote, destName := config.ParseRemoteAndContainer(args[1])
+
+	source, err := lxd.NewClient(config, sourceRemote)
+	if err != nil {
+		return err
+	}
+
+	dest, err := lxd.NewClient(config, destRemote)
+	if err != nil {
+		return err
+	}
+
+	to, err := source.MigrateTo(sourceName, dest)
+	if err != nil {
+		return err
+	}
+
+	secrets := map[string]string{}
+	if err := json.Unmarshal(to.Metadata, &secrets); err != nil {
+		return err
+	}
+
+	url := "wss://" + source.Remote.Addr + path.Join(to.Operation, "websocket")
+	migration, err := dest.MigrateFrom(destName, url, secrets)
+	if err != nil {
+		return err
+	}
+
+	return dest.WaitForSuccess(migration.Operation)
+}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -220,16 +220,13 @@ func StartDaemon(listenAddr string) (*Daemon, error) {
 
 	var tcpListen func() error
 	if listenAddr != "" {
-		// Watch out. There's a listener active which must be closed on errors.
-		mycert, err := tls.LoadX509KeyPair(d.certf, d.keyf)
+		config, err := shared.GetTLSConfig(d.certf, d.keyf)
 		if err != nil {
+			d.unixl.Close()
 			return nil, err
 		}
-		config := tls.Config{Certificates: []tls.Certificate{mycert},
-			ClientAuth: tls.RequireAnyClientCert,
-			MinVersion: tls.VersionTLS12,
-			MaxVersion: tls.VersionTLS12}
-		tcpl, err := tls.Listen("tcp", listenAddr, &config)
+
+		tcpl, err := tls.Listen("tcp", listenAddr, config)
 		if err != nil {
 			d.unixl.Close()
 			return nil, fmt.Errorf("cannot listen on unix socket: %v", err)

--- a/lxd/migration/migrate.go
+++ b/lxd/migration/migrate.go
@@ -183,7 +183,7 @@ func (s *migrationSourceWs) Do() shared.OperationResult {
 	<-s.allConnected
 
 	header := MigrationHeader{
-		Fs:   FilesystemType_RSYNC.Enum(),
+		Fs:   MigrationFSType_RSYNC.Enum(),
 		Criu: CRIUType_CRIU_RSYNC.Enum(),
 	}
 
@@ -197,7 +197,7 @@ func (s *migrationSourceWs) Do() shared.OperationResult {
 		return shared.OperationError(err)
 	}
 
-	if *header.Fs != FilesystemType_RSYNC {
+	if *header.Fs != MigrationFSType_RSYNC {
 		err := fmt.Errorf("formats other than rsync not understood")
 		s.sendControl(err)
 		return shared.OperationError(err)
@@ -325,7 +325,7 @@ func (c *migrationSink) do() error {
 		return err
 	}
 
-	resp := MigrationHeader{Fs: FilesystemType_RSYNC.Enum(), Criu: CRIUType_CRIU_RSYNC.Enum()}
+	resp := MigrationHeader{Fs: MigrationFSType_RSYNC.Enum(), Criu: CRIUType_CRIU_RSYNC.Enum()}
 	if err := c.send(&resp); err != nil {
 		c.sendControl(err)
 		return err

--- a/lxd/migration/migrate.go
+++ b/lxd/migration/migrate.go
@@ -1,0 +1,394 @@
+// Package migration provides the primitives for migration in LXD.
+//
+// Migration has two pieces, a "source", that is, the host that already has the
+// container, and a "sink", the host that's getting the container. Currently,
+// in the 'pull' mode, the source sets up an operation, and the sink connects
+// to the source and pulls the container.
+//
+// There are three websockets (channels) used in migration: 1. the control
+// stream, 2. the criu images stream, and 3. the filesystem stream. When a
+// migration is initiated, information about the container, its configuration,
+// etc. are sent over the control channel, the criu images and container
+// filesystem are synced over their respective channels, and the result of the
+// restore operation is sent from the sink to the source over the control
+// channel.
+//
+// In particular, the protocol that is spoken over the criu channel and
+// filesystem channel can vary, depending on what is negotiated over the
+// control socket. For example, both the source and the sink's LXD directory is
+// on btrfs, the filesystem socket can speak btrfs-send/receive. Additionally,
+// although we do a "stop the world" type migration right now, support for
+// criu's p.haul protocol will happen over the criu socket.
+package migration
+
+import (
+	"encoding/gob"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
+	"gopkg.in/lxc/go-lxc.v2"
+)
+
+type FilesystemType int
+
+const (
+	Rsync FilesystemType = 0
+)
+
+type MigrationHeader struct {
+	FSType FilesystemType
+}
+
+type ControlMessageType int
+
+const (
+	Failure ControlMessageType = 0
+	Success ControlMessageType = 1
+)
+
+type MigrationControl struct {
+	Type    ControlMessageType
+	Message string
+}
+
+type migrationFields struct {
+	controlSecret string
+	controlConn   *websocket.Conn
+
+	criuSecret string
+	criuConn   *websocket.Conn
+
+	fsSecret string
+	fsConn   *websocket.Conn
+
+	container *lxc.Container
+}
+
+func (c *migrationFields) send(m interface{}) error {
+	w, err := c.controlConn.NextWriter(websocket.BinaryMessage)
+	if err != nil {
+		return err
+	}
+
+	defer w.Close()
+
+	// TODO: We should change the encoding here to be a protobuf, so that
+	// non-go users can easily talk to the migration socket if we want.
+	// I'll (tych0) investigate that in a bit, but for now gob is easier to
+	// use.
+	return gob.NewEncoder(w).Encode(m)
+}
+
+func (c *migrationFields) recv(m interface{}) error {
+	_, r, err := c.controlConn.NextReader()
+	if err != nil {
+		return err
+	}
+	return gob.NewDecoder(r).Decode(m)
+}
+
+func (c *migrationFields) disconnect() {
+	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+	if c.controlConn != nil {
+		c.controlConn.WriteMessage(websocket.CloseMessage, closeMsg)
+	}
+
+	if c.fsConn != nil {
+		c.fsConn.WriteMessage(websocket.CloseMessage, closeMsg)
+	}
+
+	if c.criuConn != nil {
+		c.criuConn.WriteMessage(websocket.CloseMessage, closeMsg)
+	}
+}
+
+func (c *migrationFields) sendControl(err error) {
+	msg := MigrationControl{}
+	if err != nil {
+		msg.Type = Failure
+		msg.Message = err.Error()
+	} else {
+		msg.Type = Success
+	}
+
+	c.send(&msg)
+
+	if err != nil {
+		c.disconnect()
+	}
+}
+
+func (c *migrationFields) controlChannel() <-chan MigrationControl {
+	ch := make(chan MigrationControl)
+	go func() {
+		msg := MigrationControl{}
+		err := c.recv(&msg)
+		if err != nil {
+			shared.Debugf("got error reading migration control socket %s", err)
+			close(ch)
+			return
+		}
+		ch <- msg
+	}()
+
+	return ch
+}
+
+type migrationSourceWs struct {
+	migrationFields
+
+	allConnected chan bool
+}
+
+func NewMigrationSource(c *lxc.Container) (shared.OperationWebsocket, error) {
+	ret := migrationSourceWs{migrationFields{container: c}, make(chan bool, 1)}
+
+	var err error
+	ret.controlSecret, err = shared.RandomCryptoString()
+	if err != nil {
+		return nil, err
+	}
+
+	ret.fsSecret, err = shared.RandomCryptoString()
+	if err != nil {
+		return nil, err
+	}
+
+	ret.criuSecret, err = shared.RandomCryptoString()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ret, nil
+}
+
+func (s *migrationSourceWs) Metadata() interface{} {
+	return shared.Jmap{
+		"control": s.controlSecret,
+		"fs":      s.fsSecret,
+		"criu":    s.criuSecret,
+	}
+}
+
+func (s *migrationSourceWs) Connect(secret string, r *http.Request, w http.ResponseWriter) error {
+	var conn **websocket.Conn
+
+	switch secret {
+	case s.controlSecret:
+		conn = &s.controlConn
+	case s.criuSecret:
+		conn = &s.criuConn
+	case s.fsSecret:
+		conn = &s.fsConn
+	default:
+		/* If we didn't find the right secret, the user provided a bad one,
+		 * which 403, not 404, since this operation actually exists */
+		return os.ErrPermission
+	}
+
+	c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return err
+	}
+
+	*conn = c
+
+	if s.controlConn != nil && s.criuConn != nil && s.fsConn != nil {
+		s.allConnected <- true
+	}
+
+	return nil
+}
+
+func (s *migrationSourceWs) Do() shared.OperationResult {
+	<-s.allConnected
+
+	err := s.send(&MigrationHeader{Rsync})
+	if err != nil {
+		s.disconnect()
+		return shared.OperationError(err)
+	}
+
+	checkpointDir, err := ioutil.TempDir("", "lxd_migration")
+	if err != nil {
+		s.sendControl(err)
+		return shared.OperationError(err)
+	}
+	defer os.RemoveAll(checkpointDir)
+
+	opts := lxc.CheckpointOptions{Stop: true, Directory: checkpointDir}
+	if err := s.container.Checkpoint(opts); err != nil {
+		// TODO: we should probably clean up checkpointDir here, but
+		// where should we put the checkpoint log so people can debug
+		// why things didn't checkpoint?
+		s.sendControl(err)
+		return shared.OperationError(err)
+	}
+
+	/*
+	 * We do the serially right now, but there's really no reason for us
+	 * to; since we have separate websockets, we can do it in parallel if
+	 * we wanted to. However, assuming we're network bound, there's really
+	 * no reason to do these in parallel. In the future when we're using
+	 * p.haul's protocol, it will make sense to do these in parallel.
+	 */
+	if err := RsyncSend(checkpointDir, s.criuConn); err != nil {
+		s.sendControl(err)
+		return shared.OperationError(err)
+	}
+
+	fsDir := s.container.ConfigItem("lxc.rootfs")[0]
+	if err := RsyncSend(fsDir, s.fsConn); err != nil {
+		s.sendControl(err)
+		return shared.OperationError(err)
+	}
+
+	msg := MigrationControl{}
+	if err = s.recv(&msg); err != nil {
+		s.disconnect()
+		return shared.OperationError(err)
+	}
+
+	// TODO: should we add some config here about automatically restarting
+	// the container migrate failure? What about the failures above?
+	if msg.Type == Failure {
+		return shared.OperationError(fmt.Errorf(msg.Message))
+	}
+
+	return shared.OperationSuccess
+}
+
+type migrationSink struct {
+	migrationFields
+
+	url    string
+	dialer websocket.Dialer
+}
+
+func NewMigrationSink(url string, dialer websocket.Dialer, c *lxc.Container, secrets map[string]string) (func() error, error) {
+	sink := migrationSink{migrationFields{container: c}, url, dialer}
+
+	var ok bool
+	sink.controlSecret, ok = secrets["control"]
+	if !ok {
+		return nil, fmt.Errorf("missing control secret")
+	}
+
+	sink.fsSecret, ok = secrets["fs"]
+	if !ok {
+		return nil, fmt.Errorf("missing fs secret")
+	}
+
+	sink.criuSecret, ok = secrets["criu"]
+	if !ok {
+		return nil, fmt.Errorf("missing criu secret")
+	}
+
+	return sink.do, nil
+}
+
+func (c *migrationSink) connectWithSecret(secret string) (*websocket.Conn, error) {
+
+	query := url.Values{"secret": []string{secret}}
+
+	// TODO: we shouldn't assume this is a HTTP URL
+	url := c.url + "?" + query.Encode()
+
+	return lxd.WebsocketDial(c.dialer, url)
+}
+
+func (c *migrationSink) do() error {
+	var err error
+	c.controlConn, err = c.connectWithSecret(c.controlSecret)
+	if err != nil {
+		return err
+	}
+	defer c.disconnect()
+
+	c.fsConn, err = c.connectWithSecret(c.fsSecret)
+	if err != nil {
+		c.sendControl(err)
+		return err
+	}
+
+	c.criuConn, err = c.connectWithSecret(c.criuSecret)
+	if err != nil {
+		c.sendControl(err)
+		return err
+	}
+
+	header := MigrationHeader{FSType: Rsync}
+	if err := c.recv(&header); err != nil {
+		c.sendControl(err)
+		return err
+	}
+
+	if header.FSType != Rsync {
+		err = fmt.Errorf("formats other than rsync not understood")
+		c.sendControl(err)
+		return err
+	}
+
+	imagesDir, err := ioutil.TempDir("", "lxd_migration")
+	if err != nil {
+		os.RemoveAll(imagesDir)
+		c.sendControl(err)
+		return err
+	}
+
+	restore := make(chan error)
+	go func() {
+		if err := RsyncRecv(AddSlash(imagesDir), c.criuConn); err != nil {
+			restore <- err
+			os.RemoveAll(imagesDir)
+			c.sendControl(err)
+			return
+		}
+
+		fsDir := c.container.ConfigItem("lxc.rootfs")[0]
+		if err := RsyncRecv(AddSlash(fsDir), c.fsConn); err != nil {
+			restore <- err
+			os.RemoveAll(fsDir)
+			c.sendControl(err)
+			return
+		}
+
+		opts := lxc.RestoreOptions{Directory: imagesDir, Verbose: true}
+		err := c.container.Restore(opts)
+		// TODO: We should remove this directory, but for now we leave
+		// it for debugging restores. Perhaps we should copy the log
+		// somewhere and delete it?
+		// os.RemoveAll(imagesDir)
+		restore <- err
+	}()
+
+	source := c.controlChannel()
+
+	for {
+		select {
+		case err = <-restore:
+			c.sendControl(err)
+			return err
+		case msg, ok := <-source:
+			if !ok {
+				c.disconnect()
+				return fmt.Errorf("got error reading source")
+			}
+			if msg.Type == Failure {
+				c.disconnect()
+				return fmt.Errorf(msg.Message)
+			} else {
+				// The source can only tell us it failed (e.g. if
+				// checkpointing failed). We have to tell the source
+				// whether or not the restore was successful.
+				shared.Debugf("unknown message %v from source", msg)
+			}
+		}
+	}
+}

--- a/lxd/migration/migrate.proto
+++ b/lxd/migration/migrate.proto
@@ -1,6 +1,6 @@
 package migration;
 
-enum FilesystemType {
+enum MigrationFSType {
   RSYNC = 0;
   BTRFS = 1;
 }
@@ -11,7 +11,7 @@ enum CRIUType {
 }
 
 message MigrationHeader {
-  required FilesystemType fs = 1;
+  required MigrationFSType fs = 1;
   required CRIUType       criu = 2;
 }
 

--- a/lxd/migration/migrate.proto
+++ b/lxd/migration/migrate.proto
@@ -1,0 +1,23 @@
+package migration;
+
+enum FilesystemType {
+  RSYNC = 0;
+  BTRFS = 1;
+}
+
+enum CRIUType {
+  CRIU_RSYNC = 0;
+  PHAUL = 1;
+}
+
+message MigrationHeader {
+  required FilesystemType fs = 1;
+  required CRIUType       criu = 2;
+}
+
+message MigrationControl {
+  required bool success = 1;
+
+  /* optional failure message if sending a failure */
+  optional string message = 2;
+}

--- a/lxd/migration/rsync.go
+++ b/lxd/migration/rsync.go
@@ -1,0 +1,112 @@
+package migration
+
+import (
+	"net"
+	"os/exec"
+
+	"github.com/gorilla/websocket"
+	"github.com/lxc/lxd/shared"
+)
+
+func rsyncWebsocket(cmd *exec.Cmd, conn *websocket.Conn) error {
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	shared.WebsocketMirror(conn, stdin, stdout)
+	return cmd.Wait()
+}
+
+// AddSlash adds a slash to the end of paths if they don't already have one.
+// This can be useful for rsyncing things, since rsync has behavior present on
+// the presence or absence of a trailing slash.
+func AddSlash(path string) string {
+	if path[len(path)-1] != '/' {
+		return path + "/"
+	}
+
+	return path
+}
+
+func rsyncSendSetup(path string) (*exec.Cmd, net.Conn, error) {
+	/*
+	 * The way rsync works, it invokes a subprocess that does the actual
+	 * talking (given to it by a -E argument). Since there isn't an easy
+	 * way for us to capture this process' stdin/stdout, we just use netcat
+	 * and write to/from a unix socket.
+	 *
+	 * In principle we don't need this socket. It seems to me that some
+	 * clever invocation of rsync --server --sender and usage of that
+	 * process' stdin/stdout could work around the need for this socket,
+	 * but I couldn't get it to work. Another option would be to look at
+	 * the spawned process' first child and read/write from its
+	 * stdin/stdout, but that also seemed messy. In any case, this seems to
+	 * work just fine.
+	 */
+	l, err := net.Listen("unix", "/tmp/rsync-socket")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	/*
+	 * Here, the path /tmp/foo is ignored. Since we specify localhost,
+	 * rsync thinks we are syncing to a remote host (in this case, the
+	 * other end of the lxd websocket), and so the path specified on the
+	 * --server instance of rsync takes precedence.
+	 *
+	 * Additionally, we use sh -c instead of just calling nc directly
+	 * because rsync passes a whole bunch of arguments to the wrapper
+	 * command (i.e. the command to run on --server). However, we're
+	 * hardcoding that at the other end, so we can just ignore it.
+	 */
+	cmd := exec.Command("rsync", "-arvPz", "--devices", "--partial", path, "localhost:/tmp/foo", "-e", "sh -c \"nc -U /tmp/rsync-socket\"")
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	conn, err := l.Accept()
+	if err != nil {
+		return nil, nil, err
+	}
+	l.Close()
+
+	return cmd, conn, nil
+}
+
+// RsyncSend sets up the sending half of an rsync, to recursively send the
+// directory pointed to by path over the websocket.
+func RsyncSend(path string, conn *websocket.Conn) error {
+	cmd, dataSocket, err := rsyncSendSetup(path)
+	if dataSocket != nil {
+		defer dataSocket.Close()
+	}
+	if err != nil {
+		return err
+	}
+
+	shared.WebsocketMirror(conn, dataSocket, dataSocket)
+
+	return cmd.Wait()
+}
+
+func rsyncRecvCmd(path string) *exec.Cmd {
+	return exec.Command("rsync", "--server", "-vlogDtprze.iLsfx", "--devices", "--partial", ".", path)
+}
+
+// RsyncRecv sets up the receiving half of the websocket to rsync (the other
+// half set up by RsyncSend), putting the contents in the directory specified
+// by path.
+func RsyncRecv(path string, conn *websocket.Conn) error {
+	return rsyncWebsocket(rsyncRecvCmd(path), conn)
+}

--- a/lxd/migration/rsync_test.go
+++ b/lxd/migration/rsync_test.go
@@ -1,0 +1,104 @@
+package migration
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+const helloWorld = "hello world\n"
+
+func TestRsyncSendRecv(t *testing.T) {
+	source, err := ioutil.TempDir("", "source")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.RemoveAll(source)
+
+	sink, err := ioutil.TempDir("", "sink")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.RemoveAll(sink)
+
+	/* now, write something to rsync over */
+	f, err := os.Create(path.Join(source, "foo"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	f.Write([]byte(helloWorld))
+	f.Close()
+
+	send, sendConn, err := rsyncSendSetup(AddSlash(source))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	recv := rsyncRecvCmd(sink)
+
+	recvOut, err := recv.StdoutPipe()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	recvIn, err := recv.StdinPipe()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if err := recv.Start(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	go func() {
+		defer sendConn.Close()
+		if _, err := io.Copy(sendConn, recvOut); err != nil {
+			t.Error(err)
+		}
+
+		if err := recv.Wait(); err != nil {
+			t.Error(err)
+		}
+
+	}()
+
+	/*
+	 * We close the socket in the above gofunc, but go tells us
+	 * https://github.com/golang/go/issues/4373 that this is an error
+	 * because we were reading from a socket that was closed. Thus, we
+	 * ignore it
+	 */
+	io.Copy(recvIn, sendConn)
+
+	if err := send.Wait(); err != nil {
+		t.Error(err)
+		return
+	}
+
+	f, err = os.Open(path.Join(sink, "foo"))
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer f.Close()
+
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	if string(buf) != helloWorld {
+		t.Errorf("expected %s got %s", helloWorld, buf)
+		return
+	}
+}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -221,4 +221,4 @@ func operationWebsocketGet(d *Daemon, r *http.Request) Response {
 	return &websocketServe{r, secret, op}
 }
 
-var operationWebsocket = Command{name: "operations/{id}/websocket", get: operationWebsocketGet}
+var operationWebsocket = Command{name: "operations/{id}/websocket", untrustedGet: true, get: operationWebsocketGet}

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -68,9 +68,11 @@ type asyncResponse struct {
 	cancel     func() error
 	ws         shared.OperationWebsocket
 	containers []string
+	done       chan shared.OperationResult
 }
 
 func (r *asyncResponse) Render(w http.ResponseWriter) error {
+
 	op, err := CreateOperation(nil, r.run, r.cancel, r.ws)
 	if err != nil {
 		return err

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-03-06 00:04-0500\n"
+        "POT-Creation-Date: 2015-03-06 08:38-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -39,11 +39,11 @@ msgstr  ""
 msgid   "Alternate config directory."
 msgstr  ""
 
-#: client.go:567
+#: client.go:543
 msgid   "Certificate already stored.\n"
 msgstr  ""
 
-#: client.go:571
+#: client.go:547
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -57,7 +57,7 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: client.go:585
+#: client.go:561
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -69,12 +69,12 @@ msgstr  ""
 msgid   "Delete a container or container snapshot.\n"
 msgstr  ""
 
-#: lxc/config.go:458
+#: lxc/config.go:475
 #, c-format
 msgid   "Device %s added to %s\n"
 msgstr  ""
 
-#: lxc/config.go:486
+#: lxc/config.go:503
 #, c-format
 msgid   "Device %s removed from %s\n"
 msgstr  ""
@@ -145,11 +145,15 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
+#: lxc/move.go:21
+msgid   "Move containers within or in between lxd instances.\n"
+msgstr  ""
+
 #: lxc/config.go:142
 msgid   "No cert provided to add"
 msgstr  ""
 
-#: client.go:563
+#: client.go:539
 msgid   "No certificate on this connection"
 msgstr  ""
 
@@ -157,15 +161,15 @@ msgstr  ""
 msgid   "No fingerprint specified."
 msgstr  ""
 
-#: client.go:827
+#: client.go:803
 msgid   "Non-async response from delete!"
 msgstr  ""
 
-#: client.go:696
+#: client.go:672
 msgid   "Non-async response from init!"
 msgstr  ""
 
-#: client.go:994
+#: client.go:1014
 msgid   "Non-async response from snapshot!"
 msgstr  ""
 
@@ -197,11 +201,11 @@ msgstr  ""
 msgid   "Profile %s deleted\n"
 msgstr  ""
 
-#: client.go:578
+#: client.go:554
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: client.go:237
+#: client.go:228
 msgid   "Server certificate has changed"
 msgstr  ""
 
@@ -233,11 +237,11 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: client.go:1142
+#: client.go:1162
 msgid   "Unexpected async response"
 msgstr  ""
 
-#: client.go:1091 client.go:1210 client.go:1235 client.go:1274
+#: client.go:1111 client.go:1230 client.go:1255 client.go:1294
 msgid   "Unexpected non-async response"
 msgstr  ""
 
@@ -273,11 +277,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: client.go:396
+#: client.go:372
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:454 client.go:1026 client.go:1033
+#: client.go:430 client.go:1046 client.go:1053
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -286,17 +290,17 @@ msgstr  ""
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:1179
+#: client.go:1199
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
 
-#: client.go:550
+#: client.go:526
 msgid   "bad response type from image list!"
 msgstr  ""
 
-#: client.go:434 client.go:511 client.go:1012 client.go:1159 client.go:1315
-#: client.go:1354
+#: client.go:410 client.go:487 client.go:1032 client.go:1179 client.go:1335
+#: client.go:1374 client.go:1432
 msgid   "bad response type from list!"
 msgstr  ""
 
@@ -304,15 +308,15 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:458 client.go:1037
+#: client.go:434 client.go:1057
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1183
+#: client.go:1203
 msgid   "bad version in profile url"
 msgstr  ""
 
-#: client.go:350 client.go:355
+#: client.go:326 client.go:331
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
@@ -334,12 +338,12 @@ msgstr  ""
 msgid   "error: unknown command: %s\n"
 msgstr  ""
 
-#: client.go:784
+#: client.go:760
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
 
-#: client.go:721
+#: client.go:697
 msgid   "got bad response type from exec"
 msgstr  ""
 
@@ -347,7 +351,11 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: client.go:846 client.go:869
+#: client.go:934 client.go:959
+msgid   "got non-async response!"
+msgstr  ""
+
+#: client.go:822 client.go:845
 msgid   "got non-sync response from containers get!"
 msgstr  ""
 
@@ -356,7 +364,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:948
+#: client.go:968
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -374,15 +382,15 @@ msgstr  ""
 msgid   "lxc launch ubuntu [<name>]\n"
 msgstr  ""
 
-#: client.go:104
+#: client.go:102
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1251 client.go:1331
+#: client.go:1271 client.go:1351
 msgid   "no value found in %q\n"
 msgstr  ""
 
-#: client.go:572
+#: client.go:548
 msgid   "ok (y/n)? "
 msgstr  ""
 
@@ -401,7 +409,7 @@ msgstr  ""
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: client.go:214
+#: client.go:205
 msgid   "unknown remote name: %q"
 msgstr  ""
 
@@ -409,6 +417,6 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:119
+#: lxc/main.go:120
 msgid   "wrong number of subcommand arguments"
 msgstr  ""

--- a/shared/operation.go
+++ b/shared/operation.go
@@ -73,6 +73,8 @@ type OperationResult struct {
 	Error    error
 }
 
+var OperationSuccess OperationResult = OperationResult{}
+
 func OperationWrap(f func() error) func() OperationResult {
 	return func() OperationResult { return OperationError(f()) }
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -7,6 +7,7 @@ import (
 	"bufio"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
@@ -287,11 +288,11 @@ func WebsocketRecvStream(w io.WriteCloser, conn *websocket.Conn) chan bool {
 	return ch
 }
 
-func WebsocketMirror(conn *websocket.Conn, w io.Writer, r io.ReadCloser) (chan bool, chan bool) {
-	readDone := make(chan bool)
-	writeDone := make(chan bool)
-
-	go func(conn *websocket.Conn, w io.Writer) {
+// WebsocketMirror allows mirroring a reader to a websocket and taking the
+// result and writing it to a writer.
+func WebsocketMirror(conn *websocket.Conn, w io.WriteCloser, r io.Reader) chan bool {
+	done := make(chan bool, 1)
+	go func(conn *websocket.Conn, w io.WriteCloser) {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {
@@ -311,22 +312,26 @@ func WebsocketMirror(conn *websocket.Conn, w io.Writer, r io.ReadCloser) (chan b
 			i, err := w.Write(buf)
 			if i != len(buf) {
 				Debugf("didn't write all of buf")
+				break
 			}
 			if err != nil {
 				Debugf("error writing buf %s", err)
+				break
 			}
 		}
-		r.Close()
-		readDone <- true
-		close(readDone)
+		done <- true
+		w.Close()
 	}(conn, w)
 
-	go func(conn *websocket.Conn, r io.ReadCloser) {
+	go func(conn *websocket.Conn, r io.Reader) {
 		in := ReaderToChannel(r)
 		for {
 			buf, ok := <-in
 			if !ok {
-				break
+				done <- true
+				conn.WriteMessage(websocket.CloseMessage, []byte{})
+				conn.Close()
+				return
 			}
 			w, err := conn.NextWriter(websocket.BinaryMessage)
 			if err != nil {
@@ -343,11 +348,10 @@ func WebsocketMirror(conn *websocket.Conn, w io.Writer, r io.ReadCloser) (chan b
 		}
 		closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
 		conn.WriteMessage(websocket.CloseMessage, closeMsg)
-		writeDone <- true
-		close(writeDone)
+		done <- true
 	}(conn, r)
 
-	return readDone, writeDone
+	return done
 }
 
 // Returns a random base64 encoded string from crypto/rand.
@@ -476,4 +480,23 @@ func IsDir(name string) bool {
 		return false
 	}
 	return stat.IsDir()
+}
+
+func GetTLSConfig(certf string, keyf string) (*tls.Config, error) {
+	cert, err := tls.LoadX509KeyPair(certf, keyf)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: true,
+		ClientAuth:         tls.RequireAnyClientCert,
+		Certificates:       []tls.Certificate{cert},
+		MinVersion:         tls.VersionTLS12,
+		MaxVersion:         tls.VersionTLS12,
+	}
+
+	tlsConfig.BuildNameToCertificate()
+
+	return tlsConfig, nil
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -5,6 +5,7 @@ package shared
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
 	"crypto/tls"
@@ -499,4 +500,23 @@ func GetTLSConfig(certf string, keyf string) (*tls.Config, error) {
 	tlsConfig.BuildNameToCertificate()
 
 	return tlsConfig, nil
+}
+
+func WriteAll(w io.Writer, buf []byte) error {
+	return WriteAllBuf(w, bytes.NewBuffer(buf))
+}
+
+func WriteAllBuf(w io.Writer, buf *bytes.Buffer) error {
+	toWrite := int64(buf.Len())
+	for {
+		n, err := io.Copy(w, buf)
+		if err != nil {
+			return err
+		}
+
+		toWrite -= n
+		if toWrite <= 0 {
+			return nil
+		}
+	}
 }

--- a/specs/migration.md
+++ b/specs/migration.md
@@ -1,0 +1,40 @@
+# Live Migration in LXD
+
+## Overview
+
+Migration has two pieces, a "source", that is, the host that already has the
+container, and a "sink", the host that's getting the container. Currently,
+in the 'pull' mode, the source sets up an operation, and the sink connects
+to the source and pulls the container.
+
+There are three websockets (channels) used in migration: 1. the control stream,
+2. the criu images stream, and 3. the filesystem stream. When a migration is
+initiated, information about the container, its configuration, etc. are sent
+over the control channel (a full description of this process is below), the
+criu images and container filesystem are synced over their respective channels,
+and the result of the restore operation is sent from the sink to the source
+over the control channel.
+
+In particular, the protocol that is spoken over the criu channel and filesystem
+channel can vary, depending on what is negotiated over the control socket. For
+example, both the source and the sink's LXD directory is on btrfs, the
+filesystem socket can speak btrfs-send/receive. Additionally, although we do a
+"stop the world" type migration right now, support for criu's p.haul protocol
+will happen over the criu socket.
+
+## Control Socket
+
+Once all three websockets are connected between the two endpoints, the source
+sends a MigrationHeader (protobuf description found in
+`/lxd/migration/migrate.proto`). This header contains the container
+configuration which will be added to the new container (TODO: profiles?). There
+are also two fields indicating the filesystem and criu protocol to speak. For
+example, if a server is hosted on a btrfs filesystem, it can indicate that it
+wants to do a `btrfs send` instead of a simple rsync (similarly, it could
+indicate that it wants to speak the p.haul protocol, instead of just rsyncing
+the images over slowly). The sink then examines this message and responds with
+whatever it supports. Continuing our example, if the sink is not on a btrfs
+filesystem, it responds with the lowest common denominator (rsync, in this
+case), and the source is to send the root filesystem using rsync. Similarly
+with the criu connection; if the sink doesn't have support for the p.haul
+protocol (or whatever), we fall back to rsync.

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -382,17 +382,22 @@ Input (restore snapshot):
  * Operation: async
  * Return: background operation or standard error
 
+Renaming to an existing name must return the 409 (Conflict) HTTP code.
+
 Input (simple rename):
 
     {
         'name': "new-name"
     }
 
+Input (migration across lxd instances):
+    {
+        "migration": true,
+        "name": "new-name"
+    }
 
-Renaming to an existing name must return the 409 (Conflict) HTTP code.
-
-TODO: Cross host rename/migration.
-
+The migration does not actually start until someone (i.e. another lxd instance)
+connects to the websocket with the secret.
 
 ### DELETE
  * Description: remove the container
@@ -846,8 +851,9 @@ Input (wait for the operation to succeed or timeout): ?status\_code=200&timeout=
    stdin/stdout/stderr to flow to and from the process inside the container.
    In the case of migration, it will be the primary interface over which the
    migration information is communicated. The secret here is the one that was
-   provided when the operation was created.
- * Authentication: trusted
+   provided when the operation was created. Guests are allowed to connect
+   provided they have the right secret.
+ * Authentication: guest or trusted
  * Operation: sync
  * Return: websocket stream or standard error
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -124,6 +124,7 @@ test_database_lock
 
 # Anything below this will not get run inside Travis-CI
 if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+  RESULT=success
   return
 fi
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -122,12 +122,6 @@ test_fuidshift
 echo "==> TEST: database lock"
 test_database_lock
 
-# Anything below this will not get run inside Travis-CI
-if [ -n "$TRAVIS_PULL_REQUEST" ]; then
-  RESULT=success
-  return
-fi
-
 echo "==> TEST: migration"
 test_migration
 

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -1,4 +1,8 @@
 test_migration() {
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    return
+  fi
+
   if [ -z "$(which criu)" ]; then
       echo "==> Skipping migration tests; no criu binary found"
       return

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -1,0 +1,15 @@
+test_migration() {
+  export LXD2_DIR=$(mktemp -d -p $(pwd))
+  chmod 777 "${LXD2_DIR}"
+  spawn_lxd 127.0.0.1:8444 "${LXD2_DIR}"
+  lxd2_pid=$1
+
+  (echo y; sleep 3; echo foo) | lxc remote add lxd2 127.0.0.1:8444
+  lxc launch testimage migratee
+
+  lxc move migratee lxd2:migratee
+  lxc stop lxd2:migratee
+
+  kill -9 lxd2_pid
+  rm -rf "${LXD2_DIR}"
+}

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -1,4 +1,9 @@
 test_migration() {
+  if [ -z "$(which criu)" ]; then
+      echo "==> Skipping migration tests; no criu binary found"
+      return
+  fi
+
   export LXD2_DIR=$(mktemp -d -p $(pwd))
   chmod 777 "${LXD2_DIR}"
   spawn_lxd 127.0.0.1:8444 "${LXD2_DIR}"


### PR DESCRIPTION
This commit adds live migration support to LXD. As you can see from the diff,
there are several TODOs, notably:

* we need to transport the container config too (more robust config support
  will be arriving shortly, so I'll use that when it's here)
* we need to use protobufs for the control socket protocol so others can
  interact with us
* we need to use p.haul and other similar optimizations
* we need to figure out what to do with criu log files so that people have a
  nice debugging experience

To set up a container for migration, its configuration needs to have the
following entries:

    lxc.console = none
    lxc.tty = 0
    lxc.cgroup.devices.deny = c 5:1 rwm

Which can be acheived by using raw.lxc for now. You also (of course) need to
have a relatively recent version of criu installed. For this patch, I tested
with 1.4.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>