### PR TITLE
Export Image

### DIFF
--- a/client.go
+++ b/client.go
@@ -464,6 +464,39 @@ func (c *Client) ListContainers() ([]string, error) {
 	return names, nil
 }
 
+func (c *Client) ExportImage(image string) (*Response, error) {
+
+	uri := c.url(shared.APIVersion, "images", image, "export")
+
+	req, err := http.NewRequest("GET", uri, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	raw, err := c.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// because it is raw data, we need to check for http status
+	if raw.StatusCode != 200 {
+		resp, err := ParseResponse(raw)
+		if err != nil {
+			return nil, err
+		}
+		return nil, ParseError(resp)
+	}
+	_, err = io.Copy(os.Stdout, raw.Body)
+
+	if err != nil {
+		return nil, err
+	}
+	
+	// it streams to stdout, so no response returned
+	return nil, nil
+
+}
+
 func (c *Client) PostImage(filename string) (*Response, error) {
 	uri := c.url(shared.APIVersion, "images")
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -19,6 +19,7 @@ func (c *imageCmd) usage() string {
 			"\n" +
 			"lxc image list [resource:] [filter]\n" +
 			"lxc image delete [resource:]<image>\n" +
+			"lxc image export [resource:]<image>\n" +
 			"\n" +
 			"Lists the images at resource, or local images.\n" +
 			"Filters are not yet supported.\n" +
@@ -177,7 +178,21 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		}
 		return nil
 	case "export":
-		
+		if len(args) < 2 {
+			return errArgs
+		}
+
+		remote, image := config.ParseRemoteAndContainer(args[1])
+		d, err := lxd.NewClient(config, remote)
+		if err != nil {
+			return err
+		}
+
+		_, err = d.ExportImage(image)
+		if err != nil {
+			return err
+		}
+
 		return nil
 	default:
 		return fmt.Errorf(gettext.Gettext("Unknown image command %s"), args[0])

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -178,7 +178,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		}
 		return nil
 	case "export":
-		if len(args) < 2 {
+		if len(args) < 3 {
 			return errArgs
 		}
 
@@ -188,7 +188,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		_, err = d.ExportImage(image)
+		_, err = d.ExportImage(image, args[2])
 		if err != nil {
 			return err
 		}

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -176,6 +176,9 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			}
 		}
 		return nil
+	case "export":
+		
+		return nil
 	default:
 		return fmt.Errorf(gettext.Gettext("Unknown image command %s"), args[0])
 	}

--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -24,6 +24,7 @@ var api10 = []Command{
 	aliasesCmd,
 	imageCmd,
 	imagesCmd,
+	imagesExportCmd,
 	operationsCmd,
 	operationCmd,
 	operationWait,

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -384,7 +384,6 @@ func imageExport(d *Daemon, r *http.Request) Response {
 
 	name := mux.Vars(r)["name"]
 
-	// check for fingerprint
 	rows, err := d.db.Query(`SELECT images.filename, images.size FROM images WHERE images.fingerprint=?`, name)
 	if err != nil {
 		return InternalError(err)
@@ -415,7 +414,7 @@ func imageExport(d *Daemon, r *http.Request) Response {
 
 }
 
-var imagesExportCmd = Command{name: "images/export/{name}", get: imageExport}
+var imagesExportCmd = Command{name: "images/{name}/export", get: imageExport}
 
 var aliasesCmd = Command{name: "images/aliases", post: aliasesPost, get: aliasesGet}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -400,7 +400,7 @@ func imageExport(d *Daemon, r *http.Request) Response {
 		// test compression, for content type header
 		// if unknown compression we send standard header
 		_, err := detectCompression(filename)
-	
+
 		ctype := "application/x-gtar"
 		if err != nil {
 			ctype = "application/octet-stream"

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strconv"
-	"io"
 
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strconv"
+	"io"
 
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
@@ -25,6 +28,42 @@ type Response interface {
 type syncResponse struct {
 	success  bool
 	metadata interface{}
+}
+
+/*
+  Used for returning images.
+  fname: name of the file without path
+  clength: sets content-size of response
+  ctype: content-type, depends on compression
+*/
+type fileResponse struct {
+	fname   string
+	clength int64
+	ctype   string
+}
+
+func FileResponse(fname string, size int64, ctype string) Response {
+	return &fileResponse{fname, size, ctype}
+}
+
+func (r *fileResponse) Render(w http.ResponseWriter) error {
+
+	// export name of the file, without path
+	ename := filepath.Base(r.fname)
+
+	w.Header().Set("Content-Type", r.ctype)
+	w.Header().Set("Content-Length", strconv.FormatInt(r.clength, 10))
+	w.Header().Set("Content-Disposition", fmt.Sprintf("inline;filename=%s", ename))
+
+	f, err := os.Open(r.fname)
+	defer f.Close()
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(w, f)
+	return err
+
 }
 
 func (r *syncResponse) Render(w http.ResponseWriter) error {


### PR DESCRIPTION
Some workers cut my telephone line this morning, so I had some time. :) Don't know if that is, what you want from image export, but maybe it is a start. If that is at least close to what you want, there are a few questions:

- At the moment it streams to stdout, which is in general ok, because you can pipe it in a file. The only problem is, that the user has no idea, which compression method has been used. One solution could be, to have a command like `lxc image export hash /path/to/folder` and the file name in the database will be used. In the spec there is a hint, that you want to use the file name for export.

- Another option would be, also hinted in the spec, that  users can upload any compression format, but on the server side everything is getting "re-compressed" to xz.

All the old rules for my pull requests apply. If you don't like it, throw it away ;)

Btw, test failed and I would not submit without passing test, but it fails within a container test. That can not be me...