### PR TITLE
lxd: fail at startup if setfacl does not exist.

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"math/rand"
 	"os"
+	"os/exec"
 	"os/signal"
 	"syscall"
 	"time"
@@ -60,6 +61,14 @@ func run() error {
 	if *verbose || *debug {
 		shared.SetLogger(log.New(os.Stderr, "", log.LstdFlags))
 		shared.SetDebug(*debug)
+	}
+
+	needed_programs := []string{"setfacl", "rsync", "tar", "xz"}
+	for _, p := range needed_programs {
+		_, err := exec.LookPath(p)
+		if err != nil {
+			return err
+		}
 	}
 
 	d, err := StartDaemon(*listenAddr)


### PR DESCRIPTION
Closes #305

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>