### PR TITLE
images: set properties into the db

### DIFF
--- a/client.go
+++ b/client.go
@@ -522,7 +522,7 @@ func (c *Client) ExportImage(image string, target string) (*Response, error) {
 
 }
 
-func (c *Client) PostImage(filename string) (*Response, error) {
+func (c *Client) PostImage(filename string, properties []string) (*Response, error) {
 	uri := c.url(shared.APIVersion, "images")
 
 	f, err := os.Open(filename)
@@ -540,7 +540,10 @@ func (c *Client) PostImage(filename string) (*Response, error) {
 	mode := 0 // private
 	req.Header.Set("X-LXD-public", fmt.Sprintf("%04o", mode))
 	//req.Header.Set("X-LXD-fingerprint", fmt.Sprintf("%04o", mode))
-	//req.Header.Set("X-LXD-properties", fmt.Sprintf("%04o", mode))
+	if len(properties) != 0 {
+		props := strings.Join(properties, "; ")
+		req.Header.Set("X-LXD-properties", props)
+	}
 
 	raw, err := c.http.Do(req)
 	if err != nil {


### PR DESCRIPTION
All this does is take prop=value elements from the lxc import tarball
command and get them into the db, and delete them when the image is
deleted.

Searching at 'image list' based on properties, and editing them with
"lxc image edit", are still todo, and should at this point be quite
easy.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>