### PR TITLE
exec: split ourselves from the main lxd daemon for interactive mode

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1,3 +1,6 @@
+// +build linux
+// +build cgo
+
 package main
 
 import (
@@ -24,6 +27,26 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"gopkg.in/lxc/go-lxc.v2"
 )
+
+// #cgo LDFLAGS: -lutil
+/*
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <grp.h>
+#include <pty.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <termios.h>
+
+void own_pty(int fd) {
+	if (ioctl(fd, TIOCSCTTY, (char *)NULL) == -1)
+		printf("Failed TIOCSCTTY: %s\n", strerror(errno));
+}
+*/
+import "C"
 
 type containerType int
 
@@ -1372,12 +1395,49 @@ func (s *execWs) Connect(secret string, r *http.Request, w http.ResponseWriter) 
 	return os.ErrPermission
 }
 
-func runCommand(container *lxc.Container, command []string, options lxc.AttachOptions) shared.OperationResult {
-	status, err := container.RunCommandStatus(command, options)
-	if err != nil {
-		shared.Debugf("Failed running command: %q", err.Error())
-		return shared.OperationError(err)
+func runCommandNofork(container *lxc.Container, command []string, options lxc.AttachOptions) shared.OperationResult {
+        status, err := container.RunCommandStatus(command, options)
+        if err != nil {
+                shared.Debugf("Failed running command: %q", err.Error())
+                return shared.OperationError(err)
+        }
+
+        metadata, err := json.Marshal(shared.Jmap{"return": status})
+        if err != nil {
+                return shared.OperationError(err)
+        }
+
+        return shared.OperationResult{Metadata: metadata, Error: nil}
+}
+
+func runCommand(container *lxc.Container, command []string, options lxc.AttachOptions, interactive bool) shared.OperationResult {
+	if ! interactive {
+		return runCommandNofork(container, command, options)
 	}
+	pid, errno := shared.Fork()
+	if errno != 0 {
+		return shared.OperationError(fmt.Errorf("Fork failed"))
+	}
+	if pid == 0 {
+		_, _ = syscall.Setsid()
+		C.own_pty(C.int(options.StdinFd))
+		status, err := container.RunCommandStatus(command, options)
+		if err != nil {
+			os.Exit(1)
+		}
+		os.Exit(status)
+	}
+
+	var wstatus syscall.WaitStatus
+	var rusage syscall.Rusage
+	rpid, err := syscall.Wait4(int(pid), &wstatus, 0, &rusage)
+
+	if int(rpid) != int(pid) {
+		shared.Debugf("runcommand: got return value %d not pid %d\n", int(rpid), int(pid))
+	}
+
+	status := int(wstatus)
+
 
 	metadata, err := json.Marshal(shared.Jmap{"return": status})
 	if err != nil {
@@ -1436,6 +1496,7 @@ func (s *execWs) Do() shared.OperationResult {
 			s.container,
 			s.command,
 			s.options,
+			s.interactive,
 		)
 
 		for _, tty := range ttys {
@@ -1531,7 +1592,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 		opts.StdoutFd = nullfd
 		opts.StderrFd = nullfd
 
-		return runCommand(c.c, post.Command, opts)
+		return runCommand(c.c, post.Command, opts, post.Interactive)
 	}
 
 	return AsyncResponse(run, nil)

--- a/shared/util.go
+++ b/shared/util.go
@@ -39,6 +39,7 @@ import (
 #include <fcntl.h>
 #include <string.h>
 #include <stdio.h>
+#include <termios.h>
 
 // This is an adaption from https://codereview.appspot.com/4589049, to be
 // included in the stdlib with the stdlib's license.
@@ -112,8 +113,17 @@ void create_pipe(int *master, int *slave) {
 	*slave = pipefd[1];
 }
 
+void own_pty(int fd) {
+	printf("fd is %d\n", fd);
+	if (ioctl(fd, TIOCSCTTY, (char *)NULL) == -1)
+		printf("Failed TIOCSCTTY: %s\n", strerror(errno));
+}
 */
 import "C"
+
+func OwnPty(fd uintptr) {
+	C.own_pty(C.int(fd))
+}
 
 func OpenPty() (master *os.File, slave *os.File, err error) {
 	fd_master := C.int(-1)

--- a/shared/util.go
+++ b/shared/util.go
@@ -520,3 +520,13 @@ func WriteAllBuf(w io.Writer, buf *bytes.Buffer) error {
 		}
 	}
 }
+
+func Fork() (uintptr, syscall.Errno) {
+	r1, _, err1 := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
+
+	if err1 != 0 {
+		return 0, err1
+	}
+
+	return r1, 0
+}


### PR DESCRIPTION
fork, setsid(), and own the controlling terminal.

This fixes bash's complaints about the terminal.  ctrl-c and ctrl-d
and ctrl-z work.

Closes #263

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>