### PR TITLE
Log things a bit better

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -859,6 +859,16 @@ func newLxdContainer(name string, daemon *Daemon) (*lxdContainer, error) {
 	}
 	d.c = c
 
+	dir := shared.LogPath(c.Name())
+	err = os.MkdirAll(dir, 0700)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = d.c.SetLogFile(filepath.Join(dir, "lxc.log")); err != nil {
+		return nil, err
+	}
+
 	var txtarch string
 	switch arch {
 	case 0:

--- a/shared/util.go
+++ b/shared/util.go
@@ -169,6 +169,19 @@ func VarPath(path ...string) string {
 	return filepath.Join(items...)
 }
 
+// LogPath returns the directory that LXD should put logs under. If LXD_DIR is
+// set, this path is $LXD_DIR/logs, otherwise it is /var/log/lxd.
+func LogPath(path ...string) string {
+	varDir := os.Getenv("LXD_DIR")
+	logDir := "/var/log/lxd"
+	if varDir != "" {
+		logDir = filepath.Join(varDir, "logs")
+	}
+	items := []string{logDir}
+	items = append(items, path...)
+	return filepath.Join(items...)
+}
+
 func ParseLXDFileHeaders(headers http.Header) (uid int, gid int, mode os.FileMode, err error) {
 
 	uid, err = strconv.Atoi(headers.Get("X-LXD-uid"))


### PR DESCRIPTION
1. log lxc things to /var/log/lxd/<container>/lxc.log
2. when migrating, save the criu dump/restore logs.

The result looks something like this:

/var/log/lxd
└── mig
    ├── lxc.log
    └── migration_dump_2015-03-11T18:07:03Z.log

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>