### PR TITLE
Don't list loopback addresses

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -46,6 +46,10 @@ func listContainers(d *lxd.Client, cts []string, showsnaps bool) error {
 			ipv4s := []string{}
 			ipv6s := []string{}
 			for _, ip := range c.Status.Ips {
+				if ip.Interface == "lo" {
+					continue
+				}
+
 				if ip.Protocol == "IPV6" {
 					ipv6s = append(ipv6s, ip.Address)
 				} else {


### PR DESCRIPTION
They're typically not very useful for most people
(who want to connect remotely).

Once we have properly defined runtime status information for the
containers, I expect we'll have per-interface addresses exported over
the API so we can move that kind of filtering to the client.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>