### PR TITLE
implement container init from remote image

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/internal/gnuflag"
 	"github.com/lxc/lxd/shared"
 	"github.com/olekukonko/tablewriter"
 	"gopkg.in/yaml.v2"
@@ -38,7 +39,7 @@ var imageEditHelp string = gettext.Gettext(
 
 func (c *imageCmd) usage() string {
 	return gettext.Gettext(
-		"lxc image import <tarball> [target] [--created-at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] [prop=value]\n" +
+		"lxc image import <tarball> [target] [--public] [--created-at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] [prop=value]\n" +
 			"\n" +
 			"lxc image delete [resource:]<image>\n" +
 			"lxc image edit [resource:]\n" +
@@ -55,7 +56,11 @@ func (c *imageCmd) usage() string {
 			"create, delete, list image aliases\n")
 }
 
-func (c *imageCmd) flags() {}
+var public_image bool = false
+
+func (c *imageCmd) flags() {
+	gnuflag.BoolVar(&public_image, "public", false, gettext.Gettext("Make image public"))
+}
 
 func doImageAlias(config *lxd.Config, args []string) error {
 	var remote string
@@ -211,7 +216,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		_, err = d.PostImage(imagefile, properties)
+		_, err = d.PostImage(imagefile, properties, public_image)
 		if err != nil {
 			return err
 		}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -106,8 +106,7 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 		return errArgs
 	}
 
-	/* TODO: image could also be a resource:name */
-	image := args[0]
+	iremote, image := config.ParseRemoteAndContainer(args[0])
 
 	var name string
 	var remote string
@@ -140,9 +139,9 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 		profiles = append(profiles, p)
 	}
 	if !requested_empty_profiles && len(profiles) == 0 {
-		resp, err = d.Init(name, image, nil)
+		resp, err = d.Init(name, iremote, image, nil)
 	} else {
-		resp, err = d.Init(name, image, &profiles)
+		resp, err = d.Init(name, iremote, image, &profiles)
 	}
 	if err != nil {
 		return err

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -43,7 +43,7 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 		return errArgs
 	}
 
-	image := args[0]
+	iremote, image := config.ParseRemoteAndContainer(args[0])
 
 	var name string
 	var remote string
@@ -75,9 +75,9 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 		profiles = append(profiles, p)
 	}
 	if !requested_empty_profiles && len(profiles) == 0 {
-		resp, err = d.Init(name, image, nil)
+		resp, err = d.Init(name, iremote, image, nil)
 	} else {
-		resp, err = d.Init(name, image, &profiles)
+		resp, err = d.Init(name, iremote, image, &profiles)
 	}
 	if err != nil {
 		return err

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -59,6 +59,7 @@ type containerImageSource struct {
 	/* for "image" type */
 	Alias       string `json:"alias"`
 	Fingerprint string `json:"fingerprint"`
+	Server      string `json:"server"`
 
 	/* for "migration" type */
 	Mode       string            `json:"mode"`
@@ -75,20 +76,27 @@ type containerPostReq struct {
 
 func createFromImage(d *Daemon, req *containerPostReq) Response {
 	var uuid string
+	var err error
 	if req.Source.Alias != "" {
-		_, iId, err := dbAliasGet(d, req.Source.Alias)
-		if err == nil {
+		if req.Source.Mode == "pull" && req.Source.Server != "" {
+			uuid, err = remoteGetFingerprint(d, req.Source.Server, req.Source.Alias)
+			if err != nil {
+				return InternalError(err)
+			}
+		} else {
+			_, iId, err := dbAliasGet(d, req.Source.Alias)
+			if err != nil {
+				return InternalError(err)
+			}
 			uuid, err = dbImageGetById(d, iId)
 			if err != nil {
 				return InternalError(fmt.Errorf("Stale alias"))
 			}
-		} else {
-			return InternalError(err)
 		}
 
 	} else if req.Source.Fingerprint != "" {
 
-		imgInfo, err := dbImageGet(d, req.Source.Fingerprint)
+		imgInfo, err := dbImageGet(d, req.Source.Fingerprint, false)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -99,13 +107,20 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 		return BadRequest(fmt.Errorf("must specify one of alias or fingerprint for init from image"))
 	}
 
+	if req.Source.Server != "" {
+		err := ensureLocalImage(d, req.Source.Server, uuid)
+		if err != nil {
+			return InternalError(err)
+		}
+	}
+
 	dpath := shared.VarPath("lxc", req.Name)
 	if shared.PathExists(dpath) {
 		return InternalError(fmt.Errorf("Container exists"))
 	}
 
 	rootfsPath := fmt.Sprintf("%s/rootfs", dpath)
-	err := os.MkdirAll(rootfsPath, 0700)
+	err = os.MkdirAll(rootfsPath, 0700)
 	if err != nil {
 		return InternalError(fmt.Errorf("Error creating rootfs directory"))
 	}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -79,7 +79,7 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 	var err error
 	if req.Source.Alias != "" {
 		if req.Source.Mode == "pull" && req.Source.Server != "" {
-			uuid, err = remoteGetFingerprint(d, req.Source.Server, req.Source.Alias)
+			uuid, err = remoteGetImageFingerprint(d, req.Source.Server, req.Source.Alias)
 			if err != nil {
 				return InternalError(err)
 			}

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func remoteGetFingerprint(d *Daemon, server string, alias string) (string, error) {
+	url := fmt.Sprintf("%s/%s/images/aliases/%s", server, shared.APIVersion, alias)
+
+	resp, err := d.httpGetSync(url)
+	if err != nil {
+		return "", err
+	}
+
+	var result shared.ImageAlias
+	if err = json.Unmarshal(resp.Metadata, &result); err != nil {
+		return "", fmt.Errorf("Error reading alias\n")
+	}
+	return result.Name, nil
+}
+
+func (d *Daemon) dbGetimage(fp string) int {
+	q := `SELECT id FROM images WHERE fingerprint=?`
+	rows, err := d.db.Query(q, fp)
+	if err != nil {
+		return -1
+	}
+	defer rows.Close()
+	id := -1
+	for rows.Next() {
+		var xId int
+		rows.Scan(&xId)
+		id = xId
+	}
+	if id != -1 {
+		return id
+	}
+
+	return -1
+}
+
+func ensureLocalImage(d *Daemon, server, fp string) error {
+	if d.dbGetimage(fp) != -1 {
+		// already have it
+		return nil
+	}
+
+	/* grab the metadata from /1.0/images/%s */
+	url := fmt.Sprintf("%s/%s/images/%s", server, shared.APIVersion, fp)
+
+	resp, err := d.httpGetSync(url)
+	if err != nil {
+		return nil
+	}
+
+	info := shared.ImageInfo{}
+	if err := json.Unmarshal(resp.Metadata, &info); err != nil {
+		return err
+	}
+
+	/* now grab the actual file from /1.0/images/%s/export */
+	exporturl := fmt.Sprintf("%s/%s/images/%s/export", server, shared.APIVersion, fp)
+
+	raw, err := d.httpGetFile(exporturl)
+	if err != nil {
+		return err
+	}
+
+	destDir := shared.VarPath("images")
+	err = os.MkdirAll(destDir, 0700)
+	if err != nil {
+		return err
+	}
+	destName := shared.VarPath("images", fp)
+	if _, err := os.Stat(destName); err == nil {
+		os.Remove(destName)
+	}
+
+	f, err := os.Create(destName)
+	if err != nil {
+		return err
+	}
+	var wr io.Writer
+	wr = f
+
+	size, err := io.Copy(wr, raw.Body)
+	f.Close()
+	if err != nil {
+		os.Remove(destName)
+		return err
+	}
+
+	/* todo - we need to add arch and tarname to shared.ImageInfo */
+	tarname := ""
+	arch := 0
+
+	/* insert into db - do we want to add properties? */
+	q := `INSERT INTO images (fingerprint, filename, size, public, architecture, upload_date) VALUES (?, ?, ?, ?, ?, strftime("%s"))`
+
+	_, err = d.db.Exec(q, fp, tarname, size, info.Public, arch)
+	if err != nil {
+		os.Remove(destName)
+		return err
+	}
+
+	return nil
+}

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func remoteGetFingerprint(d *Daemon, server string, alias string) (string, error) {
+func remoteGetImageFingerprint(d *Daemon, server string, alias string) (string, error) {
 	url := fmt.Sprintf("%s/%s/images/aliases/%s", server, shared.APIVersion, alias)
 
 	resp, err := d.httpGetSync(url)

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-03-12 15:44-0500\n"
+        "POT-Creation-Date: 2015-03-14 00:30-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/image.go:24
+#: lxc/image.go:25
 msgid   "### This is a yaml representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -58,12 +58,12 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name\n"
 msgstr  ""
 
-#: lxc/image.go:84
+#: lxc/image.go:89
 #, c-format
 msgid   "(Bad alias entry: %s\n"
 msgstr  ""
 
-#: lxc/image.go:244
+#: lxc/image.go:250
 #, c-format
 msgid   "(Bad image entry: %s\n"
 msgstr  ""
@@ -73,7 +73,7 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:178
+#: lxc/image.go:184
 msgid   "Aliases:\n"
 msgstr  ""
 
@@ -81,16 +81,16 @@ msgstr  ""
 msgid   "Alternate config directory."
 msgstr  ""
 
-#: client.go:555
+#: client.go:558
 #, c-format
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1340
+#: client.go:1365
 msgid   "Cannot change profile name"
 msgstr  ""
 
-#: client.go:690
+#: client.go:693
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -110,7 +110,7 @@ msgstr  ""
 msgid   "Container not found"
 msgstr  ""
 
-#: client.go:704
+#: client.go:707
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -146,11 +146,11 @@ msgstr  ""
 msgid   "Enables verbose mode."
 msgstr  ""
 
-#: lxc/init.go:96 lxc/init.go:97 lxc/launch.go:36 lxc/launch.go:37
+#: lxc/init.go:100 lxc/init.go:101 lxc/launch.go:36 lxc/launch.go:37
 msgid   "Ephemeral container"
 msgstr  ""
 
-#: lxc/init.go:118 lxc/launch.go:58
+#: lxc/init.go:121 lxc/launch.go:58
 msgid   "Ephemeral containers not yet supported\n"
 msgstr  ""
 
@@ -174,7 +174,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute...\n"
 msgstr  ""
 
-#: lxc/image.go:168
+#: lxc/image.go:174
 #, c-format
 msgid   "Hash: %s\n"
 msgstr  ""
@@ -209,6 +209,10 @@ msgid   "Lists the available resources.\n"
         "\n"
         "Currently resource must be a defined remote, and list only lists\n"
         "the defined containers.\n"
+msgstr  ""
+
+#: lxc/image.go:62
+msgid   "Make image public"
 msgstr  ""
 
 #: lxc/config.go:45
@@ -280,7 +284,6 @@ msgstr  ""
 #: lxc/move.go:23
 msgid   "Move containers within or in between lxd instances.\n"
         "\n"
-        "(currently only live migration is supported)\n"
         "lxc move <source container> <destination container>\n"
 msgstr  ""
 
@@ -288,7 +291,7 @@ msgstr  ""
 msgid   "No cert provided to add"
 msgstr  ""
 
-#: client.go:683
+#: client.go:686
 msgid   "No certificate on this connection"
 msgstr  ""
 
@@ -296,15 +299,15 @@ msgstr  ""
 msgid   "No fingerprint specified."
 msgstr  ""
 
-#: client.go:965
+#: client.go:990
 msgid   "Non-async response from delete!"
 msgstr  ""
 
-#: client.go:834
+#: client.go:859
 msgid   "Non-async response from init!"
 msgstr  ""
 
-#: client.go:1181
+#: client.go:1206
 msgid   "Non-async response from snapshot!"
 msgstr  ""
 
@@ -340,16 +343,16 @@ msgstr  ""
 msgid   "Profile %s deleted\n"
 msgstr  ""
 
-#: lxc/image.go:174
+#: lxc/image.go:180
 msgid   "Properties:\n"
 msgstr  ""
 
-#: lxc/image.go:173
+#: lxc/image.go:179
 #, c-format
 msgid   "Public: %s\n"
 msgstr  ""
 
-#: client.go:697
+#: client.go:700
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
@@ -387,15 +390,15 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: client.go:1332 client.go:1353
+#: client.go:1357 client.go:1378
 msgid   "Unexpected async response"
 msgstr  ""
 
-#: client.go:1278 client.go:1421 client.go:1446 client.go:1485
+#: client.go:1303 client.go:1446 client.go:1471 client.go:1510
 msgid   "Unexpected non-async response"
 msgstr  ""
 
-#: lxc/image.go:347
+#: lxc/image.go:353
 #, c-format
 msgid   "Unknown image command %s"
 msgstr  ""
@@ -431,26 +434,26 @@ msgstr  ""
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:432 client.go:1213 client.go:1220
+#: client.go:432 client.go:1238 client.go:1245
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
 
-#: lxc/launch.go:103
+#: lxc/launch.go:104
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:1390
+#: client.go:1415
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
 
-#: client.go:670
+#: client.go:673
 msgid   "bad response type from image list!"
 msgstr  ""
 
-#: client.go:412 client.go:628 client.go:1199 client.go:1370 client.go:1526
-#: client.go:1565 client.go:1623
+#: client.go:412 client.go:631 client.go:1224 client.go:1395 client.go:1551
+#: client.go:1590 client.go:1648
 msgid   "bad response type from list!"
 msgstr  ""
 
@@ -458,11 +461,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:436 client.go:1224
+#: client.go:436 client.go:1249
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1394
+#: client.go:1419
 msgid   "bad version in profile url"
 msgstr  ""
 
@@ -470,7 +473,7 @@ msgstr  ""
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
-#: lxc/launch.go:87 lxc/launch.go:92
+#: lxc/launch.go:88 lxc/launch.go:93
 msgid   "didn't get any affected resources from server"
 msgstr  ""
 
@@ -488,24 +491,24 @@ msgstr  ""
 msgid   "error: unknown command: %s\n"
 msgstr  ""
 
-#: client.go:922
+#: client.go:947
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
 
-#: client.go:859
+#: client.go:884
 msgid   "got bad response type from exec"
 msgstr  ""
 
-#: lxc/launch.go:107
+#: lxc/launch.go:108
 msgid   "got bad version"
 msgstr  ""
 
-#: client.go:1096 client.go:1126
+#: client.go:1121 client.go:1151
 msgid   "got non-async response!"
 msgstr  ""
 
-#: client.go:592 client.go:984 client.go:1007
+#: client.go:595 client.go:1009 client.go:1032
 msgid   "got non-sync response from containers get!"
 msgstr  ""
 
@@ -514,14 +517,15 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1135
+#: client.go:1160
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
 
-#: lxc/image.go:41
-msgid   "lxc image import <tarball> [target] [--created-at=ISO-8601] [--"
-        "expires-at=ISO-8601] [--fingerprint=HASH] [prop=value]\n"
+#: lxc/image.go:42
+msgid   "lxc image import <tarball> [target] [--public] [--created-"
+        "at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] "
+        "[prop=value]\n"
         "\n"
         "lxc image delete [resource:]<image>\n"
         "lxc image edit [resource:]\n"
@@ -568,15 +572,15 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1462 client.go:1542
+#: client.go:1487 client.go:1567
 msgid   "no value found in %q\n"
 msgstr  ""
 
-#: lxc/move.go:69
+#: lxc/move.go:72
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
-#: client.go:691
+#: client.go:694
 msgid   "ok (y/n)? "
 msgstr  ""
 

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -19,7 +19,7 @@ test_basic_usage() {
   fi
   [ "$sum" = "$(sha256sum ${LXD_DIR}/${name} | cut -d' ' -f1)" ]
 
-  # Test iamge delete
+  # Test image delete
   lxc image delete testimage
 
   # Re-import the image

--- a/test/main.sh
+++ b/test/main.sh
@@ -49,6 +49,7 @@ cleanup() {
     sleep 3
     rm -Rf ${LXD_DIR}
     rm -Rf ${LXD_CONF}
+    rm -f foo.img
     [ -n "${LXD2_DIR}" ] && rm -Rf "${LXD2_DIR}"
 
     echo ""
@@ -97,6 +98,11 @@ spawn_lxd() {
 spawn_lxd 127.0.0.1:8443 $LXD_DIR
 lxd_pid=$!
 
+export LXD2_DIR=$(mktemp -d -p $(pwd))
+chmod 777 "${LXD2_DIR}"
+spawn_lxd 127.0.0.1:8444 "${LXD2_DIR}"
+lxd2_pid=$!
+
 # allow for running a specific set of tests
 if [ "$#" -gt 0 ]; then
   test_$1
@@ -110,11 +116,14 @@ test_commits_signed_off
 echo "==> TEST: doing static analysis of commits"
 static_analysis
 
-echo "==> TEST: lxc remote"
-test_remote
+echo "==> TEST: lxc remote administration"
+test_remote_admin
 
 echo "==> TEST: basic usage"
 test_basic_usage
+
+echo "==> TEST: lxc remote usage"
+test_remote_usage
 
 echo "==> TEST: snapshots"
 test_snapshots

--- a/test/main.sh
+++ b/test/main.sh
@@ -9,7 +9,7 @@ chmod 777 "${LXD_DIR}"
 export LXD_CONF=$(mktemp -d)
 export LXD_FUIDMAP_DIR=${LXD_DIR}/fuidmap
 mkdir -p ${LXD_FUIDMAP_DIR}
-BASEURL=https://127.0.0.1:8443
+BASEURL=https://127.0.0.1:18443
 RESULT=failure
 lxd_pid=0
 
@@ -20,7 +20,7 @@ fi
 
 echo "==> Running the LXD testsuite"
 
-BASEURL=https://127.0.0.1:8443
+BASEURL=https://127.0.0.1:18443
 my_curl() {
   curl -k -s --cert "${LXD_CONF}/client.crt" --key "${LXD_CONF}/client.key" $@
 }
@@ -94,12 +94,12 @@ spawn_lxd() {
   LXD_DIR=$2 lxc config set password foo
 }
 
-spawn_lxd 127.0.0.1:8443 $LXD_DIR
+spawn_lxd 127.0.0.1:18443 $LXD_DIR
 lxd_pid=$!
 
 export LXD2_DIR=$(mktemp -d -p $(pwd))
 chmod 777 "${LXD2_DIR}"
-spawn_lxd 127.0.0.1:8444 "${LXD2_DIR}"
+spawn_lxd 127.0.0.1:18444 "${LXD2_DIR}"
 lxd2_pid=$!
 
 # allow for running a specific set of tests

--- a/test/main.sh
+++ b/test/main.sh
@@ -49,7 +49,6 @@ cleanup() {
     sleep 3
     rm -Rf ${LXD_DIR}
     rm -Rf ${LXD_CONF}
-    rm -f foo.img
     [ -n "${LXD2_DIR}" ] && rm -Rf "${LXD2_DIR}"
 
     echo ""

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -1,10 +1,4 @@
 test_migration() {
-  export LXD2_DIR=$(mktemp -d -p $(pwd))
-  chmod 777 "${LXD2_DIR}"
-  spawn_lxd 127.0.0.1:8444 "${LXD2_DIR}"
-  lxd2_pid=$!
-
-  (echo y; sleep 3; echo foo) | lxc remote add lxd2 127.0.0.1:8444
 
   lxc image list
   lxc init testimage nonlive

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -9,7 +9,7 @@ gen_second_cert() {
 	mv $LXD_CONF/client.key.bak $LXD_CONF/client.key
 }
 
-test_remote() {
+test_remote_admin() {
   bad=0
   (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:8443 $debug || true
   lxc list badpass && bad=1 || true
@@ -41,4 +41,29 @@ test_remote() {
   lxc config trust add "$LXD_CONF/client2.crt"
   lxc config trust list | grep client2
   lxc config trust remove client2
+}
+
+test_remote_usage() {
+  (echo y;  sleep 3;  echo foo) |  lxc remote add lxd2 127.0.0.1:8444 $debug
+
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    return
+  fi
+
+  # we need a public image on local
+  lxc image export local:testimage foo.img
+  lxc image delete local:testimage
+  sum=`sha256sum foo.img`
+  lxc image import foo.img local: --public
+  lxc image alias create local:testimage $sum
+
+  # launch testimage stored on local as container c1 on lxd2
+  lxc launch local:testimage lxd2:c1
+
+  # make sure it is running
+  lxc list lxd2: | grep c1 | grep RUNNING
+
+  lxc stop lxd2:c1
+
+  lxc delete lxd2:c1
 }

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -51,10 +51,10 @@ test_remote_usage() {
   fi
 
   # we need a public image on local
-  lxc image export local:testimage foo.img
+  lxc image export local:testimage ${LXD_DIR}/foo.img
   lxc image delete local:testimage
-  sum=`sha256sum foo.img`
-  lxc image import foo.img local: --public
+  sum=`sha256sum ${LXD_DIR}/foo.img`
+  lxc image import ${LXD_DIR}/foo.img local: --public
   lxc image alias create local:testimage $sum
 
   # launch testimage stored on local as container c1 on lxd2

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -11,13 +11,13 @@ gen_second_cert() {
 
 test_remote_admin() {
   bad=0
-  (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:8443 $debug || true
+  (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:18443 $debug || true
   lxc list badpass && bad=1 || true
   if [ "$bad" -eq 1 ]; then
       echo "bad password accepted" && false
   fi
 
-  (echo y;  sleep 3;  echo foo) |  lxc remote add local 127.0.0.1:8443 $debug
+  (echo y;  sleep 3;  echo foo) |  lxc remote add local 127.0.0.1:18443 $debug
   lxc remote list | grep 'local'
 
   lxc remote set-default local
@@ -33,7 +33,7 @@ test_remote_admin() {
 
   # This is a test for #91, we expect this to hang asking for a password if we
   # tried to re-add our cert.
-  echo y | lxc remote add local 127.0.0.1:8443 $debug
+  echo y | lxc remote add local 127.0.0.1:18443 $debug
 
   # we just re-add our cert under a different name to test the cert
   # manipulation mechanism.
@@ -44,7 +44,7 @@ test_remote_admin() {
 }
 
 test_remote_usage() {
-  (echo y;  sleep 3;  echo foo) |  lxc remote add lxd2 127.0.0.1:8444 $debug
+  (echo y;  sleep 3;  echo foo) |  lxc remote add lxd2 127.0.0.1:18444 $debug
 
   if [ -n "$TRAVIS_PULL_REQUEST" ]; then
     return


### PR DESCRIPTION
1. implement --public for lxc image import so we have something to work with

2. in client, detect remote:image for image.  In that case, check with remote
whehter image is an alias or fingerprint

3. in containersPost, look for source type=pull and server!="".  In that
case, dereference alias if needed, and then fetch the fingerprint if not
already downloaded.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>