### PR TITLE
fuidshift: Use lchown so we switch symlinks too

### DIFF
--- a/shared/idmapset.go
+++ b/shared/idmapset.go
@@ -146,7 +146,7 @@ func Uidshift(dir string, idmap IdmapSet, testmode bool) error {
 		if testmode {
 			fmt.Printf("I would shift %q to %d %d\n", path, newuid, newgid)
 		} else {
-			err = os.Chown(path, int(newuid), int(newgid))
+			err = os.Lchown(path, int(newuid), int(newgid))
 			if err == nil {
 				m := fi.Mode()
 				if m&os.ModeSymlink == 0 {


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>