### PR TITLE
Stop fork()ing from lxd

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1,3 +1,6 @@
+// +build linux
+// +build cgo
+
 package main
 
 import (
@@ -24,6 +27,26 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 	"gopkg.in/lxc/go-lxc.v2"
 )
+
+// #cgo LDFLAGS: -lutil
+/*
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <grp.h>
+#include <pty.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <stdio.h>
+#include <termios.h>
+
+void own_pty(int fd) {
+	if (ioctl(fd, TIOCSCTTY, (char *)NULL) == -1)
+		printf("Failed TIOCSCTTY: %s\n", strerror(errno));
+}
+*/
+import "C"
 
 type containerType int
 
@@ -1366,22 +1389,22 @@ func (s *execWs) Connect(secret string, r *http.Request, w http.ResponseWriter) 
 }
 
 func runCommandNofork(container *lxc.Container, command []string, options lxc.AttachOptions) shared.OperationResult {
-	status, err := container.RunCommandStatus(command, options)
-	if err != nil {
-		shared.Debugf("Failed running command: %q", err.Error())
-		return shared.OperationError(err)
-	}
+        status, err := container.RunCommandStatus(command, options)
+        if err != nil {
+                shared.Debugf("Failed running command: %q", err.Error())
+                return shared.OperationError(err)
+        }
 
-	metadata, err := json.Marshal(shared.Jmap{"return": status})
-	if err != nil {
-		return shared.OperationError(err)
-	}
+        metadata, err := json.Marshal(shared.Jmap{"return": status})
+        if err != nil {
+                return shared.OperationError(err)
+        }
 
-	return shared.OperationResult{Metadata: metadata, Error: nil}
+        return shared.OperationResult{Metadata: metadata, Error: nil}
 }
 
 func runCommand(container *lxc.Container, command []string, options lxc.AttachOptions, interactive bool) shared.OperationResult {
-	if !interactive {
+	if ! interactive {
 		return runCommandNofork(container, command, options)
 	}
 	pid, errno := shared.Fork()
@@ -1390,7 +1413,7 @@ func runCommand(container *lxc.Container, command []string, options lxc.AttachOp
 	}
 	if pid == 0 {
 		_, _ = syscall.Setsid()
-		shared.OwnPty(options.StdinFd)
+		C.own_pty(C.int(options.StdinFd))
 		status, err := container.RunCommandStatus(command, options)
 		if err != nil {
 			os.Exit(1)
@@ -1407,6 +1430,7 @@ func runCommand(container *lxc.Container, command []string, options lxc.AttachOp
 	}
 
 	status := int(wstatus)
+
 
 	metadata, err := json.Marshal(shared.Jmap{"return": status})
 	if err != nil {

--- a/shared/util.go
+++ b/shared/util.go
@@ -533,13 +533,3 @@ func WriteAllBuf(w io.Writer, buf *bytes.Buffer) error {
 		}
 	}
 }
-
-func Fork() (uintptr, syscall.Errno) {
-	r1, _, err1 := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
-
-	if err1 != 0 {
-		return 0, err1
-	}
-
-	return r1, 0
-}

--- a/shared/util.go
+++ b/shared/util.go
@@ -39,7 +39,6 @@ import (
 #include <fcntl.h>
 #include <string.h>
 #include <stdio.h>
-#include <termios.h>
 
 // This is an adaption from https://codereview.appspot.com/4589049, to be
 // included in the stdlib with the stdlib's license.
@@ -113,17 +112,8 @@ void create_pipe(int *master, int *slave) {
 	*slave = pipefd[1];
 }
 
-void own_pty(int fd) {
-	printf("fd is %d\n", fd);
-	if (ioctl(fd, TIOCSCTTY, (char *)NULL) == -1)
-		printf("Failed TIOCSCTTY: %s\n", strerror(errno));
-}
 */
 import "C"
-
-func OwnPty(fd uintptr) {
-	C.own_pty(C.int(fd))
-}
 
 func OpenPty() (master *os.File, slave *os.File, err error) {
 	fd_master := C.int(-1)

--- a/shared/util.go
+++ b/shared/util.go
@@ -118,10 +118,6 @@ void own_pty(int fd) {
 	if (ioctl(fd, TIOCSCTTY, (char *)NULL) == -1)
 		printf("Failed TIOCSCTTY: %s\n", strerror(errno));
 }
-
-int do_fork() {
-	return fork();
-}
 */
 import "C"
 
@@ -548,12 +544,12 @@ func WriteAllBuf(w io.Writer, buf *bytes.Buffer) error {
 	}
 }
 
-func Fork() (int, int) {
-	pid := C.do_fork()
+func Fork() (uintptr, syscall.Errno) {
+	r1, _, err1 := syscall.RawSyscall(syscall.SYS_FORK, 0, 0, 0)
 
-	if pid < 0 {
-		return 0, int(pid)
+	if err1 != 0 {
+		return 0, err1
 	}
 
-	return int(pid), 0
+	return r1, 0
 }


### PR DESCRIPTION
We used to call fork() in LXD to setup the control tty. I've since moved the needed fix in LXC itself, so this workaround is no longer required and is actually harmful as Go doesn't like us doing this at all.