### PR TITLE
add json annotations to image fields

### DIFF
--- a/shared/image.go
+++ b/shared/image.go
@@ -16,10 +16,10 @@ type ImageAlias struct {
 type ImageAliases []ImageAlias
 
 type ImageInfo struct {
-	Fingerprint string
-	Properties  ImageProperties
-	Aliases     ImageAliases
-	Public      int
+	Fingerprint string          `json:"fingerprint"`
+	Properties  ImageProperties `json:"properties"`
+	Aliases     ImageAliases    `json:"aliases"`
+	Public      int             `json:"public"`
 }
 
 type ImageBaseInfo struct {


### PR DESCRIPTION
This causes a get of /1.0/images/<fingerprint> to give the proper
lower-case field names

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>