### PR TITLE
Add missing fields to images struct passed over rest api

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -362,13 +362,12 @@ func imageGet(d *Daemon, r *http.Request) Response {
 		return InternalError(err)
 	}
 	defer rows2.Close()
-	properties := shared.ImageProperties{}
+	properties := map[string]string{}
 	for rows2.Next() {
 		var key, value string
 		var imagetype int
 		rows2.Scan(&imagetype, &key, &value)
-		i := shared.ImageProperty{Imagetype: imagetype, Key: key, Value: value}
-		properties = append(properties, i)
+		properties[key] = value
 	}
 
 	rows3, err := shared.DbQuery(d.db, "SELECT name, description FROM images_aliases WHERE image_id=?", imgInfo.Id)
@@ -384,7 +383,14 @@ func imageGet(d *Daemon, r *http.Request) Response {
 		aliases = append(aliases, a)
 	}
 
-	info := shared.ImageInfo{Fingerprint: imgInfo.Fingerprint, Properties: properties, Aliases: aliases, Public: imgInfo.Public}
+	info := shared.ImageInfo{Fingerprint: imgInfo.Fingerprint,
+		Properties: properties, Aliases: aliases,
+		Public: imgInfo.Public, Size: imgInfo.Size,
+		Architecture: imgInfo.Architecture,
+		CreationDate: imgInfo.CreationDate,
+		ExpiryDate:   imgInfo.ExpiryDate,
+		UploadDate:   imgInfo.UploadDate}
+
 	return SyncResponse(true, info)
 }
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-03-17 10:46-0600\n"
+        "POT-Creation-Date: 2015-03-17 14:39-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/image.go:25
+#: lxc/image.go:26
 msgid   "### This is a yaml representation of the image properties.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -58,12 +58,12 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name\n"
 msgstr  ""
 
-#: lxc/image.go:89
+#: lxc/image.go:90
 #, c-format
 msgid   "(Bad alias entry: %s\n"
 msgstr  ""
 
-#: lxc/image.go:250
+#: lxc/image.go:264
 #, c-format
 msgid   "(Bad image entry: %s\n"
 msgstr  ""
@@ -73,12 +73,17 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:184
+#: lxc/image.go:198
 msgid   "Aliases:\n"
 msgstr  ""
 
 #: lxc/main.go:29
 msgid   "Alternate config directory."
+msgstr  ""
+
+#: lxc/image.go:181
+#, c-format
+msgid   "Architecture: %s\n"
 msgstr  ""
 
 #: client.go:574
@@ -180,7 +185,7 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute...\n"
 msgstr  ""
 
-#: lxc/image.go:174
+#: lxc/image.go:175
 #, c-format
 msgid   "Hash: %s\n"
 msgstr  ""
@@ -225,7 +230,7 @@ msgid   "Lists the available resources.\n"
         "* \"s.privileged=1\" will do the same\n"
 msgstr  ""
 
-#: lxc/image.go:62
+#: lxc/image.go:63
 msgid   "Make image public"
 msgstr  ""
 
@@ -345,11 +350,11 @@ msgstr  ""
 msgid   "Profile %s deleted\n"
 msgstr  ""
 
-#: lxc/image.go:180
+#: lxc/image.go:194
 msgid   "Properties:\n"
 msgstr  ""
 
-#: lxc/image.go:179
+#: lxc/image.go:182
 #, c-format
 msgid   "Public: %s\n"
 msgstr  ""
@@ -384,6 +389,10 @@ msgstr  ""
 msgid   "Show all commands (not just interesting ones)"
 msgstr  ""
 
+#: lxc/image.go:180
+msgid   "Size: %.2vMB\n"
+msgstr  ""
+
 #: lxc/delete.go:76
 msgid   "Stopping container failed!"
 msgstr  ""
@@ -392,7 +401,11 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: lxc/image.go:353
+#: lxc/image.go:183
+msgid   "Timestamps:\n"
+msgstr  ""
+
+#: lxc/image.go:367
 #, c-format
 msgid   "Unknown image command %s"
 msgstr  ""
@@ -509,7 +522,7 @@ msgstr  ""
 msgid   "invalid wait url %s"
 msgstr  ""
 
-#: lxc/image.go:42
+#: lxc/image.go:43
 msgid   "lxc image import <tarball> [target] [--public] [--created-"
         "at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] "
         "[prop=value]\n"

--- a/shared/image.go
+++ b/shared/image.go
@@ -16,16 +16,25 @@ type ImageAlias struct {
 type ImageAliases []ImageAlias
 
 type ImageInfo struct {
-	Fingerprint string          `json:"fingerprint"`
-	Properties  ImageProperties `json:"properties"`
-	Aliases     ImageAliases    `json:"aliases"`
-	Public      int             `json:"public"`
+	Aliases      ImageAliases      `json:"aliases"`
+	Architecture int               `json:"architecture"`
+	Fingerprint  string            `json:"fingerprint"`
+	Properties   map[string]string `json:"properties"`
+	Public       int               `json:"public"`
+	Size         int64             `json:"size"`
+	CreationDate int64             `json:"created_at"`
+	ExpiryDate   int64             `json:"expires_at"`
+	UploadDate   int64             `json:"uploaded_at"`
 }
 
 type ImageBaseInfo struct {
-	Id          int
-	Fingerprint string
-	Filename    string
-	Size        int64
-	Public      int
+	Id           int
+	Fingerprint  string
+	Filename     string
+	Size         int64
+	Public       int
+	Architecture int
+	CreationDate int64
+	ExpiryDate   int64
+	UploadDate   int64
 }

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -287,11 +287,11 @@ lxc image alias create centos/7 \<hash\>                                        
 
 **Example output (lxc image list)**
 
-    ALIAS                   HASH            PUBLIC  DESCRIPTION
-    ------------------------------------------------------------------------------
-    busybox-amd64           146246146827... yes     -
-    ubuntu/devel (3 more)   95830b5e4e04... yes     Ubuntu 15.04 (devel) x86 64bit
-    -                       a1420943168a... no      Test image
+    ALIAS                   HASH            PUBLIC  DESCRIPTION                     UPLOAD DATE
+    -------------------------------------------------------------------------------------------
+    busybox-amd64           146246146827... yes     -                               Mar 12, 2015 at 10:41pm (CDT)
+    ubuntu/devel (3 more)   95830b5e4e04... yes     Ubuntu 15.04 (devel) x86 64bit  Mar 8, 2015 at 1:27am (CST)
+    -                       a1420943168a... no      Test image                      Mar 4, 2015 at 3:41pm (CST)
 
 **Example output (lxc image info)**
 


### PR DESCRIPTION
Also add info to the lxc image list and lxc image info commands.

Closes #399 

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>