### PR TITLE
image export: fix usage

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -342,7 +342,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		return err
 
 	case "export":
-		if len(args) < 3 {
+		if len(args) < 2 {
 			return errArgs
 		}
 
@@ -357,11 +357,18 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 
 		image := dereferenceAlias(d, inName)
 
-		_, err = d.ExportImage(image, args[2])
+		target := "."
+		if len(args) > 2 {
+			target = args[2]
+		}
+		_, outfile, err := d.ExportImage(image, target)
 		if err != nil {
 			return err
 		}
 
+		if target != "-" {
+			fmt.Printf("Output is in %s\n", outfile)
+		}
 		return nil
 	default:
 		return fmt.Errorf(gettext.Gettext("Unknown image command %s"), args[0])

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -247,7 +247,7 @@ lxc file pull dakara:c2/etc/hosts /tmp/                 | Grab /etc/hosts from c
     image copy <image> <target host and image name>
     image delete <image>
     image edit <image>
-    image export <image>
+    image export <image> [target]
     image import <tarball> [target] [--public] [--created-at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] [--alias=ALIAS].. [prop=value]
     image info <image>
     image list [filter]


### PR DESCRIPTION
According to the spec, 'image export' does not require a target-file or
target-dir argument.  If not present, then the filename given at import
time is used.  Also, so long as stdout is not listed as the target, print
out the destination file.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>