### PR TITLE
dereference alias in image copy command

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -178,7 +178,8 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		if err != nil {
 			return err
 		}
-		return d.CopyImage(inName, dest, copyAliases, addAliases)
+		image := dereferenceAlias(d, inName)
+		return d.CopyImage(image, dest, copyAliases, addAliases)
 
 	case "delete":
 		/* delete [<remote>:]<image> */


### PR DESCRIPTION
I was moving it from one file to another and just plain dropped it.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>