### PR TITLE
implement a default 'local' remote which is unix:/var/lib/lxd/unix.socke...

### DIFF
--- a/client.go
+++ b/client.go
@@ -192,7 +192,7 @@ func NewClient(config *Config, remote string) (*Client, error) {
 
 	// TODO: Here, we don't support configurable local remotes, we only
 	// support the default local LXD at /var/lib/lxd/unix.socket.
-	if remote == "" || remote == "local" {
+	if remote == "" {
 		c.baseURL = "http://unix.socket"
 		c.baseWSURL = "ws://unix.socket"
 		c.http.Transport = &unixTransport

--- a/config.go
+++ b/config.go
@@ -35,6 +35,9 @@ type RemoteConfig struct {
 	Addr string `yaml:"addr"`
 }
 
+var localRemote = RemoteConfig{Addr: "unix:/var/lib/lxd/unix.socket"}
+var defaultRemote = map[string]RemoteConfig{"local": localRemote}
+
 var ConfigDir = "$HOME/.config/lxc"
 var configFileName = "config.yml"
 
@@ -51,7 +54,7 @@ func LoadConfig() (*Config, error) {
 	data, err := ioutil.ReadFile(ConfigPath(configFileName))
 	if os.IsNotExist(err) {
 		// A missing file is equivalent to the default configuration.
-		return &Config{}, nil
+		return &Config{Remotes: defaultRemote}, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("cannot read config file: %v", err)
@@ -66,7 +69,6 @@ func LoadConfig() (*Config, error) {
 		c.Remotes = make(map[string]RemoteConfig)
 	}
 
-	c.Remotes["local"] = RemoteConfig{Addr: "unix:/var/lib/lxd/unix.socket"}
 	return &c, nil
 }
 

--- a/config.go
+++ b/config.go
@@ -65,6 +65,8 @@ func LoadConfig() (*Config, error) {
 	if c.Remotes == nil {
 		c.Remotes = make(map[string]RemoteConfig)
 	}
+
+	c.Remotes["local"] = RemoteConfig{Addr: "unix:/var/lib/lxd/unix.socket"}
 	return &c, nil
 }
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -125,10 +125,6 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 			return errArgs
 		}
 
-		if args[1] == "local" {
-			return fmt.Errorf(gettext.Gettext("'local' cannot be removed"))
-		}
-
 		if _, ok := config.Remotes[args[1]]; !ok {
 			return fmt.Errorf(gettext.Gettext("remote %s doesn't exist"), args[1])
 		}

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -41,6 +41,12 @@ func addServer(config *lxd.Config, server string, addr string) error {
 		return err
 	}
 
+	if len(addr) > 5 && addr[0:5] == "unix:" {
+		// NewClient succeeded so there was a lxd there (we fingered
+		// it) so just accept it
+		return nil
+	}
+
 	host, _, err := net.SplitHostPort(addr)
 	if err != nil {
 		host = addr
@@ -117,6 +123,10 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 	case "remove":
 		if len(args) != 2 {
 			return errArgs
+		}
+
+		if args[1] == "local" {
+			return fmt.Errorf(gettext.Gettext("'local' cannot be removed"))
 		}
 
 		if _, ok := config.Remotes[args[1]]; !ok {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-03-19 23:53-0500\n"
+        "POT-Creation-Date: 2015-03-20 18:40-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -58,6 +58,10 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name\n"
 msgstr  ""
 
+#: lxc/remote.go:129
+msgid   "'local' cannot be removed"
+msgstr  ""
+
 #: lxc/image.go:110
 #, c-format
 msgid   "(Bad alias entry: %s\n"
@@ -68,7 +72,7 @@ msgstr  ""
 msgid   "(Bad image entry: %s\n"
 msgstr  ""
 
-#: lxc/remote.go:59
+#: lxc/remote.go:65
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -86,12 +90,12 @@ msgstr  ""
 msgid   "Architecture: %s\n"
 msgstr  ""
 
-#: client.go:680
+#: client.go:675
 #, c-format
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1292
+#: client.go:1271
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -99,7 +103,7 @@ msgstr  ""
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: client.go:776
+#: client.go:771
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -111,7 +115,7 @@ msgid   "Changes a containers state to %s.\n"
         "lxd %s <name>\n"
 msgstr  ""
 
-#: lxc/remote.go:80
+#: lxc/remote.go:86
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -129,7 +133,7 @@ msgid   "Copy containers within or in between lxd instances.\n"
         "lxc copy <source container> <destination container>\n"
 msgstr  ""
 
-#: client.go:791
+#: client.go:786
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -173,7 +177,7 @@ msgstr  ""
 msgid   "Ephemeral containers not yet supported\n"
 msgstr  ""
 
-#: client.go:543 client.go:553
+#: client.go:556 client.go:566
 #, c-format
 msgid   "Error adding alias %s\n"
 msgstr  ""
@@ -326,7 +330,7 @@ msgstr  ""
 msgid   "No cert provided to add"
 msgstr  ""
 
-#: client.go:764
+#: client.go:759
 msgid   "No certificate on this connection"
 msgstr  ""
 
@@ -375,17 +379,17 @@ msgstr  ""
 msgid   "Public: %s\n"
 msgstr  ""
 
-#: client.go:783
+#: client.go:778
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: client.go:271
+#: client.go:276
 #, c-format
 msgid   "Server certificate for host %s has changed. Add correct certificate "
         "or remove certificate in %s"
 msgstr  ""
 
-#: lxc/remote.go:77
+#: lxc/remote.go:83
 msgid   "Server doesn't trust us after adding our cert"
 msgstr  ""
 
@@ -434,7 +438,7 @@ msgstr  ""
 msgid   "Unknown image command %s"
 msgstr  ""
 
-#: lxc/remote.go:191
+#: lxc/remote.go:201
 #, c-format
 msgid   "Unknown remote subcommand %s"
 msgstr  ""
@@ -461,11 +465,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: client.go:419
+#: client.go:448
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:470 client.go:1193 client.go:1200
+#: client.go:499 client.go:1172 client.go:1179
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -474,7 +478,7 @@ msgstr  ""
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:1323
+#: client.go:1302
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -483,15 +487,15 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:474 client.go:1204
+#: client.go:503 client.go:1183
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1327
+#: client.go:1306
 msgid   "bad version in profile url"
 msgstr  ""
 
-#: client.go:382 client.go:387
+#: client.go:411 client.go:416
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
@@ -517,12 +521,12 @@ msgstr  ""
 msgid   "error: unknown command: %s\n"
 msgstr  ""
 
-#: client.go:503 client.go:581
+#: client.go:363
 #, c-format
 msgid   "expected error, got %s"
 msgstr  ""
 
-#: client.go:990
+#: client.go:985
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
@@ -541,7 +545,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1139
+#: client.go:1118
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -551,8 +555,8 @@ msgid   "lxc image import <tarball> [target] [--public] [--created-"
         "at=ISO-8601] [--expires-at=ISO-8601] [--fingerprint=HASH] "
         "[prop=value]\n"
         "\n"
-        "lxc image copy [resource:]<image> [resource:]<image> [--"
-        "alias=ALIAS].. [--copy-alias]\n"
+        "lxc image copy [resource:]<image> <resource>: [--alias=ALIAS].. [--"
+        "copy-alias]\n"
         "lxc image delete [resource:]<image>\n"
         "lxc image edit [resource:]\n"
         "lxc image export [resource:]<image>\n"
@@ -598,7 +602,7 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1369 client.go:1423
+#: client.go:1348 client.go:1402
 msgid   "no value found in %q\n"
 msgstr  ""
 
@@ -610,26 +614,26 @@ msgstr  ""
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
-#: client.go:777
+#: client.go:772
 msgid   "ok (y/n)? "
 msgstr  ""
 
-#: lxc/remote.go:153
+#: lxc/remote.go:163
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:123 lxc/remote.go:149 lxc/remote.go:169 lxc/remote.go:180
+#: lxc/remote.go:133 lxc/remote.go:159 lxc/remote.go:179 lxc/remote.go:190
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:103
+#: lxc/remote.go:109
 #, c-format
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: client.go:240
+#: client.go:245
 msgid   "unknown remote name: %q"
 msgstr  ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-03-20 18:40-0500\n"
+        "POT-Creation-Date: 2015-03-21 00:11-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -56,10 +56,6 @@ msgstr  ""
 
 #: lxc/snapshot.go:50
 msgid   "'/' not allowed in snapshot name\n"
-msgstr  ""
-
-#: lxc/remote.go:129
-msgid   "'local' cannot be removed"
 msgstr  ""
 
 #: lxc/image.go:110
@@ -438,7 +434,7 @@ msgstr  ""
 msgid   "Unknown image command %s"
 msgstr  ""
 
-#: lxc/remote.go:201
+#: lxc/remote.go:197
 #, c-format
 msgid   "Unknown remote subcommand %s"
 msgstr  ""
@@ -618,12 +614,12 @@ msgstr  ""
 msgid   "ok (y/n)? "
 msgstr  ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:159
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:133 lxc/remote.go:159 lxc/remote.go:179 lxc/remote.go:190
+#: lxc/remote.go:129 lxc/remote.go:155 lxc/remote.go:175 lxc/remote.go:186
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -17,15 +17,15 @@ test_remote_admin() {
       echo "bad password accepted" && false
   fi
 
-  (echo y;  sleep 3;  echo foo) |  lxc remote add local 127.0.0.1:18443 $debug
-  lxc remote list | grep 'local'
+  (echo y;  sleep 3;  echo foo) |  lxc remote add localhost 127.0.0.1:18443 $debug
+  lxc remote list | grep 'localhost'
 
-  lxc remote set-default local
-  [ "$(lxc remote get-default)" = "local" ]
+  lxc remote set-default localhost
+  [ "$(lxc remote get-default)" = "localhost" ]
 
-  lxc remote rename local foo
+  lxc remote rename localhost foo
   lxc remote list | grep 'foo'
-  lxc remote list | grep -v 'local'
+  lxc remote list | grep -v 'localhost'
   [ "$(lxc remote get-default)" = "foo" ]
 
   lxc remote remove foo
@@ -33,7 +33,7 @@ test_remote_admin() {
 
   # This is a test for #91, we expect this to hang asking for a password if we
   # tried to re-add our cert.
-  echo y | lxc remote add local 127.0.0.1:18443 $debug
+  echo y | lxc remote add localhost 127.0.0.1:18443 $debug
 
   # we just re-add our cert under a different name to test the cert
   # manipulation mechanism.
@@ -54,15 +54,15 @@ test_remote_usage() {
     return
   fi
 
-  # we need a public image on local
-  lxc image export local:testimage ${LXD_DIR}/foo.img
-  lxc image delete local:testimage
+  # we need a public image on localhost
+  lxc image export localhost:testimage ${LXD_DIR}/foo.img
+  lxc image delete localhost:testimage
   sum=`sha256sum ${LXD_DIR}/foo.img`
-  lxc image import ${LXD_DIR}/foo.img local: --public
-  lxc image alias create local:testimage $sum
+  lxc image import ${LXD_DIR}/foo.img localhost: --public
+  lxc image alias create localhost:testimage $sum
 
-  # launch testimage stored on local as container c1 on lxd2
-  lxc launch local:testimage lxd2:c1
+  # launch testimage stored on localhost as container c1 on lxd2
+  lxc launch localhost:testimage lxd2:c1
 
   # make sure it is running
   lxc list lxd2: | grep c1 | grep RUNNING


### PR DESCRIPTION
...t

and implement support for unix: remotes

tests: cannot use local as remote name, use localhost

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>