### PR TITLE
Fix launching of remote image by fingerprint

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -92,16 +92,8 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 				return InternalError(fmt.Errorf("Stale alias"))
 			}
 		}
-
 	} else if req.Source.Fingerprint != "" {
-
-		imgInfo, err := dbImageGet(d, req.Source.Fingerprint, false)
-		if err != nil {
-			return InternalError(err)
-		}
-
-		uuid = imgInfo.Fingerprint
-
+		uuid = req.Source.Fingerprint
 	} else {
 		return BadRequest(fmt.Errorf("must specify one of alias or fingerprint for init from image"))
 	}


### PR DESCRIPTION
We don't need to get the full fingerprint or ensure it's in the db at
this point.  Rather, if a fingerprint is listed in the /1.0/containers
post request, use it.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>