### PR TITLE
Disable all ttys

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -923,6 +923,10 @@ func newLxdContainer(name string, daemon *Daemon) (*lxdContainer, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = c.SetConfigItem("lxc.tty", "0")
+	if err != nil {
+		return nil, err
+	}
 
 	/* apply profiles */
 	for _, p := range profiles {


### PR DESCRIPTION
LXD doesn't use ttys so let's not waste resources spawning them.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>