### PR TITLE
db: set a 30 second busy timeout

### DIFF
--- a/lxd/db.go
+++ b/lxd/db.go
@@ -366,13 +366,15 @@ func initDb(d *Daemon) error {
 	dbpath := shared.VarPath("lxd.db")
 	var db *sql.DB
 	var err error
+	timeout := 30 // TODO - make this command-line configurable?
+	openPath := fmt.Sprintf("%s?_busy_timeout=%d", dbpath, timeout*1000)
 	if !shared.PathExists(dbpath) {
-		db, err = createDb(dbpath)
+		db, err = createDb(openPath)
 		if err != nil {
 			return err
 		}
 	} else {
-		db, err = sql.Open("sqlite3", dbpath)
+		db, err = sql.Open("sqlite3", openPath)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This uses a new feature exported by the go-sqlite3 binding to do
the timeout right in the database.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>