### PR TITLE
Better handle rows.Scan

### DIFF
--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -48,11 +48,18 @@ func profilesGet(d *Daemon, r *http.Request) Response {
 	result := []string{}
 	for rows.Next() {
 		name := ""
-		if err := rows.Scan(&name); err != nil {
+		err = rows.Scan(&name)
+		if err != nil {
+			fmt.Printf("DBERR: profilesGet: scan returned error %q\n", err)
 			return InternalError(err)
 		}
 
 		result = append(result, fmt.Sprintf("/%s/profiles/%s", shared.APIVersion, name))
+	}
+	err = rows.Err()
+	if err != nil {
+		fmt.Printf("DBERR: profilesGet: Err returned an error %q\n", err)
+		return InternalError(err)
 	}
 
 	return SyncResponse(true, result)
@@ -174,10 +181,19 @@ func profilePut(d *Daemon, r *http.Request) Response {
 	var id int
 	for rows.Next() {
 		var i int
-		rows.Scan(&i)
+		err = rows.Scan(&i)
+		if err != nil {
+			fmt.Printf("DBERR: profilePut: scan returned error %q\n", err)
+			return InternalError(err)
+		}
 		id = i
 	}
 	rows.Close()
+	err = rows.Err()
+	if err != nil {
+		fmt.Printf("DBERR: profilePut: Err returned an error %q\n", err)
+		return InternalError(err)
+	}
 
 	err = dbClearProfileConfig(tx, id)
 	if err != nil {

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -26,22 +26,14 @@ func remoteGetImageFingerprint(d *Daemon, server string, alias string) (string, 
 
 func (d *Daemon) dbGetimage(fp string) int {
 	q := `SELECT id FROM images WHERE fingerprint=?`
-	rows, err := shared.DbQuery(d.db, q, fp)
+	id := -1
+	arg1 := []interface{}{fp}
+	arg2 := []interface{}{&id}
+	err := shared.DbQueryRowScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return -1
 	}
-	defer rows.Close()
-	id := -1
-	for rows.Next() {
-		var xId int
-		rows.Scan(&xId)
-		id = xId
-	}
-	if id != -1 {
-		return id
-	}
-
-	return -1
+	return id
 }
 
 func ensureLocalImage(d *Daemon, server, fp string) error {


### PR DESCRIPTION
Switch several cases to using shared.DbRowScan().

Have all rows.Scan() cases check for errors.

Switch some cases of multi-row Scan to using wrapper functions
so we can retry on Err{Locked,Busy}.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>