### PR TITLE
More consistent remote URLs

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -83,7 +83,7 @@ func copyContainer(config *lxd.Config, sourceResource string, destResource strin
 		return err
 	}
 
-	url := "wss://" + source.Remote.Addr + path.Join(to.Operation, "websocket")
+	url := source.BaseWSURL + path.Join(to.Operation, "websocket")
 	migration, err := dest.MigrateFrom(sourceName, url, secrets, status.Config, status.Profiles)
 	if err != nil {
 		return err

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net"
+	"net/url"
 	"os"
 
 	"github.com/gosexy/gettext"
@@ -35,6 +36,69 @@ func (c *remoteCmd) usage() string {
 func (c *remoteCmd) flags() {}
 
 func addServer(config *lxd.Config, server string, addr string) error {
+	var r_scheme string
+	var r_host string
+	var r_port string
+
+	remote_url, err := url.Parse(addr)
+	if err != nil {
+		return err
+	}
+
+	if remote_url.Scheme != "" {
+		if remote_url.Scheme != "unix" && remote_url.Scheme != "https" {
+			r_scheme = "https"
+		} else {
+			r_scheme = remote_url.Scheme
+		}
+	} else if addr[0] == '/' {
+		r_scheme = "unix"
+	} else {
+		_, err := os.Stat(addr)
+		if err != nil && os.IsNotExist(err) {
+			r_scheme = "https"
+		} else {
+			r_scheme = "unix"
+		}
+	}
+
+	if remote_url.Host != "" {
+		r_host = remote_url.Host
+	} else {
+		r_host = addr
+	}
+
+	host, port, err := net.SplitHostPort(r_host)
+	if err == nil {
+		r_host = host
+		r_port = port
+	} else {
+		r_port = "8443"
+	}
+
+	if r_scheme == "unix" {
+		if addr[0:5] == "unix:" {
+			if addr[0:7] == "unix://" {
+				r_host = addr[8:]
+			} else {
+				r_host = addr[6:]
+			}
+		}
+		r_port = ""
+	}
+
+	if r_port != "" {
+		addr = r_scheme + "://" + r_host + ":" + r_port
+	} else {
+		addr = r_scheme + "://" + r_host
+	}
+
+	if config.Remotes == nil {
+		config.Remotes = make(map[string]lxd.RemoteConfig)
+	}
+
+	config.Remotes[server] = lxd.RemoteConfig{Addr: addr}
+
 	remote := config.ParseRemote(server)
 	c, err := lxd.NewClient(config, remote)
 	if err != nil {
@@ -45,11 +109,6 @@ func addServer(config *lxd.Config, server string, addr string) error {
 		// NewClient succeeded so there was a lxd there (we fingered
 		// it) so just accept it
 		return nil
-	}
-
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		host = addr
 	}
 
 	err = c.UserAuthServerCert(host)
@@ -108,11 +167,6 @@ func (c *remoteCmd) run(config *lxd.Config, args []string) error {
 		if rc, ok := config.Remotes[args[1]]; ok {
 			return fmt.Errorf(gettext.Gettext("remote %s exists as <%s>"), args[1], rc.Addr)
 		}
-
-		if config.Remotes == nil {
-			config.Remotes = make(map[string]lxd.RemoteConfig)
-		}
-		config.Remotes[args[1]] = lxd.RemoteConfig{Addr: args[2]}
 
 		err := addServer(config, args[1], args[2])
 		if err != nil {

--- a/test/main.sh
+++ b/test/main.sh
@@ -115,6 +115,9 @@ test_commits_signed_off
 echo "==> TEST: doing static analysis of commits"
 static_analysis
 
+echo "==> TEST: lxc remote url"
+test_remote_url
+
 echo "==> TEST: lxc remote administration"
 test_remote_admin
 

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -9,6 +9,21 @@ gen_second_cert() {
 	mv $LXD_CONF/client.key.bak $LXD_CONF/client.key
 }
 
+test_remote_url() {
+  for url in localhost:18443 https://localhost:18443; do
+    (echo y;  sleep 3;  echo foo) | lxc remote add test $url
+    lxc finger test:
+    lxc config trust remove localhost
+    lxc remote remove test
+  done
+
+  for url in images.linuxcontainers.org https://images.linuxcontainers.org ${LXD_DIR}/unix.socket unix:${LXD_DIR}/unix.socket unix://${LXD_DIR}/unix.socket; do
+    lxc remote add test $url
+    lxc finger test:
+    lxc remote remove test
+  done
+}
+
 test_remote_admin() {
   bad=0
   (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:18443 $debug || true


### PR DESCRIPTION
This adds full support for the following URL schemes:
 - https://\<host\>:\<port\>
 - unix://\<path\>
 - unix:\<path\> (backward compatibility)

And the following aliases:
 - \<host\> => assumed https on 8443
 - \<host\>:\<port\> => assumed https
 - https://\<host\> => assumed port 8443
 - \<path\> => assumed unix

Closes #408

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>