### PR TITLE
Don't generate a new client cert/key when calling help/version

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -72,7 +72,7 @@ func run() error {
 	_, err = os.Stat(certf)
 	_, err2 := os.Stat(keyf)
 
-	if err != nil || err2 != nil {
+	if os.Args[0] != "help" && os.Args[0] != "version" && (err != nil || err2 != nil) {
 		fmt.Fprintf(os.Stderr, gettext.Gettext("Generating a client certificate. This may take a minute...\n"))
 
 		err = shared.FindOrGenCert(certf, keyf)


### PR DESCRIPTION
This is to avoid requiring a writable home-dir during package builds
calling help2man.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>