### PR TITLE
Client certificate not available

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -137,6 +137,11 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 		name = req.Name
 
 	} else {
+				
+		if len(r.TLS.PeerCertificates) < 1 {
+			return BadRequest(fmt.Errorf("No client certificate provided"))
+		}
+		
 		cert = r.TLS.PeerCertificates[len(r.TLS.PeerCertificates)-1]
 		name = r.TLS.ServerName
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -137,11 +137,10 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 		name = req.Name
 
 	} else {
-				
+
 		if len(r.TLS.PeerCertificates) < 1 {
 			return BadRequest(fmt.Errorf("No client certificate provided"))
 		}
-		
 		cert = r.TLS.PeerCertificates[len(r.TLS.PeerCertificates)-1]
 		name = r.TLS.ServerName
 	}


### PR DESCRIPTION
Should not happen as long as you use lxc as a client, but ran into this when I did a little test using a different client for lxd.