### PR TITLE
Rearrange error handling

### DIFF
--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -161,7 +161,7 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 
 	err := saveCert(d, name, cert)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	d.clientCerts[name] = *cert

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -12,6 +12,10 @@ import (
 
 const DB_CURRENT_VERSION int = 4
 
+var (
+	DbErrAlreadyDefined = fmt.Errorf("already exists")
+)
+
 func createDb(p string) (*sql.DB, error) {
 	db, err := sql.Open("sqlite3", p)
 	if err != nil {

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
+	"github.com/stgraber/lxd-go-sqlite3"
 )
 
 type resp struct {
@@ -187,8 +189,16 @@ func SmartError(err error) Response {
 	switch err {
 	case os.ErrNotExist:
 		return NotFound
+	case sql.ErrNoRows:
+		return NotFound
+	case NoSuchImageError:
+		return NotFound
 	case os.ErrPermission:
 		return Forbidden
+	case DbErrAlreadyDefined:
+		return Conflict
+	case sqlite3.ErrConstraintUnique:
+		return Conflict
 	default:
 		return InternalError(err)
 	}


### PR DESCRIPTION
* return 404/409 for lots more errors types
* don't have two sleep loops for imagesGet
* Switch some InternalErrors to BadRequests (when the user supplies bad data,
  we shouldn't send a 500)

Closes #458
Closes #441

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>