### PR TITLE
travis: Update the PPA names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ go:
   - 1.4
 
 before_install:
-  - sudo apt-add-repository -y ppa:ubuntu-lxc/daily
-  - sudo apt-add-repository -y ppa:ubuntu-lxc/lxd-daily
+  - sudo apt-add-repository -y ppa:ubuntu-lxc/buildd-backports
+  - sudo apt-add-repository -y ppa:ubuntu-lxc/lxc-stable
   - sudo apt-get update
   - sudo apt-get install -y libssl1.0.0 libssl-dev libssl-doc curl libcurl3 libcurl3-gnutls libcurl4-openssl-dev gettext
   - sudo apt-get install -y acl lxc lxc-dev sqlite3 jq busybox-static protobuf-compiler


### PR DESCRIPTION
We currently need the latest stable version of LXC for Ubuntu 12.04 and
a few more backports.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>