### PR TITLE
fix previous commit

### DIFF
--- a/test/basic.sh
+++ b/test/basic.sh
@@ -90,11 +90,11 @@ test_basic_usage() {
 
   lxc file push ${LXD_DIR}/in foo/root/
   lxc exec foo /bin/cat /root/in | grep abc
-  lxc exec foo /bin/rm /-f root/in
+  lxc exec foo -- /bin/rm -f root/in
 
   lxc file push ${LXD_DIR}/in foo/root/in1
   lxc exec foo /bin/cat /root/in1 | grep abc
-  lxc exec foo /bin/rm -f /root/in1
+  lxc exec foo -- /bin/rm -f /root/in1
 
   echo foo | lxc exec foo tee /tmp/foo
 


### PR DESCRIPTION
remove spurious '/', and use '--' in the lxc exec rm commands
to keep 'lxc' itself from interpreting the -f we are passing
to rm.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>