### PR TITLE
list: ignore notfound errors

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -102,7 +102,7 @@ func listContainers(d *lxd.Client, cts []string, filters []string, showsnaps boo
 		if err == nil {
 			d = []string{ct, c.Status.State}
 		} else if err == lxd.LXDErrors[http.StatusNotFound] {
-			return fmt.Errorf(gettext.Gettext("Container not found"))
+			continue
 		} else {
 			return err
 		}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-04-14 23:36-0500\n"
+        "POT-Creation-Date: 2015-04-16 12:29-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -81,12 +81,12 @@ msgstr  ""
 msgid   "Architecture: %s\n"
 msgstr  ""
 
-#: client.go:690
+#: client.go:691
 #, c-format
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1371
+#: client.go:1372
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -94,7 +94,7 @@ msgstr  ""
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: client.go:810
+#: client.go:811
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -110,10 +110,6 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: lxc/list.go:105
-msgid   "Container not found"
-msgstr  ""
-
 #: lxc/image.go:82
 msgid   "Copy aliases from source"
 msgstr  ""
@@ -124,7 +120,7 @@ msgid   "Copy containers within or in between lxd instances.\n"
         "lxc copy <source container> <destination container>\n"
 msgstr  ""
 
-#: client.go:825
+#: client.go:826
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -164,7 +160,7 @@ msgstr  ""
 msgid   "Ephemeral container"
 msgstr  ""
 
-#: client.go:571 client.go:581 client.go:723
+#: client.go:572 client.go:582 client.go:724
 #, c-format
 msgid   "Error adding alias %s\n"
 msgstr  ""
@@ -322,7 +318,7 @@ msgstr  ""
 msgid   "No cert provided to add"
 msgstr  ""
 
-#: client.go:798
+#: client.go:799
 msgid   "No certificate on this connection"
 msgstr  ""
 
@@ -371,11 +367,11 @@ msgstr  ""
 msgid   "Public: %s\n"
 msgstr  ""
 
-#: client.go:817
+#: client.go:818
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: client.go:287
+#: client.go:288
 #, c-format
 msgid   "Server certificate for host %s has changed. Add correct certificate "
         "or remove certificate in %s"
@@ -457,11 +453,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: client.go:459
+#: client.go:460
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:510 client.go:1272 client.go:1279
+#: client.go:511 client.go:1273 client.go:1280
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -470,7 +466,7 @@ msgstr  ""
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:1402
+#: client.go:1403
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -479,11 +475,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:514 client.go:1283
+#: client.go:515 client.go:1284
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1406
+#: client.go:1407
 msgid   "bad version in profile url"
 msgstr  ""
 
@@ -491,7 +487,7 @@ msgstr  ""
 msgid   "can't copy to the same container name"
 msgstr  ""
 
-#: client.go:422 client.go:427
+#: client.go:423 client.go:428
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
@@ -517,12 +513,12 @@ msgstr  ""
 msgid   "error: unknown command: %s\n"
 msgstr  ""
 
-#: client.go:374
+#: client.go:375
 #, c-format
 msgid   "expected error, got %s"
 msgstr  ""
 
-#: client.go:1085
+#: client.go:1086
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
@@ -541,7 +537,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1218
+#: client.go:1219
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -598,7 +594,7 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1448 client.go:1502
+#: client.go:1449 client.go:1503
 msgid   "no value found in %q\n"
 msgstr  ""
 
@@ -610,7 +606,7 @@ msgstr  ""
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
-#: client.go:811
+#: client.go:812
 msgid   "ok (y/n)? "
 msgstr  ""
 
@@ -629,7 +625,7 @@ msgstr  ""
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: client.go:256
+#: client.go:257
 msgid   "unknown remote name: %q"
 msgstr  ""
 


### PR DESCRIPTION
list is inherently racy:  get a list of containers, then check each
url for container details.  In between those GETs some containers
could be deleted.  Don't fail the 'lxc list' in that case, just ignore
the deleted container.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>