### PR TITLE
20150416.dbreorg.1.rebase

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -66,7 +66,6 @@ func doContainersGet(d *Daemon) ([]string, error) {
 	for _, r := range result {
 		container := string(r[0].(string))
 		url := fmt.Sprintf("/%s/containers/%s", shared.APIVersion, container)
-		shared.Debugf("ZZZZ doContainersGet: got string %s\n", container)
 		str = append(str, url)
 	}
 	return str, nil

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -47,6 +47,8 @@ func containersGet(d *Daemon, r *http.Request) Response {
 		}
 		// 1 s may seem drastic, but we really don't want to thrash
 		// perhaps we should use a random amount
+		shared.Debugf("DBERR: containersGet, db is locked\n")
+		shared.PrintStack()
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -55,30 +55,21 @@ func containersGet(d *Daemon, r *http.Request) Response {
 
 func doContainersGet(d *Daemon) ([]string, error) {
 	q := fmt.Sprintf("SELECT name FROM containers WHERE type=?")
-	rows, err := shared.DbQuery(d.db, q, cTypeRegular)
+	arg1 := []interface{}{cTypeRegular}
+	var container string
+	arg2 := []interface{}{container}
+	result, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	str := []string{}
 	if err != nil {
-		return []string{}, err
+		return str, err
 	}
-	defer rows.Close()
-
-	result := []string{}
-	for rows.Next() {
-		container := ""
-		err = rows.Scan(&container)
-		if err != nil {
-			shared.Debugf("DBERR: doContainersGet: scan returned error %q\n", err)
-			return []string{}, err
-		}
-
-		result = append(result, fmt.Sprintf("/%s/containers/%s", shared.APIVersion, container))
+	for _, r := range result {
+		container := string(r[0].(string))
+		url := fmt.Sprintf("/%s/containers/%s", shared.APIVersion, container)
+		shared.Debugf("ZZZZ doContainersGet: got string %s\n", container)
+		str = append(str, url)
 	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: doContainersGet: scan returned error %q\n", err)
-		return []string{}, err
-	}
-
-	return result, nil
+	return str, nil
 }
 
 type containerImageSource struct {
@@ -473,36 +464,31 @@ func containerGet(d *Daemon, r *http.Request) Response {
 func containerDeleteSnapshots(d *Daemon, cname string) []string {
 	prefix := fmt.Sprintf("%s/", cname)
 	length := len(prefix)
-	rows, err := shared.DbQuery(d.db, "SELECT name, id FROM containers WHERE type=? AND SUBSTR(name,1,?)=?",
-		cTypeSnapshot, length, prefix)
+	q := "SELECT name, id FROM containers WHERE type=? AND SUBSTR(name,1,?)=?"
+	var id int
+	var sname string
+	arg1 := []interface{}{cTypeSnapshot, length, prefix}
+	arg2 := []interface{}{sname, id}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return nil
 	}
 
-	var results []string
+	var response []string
 	var ids []int
 
-	for rows.Next() {
-		var id int
-		var sname string
-		err = rows.Scan(&sname, &id)
-		if err != nil {
-			shared.Debugf("DBERR: containerDeleteSnapshots: scan returned error %q\n", err)
-			break
-		}
+	for _, r := range results {
+		sname = r[0].(string)
+		id = r[1].(int)
 		ids = append(ids, id)
 		cdir := shared.VarPath("lxc", cname, "snapshots", sname)
-		results = append(results, cdir)
+		response = append(response, cdir)
 	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: containerDeleteSnapshots: Err returned an error %q\n", err)
-	}
-	rows.Close()
+
 	for _, id := range ids {
 		_, _ = shared.DbExec(d.db, "DELETE FROM containers WHERE id=?", id)
 	}
-	return results
+	return response
 }
 
 type containerConfigReq struct {
@@ -921,32 +907,25 @@ func (d *lxdContainer) applyConfig(config map[string]string) error {
 }
 
 func applyProfile(daemon *Daemon, d *lxdContainer, p string) error {
-	rows, err := shared.DbQuery(daemon.db, `SELECT key, value FROM profiles_config
+	q := `SELECT key, value FROM profiles_config
 		JOIN profiles ON profiles.id=profiles_config.profile_id
-		WHERE profiles.name=?`, p)
+		WHERE profiles.name=?`
+	var k, v string
+	arg1 := []interface{}{p}
+	arg2 := []interface{}{k, v}
+	result, err := shared.DbQueryScan(daemon.db, q, arg1, arg2)
 
 	if err != nil {
 		return err
 	}
-	defer rows.Close()
 
 	config := map[string]string{}
+	for _, r := range result {
+		k = r[0].(string)
+		v = r[1].(string)
 
-	for rows.Next() {
-		var k string
-		var v string
-		err = rows.Scan(&k, &v)
-		if err != nil {
-			shared.Debugf("DBERR: applyProfile: scan returned error %q\n", err)
-			return err
-		}
 		shared.Debugf("applying %s: %s", k, v)
 		config[k] = v
-	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: applyProfile: Err returned an error %q\n", err)
-		return err
 	}
 
 	newdevs, err := dbGetDevices(daemon, p, true)
@@ -1380,29 +1359,22 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 
 	regexp := fmt.Sprintf("%s/", cname)
 	length := len(regexp)
-	rows, err := shared.DbQuery(d.db, "SELECT name FROM containers WHERE type=? AND SUBSTR(name,1,?)=?",
-		cTypeSnapshot, length, regexp)
+	q := "SELECT name FROM containers WHERE type=? AND SUBSTR(name,1,?)=?"
+	var name string
+	arg1 := []interface{}{cTypeSnapshot, length, regexp}
+	arg2 := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return SmartError(err)
 	}
-	defer rows.Close()
 
 	var body []string
 
-	for rows.Next() {
-		var name string
-		err = rows.Scan(&name)
-		if err != nil {
-			shared.Debugf("DBERR: containerSnapshotsGet: scan returned error %q\n", err)
-			return InternalError(err)
-		}
+	for _, r := range results {
+		name = r[0].(string)
+
 		url := fmt.Sprintf("/%s/containers/%s/snapshots/%s", shared.APIVersion, cname, name)
 		body = append(body, url)
-	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: containerSnapshotsGet: Err returned an error %q\n", err)
-		return InternalError(err)
 	}
 
 	return SyncResponse(true, body)
@@ -1416,25 +1388,23 @@ func nextSnapshot(d *Daemon, name string) int {
 	base := fmt.Sprintf("%s/snap", name)
 	length := len(base)
 	q := fmt.Sprintf("SELECT MAX(name) FROM containers WHERE type=? AND SUBSTR(name,1,?)=?")
-	rows, err := shared.DbQuery(d.db, q, cTypeSnapshot, length, base)
+	var numstr string
+	arg1 := []interface{}{cTypeSnapshot, length, base}
+	arg2 := []interface{}{numstr}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return 0
 	}
-	defer rows.Close()
 	max := 0
-	for rows.Next() {
-		var tmp string
-		var num int
-		err = rows.Scan(&tmp)
-		if err != nil {
-			shared.Debugf("DBERR: nextSnapshot: scan returned error %q\n", err)
-			break
-		}
-		if len(tmp) <= length {
+
+	for _, r := range results {
+		numstr = r[0].(string)
+		if len(numstr) <= length {
 			continue
 		}
-		tmp2 := tmp[length:]
-		count, err := fmt.Sscanf(tmp2, "%d", &num)
+		substr := numstr[length:]
+		var num int
+		count, err := fmt.Sscanf(substr, "%d", &num)
 		if err != nil || count != 1 {
 			continue
 		}
@@ -1442,10 +1412,7 @@ func nextSnapshot(d *Daemon, name string) int {
 			max = num + 1
 		}
 	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: nextSnapshot: Err returned an error %q\n", err)
-	}
+
 	return max
 }
 

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -55,10 +55,10 @@ func containersGet(d *Daemon, r *http.Request) Response {
 
 func doContainersGet(d *Daemon) ([]string, error) {
 	q := fmt.Sprintf("SELECT name FROM containers WHERE type=?")
-	arg1 := []interface{}{cTypeRegular}
+	inargs := []interface{}{cTypeRegular}
 	var container string
-	arg2 := []interface{}{container}
-	result, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	outfmt := []interface{}{container}
+	result, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	str := []string{}
 	if err != nil {
 		return str, err
@@ -467,9 +467,9 @@ func containerDeleteSnapshots(d *Daemon, cname string) []string {
 	q := "SELECT name, id FROM containers WHERE type=? AND SUBSTR(name,1,?)=?"
 	var id int
 	var sname string
-	arg1 := []interface{}{cTypeSnapshot, length, prefix}
-	arg2 := []interface{}{sname, id}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{cTypeSnapshot, length, prefix}
+	outfmt := []interface{}{sname, id}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return nil
 	}
@@ -911,9 +911,9 @@ func applyProfile(daemon *Daemon, d *lxdContainer, p string) error {
 		JOIN profiles ON profiles.id=profiles_config.profile_id
 		WHERE profiles.name=?`
 	var k, v string
-	arg1 := []interface{}{p}
-	arg2 := []interface{}{k, v}
-	result, err := shared.DbQueryScan(daemon.db, q, arg1, arg2)
+	inargs := []interface{}{p}
+	outfmt := []interface{}{k, v}
+	result, err := shared.DbQueryScan(daemon.db, q, inargs, outfmt)
 
 	if err != nil {
 		return err
@@ -1361,9 +1361,9 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 	length := len(regexp)
 	q := "SELECT name FROM containers WHERE type=? AND SUBSTR(name,1,?)=?"
 	var name string
-	arg1 := []interface{}{cTypeSnapshot, length, regexp}
-	arg2 := []interface{}{name}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{cTypeSnapshot, length, regexp}
+	outfmt := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -1389,9 +1389,9 @@ func nextSnapshot(d *Daemon, name string) int {
 	length := len(base)
 	q := fmt.Sprintf("SELECT MAX(name) FROM containers WHERE type=? AND SUBSTR(name,1,?)=?")
 	var numstr string
-	arg1 := []interface{}{cTypeSnapshot, length, base}
-	arg2 := []interface{}{numstr}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{cTypeSnapshot, length, base}
+	outfmt := []interface{}{numstr}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return 0
 	}

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -579,9 +579,9 @@ func dbAddAlias(d *Daemon, name string, tgt int, desc string) error {
 func dbGetConfig(d *Daemon, c *lxdContainer) (map[string]string, error) {
 	q := `SELECT key, value FROM containers_config WHERE container_id=?`
 	var key, value string
-	arg1 := []interface{}{c.id}
-	arg2 := []interface{}{key, value}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{c.id}
+	outfmt := []interface{}{key, value}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}
@@ -615,9 +615,9 @@ func dbGetProfileConfig(d *Daemon, name string) (map[string]string, error) {
 		ON profiles_config.profile_id=profiles.id
 		WHERE name=?`
 	var key, value string
-	arg1 = []interface{}{name}
-	arg2 = []interface{}{key, value}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{name}
+	outfmt := []interface{}{key, value}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}
@@ -645,9 +645,9 @@ func dbGetProfiles(d *Daemon, c *lxdContainer) ([]string, error) {
 		ON containers_profiles.profile_id=profiles.id
 		WHERE container_id=? ORDER BY containers_profiles.apply_order`
 	var name string
-	arg1 := []interface{}{c.id}
-	arg2 := []interface{}{name}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{c.id}
+	outfmt := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}
@@ -672,9 +672,9 @@ func dbGetDeviceConfig(db *sql.DB, id int, isprofile bool) (shared.Device, error
 	}
 	newdev := shared.Device{}
 	var key, value string
-	arg1 := []interface{}{id}
-	arg2 := []interface{}{key, value}
-	results, err := shared.DbQueryScan(db, q, arg1, arg2)
+	inargs := []interface{}{id}
+	outfmt := []interface{}{key, value}
+	results, err := shared.DbQueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return newdev, err
 	}
@@ -703,9 +703,9 @@ func dbGetDevices(d *Daemon, qName string, isprofile bool) (shared.Devices, erro
 	}
 	var id int
 	var name, dtype string
-	arg1 := []interface{}{qName}
-	arg2 := []interface{}{id, name, dtype}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{qName}
+	outfmt := []interface{}{id, name, dtype}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -441,7 +441,7 @@ func initDb(d *Daemon) error {
 	var db *sql.DB
 	var err error
 	timeout := 5 // TODO - make this command-line configurable?
-	openPath := fmt.Sprintf("%s?_busy_timeout=%d&_txlock=immediate", dbpath, timeout*1000)
+	openPath := fmt.Sprintf("%s?_busy_timeout=%d&_txlock=exclusive", dbpath, timeout*1000)
 	if !shared.PathExists(dbpath) {
 		db, err = createDb(openPath)
 		if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -314,9 +314,9 @@ func doImagesGet(d *Daemon, recursion int, public bool) (interface{}, error) {
 	if public == true {
 		q = "SELECT fingerprint FROM images WHERE public=1"
 	}
-	arg1 := []interface{}{}
-	arg2 := []interface{}{name}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{}
+	outfmt := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
 	}
@@ -382,9 +382,9 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 
 	q := "SELECT key, value FROM images_properties where image_id=?"
 	var key, value, name, desc string
-	arg1 := []interface{}{imgInfo.Id}
-	arg2 := []interface{}{key, value}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{imgInfo.Id}
+	outfmt := []interface{}{key, value}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return shared.ImageInfo{}, SmartError(err)
 	}
@@ -396,9 +396,9 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 	}
 
 	q = "SELECT name, description FROM images_aliases WHERE image_id=?"
-	arg1 = []interface{}{imgInfo.Id}
-	arg2 = []interface{}{name, desc}
-	results, err = shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs = []interface{}{imgInfo.Id}
+	outfmt = []interface{}{name, desc}
+	results, err = shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return shared.ImageInfo{}, InternalError(err)
 	}
@@ -580,9 +580,9 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 func aliasesGet(d *Daemon, r *http.Request) Response {
 	q := "SELECT name FROM images_aliases"
 	var name string
-	arg1 := []interface{}{}
-	arg2 := []interface{}{name}
-	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	inargs := []interface{}{}
+	outfmt := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -306,28 +306,23 @@ func imagesGet(d *Daemon, r *http.Request) Response {
 }
 
 func doImagesGet(d *Daemon, recursion int, public bool) (interface{}, error) {
-	var err error
-	var rows *sql.Rows
 	result_string := make([]string, 0)
 	result_map := make([]shared.ImageInfo, 0)
 
+	q := "SELECT fingerprint FROM images"
+	var name string
 	if public == true {
-		rows, err = shared.DbQuery(d.db, "SELECT fingerprint FROM images WHERE public=1")
-	} else {
-		rows, err = shared.DbQuery(d.db, "SELECT fingerprint FROM images")
+		q = "SELECT fingerprint FROM images WHERE public=1"
 	}
+	arg1 := []interface{}{}
+	arg2 := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return []string{}, err
 	}
-	defer rows.Close()
 
-	for rows.Next() {
-		var name string
-		err = rows.Scan(&name)
-		if err != nil {
-			shared.Debugf("DBERR: doImagesGet: scan returned error %q\n", err)
-			return []string{}, err
-		}
+	for _, r := range results {
+		name = r[0].(string)
 		if recursion == 0 {
 			url := fmt.Sprintf("/%s/images/%s", shared.APIVersion, name)
 			result_string = append(result_string, url)
@@ -338,11 +333,6 @@ func doImagesGet(d *Daemon, recursion int, public bool) (interface{}, error) {
 			}
 			result_map = append(result_map, image)
 		}
-	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: doImagesGet: scan returned error %q\n", err)
-		return []string{}, err
 	}
 
 	if recursion == 0 {
@@ -390,48 +380,34 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 		return shared.ImageInfo{}, SmartError(err)
 	}
 
-	rows2, err := shared.DbQuery(d.db, "SELECT type, key, value FROM images_properties where image_id=?", imgInfo.Id)
+	q := "SELECT key, value FROM images_properties where image_id=?"
+	var key, value, name, desc string
+	arg1 := []interface{}{imgInfo.Id}
+	arg2 := []interface{}{key, value}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return shared.ImageInfo{}, SmartError(err)
 	}
-	defer rows2.Close()
 	properties := map[string]string{}
-	for rows2.Next() {
-		var key, value string
-		var imagetype int
-		err = rows2.Scan(&imagetype, &key, &value)
-		if err != nil {
-			shared.Debugf("DBERR: imageGet: scan returned error %q\n", err)
-			return shared.ImageInfo{}, InternalError(err)
-		}
+	for _, r := range results {
+		key = r[0].(string)
+		value = r[1].(string)
 		properties[key] = value
 	}
-	err = rows2.Err()
-	if err != nil {
-		shared.Debugf("DBERR: imageGet: Err returned an error %q\n", err)
-		return shared.ImageInfo{}, InternalError(err)
-	}
 
-	rows3, err := shared.DbQuery(d.db, "SELECT name, description FROM images_aliases WHERE image_id=?", imgInfo.Id)
+	q = "SELECT name, description FROM images_aliases WHERE image_id=?"
+	arg1 = []interface{}{imgInfo.Id}
+	arg2 = []interface{}{name, desc}
+	results, err = shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return shared.ImageInfo{}, InternalError(err)
 	}
-	defer rows3.Close()
 	aliases := shared.ImageAliases{}
-	for rows3.Next() {
-		var name, desc string
-		err = rows3.Scan(&name, &desc)
-		if err != nil {
-			shared.Debugf("DBERR: imageGet (2): scan returned error %q\n", err)
-			return shared.ImageInfo{}, InternalError(err)
-		}
+	for _, r := range results {
+		name = r[0].(string)
+		desc = r[0].(string)
 		a := shared.ImageAlias{Name: name, Description: desc}
 		aliases = append(aliases, a)
-	}
-	err = rows3.Err()
-	if err != nil {
-		shared.Debugf("DBERR: imageGet (2): Err returned an error %q\n", err)
-		return shared.ImageInfo{}, InternalError(err)
 	}
 
 	info := shared.ImageInfo{Fingerprint: imgInfo.Fingerprint,
@@ -602,29 +578,22 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 }
 
 func aliasesGet(d *Daemon, r *http.Request) Response {
-	rows, err := shared.DbQuery(d.db, "SELECT name FROM images_aliases")
+	q := "SELECT name FROM images_aliases"
+	var name string
+	arg1 := []interface{}{}
+	arg2 := []interface{}{name}
+	results, err := shared.DbQueryScan(d.db, q, arg1, arg2)
 	if err != nil {
 		return BadRequest(err)
 	}
-	defer rows.Close()
-	result := make([]string, 0)
-	for rows.Next() {
-		var name string
-		err = rows.Scan(&name)
-		if err != nil {
-			shared.Debugf("DBERR: aliasesGet: scan returned error %q\n", err)
-			return InternalError(err)
-		}
+	response := make([]string, 0)
+	for _, r := range results {
+		name = r[0].(string)
 		url := fmt.Sprintf("/%s/images/aliases/%s", shared.APIVersion, name)
-		result = append(result, url)
-	}
-	err = rows.Err()
-	if err != nil {
-		shared.Debugf("DBERR: aliasesGet: Err returned an error %q\n", err)
-		return InternalError(err)
+		response = append(response, url)
 	}
 
-	return SyncResponse(true, result)
+	return SyncResponse(true, response)
 }
 
 func aliasGet(d *Daemon, r *http.Request) Response {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -325,6 +325,7 @@ func doImagesGet(d *Daemon, recursion int, public bool) (interface{}, error) {
 		var name string
 		err = rows.Scan(&name)
 		if err != nil {
+			shared.Debugf("DBERR: doImagesGet: scan returned error %q\n", err)
 			return []string{}, err
 		}
 		if recursion == 0 {
@@ -340,6 +341,7 @@ func doImagesGet(d *Daemon, recursion int, public bool) (interface{}, error) {
 	}
 	err = rows.Err()
 	if err != nil {
+		shared.Debugf("DBERR: doImagesGet: scan returned error %q\n", err)
 		return []string{}, err
 	}
 
@@ -399,14 +401,14 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 		var imagetype int
 		err = rows2.Scan(&imagetype, &key, &value)
 		if err != nil {
-			fmt.Printf("DBERR: imageGet: scan returned error %q\n", err)
+			shared.Debugf("DBERR: imageGet: scan returned error %q\n", err)
 			return shared.ImageInfo{}, InternalError(err)
 		}
 		properties[key] = value
 	}
 	err = rows2.Err()
 	if err != nil {
-		fmt.Printf("DBERR: imageGet: Err returned an error %q\n", err)
+		shared.Debugf("DBERR: imageGet: Err returned an error %q\n", err)
 		return shared.ImageInfo{}, InternalError(err)
 	}
 
@@ -420,7 +422,7 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 		var name, desc string
 		err = rows3.Scan(&name, &desc)
 		if err != nil {
-			fmt.Printf("DBERR: imageGet (2): scan returned error %q\n", err)
+			shared.Debugf("DBERR: imageGet (2): scan returned error %q\n", err)
 			return shared.ImageInfo{}, InternalError(err)
 		}
 		a := shared.ImageAlias{Name: name, Description: desc}
@@ -428,7 +430,7 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 	}
 	err = rows3.Err()
 	if err != nil {
-		fmt.Printf("DBERR: imageGet (2): Err returned an error %q\n", err)
+		shared.Debugf("DBERR: imageGet (2): Err returned an error %q\n", err)
 		return shared.ImageInfo{}, InternalError(err)
 	}
 
@@ -610,7 +612,7 @@ func aliasesGet(d *Daemon, r *http.Request) Response {
 		var name string
 		err = rows.Scan(&name)
 		if err != nil {
-			fmt.Printf("DBERR: aliasesGet: scan returned error %q\n", err)
+			shared.Debugf("DBERR: aliasesGet: scan returned error %q\n", err)
 			return InternalError(err)
 		}
 		url := fmt.Sprintf("/%s/images/aliases/%s", shared.APIVersion, name)
@@ -618,7 +620,7 @@ func aliasesGet(d *Daemon, r *http.Request) Response {
 	}
 	err = rows.Err()
 	if err != nil {
-		fmt.Printf("DBERR: aliasesGet: Err returned an error %q\n", err)
+		shared.Debugf("DBERR: aliasesGet: Err returned an error %q\n", err)
 		return InternalError(err)
 	}
 

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -38,10 +38,10 @@ type profilesPostReq struct {
 
 func profilesGet(d *Daemon, r *http.Request) Response {
 	q := fmt.Sprintf("SELECT name FROM profiles")
-	arg1 := []interface{}{}
+	inargs := []interface{}{}
 	var name string
-	arg2 := []interface{}{name}
-	result, err := shared.DbQueryScan(d.db, q, arg1, arg2)
+	outfmt := []interface{}{name}
+	result, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -49,7 +49,7 @@ func profilesGet(d *Daemon, r *http.Request) Response {
 		name := ""
 		err = rows.Scan(&name)
 		if err != nil {
-			fmt.Printf("DBERR: profilesGet: scan returned error %q\n", err)
+			shared.Debugf("DBERR: profilesGet: scan returned error %q\n", err)
 			return InternalError(err)
 		}
 
@@ -57,7 +57,7 @@ func profilesGet(d *Daemon, r *http.Request) Response {
 	}
 	err = rows.Err()
 	if err != nil {
-		fmt.Printf("DBERR: profilesGet: Err returned an error %q\n", err)
+		shared.Debugf("DBERR: profilesGet: Err returned an error %q\n", err)
 		return InternalError(err)
 	}
 
@@ -180,7 +180,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 		var i int
 		err = rows.Scan(&i)
 		if err != nil {
-			fmt.Printf("DBERR: profilePut: scan returned error %q\n", err)
+			shared.Debugf("DBERR: profilePut: scan returned error %q\n", err)
 			tx.Rollback()
 			return InternalError(err)
 		}
@@ -189,7 +189,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 	rows.Close()
 	err = rows.Err()
 	if err != nil {
-		fmt.Printf("DBERR: profilePut: Err returned an error %q\n", err)
+		shared.Debugf("DBERR: profilePut: Err returned an error %q\n", err)
 		tx.Rollback()
 		return InternalError(err)
 	}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-04-16 12:29-0500\n"
+        "POT-Creation-Date: 2015-04-16 23:06-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-04-16 23:06-0500\n"
+        "POT-Creation-Date: 2015-04-17 14:04-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"

--- a/shared/db.go
+++ b/shared/db.go
@@ -2,10 +2,18 @@ package shared
 
 import (
 	"database/sql"
+	"fmt"
+	"runtime"
 	"time"
 
 	"github.com/mattn/go-sqlite3"
 )
+
+func PrintStack() {
+	buf := make([]byte, 1<<16)
+	runtime.Stack(buf, true)
+	fmt.Printf("%s", buf)
+}
 
 func IsDbLockedError(err error) bool {
 	if err == nil {
@@ -31,6 +39,7 @@ func TxCommit(tx *sql.Tx) error {
 			return err
 		}
 		Debugf("Txcommit: db was locked\n")
+		PrintStack()
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -46,6 +55,7 @@ func DbQueryRowScan(db *sql.DB, q string, args []interface{}, outargs []interfac
 			return err
 		}
 		Debugf("DbQueryRowScan: query %q args %q, DB was locked\n", q, args)
+		PrintStack()
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -61,6 +71,7 @@ func DbQuery(db *sql.DB, q string, args ...interface{}) (*sql.Rows, error) {
 			return nil, err
 		}
 		Debugf("DbQuery: query %q args %q, DB was locked\n", q, args)
+		PrintStack()
 		time.Sleep(1 * time.Second)
 	}
 }
@@ -76,6 +87,7 @@ func DbExec(db *sql.DB, q string, args ...interface{}) (sql.Result, error) {
 			return nil, err
 		}
 		Debugf("DbExec: query %q args %q, DB was locked\n", q, args)
+		PrintStack()
 		time.Sleep(1 * time.Second)
 	}
 }

--- a/shared/db.go
+++ b/shared/db.go
@@ -21,7 +21,6 @@ func IsDbLockedError(err error) bool {
 }
 
 func TxCommit(tx *sql.Tx) error {
-	slept := time.Millisecond * 0
 	for {
 		err := tx.Commit()
 		if err == nil {
@@ -31,36 +30,27 @@ func TxCommit(tx *sql.Tx) error {
 			Debugf("Txcommit: error %q\n", err)
 			return err
 		}
-		if slept == 30*time.Second {
-			Debugf("DB Locked for 30 seconds\n")
-			return err
-		}
-		time.Sleep(100 * time.Millisecond)
-		slept = slept + 100*time.Millisecond
+		Debugf("Txcommit: db was locked\n")
+		time.Sleep(1 * time.Second)
 	}
 }
 
 func DbQueryRowScan(db *sql.DB, q string, args []interface{}, outargs []interface{}) error {
-	slept := time.Millisecond * 0
 	for {
 		err := db.QueryRow(q, args...).Scan(outargs...)
 		if err == nil {
 			return nil
 		}
 		if !IsDbLockedError(err) {
+			Debugf("DbQuery: query %q error %q\n", q, err)
 			return err
 		}
-		if slept == 30*time.Second {
-			Debugf("DB Locked for 30 seconds\n")
-			return err
-		}
-		time.Sleep(100 * time.Millisecond)
-		slept = slept + 100*time.Millisecond
+		Debugf("DbQueryRowScan: query %q args %q, DB was locked\n", q, args)
+		time.Sleep(1 * time.Second)
 	}
 }
 
 func DbQuery(db *sql.DB, q string, args ...interface{}) (*sql.Rows, error) {
-	slept := time.Millisecond * 0
 	for {
 		result, err := db.Query(q, args...)
 		if err == nil {
@@ -70,17 +60,12 @@ func DbQuery(db *sql.DB, q string, args ...interface{}) (*sql.Rows, error) {
 			Debugf("DbQuery: query %q error %q\n", q, err)
 			return nil, err
 		}
-		if slept == 30*time.Second {
-			Debugf("DB Locked for 30 seconds\n")
-			return nil, err
-		}
-		time.Sleep(100 * time.Millisecond)
-		slept = slept + 100*time.Millisecond
+		Debugf("DbQuery: query %q args %q, DB was locked\n", q, args)
+		time.Sleep(1 * time.Second)
 	}
 }
 
 func DbExec(db *sql.DB, q string, args ...interface{}) (sql.Result, error) {
-	slept := time.Millisecond * 0
 	for {
 		result, err := db.Exec(q, args...)
 		if err == nil {
@@ -90,11 +75,7 @@ func DbExec(db *sql.DB, q string, args ...interface{}) (sql.Result, error) {
 			Debugf("DbExec: query %q error %q\n", q, err)
 			return nil, err
 		}
-		if slept == 30*time.Second {
-			Debugf("DB Locked for 30 seconds\n")
-			return nil, err
-		}
-		time.Sleep(100 * time.Millisecond)
-		slept = slept + 100*time.Millisecond
+		Debugf("DbExec: query %q args %q, DB was locked\n", q, args)
+		time.Sleep(1 * time.Second)
 	}
 }

--- a/shared/db.go
+++ b/shared/db.go
@@ -16,7 +16,7 @@ import (
 )
 
 func PrintStack() {
-	if ! debug || logger == nil {
+	if !debug || logger == nil {
 		return
 	}
 

--- a/shared/db.go
+++ b/shared/db.go
@@ -16,9 +16,13 @@ import (
 )
 
 func PrintStack() {
+	if ! debug || logger == nil {
+		return
+	}
+
 	buf := make([]byte, 1<<16)
 	runtime.Stack(buf, true)
-	fmt.Printf("%s", buf)
+	Debugf("%s", buf)
 }
 
 func IsDbLockedError(err error) bool {

--- a/test/concurrent.sh
+++ b/test/concurrent.sh
@@ -1,0 +1,28 @@
+test_concurrent() {
+  spawn_container() {
+    name=concurrent-${1}
+
+    lxc launch testimage ${name}
+    lxc list ${name} | grep RUNNING
+    echo abc | lxc exec ${name} -- cat | grep abc
+    lxc stop ${name} --force
+    lxc delete ${name}
+  }
+
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    return
+  fi
+
+  PIDS=""
+
+  for id in $(seq 50); do
+     spawn_container $id &
+     PIDS="$PIDS $!"
+  done
+
+  for pid in $PIDS; do
+      wait $pid || true
+  done
+
+  ! lxc list | grep -q concurrent
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -80,6 +80,7 @@ if [ -z "`which lxc`" ]; then
 fi
 
 . ./basic.sh
+. ./concurrent.sh
 . ./database.sh
 . ./fuidshift.sh
 . ./migration.sh
@@ -140,6 +141,9 @@ test_remote_admin
 
 echo "==> TEST: basic usage"
 test_basic_usage
+
+echo "==> TEST: concurrent startup"
+test_concurrent
 
 echo "==> TEST: lxc remote usage"
 test_remote_usage


### PR DESCRIPTION
This includes stgraber's concurrency test.  With this patchset, the chances of the concurrency test passing go up drastically.  (I've seen one failure but didn't track it down)

The new approach is:

1. use begin exclusive.  This way the db is fully locked at the 'begin'n time, which makes tx.commit safe
2. go back to a 5 second timeout in sqlite3
3. in our code, we retry forever when db is locked.  We sleep for 1 second between attempts to avoid thrashing.  Note - I think switching to 1 second + Random(0..100) milliseconds may be a good idea, but didn't d it here.
4. implement shared.DbQueryScan which wraps query and rows.scan loops.  It implements all the error checking and retries on locked database.
5. print the full lxd stack whenever we do get a db locked error.  this should eventually only be done when in debugging, or perhaps even in extra-debugging mode.