### PR TITLE
2015 04 21.push

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1148,6 +1148,11 @@ func newLxdContainer(name string, daemon *Daemon) (*lxdContainer, error) {
 	if err != nil {
 		return nil, err
 	}
+	logPath := shared.VarPath("lxc", name, "log")
+	err = c.SetConfigItem("lxc.logfile", logPath)
+	if err != nil {
+		return nil, err
+	}
 	err = c.SetConfigItem("lxc.loglevel", "0")
 	if err != nil {
 		return nil, err

--- a/test/main.sh
+++ b/test/main.sh
@@ -52,6 +52,9 @@ lxc() {
 }
 
 cleanup() {
+    if [ -n "$LXD_INSPECT" ]; then
+        read -p "Tests Completed ($RESULT): hit enter to continue" x
+    fi
     echo "==> Cleaning up"
 
     # Try to stop all the containers
@@ -99,7 +102,7 @@ spawn_lxd() {
   # overwrites the environment and we would lose LXD_DIR's value otherwise.
   local LXD_DIR
   echo "==> Spawning lxd on $1 in $2"
-  LXD_DIR=$2 lxd $debug --tcp $1 &
+  LXD_DIR=$2 lxd $debug --tcp $1 2>&1 | tee $2/lxd.log &
 
   echo "==> Confirming lxd on $1 is responsive"
   alive=0


### PR DESCRIPTION
A few updates to improve debugging:

1. set the container logfile to the file called 'log' in the container's dir (next to its rootfs)

2. if LXD_INSPECT is defined, wait until user hits enter before cleaning up, giving us a chance to inspect.
