### PR TITLE
testsuite improvements

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -341,6 +341,10 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 		output, err := exec.Command("rsync", "-a", "--devices", oldPath, newPath).CombinedOutput()
 		if err == nil && !source.isPrivileged() {
 			err = setUnprivUserAcl(d, dpath)
+			if err != nil {
+				shared.Debugf("Error adding acl for container root: start will likely fail\n")
+			}
+			err = nil
 		} else {
 			shared.Debugf("rsync failed:\n%s", output)
 		}

--- a/test/main.sh
+++ b/test/main.sh
@@ -190,8 +190,12 @@ test_snapshots
 echo "==> TEST: profiles, devices and configuration"
 test_config_profiles
 
-echo "==> TEST: uidshift"
-test_fuidshift
+if type fuidshift >/dev/null 2>&1; then
+    echo "==> TEST: uidshift"
+    test_fuidshift
+else
+    echo "==> SKIP: fuidshift (binary missing)"
+fi
 
 echo "==> TEST: migration"
 test_migration

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -25,8 +25,8 @@ test_migration() {
   lxc list l2: | grep RUNNING | grep nonlive
   lxc stop l2:nonlive --force
 
-  if [ -z "$(which criu)" ]; then
-      echo "==> Skipping live migration tests; no criu binary found"
+  if type criu >/dev/null 2>&1; then
+      echo "==> SKIP: live migration with CRIU (missing binary)"
       return
   fi
 

--- a/test/profiling.sh
+++ b/test/profiling.sh
@@ -21,6 +21,7 @@ test_cpu_profiling() {
     kill -TERM $lxdpid
     wait $lxdpid || true
     echo top5 | go tool pprof $(which lxd) ${LXD3_DIR}/cpu.out
+    echo ""
 }
 
 test_mem_profiling() {
@@ -36,5 +37,6 @@ test_mem_profiling() {
     kill -USR1 $lxdpid
     sleep 1s
     echo top5 | go tool pprof $(which lxd) ${LXD4_DIR}/mem
+    echo ""
     kill -9 $lxdpid
 }


### PR DESCRIPTION
It turns out some Travis nodes are running on filesystems without ACL support which is what caused all those failures in the copy test.