### PR TITLE
render both local and expanded config in /1.0/containers/<name>

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -601,7 +601,12 @@ func containerGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	return SyncResponse(true, c.RenderState())
+	state, err := c.RenderState()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return SyncResponse(true, state)
 }
 
 func containerDeleteSnapshots(d *Daemon, cname string) {
@@ -772,7 +777,6 @@ func emptyProfile(l []string) bool {
  */
 func containerPut(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	shared.Debugf("containerPut: called with name %s\n", name)
 	cId, err := dbGetContainerId(d.db, name)
 	if err != nil {
 		return NotFound
@@ -909,7 +913,12 @@ func containerStateGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	return SyncResponse(true, c.RenderState().Status)
+	state, err := c.RenderState()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return SyncResponse(true, state.Status)
 }
 
 type containerStatePutReq struct {
@@ -929,16 +938,28 @@ type lxdContainer struct {
 	ephemeral bool
 }
 
-func (c *lxdContainer) RenderState() *shared.ContainerState {
-	return &shared.ContainerState{
-		Name:      c.name,
-		Profiles:  c.profiles,
-		Config:    c.config,
-		Userdata:  []byte{},
-		Status:    shared.NewStatus(c.c, c.c.State()),
-		Devices:   c.devices,
-		Ephemeral: c.ephemeral,
+func (c *lxdContainer) RenderState() (*shared.ContainerState, error) {
+	devices, err := dbGetDevices(c.daemon, c.name, false)
+	if err != nil {
+		return nil, err
 	}
+
+	config, err := dbGetConfig(c.daemon, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &shared.ContainerState{
+		Name:            c.name,
+		Profiles:        c.profiles,
+		Config:          config,
+		ExpandedConfig:  c.config,
+		Userdata:        []byte{},
+		Status:          shared.NewStatus(c.c, c.c.State()),
+		Devices:         devices,
+		ExpandedDevices: c.devices,
+		Ephemeral:       c.ephemeral,
+	}, nil
 }
 
 func (c *lxdContainer) Start() error {

--- a/shared/container.go
+++ b/shared/container.go
@@ -62,13 +62,15 @@ type Device map[string]string
 type Devices map[string]Device
 
 type ContainerState struct {
-	Name      string            `json:"name"`
-	Profiles  []string          `json:"profiles"`
-	Config    map[string]string `json:"config"`
-	Userdata  []byte            `json:"userdata"`
-	Status    ContainerStatus   `json:"status"`
-	Devices   Devices           `json:"devices"`
-	Ephemeral bool              `json:"ephemeral"`
+	Name            string            `json:"name"`
+	Profiles        []string          `json:"profiles"`
+	Config          map[string]string `json:"config"`
+	ExpandedConfig  map[string]string `json:"expanded_config"`
+	Userdata        []byte            `json:"userdata"`
+	Status          ContainerStatus   `json:"status"`
+	Devices         Devices           `json:"devices"`
+	ExpandedDevices Devices           `json:"expanded_devices"`
+	Ephemeral       bool              `json:"ephemeral"`
 }
 
 func (c *ContainerState) State() lxc.State {

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -354,7 +354,15 @@ Output:
         'architecture': "x86_64",
         'hostname': "my-container",
         'config': {"resources.cpus": "3"},
+        'expanded_config': {"resources.cpus": "3"}  # the result of expanding profiles and adding the container's local config
         'devices': {
+            'rootfs': {
+                'type': "disk",
+                'path': "/",
+                'source': "UUID=8f7fdf5e-dc60-4524-b9fe-634f82ac2fb6"}
+            }
+        },
+        'expanded_devices': {  # the result of expanding profiles and adding the container's local devices
             'rootfs': {
                 'type': "disk",
                 'path': "/",


### PR DESCRIPTION
Since one of the intended uses for the output of GET is to update it so that
it can be PUT back to set container settings, we should render only the local
settings. We add the new keys expanded_* so that people can still see the
expanded config if they want.

Closes #568

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>