### PR TITLE
Container Start: exec a new lxd

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -347,7 +347,7 @@ func doProfileEdit(client *lxd.Client, p string) error {
 		}
 	}
 	data, err := yaml.Marshal(&profile)
-	f, err := ioutil.TempFile("", "lxc_profile_")
+	f, err := ioutil.TempFile("", "lxd_lxc_profile_")
 	if err != nil {
 		return err
 	}

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -335,7 +335,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			}
 		}
 		data, err := yaml.Marshal(&properties)
-		f, err := ioutil.TempFile("", "lxc_image_")
+		f, err := ioutil.TempFile("", "lxd_lxc_image_")
 		if err != nil {
 			return err
 		}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -974,7 +974,7 @@ func (c *lxdContainer) RenderState() (*shared.ContainerState, error) {
 
 func (c *lxdContainer) Start() error {
 
-	f, err := ioutil.TempFile("", "lxc_startconfig_")
+	f, err := ioutil.TempFile("", "lxd_lxc_startconfig_")
 	if err != nil {
 		return err
 	}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -43,6 +43,10 @@ func init() {
 }
 
 func run() error {
+	if os.Args[1] == "forkstart" {
+		return startContainer(os.Args[1:])
+	}
+
 	gnuflag.Usage = func() {
 		fmt.Printf("Usage: lxd [options]\n\nOptions:\n")
 		gnuflag.PrintDefaults()

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-01 07:53-0600\n"
+        "POT-Creation-Date: 2015-05-02 19:15+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"


### PR DESCRIPTION
In this way we avoid the [lxc monitor] having a copy of all of
lxd's old memory and fds.

With this commit, the amount of memory taken by each [lxc monitor]
task is at least an order of magnitude lower than without.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>