### PR TITLE
Added first run doc on importing images.

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -79,6 +79,9 @@ func run() error {
 		if err != nil {
 			return err
 		}
+
+		fmt.Fprintf(os.Stderr, gettext.Gettext("If this is your first run, you will need to import images using the 'lxd-images script'.\n"))
+		fmt.Fprintf(os.Stderr, gettext.Gettext("For example: 'lxd-images import lxc ubuntu trusty amd64 --alias ubuntu/trusty'.\n"))
 	}
 
 	err = cmd.run(config, gnuflag.Args())

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -182,12 +182,22 @@ msgid   "Fingers the LXD instance to check if it is up and working.\n"
         "lxc finger <remote>\n"
 msgstr  ""
 
+#: lxc/main.go:84
+msgid   "For example: 'lxd-images import lxc ubuntu trusty amd64 --alias "
+        "ubuntu/trusty'.\n"
+msgstr  ""
+
 #: lxc/action.go:34
 msgid   "Force the container to shutdown."
 msgstr  ""
 
 #: lxc/main.go:76
 msgid   "Generating a client certificate. This may take a minute...\n"
+msgstr  ""
+
+#: lxc/main.go:83
+msgid   "If this is your first run, you will need to import images using the "
+        "'lxd-images script'.\n"
 msgstr  ""
 
 #: lxc/image.go:282
@@ -507,7 +517,7 @@ msgstr  ""
 msgid   "error: %v\n"
 msgstr  ""
 
-#: lxc/main.go:86
+#: lxc/main.go:89
 msgid   "error: %v\n"
         "%s"
 msgstr  ""
@@ -637,7 +647,7 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:121
+#: lxc/main.go:124
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 


### PR DESCRIPTION
When we initially generate the client certificate, odds are this is the user's first run of the lxc client. Display a quick pointer to importing images, to save the user a round trip to the documentation.

I decided to print to stderr like the previous message does (so as to be consistent), but I think all of them should instead be printed on stdout (including the generation message). Let me know if it should be changed.

Signed-off-by: Christopher Glass <christopher.glass@canonical.com>