### PR TITLE
Fix fdleak race (in the test, not the actual leak)

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -222,13 +222,6 @@ func (d *Daemon) createCmd(version string, c Command) {
 			resp = NotFound
 		}
 
-		if err := resp.Render(w); err != nil {
-			err := InternalError(err).Render(w)
-			if err != nil {
-				shared.Debugf("failed writing error for error, giving up.")
-			}
-		}
-
 		/*
 		 * When we create a new lxc.Container, it adds a finalizer (via
 		 * SetFinalizer) that frees the struct. However, it sometimes
@@ -240,6 +233,13 @@ func (d *Daemon) createCmd(version string, c Command) {
 		 * end of each request.
 		 */
 		runtime.GC()
+
+		if err := resp.Render(w); err != nil {
+			err := InternalError(err).Render(w)
+			if err != nil {
+				shared.Debugf("failed writing error for error, giving up.")
+			}
+		}
 	})
 }
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -200,9 +200,8 @@ fi
 echo "==> TEST: migration"
 test_migration
 
-# Skip this for now, since it still seems to be broken.
-# echo "==> TEST: fdleak"
-# test_fdleak
+echo "==> TEST: fdleak"
+test_fdleak
 
 echo "==> TEST: cpu profiling"
 test_cpu_profiling


### PR DESCRIPTION
I think (?) our recent travis failures were simply due to a race in how we tested for leaks. Let's not do that.