### PR TITLE
skip fdleak test on broken lxc

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -200,8 +200,16 @@ fi
 echo "==> TEST: migration"
 test_migration
 
-echo "==> TEST: fdleak"
-test_fdleak
+curversion=`dpkg -s lxc | awk '/^Version/ { print $2 }'`
+if dpkg --compare-versions "$curversion" gt 1.1.2-0ubuntu3; then
+    echo "==> TEST: fdleak"
+    test_fdleak
+else
+    # We temporarily skip the fdleak test because a bug in lxc is
+    # known to make it # fail without lxc commit
+    # 858377e: # logs: introduce a thread-local 'current' lxc_config (v2)
+    echo "==> SKIPPING TEST: fdleak"
+fi
 
 echo "==> TEST: cpu profiling"
 test_cpu_profiling


### PR DESCRIPTION
The lxc_log_fd is per-thread in older lxc (including in the stable ppa
and vivid).  This means that each separate go thread will open a new log
fd, though a re-used thread will close an old fd to open a new one.

This is fixed in lxc by the per-thread logging patch, so just disable
the fdleak test for now if we are running known-broken lxc.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>