### PR TITLE
implement lxc info <resource> --show-log

### DIFF
--- a/client.go
+++ b/client.go
@@ -1102,10 +1102,11 @@ func (c *Client) Delete(name string) (*Response, error) {
 	return c.delete(url, nil, Async)
 }
 
-func (c *Client) ContainerStatus(name string) (*shared.ContainerState, error) {
+func (c *Client) ContainerStatus(name string, showLog bool) (*shared.ContainerState, error) {
 	ct := shared.ContainerState{}
+	query := url.Values{"log": []string{fmt.Sprintf("%v", showLog)}}
 
-	resp, err := c.get(fmt.Sprintf("containers/%s", name))
+	resp, err := c.get(fmt.Sprintf("containers/%s", name) + "?" + query.Encode())
 	if err != nil {
 		return nil, err
 	}
@@ -1285,7 +1286,7 @@ func (c *Client) ListSnapshots(container string) ([]string, error) {
  * return string array representing a container's full configuration
  */
 func (c *Client) GetContainerConfig(container string) ([]string, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	var resp []string
 	if err != nil {
 		return resp, err
@@ -1304,7 +1305,7 @@ func (c *Client) GetContainerConfig(container string) ([]string, error) {
 }
 
 func (c *Client) SetContainerConfig(container, key, value string) (*Response, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1415,7 +1416,7 @@ func (c *Client) ListProfiles() ([]string, error) {
 }
 
 func (c *Client) ApplyProfile(container, profile string) (*Response, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1426,7 +1427,7 @@ func (c *Client) ApplyProfile(container, profile string) (*Response, error) {
 }
 
 func (c *Client) ContainerDeviceDelete(container, devname string) (*Response, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1438,7 +1439,7 @@ func (c *Client) ContainerDeviceDelete(container, devname string) (*Response, er
 }
 
 func (c *Client) ContainerDeviceAdd(container, devname, devtype string, props []string) (*Response, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1464,7 +1465,7 @@ func (c *Client) ContainerDeviceAdd(container, devname, devtype string, props []
 }
 
 func (c *Client) ContainerListDevices(container string) ([]string, error) {
-	st, err := c.ContainerStatus(container)
+	st, err := c.ContainerStatus(container, false)
 	if err != nil {
 		return nil, err
 	}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -266,7 +266,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		resp, err := d.ContainerStatus(container)
+		resp, err := d.ContainerStatus(container, false)
 		if err != nil {
 			return err
 		}
@@ -368,7 +368,7 @@ func doProfileCreate(client *lxd.Client, p string) error {
 }
 
 func doConfigEdit(client *lxd.Client, cont string) error {
-	config, err := client.ContainerStatus(cont)
+	config, err := client.ContainerStatus(cont, false)
 	if err != nil {
 		return err
 	}

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -48,7 +48,7 @@ func copyContainer(config *lxd.Config, sourceResource string, destResource strin
 
 	status := shared.ContainerState{}
 	if !shared.IsSnapshot(sourceName) {
-		status, err := source.ContainerStatus(sourceName)
+		status, err := source.ContainerStatus(sourceName, false)
 		if err != nil {
 			return err
 		}

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -54,7 +54,7 @@ func (c *deleteCmd) run(config *lxd.Config, args []string) error {
 		return err
 	}
 
-	ct, err := d.ContainerStatus(name)
+	ct, err := d.ContainerStatus(name, false)
 
 	if err != nil {
 		// Could be a snapshot

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -5,9 +5,12 @@ import (
 
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/internal/gnuflag"
 )
 
-type infoCmd struct{}
+type infoCmd struct {
+	showLog bool
+}
 
 func (c *infoCmd) showByDefault() bool {
 	return true
@@ -19,10 +22,12 @@ func (c *infoCmd) usage() string {
 			"\n" +
 			"This will support remotes and images as well, but only containers for now.\n" +
 			"\n" +
-			"lxc info [<remote>:]container\n")
+			"lxc info [<remote>:]container [--show-log]\n")
 }
 
-func (c *infoCmd) flags() {}
+func (c *infoCmd) flags() {
+	gnuflag.BoolVar(&c.showLog, "show-log", false, gettext.Gettext("Show the container's last 100 log lines?"))
+}
 
 func (c *infoCmd) run(config *lxd.Config, args []string) error {
 	var remote string
@@ -42,7 +47,7 @@ func (c *infoCmd) run(config *lxd.Config, args []string) error {
 	if err != nil {
 		return err
 	}
-	ct, err := d.ContainerStatus(cName)
+	ct, err := d.ContainerStatus(cName, c.showLog)
 	if err != nil {
 		return err
 	}
@@ -73,6 +78,10 @@ func (c *infoCmd) run(config *lxd.Config, args []string) error {
 		}
 		fmt.Printf("  %s\n", snap)
 		first_snapshot = false
+	}
+
+	if c.showLog {
+		fmt.Printf("\nLog:\n\n%s\n", ct.Log)
 	}
 
 	return nil

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -98,7 +98,7 @@ func listContainers(client *lxd.Client, cts []string, filters []string, listsnap
 
 	for _, ct := range cts {
 		// get more information
-		c, err := client.ContainerStatus(ct)
+		c, err := client.ContainerStatus(ct, false)
 		d := []string{}
 		if err == nil {
 			d = []string{ct, c.Status.State}

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -42,7 +42,7 @@ func (c *moveCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		status, err := source.ContainerStatus(sourceName)
+		status, err := source.ContainerStatus(sourceName, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -616,6 +616,23 @@ func containerGet(d *Daemon, r *http.Request) Response {
 		return InternalError(err)
 	}
 
+	targetPath := r.FormValue("log")
+	if strings.ToLower(targetPath) == "true" || targetPath == "1" {
+		fname := c.c.LogFile()
+
+		f, err := os.Open(fname)
+		if err != nil {
+			return InternalError(err)
+		}
+		defer f.Close()
+
+		log, err := shared.ReadLastNLines(f, 100)
+		if err != nil {
+			return InternalError(err)
+		}
+		state.Log = log
+	}
+
 	return SyncResponse(true, state)
 }
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-06 14:57-0500\n"
+        "POT-Creation-Date: 2015-05-06 15:02-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -106,7 +106,7 @@ msgstr  ""
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1373
+#: client.go:1374
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -225,7 +225,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s\n"
 msgstr  ""
 
-#: lxc/info.go:37
+#: lxc/info.go:42
 msgid   "Information about remotes not yet supported\n"
 msgstr  ""
 
@@ -239,13 +239,13 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:18
+#: lxc/info.go:21
 msgid   "List information on containers.\n"
         "\n"
         "This will support remotes and images as well, but only containers "
         "for now.\n"
         "\n"
-        "lxc info [<remote>:]container\n"
+        "lxc info [<remote>:]container [--show-log]\n"
 msgstr  ""
 
 #: lxc/list.go:23
@@ -437,6 +437,10 @@ msgstr  ""
 msgid   "Show for server is not yet supported\n"
 msgstr  ""
 
+#: lxc/info.go:29
+msgid   "Show the container's last 100 log lines?"
+msgstr  ""
+
 #: lxc/image.go:224
 msgid   "Size: %.2vMB\n"
 msgstr  ""
@@ -493,7 +497,7 @@ msgstr  ""
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:502 client.go:1264 client.go:1271
+#: client.go:502 client.go:1265 client.go:1272
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -502,7 +506,7 @@ msgstr  ""
 msgid   "bad number of things scanned from resource"
 msgstr  ""
 
-#: client.go:1404
+#: client.go:1405
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -511,11 +515,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:506 client.go:1275
+#: client.go:506 client.go:1276
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1408
+#: client.go:1409
 msgid   "bad version in profile url"
 msgstr  ""
 
@@ -573,7 +577,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1210
+#: client.go:1211
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -630,7 +634,7 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1450 client.go:1504
+#: client.go:1451 client.go:1505
 msgid   "no value found in %q\n"
 msgstr  ""
 

--- a/shared/container.go
+++ b/shared/container.go
@@ -71,6 +71,7 @@ type ContainerState struct {
 	Devices         Devices           `json:"devices"`
 	ExpandedDevices Devices           `json:"expanded_devices"`
 	Ephemeral       bool              `json:"ephemeral"`
+	Log             string            `json:"log"`
 }
 
 /*

--- a/shared/util.go
+++ b/shared/util.go
@@ -612,3 +612,32 @@ func (r BytesReadCloser) Close() error {
 func IsSnapshot(name string) bool {
 	return strings.Contains(name, "/")
 }
+
+func ReadLastNLines(f *os.File, lines int) (string, error) {
+	if lines <= 0 {
+		return "", fmt.Errorf("invalid line count")
+	}
+
+	stat, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	data, err := syscall.Mmap(int(f.Fd()), 0, int(stat.Size()), syscall.PROT_READ, syscall.MAP_SHARED)
+	if err != nil {
+		return "", err
+	}
+	defer syscall.Munmap(data)
+
+	for i := len(data) - 1; i >= 0; i-- {
+		if data[i] == '\n' {
+			lines--
+		}
+
+		if lines < 0 {
+			return string(data[i+1 : len(data)]), nil
+		}
+	}
+
+	return string(data), nil
+}

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -1,8 +1,10 @@
 package shared
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -49,5 +51,52 @@ func TestCopyFile(t *testing.T) {
 	if string(content) != string(helloWorld) {
 		t.Error("content mismatch: ", string(content), "!=", string(helloWorld))
 		return
+	}
+}
+
+func TestReadLastNLines(t *testing.T) {
+	source, err := ioutil.TempFile("", "")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	defer os.Remove(source.Name())
+
+	for i := 0; i < 50; i++ {
+		fmt.Fprintf(source, "%d\n", i)
+	}
+
+	lines, err := ReadLastNLines(source, 100)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	split := strings.Split(lines, "\n")
+	for i := 0; i < 50; i++ {
+		if fmt.Sprintf("%d", i) != split[i] {
+			t.Error(fmt.Sprintf("got %s expected %d", split[i], i))
+			return
+		}
+	}
+
+	source.Seek(0, 0)
+	for i := 0; i < 150; i++ {
+		fmt.Fprintf(source, "%d\n", i)
+	}
+
+	lines, err = ReadLastNLines(source, 100)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	fmt.Println(lines)
+
+	split = strings.Split(lines, "\n")
+	for i := 0; i < 100; i++ {
+		if fmt.Sprintf("%d", i+50) != split[i] {
+			t.Error(fmt.Sprintf("got %s expected %d", split[i], i))
+			return
+		}
 	}
 }

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -339,12 +339,14 @@ Input (using a local container):
     }
 
 
-## /1.0/containers/\<name\>
+## /1.0/containers/\<name\>?log=true
 ### GET
  * Description: Container information
  * Authentication: trusted
  * Operation: sync
- * Return: dict of the container configuration and current state
+ * Return: dict of the container configuration and current state. If the
+   optional parameter log=true is supplied, the last 100 lines of the
+   container's log are rendered as well.
 
 Output:
 
@@ -378,7 +380,11 @@ Output:
                              'address': "2001:470:b368:1020:1::2"},
                             {'interface': "eth0",
                              'protocol': "INET",
-                             'address': "172.16.15.30"}]}
+                             'address': "172.16.15.30"}]},
+        'log': "lxc-checkpoint 1430925874.468 DEBUG    lxc_commands - commands.c:lxc_cmd_get_state:574 - 'u2' is in 'RUNNING' state
+                lxc-checkpoint 1430925874.468 ERROR    lxc_criu - criu.c:criu_version_ok:242 - No such file or directory - execing criu failed, is it installed?
+                ...",
+
     }
 
 


### PR DESCRIPTION
In a lot of cases it's useful look at the container's log; let's export that
via the api as well.

We add this as a query parameter instead of doing it all the time so that we
avoid opening the file unless people really want to see the log info.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>