### PR TITLE
Refactored db.go and added ON DELETE CASCADE

### DIFF
--- a/lxd/db.go
+++ b/lxd/db.go
@@ -18,13 +18,11 @@ var (
 	DbErrAlreadyDefined = fmt.Errorf("already exists")
 )
 
-func createDb(p string) (*sql.DB, error) {
-	db, err := sql.Open("sqlite3", p)
-	if err != nil {
-		return nil, fmt.Errorf("Error creating database: %s\n", err)
-	}
+// Create the initial schema for a given SQLite DB connection.
+// This is indempotent, using the CREATE TABLE IF NOT EXISTS stanza.
+func createDb(db *sql.DB) (err error) {
 	stmt := `
-CREATE TABLE certificates (
+CREATE TABLE IF NOT EXISTS certificates (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     fingerprint VARCHAR(255) NOT NULL,
     type INTEGER NOT NULL,
@@ -32,13 +30,13 @@ CREATE TABLE certificates (
     certificate TEXT NOT NULL,
     UNIQUE (fingerprint)
 );
-CREATE TABLE config (
+CREATE TABLE IF NOT EXISTS config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
     UNIQUE (key)
 );
-CREATE TABLE containers (
+CREATE TABLE IF NOT EXISTS containers (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     architecture INTEGER NOT NULL,
@@ -47,40 +45,40 @@ CREATE TABLE containers (
     ephemeral INTEGER NOT NULL DEFAULT 0,
     UNIQUE (name)
 );
-CREATE TABLE containers_config (
+CREATE TABLE IF NOT EXISTS containers_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     container_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
-    FOREIGN KEY (container_id) REFERENCES containers (id),
+    FOREIGN KEY (container_id) REFERENCES containers (id) ON DELETE CASCADE,
     UNIQUE (container_id, key)
 );
-CREATE TABLE containers_devices (
+CREATE TABLE IF NOT EXISTS containers_devices (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_id INTEGER NOT NULL,
     name VARCHAR(255) NOT NULL,
     type INTEGER NOT NULL default 0,
-    FOREIGN KEY (container_id) REFERENCES containers (id),
+    FOREIGN KEY (container_id) REFERENCES containers (id) ON DELETE CASCADE,
     UNIQUE (container_id, name)
 );
-CREATE TABLE containers_devices_config (
+CREATE TABLE IF NOT EXISTS containers_devices_config (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_device_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
-    FOREIGN KEY (container_device_id) REFERENCES containers_devices (id),
+    FOREIGN KEY (container_device_id) REFERENCES containers_devices (id) ON DELETE CASCADE,
     UNIQUE (container_device_id, key)
 );
-CREATE TABLE containers_profiles (
+CREATE TABLE IF NOT EXISTS containers_profiles (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_id INTEGER NOT NULL,
     profile_id INTEGER NOT NULL,
     apply_order INTEGER NOT NULL default 0,
     UNIQUE (container_id, profile_id),
-    FOREIGN KEY (container_id) REFERENCES containers(id),
-    FOREIGN KEY (profile_id) REFERENCES profiles(id)
+    FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
 );
-CREATE TABLE images (
+CREATE TABLE IF NOT EXISTS images (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     fingerprint VARCHAR(255) NOT NULL,
     filename VARCHAR(255) NOT NULL,
@@ -92,7 +90,7 @@ CREATE TABLE images (
     upload_date DATETIME NOT NULL,
     UNIQUE (fingerprint)
 );
-CREATE TABLE images_aliases (
+CREATE TABLE IF NOT EXISTS images_aliases (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     image_id INTEGER NOT NULL,
@@ -100,7 +98,7 @@ CREATE TABLE images_aliases (
     FOREIGN KEY (image_id) REFERENCES images (id),
     UNIQUE (name)
 );
-CREATE TABLE images_properties (
+CREATE TABLE IF NOT EXISTS images_properties (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     image_id INTEGER NOT NULL,
     type INTEGER NOT NULL,
@@ -108,36 +106,36 @@ CREATE TABLE images_properties (
     value TEXT,
     FOREIGN KEY (image_id) REFERENCES images (id)
 );
-CREATE TABLE profiles (
+CREATE TABLE IF NOT EXISTS profiles (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     UNIQUE (name)
 );
-CREATE TABLE profiles_config (
+CREATE TABLE IF NOT EXISTS profiles_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
     value VARCHAR(255),
     UNIQUE (profile_id, key),
-    FOREIGN KEY (profile_id) REFERENCES profiles(id)
+    FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
 );
-CREATE TABLE profiles_devices (
+CREATE TABLE IF NOT EXISTS profiles_devices (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_id INTEGER NOT NULL,
     name VARCHAR(255) NOT NULL,
     type INTEGER NOT NULL default 0,
     UNIQUE (profile_id, name),
-    FOREIGN KEY (profile_id) REFERENCES profiles (id)
+    FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE
 );
-CREATE TABLE profiles_devices_config (
+CREATE TABLE IF NOT EXISTS profiles_devices_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_device_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
     UNIQUE (profile_device_id, key),
-    FOREIGN KEY (profile_device_id) REFERENCES profiles_devices (id)
+    FOREIGN KEY (profile_device_id) REFERENCES profiles_devices (id) ON DELETE CASCADE
 );
-CREATE TABLE schema (
+CREATE TABLE IF NOT EXISTS schema (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     version INTEGER NOT NULL,
     updated_at DATETIME NOT NULL,
@@ -147,12 +145,12 @@ INSERT INTO schema (version, updated_at) values (?, strftime("%s"));`
 
 	_, err = db.Exec(stmt, DB_CURRENT_VERSION)
 	if err != nil {
-		return db, err
+		return err
 	}
 
 	err = createDefaultProfile(db)
 
-	return db, err
+	return err
 }
 
 func getSchema(db *sql.DB) (int, error) {
@@ -178,7 +176,7 @@ INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
 
 func updateFromV4(db *sql.DB) error {
 	stmt := `
-CREATE TABLE config (
+CREATE TABLE IF NOT EXISTS config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     key VARCHAR(255) NOT NULL,
     value TEXT,
@@ -226,15 +224,15 @@ func updateFromV3(db *sql.DB) error {
 
 func updateFromV2(db *sql.DB) error {
 	stmt := `
-CREATE TABLE containers_devices (
+CREATE TABLE IF NOT EXISTS containers_devices (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_id INTEGER NOT NULL,
     name VARCHAR(255) NOT NULL,
     type INTEGER NOT NULL default 0,
-    FOREIGN KEY (container_id) REFERENCES containers (id),
+    FOREIGN KEY (container_id) REFERENCES containers (id) ON DELETE CASCADE,
     UNIQUE (container_id, name)
 );
-CREATE TABLE containers_devices_config (
+CREATE TABLE IF NOT EXISTS containers_devices_config (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_device_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
@@ -242,37 +240,37 @@ CREATE TABLE containers_devices_config (
     FOREIGN KEY (container_device_id) REFERENCES containers_devices (id),
     UNIQUE (container_device_id, key)
 );
-CREATE TABLE containers_profiles (
+CREATE TABLE IF NOT EXISTS containers_profiles (
     id INTEGER primary key AUTOINCREMENT NOT NULL,
     container_id INTEGER NOT NULL,
     profile_id INTEGER NOT NULL,
     apply_order INTEGER NOT NULL default 0,
     UNIQUE (container_id, profile_id),
-    FOREIGN KEY (container_id) REFERENCES containers(id),
-    FOREIGN KEY (profile_id) REFERENCES profiles(id)
+    FOREIGN KEY (container_id) REFERENCES containers(id) ON DELETE CASCADE,
+    FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
 );
-CREATE TABLE profiles (
+CREATE TABLE IF NOT EXISTS profiles (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     UNIQUE (name)
 );
-CREATE TABLE profiles_config (
+CREATE TABLE IF NOT EXISTS profiles_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
     value VARCHAR(255),
     UNIQUE (profile_id, key),
-    FOREIGN KEY (profile_id) REFERENCES profiles(id)
+    FOREIGN KEY (profile_id) REFERENCES profiles(id) ON DELETE CASCADE
 );
-CREATE TABLE profiles_devices (
+CREATE TABLE IF NOT EXISTS profiles_devices (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_id INTEGER NOT NULL,
     name VARCHAR(255) NOT NULL,
     type INTEGER NOT NULL default 0,
     UNIQUE (profile_id, name),
-    FOREIGN KEY (profile_id) REFERENCES profiles (id)
+    FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE
 );
-CREATE TABLE profiles_devices_config (
+CREATE TABLE IF NOT EXISTS profiles_devices_config (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     profile_device_id INTEGER NOT NULL,
     key VARCHAR(255) NOT NULL,
@@ -289,7 +287,7 @@ INSERT INTO schema (version, updated_at) values (?, strftime("%s"));`
 func updateFromV1(db *sql.DB) error {
 	// v1..v2 adds images aliases
 	stmt := `
-CREATE TABLE images_aliases (
+CREATE TABLE IF NOT EXISTS images_aliases (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     name VARCHAR(255) NOT NULL,
     image_id INTEGER NOT NULL,
@@ -305,7 +303,7 @@ INSERT INTO schema (version, updated_at) values (?, strftime("%s"));`
 func updateFromV0(db *sql.DB) error {
 	// v0..v1 adds schema table
 	stmt := `
-CREATE TABLE schema (
+CREATE TABLE IF NOT EXISTS schema (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     version INTEGER NOT NULL,
     updated_at DATETIME NOT NULL,
@@ -434,39 +432,49 @@ func createDefaultProfile(db *sql.DB) error {
 	return nil
 }
 
-func initDb(d *Daemon) error {
-	dbpath := shared.VarPath("lxd.db")
-	var db *sql.DB
-	var err error
+// Create a database connection object and return it.
+func initializeDbObject(openPath string) (db *sql.DB, err error) {
 	timeout := 5 // TODO - make this command-line configurable?
-	openPath := fmt.Sprintf("%s?_busy_timeout=%d&_txlock=exclusive", dbpath, timeout*1000)
-	if !shared.PathExists(dbpath) {
-		db, err = createDb(openPath)
-		if err != nil {
-			return err
-		}
-	} else {
-		db, err = sql.Open("sqlite3", openPath)
-		if err != nil {
-			return err
-		}
+
+	// Open the database. If the file doesn't exist it is created.
+	db, err = sql.Open("sqlite3", openPath)
+	if err != nil {
+		return nil, err
 	}
 
-	d.db = db
+	// Table creation is indempotent, run it every time
+	err = createDb(db)
+	if err != nil {
+		return nil, fmt.Errorf("Error creating database: %s\n", err)
+	}
+
+	// Run PRAGMA statements now since they are *per-connection*.
+	// err is not checked because SQLite explicitely doesn't error out on wrong
+	// pragma statements (it always succeeds, but is ignored if invalid).
+	db.Exec(fmt.Sprintf("PRAGMA busy_timeout = %d;", timeout*1000))
+	db.Exec("PRAGMA locking_mode = EXCLUSIVE;")
+	db.Exec("PRAGMA foreign_keys=ON;") // This allows us to use ON DELETE CASCADE
 
 	v, err := getSchema(db)
 	if err != nil {
-		return fmt.Errorf("Bad database, or database too new for this lxd version")
+		return nil, fmt.Errorf("Bad database, or database too new for this lxd version")
 	}
 
 	if v != DB_CURRENT_VERSION {
 		err = updateDb(db, v)
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
 
-	return nil
+	return db, nil
+}
+
+// Initialize a database connection and set it on the daemon.
+func initDb(d *Daemon) (err error) {
+	openPath := shared.VarPath("lxd.db")
+	d.db, err = initializeDbObject(openPath)
+	return
 }
 
 var NoSuchImageError = errors.New("No such image")

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -204,3 +204,18 @@ func Test_initializing_db_is_indempotent(t *testing.T) {
 		t.Error("The database schema is not indempotent.")
 	}
 }
+
+func Test_get_schema_returns_0_on_uninitialized_db(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	db, err = sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Error(err)
+	}
+	var result int = getSchema(db)
+
+	if result != 0 {
+		t.Error("getSchema should return 0 on uninitialized db!")
+	}
+}

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -189,3 +189,18 @@ func Test_deleting_an_image_cascades_on_related_tables(t *testing.T) {
 		t.Error(fmt.Sprintf("Deleting an image didn't delete the related images_properties! There are %d left", count))
 	}
 }
+
+func Test_initializing_db_is_indempotent(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	// This calls "createDb" once already.
+	db, err = initializeDbObject(":memory:")
+	defer db.Close()
+
+	// Let's call it a second time.
+	err = createDb(db)
+	if err != nil {
+		t.Error("The database schema is not indempotent.")
+	}
+}

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+)
+
+func Test_deleting_a_container_cascades_on_related_tables(t *testing.T) {
+	var db *sql.DB
+	var err error
+	var count int
+
+	db, err = initializeDbObject(":memory:")
+	defer db.Close()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Insert a container and a related profile.
+	statements := `
+    INSERT INTO containers (name, architecture, type) VALUES ('thename', 1, 1);
+    INSERT INTO profiles (name) VALUES ('theprofile');
+    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 2);
+    INSERT INTO containers_config (container_id, key, value) VALUES (1, 'thekey', 'thevalue');
+    INSERT INTO containers_devices (container_id, name) VALUES (1, 'somename');
+    INSERT INTO containers_devices_config (key, value, container_device_id) VALUES ('configkey', 'configvalue', 1);`
+
+	_, err = db.Exec(statements)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Drop the container we just created.
+	statements = `DELETE FROM containers WHERE name = 'thename';`
+
+	_, err = db.Exec(statements)
+	if err != nil {
+		t.Error(fmt.Sprintf("Error deleting container! %s", err))
+	}
+
+	// Make sure there are 0 container_profiles entries left.
+	statements = `SELECT count(*) FROM containers_profiles;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a container didn't delete the profile association! There are %d left", count))
+	}
+
+	// Make sure there are 0 containers_config entries left.
+	statements = `SELECT count(*) FROM containers_config;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a container didn't delete the associated container_config! There are %d left", count))
+	}
+
+	// Make sure there are 0 containers_devices entries left.
+	statements = `SELECT count(*) FROM containers_devices;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a container didn't delete the associated container_devices! There are %d left", count))
+	}
+
+	// Make sure there are 0 containers_devices_config entries left.
+	statements = `SELECT count(*) FROM containers_devices_config;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a container didn't delete the associated container_devices_config! There are %d left", count))
+	}
+
+}
+
+func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
+	var db *sql.DB
+	var err error
+	var count int
+
+	db, err = initializeDbObject(":memory:")
+	defer db.Close()
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Insert a container and a related profile. Dont't forget that the profile
+	// we insert is profile ID 2 (there is a default profile already).
+	statements := `
+    INSERT INTO containers (name, architecture, type) VALUES ('thename', 1, 1);
+    INSERT INTO profiles (name) VALUES ('theprofile');
+    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 2);
+    INSERT INTO profiles_devices (name, profile_id) VALUES ('somename', 2);
+    INSERT INTO profiles_config (key, value, profile_id) VALUES ('thekey', 'thevalue', 2);
+    INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (1, 'something', 'boring');`
+
+	_, err = db.Exec(statements)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that there is exactly one containers_profile entry.
+	statements = `SELECT count(*) FROM containers_profiles;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 1 {
+		t.Error(fmt.Sprintf("Wut? There's an exata containers_profile! There are %d", count))
+	}
+
+	// Drop the profile we just created.
+	statements = `DELETE FROM profiles WHERE name = 'theprofile';`
+
+	_, err = db.Exec(statements)
+	if err != nil {
+		t.Error(fmt.Sprintf("Error deleting profile! %s", err))
+	}
+
+	// Make sure there is 0 container_profiles entries left.
+	statements = `SELECT count(*) FROM containers_profiles;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a profile didn't delete the container association! There are %d left", count))
+	}
+
+	// Make sure there is 0 profiles_devices entries left.
+	statements = `SELECT count(*) FROM profiles_devices WHERE profile_id != 1;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a profile didn't delete the related profiles_devices! There are %d left", count))
+	}
+
+	// Make sure there is 0 profiles_config entries left.
+	statements = `SELECT count(*) FROM profiles_config;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a profile didn't delete the related profiles_config! There are %d left", count))
+	}
+
+	// Make sure there is 0 profiles_devices_config entries left.
+	statements = `SELECT count(*) FROM profiles_devices_config WHERE profeil_device_id != 1;`
+	err = db.QueryRow(statements).Scan(&count)
+
+	if count != 0 {
+		t.Error(fmt.Sprintf("Deleting a profile didn't delete the related profiles_devices_config! There are %d left", count))
+	}
+
+}


### PR DESCRIPTION
Resubmission of https://github.com/lxc/lxd/pull/605 since the previous branch was a bit weird.

This should fix https://github.com/lxc/lxd/issues/570 by enabling ON DELETE CASCADE on most of the schema. Some cascades are needed for the image-related tables, but that will come in another branch.

* Added ON DELETE CASCADE behavior to the tables related to containers
* Added ON DELETE CASCADE behavior to the tables related to profiles
* Added an extra db_test.go test file for unit testing.

Signed-off-by: Christopher Glass <christopher.glass@canonical.com>