### PR TITLE
Fix shebang in lxd-images.

### DIFF
--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # Let's stick to core python3 modules
 import argparse
 import gettext


### PR DESCRIPTION
NixOS and possibly other OSs only have the deterministic unix binaries `/bin/sh` and `/usr/bin/env`. All other software is in paths determined by build inputs.