### PR TITLE
Fix orphaned foreign keys, add tests to DB upgrades

### DIFF
--- a/test/database_update.sh
+++ b/test/database_update.sh
@@ -8,15 +8,15 @@ rm -f ${LXD_MIGRATE_DIR}/lxd.db
 cat schema1.sql | sqlite3 ${MIGRATE_DB} > /dev/null
 
 # Start an LXD demon in the tmp directory. This should start the updates.
-spawn_lxd 127.0.0.1:18445 "${LXD_MIGRATE_DIR}"
+spawn_lxd 127.0.0.1:18447 "${LXD_MIGRATE_DIR}"
 
 # Assert there are enough tables.
 expected_tables=15
 tables=`sqlite3 ${MIGRATE_DB} ".d" | grep "CREATE TABLE" | wc -l`
-! [ $tables -eq $expected_tables ] && echo "FAIL: Wrong number of tables after database migration! Found: $tables, expected $expected_tables!" return 1
+[ $tables -eq $expected_tables ] || { echo "FAIL: Wrong number of tables after database migration. Found: $tables, expected $expected_tables"; false; }
 
 # There should be 10 "ON DELETE CASCADE" occurences
 expected_cascades=10
 cascades=`sqlite3 ${MIGRATE_DB} ".d" | grep "ON DELETE CASCADE" | wc -l`
-! [ $cascades -eq $expected_cascades ] && echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys! Found: $cascades, exected: $expected_cascades"; return 1
+[ $cascades -eq $expected_cascades ] || { echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys. Found: $cascades, exected: $expected_cascades"; false; }
 }

--- a/test/database_update.sh
+++ b/test/database_update.sh
@@ -1,0 +1,22 @@
+test_database_update(){
+export LXD_MIGRATE_DIR=$(mktemp -d -p $(pwd))
+MIGRATE_DB=${LXD_MIGRATE_DIR}/lxd.db
+
+# Nuke preexisting database if it exists
+rm -f ${LXD_MIGRATE_DIR}/lxd.db
+# Create the version 1 schema as the database
+cat schema1.sql | sqlite3 ${MIGRATE_DB} > /dev/null
+
+# Start an LXD demon in the tmp directory. This should start the updates.
+spawn_lxd 127.0.0.1:18445 "${LXD_MIGRATE_DIR}"
+
+# Assert there are enough tables.
+expected_tables=15
+tables=`sqlite3 ${MIGRATE_DB} ".d" | grep "CREATE TABLE" | wc -l`
+! [ $tables -eq $expected_tables ] && echo "FAIL: Wrong number of tables after database migration! Found: $tables, expected $expected_tables!" return 1
+
+# There should be 10 "ON DELETE CASCADE" occurences
+expected_cascades=10
+cascades=`sqlite3 ${MIGRATE_DB} ".d" | grep "ON DELETE CASCADE" | wc -l`
+! [ $cascades -eq $expected_cascades ] && echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys! Found: $cascades, exected: $expected_cascades"; return 1
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -96,6 +96,7 @@ cleanup() {
     [ -n "${LXD2_DIR}" ] && wipe "${LXD2_DIR}"
     [ -n "${LXD3_DIR}" ] && wipe "${LXD3_DIR}"
     [ -n "${LXD4_DIR}" ] && wipe "${LXD4_DIR}"
+    [ -n "${LXD_MIGRATE_DIR}" ] && wipe "${LXD_MIGRATE_DIR}"
 
     echo ""
     echo ""
@@ -120,6 +121,7 @@ fi
 . ./config.sh
 . ./profiling.sh
 . ./fdleak.sh
+. ./database_update.sh
 
 if [ -n "$LXD_DEBUG" ]; then
     debug=--debug
@@ -166,6 +168,9 @@ test_commits_signed_off
 
 echo "==> TEST: doing static analysis of commits"
 static_analysis
+
+echo "==> TEST: Database schema update"
+test_database_update
 
 echo "==> TEST: lxc remote url"
 test_remote_url

--- a/test/schema1.sql
+++ b/test/schema1.sql
@@ -1,0 +1,51 @@
+-- Database schema version 1 as taken from febb96e8164fbd189698da77383c26ce68b9762a
+CREATE TABLE certificates (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    fingerprint VARCHAR(255) NOT NULL,
+    type INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    certificate TEXT NOT NULL,
+    UNIQUE (fingerprint)
+);
+CREATE TABLE containers (
+    id INTEGER primary key AUTOINCREMENT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    architecture INTEGER NOT NULL,
+    type INTEGER NOT NULL,
+    UNIQUE (name)
+);
+CREATE TABLE containers_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    container_id INTEGER NOT NULL,
+    key VARCHAR(255) NOT NULL,
+    value TEXT,
+    FOREIGN KEY (container_id) REFERENCES containers (id),
+    UNIQUE (container_id, key)
+);
+CREATE TABLE images (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    fingerprint VARCHAR(255) NOT NULL,
+    filename VARCHAR(255) NOT NULL,
+    size INTEGER NOT NULL,
+    public INTEGER NOT NULL DEFAULT 0,
+    architecture INTEGER NOT NULL,
+    creation_date DATETIME,
+    expiry_date DATETIME,
+    upload_date DATETIME NOT NULL,
+    UNIQUE (fingerprint)
+);
+CREATE TABLE images_properties (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    image_id INTEGER NOT NULL,
+    type INTEGER NOT NULL,
+    key VARCHAR(255) NOT NULL,
+    value TEXT,
+    FOREIGN KEY (image_id) REFERENCES images (id)
+);
+CREATE TABLE schema (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    version INTEGER NOT NULL,
+    updated_at DATETIME NOT NULL,
+    UNIQUE (version)
+);
+INSERT INTO schema (version, updated_at) values (1, "now");


### PR DESCRIPTION
This branch adds a system test (bash tests) layer to cover database migrations in general, and the move to foreign keys with on delete cascade in particular.

This would have caught several errors introduced recently, and so should future proof future schema changes.

LXD developers running from master should probably clean their stale database foreign keys themselves, but users should not have to once they upgrade to this code.