### PR TITLE
Changed ".d" for the longer ".dump"

### DIFF
--- a/test/database_update.sh
+++ b/test/database_update.sh
@@ -12,11 +12,11 @@ spawn_lxd 127.0.0.1:18447 "${LXD_MIGRATE_DIR}"
 
 # Assert there are enough tables.
 expected_tables=15
-tables=`sqlite3 ${MIGRATE_DB} ".d" | grep "CREATE TABLE" | wc -l`
+tables=`sqlite3 ${MIGRATE_DB} ".dump" | grep "CREATE TABLE" | wc -l`
 [ $tables -eq $expected_tables ] || { echo "FAIL: Wrong number of tables after database migration. Found: $tables, expected $expected_tables"; false; }
 
 # There should be 10 "ON DELETE CASCADE" occurences
 expected_cascades=10
-cascades=`sqlite3 ${MIGRATE_DB} ".d" | grep "ON DELETE CASCADE" | wc -l`
+cascades=`sqlite3 ${MIGRATE_DB} ".dump" | grep "ON DELETE CASCADE" | wc -l`
 [ $cascades -eq $expected_cascades ] || { echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys. Found: $cascades, exected: $expected_cascades"; false; }
 }


### PR DESCRIPTION
It seems on some SQLite vesions the shorthand command .d points to
.dbinfo instead.

Signed-off-by: Christopher Glass <christopher.glass@canonical.com>