### PR TITLE
Use the right name for certificates

### DIFF
--- a/client.go
+++ b/client.go
@@ -806,13 +806,13 @@ func (c *Client) UserAuthServerCert(name string) error {
 	return err
 }
 
-func (c *Client) CertificateList() (map[string]string, error) {
+func (c *Client) CertificateList() ([]string, error) {
 	raw, err := c.get("certificates")
 	if err != nil {
 		return nil, err
 	}
 
-	ret := make(map[string]string)
+	ret := []string{}
 	if err := json.Unmarshal(raw.Metadata, &ret); err != nil {
 		return nil, err
 	}

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -151,8 +151,8 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 				return err
 			}
 
-			for host, fingerprint := range trust {
-				fmt.Println(fmt.Sprintf("%s: %s", host, fingerprint))
+			for _, fingerprint := range trust {
+				fmt.Println(fmt.Sprintf("%s", fingerprint))
 			}
 
 			return nil
@@ -192,19 +192,6 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			d, err := lxd.NewClient(config, remote)
 			if err != nil {
 				return err
-			}
-
-			toRemove := args[len(args)-1]
-			trust, err := d.CertificateList()
-			if err != nil {
-				return err
-			}
-
-			/* Try to remove by hostname first. */
-			for host, fingerprint := range trust {
-				if host == toRemove {
-					return d.CertificateRemove(fingerprint)
-				}
 			}
 
 			return d.CertificateRemove(args[len(args)-1])

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -30,7 +30,7 @@ type Daemon struct {
 	certf       string
 	keyf        string
 	mux         *mux.Router
-	clientCerts map[string]x509.Certificate
+	clientCerts []x509.Certificate
 	db          *sql.DB
 
 	tlsconfig *tls.Config


### PR DESCRIPTION
Instead of the request.TLS.ServerName, we should use the actual client's
hostname. Further, tracking (and rendering) hostnames as paired with
certificates doesn't really make sense, because multiple users wouldn't be able
to have different certificates on the same client host. So, let's not track
certs by hostname and just use the fingerprint instead.

This broke the implementation of the API, but since it was wrong (the spec says
nothing about it being a map from host:fingerprint, just that it's a list of
fingerprints), I think that's ok.

Closes #623

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>