### PR TITLE
Add recursion support to /1.0/images/aliases #473

### DIFF
--- a/client.go
+++ b/client.go
@@ -748,13 +748,13 @@ func (c *Client) DeleteAlias(alias string) error {
 	return err
 }
 
-func (c *Client) ListAliases() ([]string, error) {
-	resp, err := c.get("images/aliases")
+func (c *Client) ListAliases() ([]shared.ImageAlias, error) {
+	resp, err := c.get("images/aliases?recursion=1")
 	if err != nil {
 		return nil, err
 	}
 
-	var result []string
+	var result []shared.ImageAlias
 
 	if err := json.Unmarshal(resp.Metadata, &result); err != nil {
 		return nil, err

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -104,15 +104,8 @@ func doImageAlias(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		for _, url := range resp {
-			/* /1.0/images/aliases/ALIAS_NAME */
-			alias := fromUrl(url, "/1.0/images/aliases/")
-			if alias == "" {
-				fmt.Printf(gettext.Gettext("(Bad alias entry: %s\n"), url)
-			} else {
-				fmt.Println(alias)
-			}
-		}
+		showAliases(resp)
+
 		return nil
 	case "create":
 		/* alias create [<remote>:]<alias> <target> */
@@ -486,6 +479,23 @@ func showImages(images []shared.ImageInfo) error {
 
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetHeader([]string{"ALIAS", "FINGERPRINT", "PUBLIC", "DESCRIPTION", "ARCH", "UPLOAD DATE"})
+
+	for _, v := range data {
+		table.Append(v)
+	}
+	table.Render()
+
+	return nil
+}
+
+func showAliases(aliases []shared.ImageAlias) error {
+	data := [][]string{}
+	for _, alias := range aliases {
+		data = append(data, []string{alias.Description, alias.Name[0:12]})
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"ALIAS", "FINGERPRINT"})
 
 	for _, v := range data {
 		table.Append(v)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/gorilla/mux"
@@ -161,6 +162,16 @@ func isJsonRequest(r *http.Request) bool {
 	}
 
 	return false
+}
+
+func (d *Daemon) isRecursionRequest(r *http.Request) bool {
+	recursion_str := r.FormValue("recursion")
+	recursion, err := strconv.Atoi(recursion_str)
+	if err != nil {
+		return false
+	}
+
+	return recursion == 1
 }
 
 func (d *Daemon) createCmd(version string, c Command) {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-13 17:18+0200\n"
+        "POT-Creation-Date: 2015-05-14 09:26+1200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -78,11 +78,6 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name\n"
 msgstr  ""
 
-#: lxc/image.go:111
-#, c-format
-msgid   "(Bad alias entry: %s\n"
-msgstr  ""
-
 #: lxc/remote.go:39
 msgid   "Accept certificate"
 msgstr  ""
@@ -92,7 +87,7 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:243
+#: lxc/image.go:236
 msgid   "Aliases:\n"
 msgstr  ""
 
@@ -100,7 +95,7 @@ msgstr  ""
 msgid   "Alternate config directory."
 msgstr  ""
 
-#: lxc/image.go:226
+#: lxc/image.go:219
 #, c-format
 msgid   "Architecture: %s\n"
 msgstr  ""
@@ -195,7 +190,7 @@ msgid   "Execute the specified command in a container.\n"
         "lxc exec container [--env EDITOR=/usr/bin/vim]... <command>\n"
 msgstr  ""
 
-#: lxc/image.go:220
+#: lxc/image.go:213
 #, c-format
 msgid   "Fingerprint: %s\n"
 msgstr  ""
@@ -224,7 +219,7 @@ msgid   "If this is your first run, you will need to import images using the "
         "'lxd-images' script.\n"
 msgstr  ""
 
-#: lxc/image.go:283
+#: lxc/image.go:276
 #, c-format
 msgid   "Image imported with fingerprint: %s\n"
 msgstr  ""
@@ -425,11 +420,11 @@ msgstr  ""
 msgid   "Profile %s deleted\n"
 msgstr  ""
 
-#: lxc/image.go:239
+#: lxc/image.go:232
 msgid   "Properties:\n"
 msgstr  ""
 
-#: lxc/image.go:227
+#: lxc/image.go:220
 #, c-format
 msgid   "Public: %s\n"
 msgstr  ""
@@ -476,7 +471,7 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/image.go:225
+#: lxc/image.go:218
 msgid   "Size: %.2vMB\n"
 msgstr  ""
 
@@ -488,11 +483,11 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: lxc/image.go:228
+#: lxc/image.go:221
 msgid   "Timestamps:\n"
 msgstr  ""
 
-#: lxc/image.go:403
+#: lxc/image.go:396
 #, c-format
 msgid   "Unknown image command %s"
 msgstr  ""

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -1,5 +1,5 @@
 test_basic_usage() {
-  if ! lxc image alias list | grep -q ^testimage$; then
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
     if [ -e "$LXD_TEST_IMAGE" ]; then
         lxc image import $LXD_TEST_IMAGE --alias testimage
     else

--- a/test/concurrent.sh
+++ b/test/concurrent.sh
@@ -1,5 +1,5 @@
 test_concurrent() {
-  if ! lxc image alias list | grep -q ^testimage$; then
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
       if [ -e "$LXD_TEST_IMAGE" ]; then
           lxc image import $LXD_TEST_IMAGE --alias testimage
       else

--- a/test/config.sh
+++ b/test/config.sh
@@ -1,5 +1,5 @@
 test_config_profiles() {
-  if ! lxc image alias list | grep -q ^testimage$; then
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
       if [ -e "$LXD_TEST_IMAGE" ]; then
           lxc image import $LXD_TEST_IMAGE --alias testimage
       else

--- a/test/fdleak.sh
+++ b/test/fdleak.sh
@@ -1,5 +1,5 @@
 test_fdleak() {
-    if ! lxc image alias list | grep -q ^testimage$; then
+    if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
         if [ -e "$LXD_TEST_IMAGE" ]; then
             lxc image import $LXD_TEST_IMAGE --alias testimage
         else


### PR DESCRIPTION
Same pattern used as the other recursion commits. 
I also added a little refactoring:
- extracted test for "recursion" query parameter to its own function ( `isRecursionRequest()` ) in daemon.go
- `doAliasGet()` returns `shared.ImageAlias{}` instead of `shared.Jmap{....}`
- `aliasGet()` returns `SmartError` instead of `NotFound` or `InternalError`

Closes #473 

Signed-off-by: Matt Morrison <matt@mojo.net.nz>