### PR TITLE
Refactored the CLI documentation for profiles

### DIFF
--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -42,18 +42,28 @@ var profileEditHelp string = gettext.Gettext(
 
 func (c *profileCmd) usage() string {
 	return gettext.Gettext(
-		"Manage profiles.\n" +
+		"Manage configuration profiles.\n" +
 			"\n" +
-			"lxc profile list [filters]                List profiles\n" +
-			"lxc profile create <profile>              Create profile\n" +
-			"lxc profile delete <profile>              Delete profile\n" +
-			"lxc profile device add <profile> <name> <type> [key=value]...\n" +
-			"               Delete profile\n" +
-			"lxc profile edit <profile>                Edit profile in external editor\n" +
-			"lxc profile device list <profile>\n" +
-			"lxc profile device remove <profile> <name>\n" +
-			"lxc profile set <profile> <key> <value>   Set profile configuration\n" +
-			"lxc profile apply <resource> <profile>    Apply profile to container\n")
+			"lxc profile list [filters]                     List available profiles\n" +
+			"lxc profile create <profile>                   Create a profile\n" +
+			"lxc profile edit <profile>                     Edit profile in external editor\n" +
+			"lxc profile set <profile> <key> <value>        Set profile configuration\n" +
+			"lxc profile delete <profile>                   Delete a profile\n" +
+			"lxc profile apply <container> <profiles>\n" +
+			"    Apply a comma-separated list of profiles to a container, in order.\n" +
+			"    All profiles passed in this call (and only those) will be applied\n" +
+			"    to the specified container.\n" +
+			"    Example: lxc profile apply foo default,bar # Apply default and bar\n" +
+			"             lxc profile apply foo default # Only default is active\n" +
+			"             lxc profile apply '' # no profiles are applied anymore\n" +
+			"             lxc profile apply bar,default # Apply default second now\n" +
+			"\n" +
+			"Devices:\n" +
+			"lxc profile device list <profile>              List devices in the given profile.\n" +
+			"lxc profile device remove <profile> <name>     Remove a device from a profile.\n" +
+			"lxc profile device add <profile name> <device name> <device type> [key=value]...\n" +
+			"    Add a profile device, such as a disk or a nic, to the containers\n" +
+			"    using the specified profile.\n")
 }
 
 func (c *profileCmd) flags() {}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-13 14:14+0000\n"
+        "POT-Creation-Date: 2015-05-13 17:18+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -114,7 +114,7 @@ msgstr  ""
 msgid   "Cannot change profile name"
 msgstr  ""
 
-#: lxc/profile.go:298
+#: lxc/profile.go:308
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
@@ -273,6 +273,42 @@ msgstr  ""
 msgid   "Make image public"
 msgstr  ""
 
+#: lxc/profile.go:45
+msgid   "Manage configuration profiles.\n"
+        "\n"
+        "lxc profile list [filters]                     List available "
+        "profiles\n"
+        "lxc profile create <profile>                   Create a profile\n"
+        "lxc profile edit <profile>                     Edit profile in "
+        "external editor\n"
+        "lxc profile set <profile> <key> <value>        Set profile "
+        "configuration\n"
+        "lxc profile delete <profile>                   Delete a profile\n"
+        "lxc profile apply <container> <profiles>\n"
+        "    Apply a comma-separated list of profiles to a container, in "
+        "order.\n"
+        "    All profiles passed in this call (and only those) will be "
+        "applied\n"
+        "    to the specified container.\n"
+        "    Example: lxc profile apply foo default,bar # Apply default and "
+        "bar\n"
+        "             lxc profile apply foo default # Only default is active\n"
+        "             lxc profile apply '' # no profiles are applied anymore\n"
+        "             lxc profile apply bar,default # Apply default second "
+        "now\n"
+        "\n"
+        "Devices:\n"
+        "lxc profile device list <profile>              List devices in the "
+        "given profile.\n"
+        "lxc profile device remove <profile> <name>     Remove a device from "
+        "a profile.\n"
+        "lxc profile device add <profile name> <device name> <device type> "
+        "[key=value]...\n"
+        "    Add a profile device, such as a disk or a nic, to the "
+        "containers\n"
+        "    using the specified profile.\n"
+msgstr  ""
+
 #: lxc/config.go:45
 msgid   "Manage configuration.\n"
         "\n"
@@ -315,23 +351,6 @@ msgid   "Manage files on a container.\n"
         "\n"
         "<source> in the case of pull and <target> in the case of push are "
         "<container name>/<path>\n"
-msgstr  ""
-
-#: lxc/profile.go:45
-msgid   "Manage profiles.\n"
-        "\n"
-        "lxc profile list [filters]                List profiles\n"
-        "lxc profile create <profile>              Create profile\n"
-        "lxc profile delete <profile>              Delete profile\n"
-        "lxc profile device add <profile> <name> <type> [key=value]...\n"
-        "               Delete profile\n"
-        "lxc profile edit <profile>                Edit profile in external "
-        "editor\n"
-        "lxc profile device list <profile>\n"
-        "lxc profile device remove <profile> <name>\n"
-        "lxc profile set <profile> <key> <value>   Set profile configuration\n"
-        "lxc profile apply <resource> <profile>    Apply profile to "
-        "container\n"
 msgstr  ""
 
 #: lxc/remote.go:27
@@ -391,17 +410,17 @@ msgid   "Prints the version number of LXD.\n"
         "lxc version\n"
 msgstr  ""
 
-#: lxc/profile.go:196
+#: lxc/profile.go:206
 #, c-format
 msgid   "Profile %s applied to %s\n"
 msgstr  ""
 
-#: lxc/profile.go:118
+#: lxc/profile.go:128
 #, c-format
 msgid   "Profile %s created\n"
 msgstr  ""
 
-#: lxc/profile.go:185
+#: lxc/profile.go:195
 #, c-format
 msgid   "Profile %s deleted\n"
 msgstr  ""
@@ -505,7 +524,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/config.go:322 lxc/profile.go:167
+#: lxc/config.go:322 lxc/profile.go:177
 msgid   "YAML parse error %v\n"
 msgstr  ""
 


### PR DESCRIPTION
This tries to make the profiles command line a little more explicit
about what it does, especially the "apply" subcommand.

Signed-off-by: Chris Glass <tribaal@gmail.com>