### PR TITLE
Added ability to accept certificates without fingerprint verification

### DIFF
--- a/client.go
+++ b/client.go
@@ -763,7 +763,7 @@ func (c *Client) ListAliases() ([]string, error) {
 	return result, nil
 }
 
-func (c *Client) UserAuthServerCert(name string) error {
+func (c *Client) UserAuthServerCert(name string, acceptCert bool) error {
 	if !c.scertDigestSet {
 		return fmt.Errorf(gettext.Gettext("No certificate on this connection"))
 	}
@@ -777,14 +777,16 @@ func (c *Client) UserAuthServerCert(name string) error {
 		Intermediates: c.scertIntermediates,
 	})
 	if err != nil {
-		fmt.Printf(gettext.Gettext("Certificate fingerprint: % x\n"), c.scertDigest)
-		fmt.Printf(gettext.Gettext("ok (y/n)? "))
-		line, err := shared.ReadStdin()
-		if err != nil {
-			return err
-		}
-		if len(line) < 1 || line[0] != 'y' && line[0] != 'Y' {
-			return fmt.Errorf(gettext.Gettext("Server certificate NACKed by user"))
+		if acceptCert == false {
+			fmt.Printf(gettext.Gettext("Certificate fingerprint: % x\n"), c.scertDigest)
+			fmt.Printf(gettext.Gettext("ok (y/n)? "))
+			line, err := shared.ReadStdin()
+			if err != nil {
+				return err
+			}
+			if len(line) < 1 || line[0] != 'y' && line[0] != 'Y' {
+				return fmt.Errorf(gettext.Gettext("Server certificate NACKed by user"))
+			}
 		}
 	}
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-12 17:42-0400\n"
+        "POT-Creation-Date: 2015-05-13 14:14+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -83,7 +83,11 @@ msgstr  ""
 msgid   "(Bad alias entry: %s\n"
 msgstr  ""
 
-#: lxc/remote.go:124
+#: lxc/remote.go:39
+msgid   "Accept certificate"
+msgstr  ""
+
+#: lxc/remote.go:128
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -106,7 +110,7 @@ msgstr  ""
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1353
+#: client.go:1355
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -114,7 +118,7 @@ msgstr  ""
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: client.go:780
+#: client.go:781
 #, c-format
 msgid   "Certificate fingerprint: % x\n"
 msgstr  ""
@@ -126,7 +130,7 @@ msgid   "Changes a containers state to %s.\n"
         "lxd %s <name>\n"
 msgstr  ""
 
-#: lxc/remote.go:145
+#: lxc/remote.go:149
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -140,7 +144,7 @@ msgid   "Copy containers within or in between lxd instances.\n"
         "lxc copy <source container> <destination container>\n"
 msgstr  ""
 
-#: client.go:795
+#: client.go:797
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -330,16 +334,23 @@ msgid   "Manage profiles.\n"
         "container\n"
 msgstr  ""
 
-#: lxc/remote.go:25
+#: lxc/remote.go:27
 msgid   "Manage remote LXD servers.\n"
         "\n"
-        "lxc remote add <name> <url>        Add the remote <name> at <url>.\n"
-        "lxc remote remove <name>           Remove the remote <name>.\n"
-        "lxc remote list                    List all remotes.\n"
-        "lxc remote rename <old> <new>      Rename remote <old> to <new>.\n"
-        "lxc remote set-url <name> <url>    Update <name>'s url to <url>.\n"
-        "lxc remote set-default <name>      Set the default remote.\n"
-        "lxc remote get-default             Print the default remote.\n"
+        "lxc remote add <name> <url> [--accept-certificate]  Add the remote "
+        "<name> at <url>.\n"
+        "lxc remote remove <name>                            Remove the "
+        "remote <name>.\n"
+        "lxc remote list                                     List all "
+        "remotes.\n"
+        "lxc remote rename <old> <new>                       Rename remote "
+        "<old> to <new>.\n"
+        "lxc remote set-url <name> <url>                     Update <name>'s "
+        "url to <url>.\n"
+        "lxc remote set-default <name>                       Set the default "
+        "remote.\n"
+        "lxc remote get-default                              Print the "
+        "default remote.\n"
 msgstr  ""
 
 #: lxc/help.go:75
@@ -404,7 +415,7 @@ msgstr  ""
 msgid   "Public: %s\n"
 msgstr  ""
 
-#: client.go:787
+#: client.go:788
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
@@ -414,7 +425,7 @@ msgid   "Server certificate for host %s has changed. Add correct certificate "
         "or remove certificate in %s"
 msgstr  ""
 
-#: lxc/remote.go:142
+#: lxc/remote.go:146
 msgid   "Server doesn't trust us after adding our cert"
 msgstr  ""
 
@@ -467,7 +478,7 @@ msgstr  ""
 msgid   "Unknown image command %s"
 msgstr  ""
 
-#: lxc/remote.go:251
+#: lxc/remote.go:255
 #, c-format
 msgid   "Unknown remote subcommand %s"
 msgstr  ""
@@ -502,7 +513,7 @@ msgstr  ""
 msgid   "api version mismatch: mine: %q, daemon: %q"
 msgstr  ""
 
-#: client.go:1244 client.go:1251
+#: client.go:1246 client.go:1253
 #, c-format
 msgid   "bad container url %s"
 msgstr  ""
@@ -511,7 +522,7 @@ msgstr  ""
 msgid   "bad number of things scanned from image, container or snapshot"
 msgstr  ""
 
-#: client.go:1384
+#: client.go:1386
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -520,11 +531,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:1255
+#: client.go:1257
 msgid   "bad version in container url"
 msgstr  ""
 
-#: client.go:1388
+#: client.go:1390
 msgid   "bad version in profile url"
 msgstr  ""
 
@@ -563,7 +574,7 @@ msgstr  ""
 msgid   "expected error, got %s"
 msgstr  ""
 
-#: client.go:1055
+#: client.go:1057
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
@@ -582,7 +593,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1190
+#: client.go:1192
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -640,7 +651,7 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1430 client.go:1484
+#: client.go:1432 client.go:1486
 msgid   "no value found in %q\n"
 msgstr  ""
 
@@ -652,21 +663,21 @@ msgstr  ""
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
-#: client.go:781
+#: client.go:782
 msgid   "ok (y/n)? "
 msgstr  ""
 
-#: lxc/remote.go:213
+#: lxc/remote.go:217
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:183 lxc/remote.go:209 lxc/remote.go:229 lxc/remote.go:240
+#: lxc/remote.go:187 lxc/remote.go:213 lxc/remote.go:233 lxc/remote.go:244
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:168
+#: lxc/remote.go:172
 #, c-format
 msgid   "remote %s exists as <%s>"
 msgstr  ""

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -509,7 +509,7 @@ lxc publish c2 dakara: --public                 | Turn c2 into a public image on
 
 **Arguments**
 
-    add <name> <URI> [--always-relay] [--password=PASSWORD]
+    add <name> <URI> [--always-relay] [--password=PASSWORD] [--accept-certificate]
     remove <name>
     list
     rename <old name> <new name>
@@ -548,15 +548,20 @@ The "--always-relay" flag of "remote add" can mean one of two things:
    prevents it from accessing the image servers and that the client needs
    to act as a relay for it.
 
+The "--accept-certificate" flag of "remote add" will automatically accept
+the remote's certificate without prompting the user to verify the certificate
+fingerprint.
+
 **Examples**
 
-Command                                                         | Result
-:------                                                         | :-----
-lxc remote add dakara dakara.local                              | Add a new remote called "dakara" using its avahi DNS record and protocol auto-detection
-lxc remote add dakara dakara.local --password=BLAH              | Add a new remote called "dakara" using its avahi DNS record and protocol auto-detection and providing the password in advance
-lxc remote add vorash https://vorash.srv.dcmtl.stgraber.net     | Add remote "vorash" pointing to a remote lxc instance using the full URI
-lxc remote set-default vorash                                   | Mark it as the default remote
-lxc start c1                                                    | Start container "c1" on it
+Command                                                                  | Result
+:------                                                                  | :-----
+lxc remote add dakara dakara.local                                       | Add a new remote called "dakara" using its avahi DNS record and protocol auto-detection
+lxc remote add dakara dakara.local --password=BLAH                       | Add a new remote called "dakara" using its avahi DNS record and protocol auto-detection and providing the password in advance
+lxc remote add dakara dakara.local --password=BLAH --accept-certificate  | Add a new remote called "dakara" using its avahi DNS record and protocol auto-detection and providing the password in advance and also accepting the certificate without fingerprint verification
+lxc remote add vorash https://vorash.srv.dcmtl.stgraber.net              | Add remote "vorash" pointing to a remote lxc instance using the full URI
+lxc remote set-default vorash                                            | Mark it as the default remote
+lxc start c1                                                             | Start container "c1" on it
 
 * * *
 

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -28,7 +28,7 @@ test_remote_url() {
 
 test_remote_admin() {
   bad=0
-  (echo y;  sleep 3;  echo bad) | lxc remote add badpass 127.0.0.1:18443 $debug || true
+  (sleep 3; echo bad) | lxc remote add badpass 127.0.0.1:18443 $debug --accept-certificate || true
   lxc list badpass: && bad=1 || true
   if [ "$bad" -eq 1 ]; then
       echo "bad password accepted" && false


### PR DESCRIPTION
This has been implemented by adding the --accept-certificate flag to
'lxc remote add'
Signed-off-by: Ben Booth <benbooth493@gmail.com>