### PR TITLE
Remove one SQL command in alias resolution

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -232,13 +232,10 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 				return InternalError(err)
 			}
 		} else {
-			_, iId, err := dbAliasGet(d, req.Source.Alias)
+
+			hash, err = dbAliasGet(d.db, req.Source.Alias)
 			if err != nil {
 				return InternalError(err)
-			}
-			hash, err = dbImageGetById(d, iId)
-			if err != nil {
-				return InternalError(fmt.Errorf("Stale alias"))
 			}
 		}
 	} else if req.Source.Fingerprint != "" {

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -17,7 +17,7 @@ const CONTAINER_AND_PROFILE string = `
 
 const IMAGE string = `
     INSERT INTO images (fingerprint, filename, size, architecture, creation_date, expiry_date, upload_date) VALUES ('fingerprint', 'filename', 1024, 0,  1431547174,  1431547175,  1431547176);
-    INSERT INTO images_aliases (name, image_id, description) VALUES ('somename', 1, 'some description');
+    INSERT INTO images_aliases (name, image_id, description) VALUES ('somealias', 1, 'some description');
     INSERT INTO images_properties (image_id, type, key, value) VALUES (1, 0, 'thekey', 'some value');`
 
 func Test_deleting_a_container_cascades_on_related_tables(t *testing.T) {
@@ -450,4 +450,51 @@ func Test_dbImageGet_for_missing_fingerprint(t *testing.T) {
 	if err != sql.ErrNoRows {
 		t.Fatal("Wrong err type returned")
 	}
+}
+
+func Test_dbAliasGet_alias_exists(t *testing.T) {
+	var db *sql.DB
+	var err error
+	var result string
+
+	db, err = initializeDbObject(":memory:")
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(IMAGE)
+	if err != nil {
+		t.Fatal("Error creating schema!")
+	}
+
+	result, err = dbAliasGet(db, "somealias")
+
+	if result != "fingerprint" {
+		t.Fatal("Fingerprint is not the expected fingerprint!")
+	}
+
+}
+
+func Test_dbAliasGet_alias_does_not_exists(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	db, err = initializeDbObject(":memory:")
+	if err != nil {
+		t.Error(err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(IMAGE)
+	if err != nil {
+		t.Fatal("Error creating schema!")
+	}
+
+	_, err = dbAliasGet(db, "whatever")
+
+	if err != NoSuchImageError {
+		t.Fatal("Error should be NoSuchImageError")
+	}
+
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -617,7 +617,8 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 		req.Description = req.Name
 	}
 
-	_, _, err := dbAliasGet(d, req.Name)
+	// This is just to see if the alias name already exists.
+	_, err := dbAliasGet(d.db, req.Name)
 	if err == nil {
 		return Conflict
 	}


### PR DESCRIPTION
Note: This superseeds https://github.com/lxc/lxd/pull/656

Since The only time we used dbImageGetById was after a call to dbAliasGet,
I changed the dbAliasGet call to perform everything in one single SQL
query, skipping the connection/parsing and offering a more simple
interface.

Added unit tests to dbAliasGet.

Signed-off-by: Chris Glass <tribaal@gmail.com>