### PR TITLE
More data layer fixes

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1174,7 +1174,7 @@ func (c *lxdContainer) RenderState() (*shared.ContainerState, error) {
 		return nil, err
 	}
 
-	config, err := dbGetConfig(c.daemon, c)
+	config, err := dbGetConfig(c.daemon.db, c.id)
 	if err != nil {
 		return nil, err
 	}
@@ -1604,13 +1604,13 @@ func newLxdContainer(name string, daemon *Daemon) (*lxdContainer, error) {
 		return nil, err
 	}
 
-	config, err := dbGetConfig(daemon, d)
+	config, err := dbGetConfig(daemon.db, d.id)
 	if err != nil {
 		return nil, err
 	}
 	d.config = config
 
-	profiles, err := dbGetProfiles(daemon, d)
+	profiles, err := dbGetProfiles(daemon.db, d.id)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1169,7 +1169,7 @@ type lxdContainer struct {
 }
 
 func (c *lxdContainer) RenderState() (*shared.ContainerState, error) {
-	devices, err := dbGetDevices(c.daemon, c.name, false)
+	devices, err := dbGetDevices(c.daemon.db, c.name, false)
 	if err != nil {
 		return nil, err
 	}
@@ -1351,7 +1351,7 @@ func applyProfile(daemon *Daemon, d *lxdContainer, p string) error {
 		config[k] = v
 	}
 
-	newdevs, err := dbGetDevices(daemon, p, true)
+	newdevs, err := dbGetDevices(daemon.db, p, true)
 	if err != nil {
 		return err
 	}
@@ -1645,7 +1645,7 @@ func newLxdContainer(name string, daemon *Daemon) (*lxdContainer, error) {
 	}
 
 	/* get container_devices */
-	newdevs, err := dbGetDevices(daemon, d.name, false)
+	newdevs, err := dbGetDevices(daemon.db, d.name, false)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -621,7 +621,7 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = dbAddAlias(d, req.Name, imgInfo.Id, req.Description)
+	err = dbAddAlias(d.db, req.Name, imgInfo.Id, req.Description)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -108,7 +108,7 @@ var profilesCmd = Command{name: "profiles", get: profilesGet, post: profilesPost
 func profileGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 
-	config, err := dbGetProfileConfig(d, name)
+	config, err := dbGetProfileConfig(d.db, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -113,7 +113,7 @@ func profileGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	devices, err := dbGetDevices(d, name, true)
+	devices, err := dbGetDevices(d.db, name, true)
 	if err != nil {
 		return SmartError(err)
 	}


### PR DESCRIPTION
Mostly focused on decoupling the data layer from the rest by passing in
references to the sql.DB instead of the daemon.

Another instance of removing a SQL statement (preemtively counting is
not necessary, just let it fail when doing the actual work).

Refactored the db_test.go file to be a little more DRY.

Signed-off-by: Chris Glass <tribaal@gmail.com>