### PR TITLE
only uidmapshift unprivileged containers on copy/migrate

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -414,12 +414,16 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 		return InternalError(err)
 	}
 
+	idMap := d.idMap
+	if c.isPrivileged() {
+		idMap = nil
+	}
 	args := migration.MigrationSinkArgs{
 		Url:       req.Source.Operation,
 		Dialer:    websocket.Dialer{TLSClientConfig: config},
 		Container: c.c,
 		Secrets:   req.Source.Websockets,
-		IdMap:     d.idMap,
+		IdMap:     idMap,
 	}
 
 	sink, err := migration.NewMigrationSink(&args)

--- a/lxd/migration/migrate.go
+++ b/lxd/migration/migrate.go
@@ -432,10 +432,12 @@ func (c *migrationSink) do() error {
 			return
 		}
 
-		if err := c.idMap.ShiftRootfs(shared.VarPath("lxc", c.container.Name())); err != nil {
-			restore <- err
-			c.sendControl(err)
-			return
+		if c.idMap != nil {
+			if err := c.idMap.ShiftRootfs(shared.VarPath("lxc", c.container.Name())); err != nil {
+				restore <- err
+				c.sendControl(err)
+				return
+			}
 		}
 
 		if c.live {


### PR DESCRIPTION
I thought we had done this before, but it must have broken somehow. Of
course, since the container are privileged, things that run as root mostly
still work anyway, but we should still not do this :)

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>