### PR TITLE
Resolution for Issue #649: Added support for "lxc profile device show" and "lxc config device show"

### DIFF
--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -45,6 +45,7 @@ func (c *profileCmd) usage() string {
 		"Manage configuration profiles.\n" +
 			"\n" +
 			"lxc profile list [filters]                     List available profiles\n" +
+			"lxc profile show <profile>                     Show details of a profile\n" +
 			"lxc profile create <profile>                   Create a profile\n" +
 			"lxc profile edit <profile>                     Edit profile in external editor\n" +
 			"lxc profile copy <profile> <remote>            Copy the profile to the specified remote\n" +
@@ -61,6 +62,7 @@ func (c *profileCmd) usage() string {
 			"\n" +
 			"Devices:\n" +
 			"lxc profile device list <profile>              List devices in the given profile.\n" +
+			"lxc profile device show <profile>              Show full device details in the given profile.\n" +
 			"lxc profile device remove <profile> <name>     Remove a device from a profile.\n" +
 			"lxc profile device add <profile name> <device name> <device type> [key=value]...\n" +
 			"    Add a profile device, such as a disk or a nic, to the containers\n" +
@@ -260,6 +262,8 @@ func doProfileDevice(config *lxd.Config, args []string) error {
 		return deviceRm(config, "profile", args)
 	case "list":
 		return deviceList(config, "profile", args)
+	case "show":
+		return deviceShow(config, "profile", args)
 	default:
 		return errArgs
 	}

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -84,6 +84,7 @@ stop        | Stop a container
     device add <resource> <device name> <type> [key=value]...
     device remove <resource> <device name>
     device list <resource>
+    device show <resource>
     trust add [remote] <certificate>
     trust remove [remote] <fingerprint>
     trust list [remote]

--- a/test/config.sh
+++ b/test/config.sh
@@ -21,9 +21,11 @@ test_config_profiles() {
   lxc profile apply foo onenic,unconfined
 
   lxc config device list foo | grep home
+  lxc config device show foo | grep "/mnt"
   lxc config show foo | grep "onenic,unconfined"
   lxc profile list | grep onenic
   lxc profile device list onenic | grep eth0
+  lxc profile device show onenic | grep lxcbr0
 
   lxc config set foo user.prop value
   lxc list user.prop=value | grep foo


### PR DESCRIPTION
Added usage text for "lxc profile show <profile>" (was missing from the usage even though the code was there)
Added support for "lxc profile device show" and "lxc config device show" (Issue #649).

I also added the new "lxc config device show" usage to the specs file. Hope this was not out of line.
    
Signed-off-by: Josh Butikofer `<joshbutikofer+github@gmail.com>`
