### PR TITLE
fix snapshot restore issue

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -940,12 +940,12 @@ func containerSnapRestore(d *Daemon, name string, snap string) error {
 	containerRootFSPath := migration.AddSlash(fmt.Sprintf("%s/%s", containerRootPath, "rootfs"))
 	shared.Debugf("RESTORE => Copying %s to %s", snapshotRootFSPath, containerRootFSPath)
 
-	rsync_debug := ""
+	rsync_verbosity := "-q"
 	if *debug {
-		rsync_debug = "-vi"
+		rsync_verbosity = "-vi"
 	}
 
-	output, err := exec.Command("rsync", "-a", "-c", "-HAX", "--devices", "--delete", rsync_debug, snapshotRootFSPath, containerRootFSPath).CombinedOutput()
+	output, err := exec.Command("rsync", "-a", "-c", "-HAX", "--devices", "--delete", rsync_verbosity, snapshotRootFSPath, containerRootFSPath).CombinedOutput()
 	shared.Debugf("RESTORE => rsync output\n%s", output)
 
 	if err == nil && !source.isPrivileged() {


### PR DESCRIPTION
Found a nasty bug with snapshot restore.
Not sure exactly what causes it, but the symptom is that restore never completes and rootfs of container continues to grow unbounded. 
This only occurs when lxd is running without --debug arg, so it seems to be related to calling rsync with an empty string as one of the arguments.

Now, when not running lxd in debug mode, use -q rsync flag instead of empty string.
```
-q, --quiet                 suppress non-error messages
```

Signed-off-by: Matt Morrison <matt@mojo.net.nz>