### PR TITLE
Add better error handling to main()

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -3,6 +3,8 @@ package main
 import (
 	"fmt"
 	"log"
+	"net"
+	"net/url"
 	"os"
 	"strings"
 
@@ -14,6 +16,26 @@ import (
 
 func main() {
 	if err := run(); err != nil {
+		// The action we take depends on the error we get.
+		switch t := err.(type) {
+		case *url.Error:
+			shared.Debugf("url.Error caught in main(). Op: %s, URL: %s, Err: %s\n", t.Op, t.URL, t.Err)
+			switch u := t.Err.(type) {
+			case *net.OpError:
+				shared.Debugf("Inner error type is a net.OpError: Op: %s Net: %s Addr: %s Err: %T", u.Op, u.Net, u.Addr, u.Err)
+				if u.Op == "dial" && u.Net == "unix" {
+					// The unix socket we are trying to conect to is refusing our connection attempt. Perhaps the server is not running?
+					// Let's at least tell the user about it, since it's hard to get information on wether something is actually listening.
+					fmt.Fprintf(os.Stderr, fmt.Sprintf(gettext.Gettext("Cannot connect to unix socket at %s Is the server running?\n"), u.Addr))
+					os.Exit(1)
+				}
+			default:
+				shared.Debugf("url.Error's inner Err type is %T", u)
+			}
+		default:
+			shared.Debugf("Error caught in main: %T\n", t)
+		}
+
 		fmt.Fprintf(os.Stderr, gettext.Gettext("error: %v\n"), err)
 		os.Exit(1)
 	}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-20 08:01+1200\n"
+        "POT-Creation-Date: 2015-05-21 10:28+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -91,7 +91,7 @@ msgstr  ""
 msgid   "Aliases:\n"
 msgstr  ""
 
-#: lxc/main.go:29
+#: lxc/main.go:51
 msgid   "Alternate config directory."
 msgstr  ""
 
@@ -107,6 +107,11 @@ msgstr  ""
 
 #: client.go:1347
 msgid   "Cannot change profile name"
+msgstr  ""
+
+#: lxc/main.go:29
+#, c-format
+msgid   "Cannot connect to unix socket at %s Is the server running?\n"
 msgstr  ""
 
 #: lxc/profile.go:313
@@ -167,11 +172,11 @@ msgstr  ""
 msgid   "Device %s removed from %s\n"
 msgstr  ""
 
-#: lxc/main.go:27
+#: lxc/main.go:49
 msgid   "Enables debug mode."
 msgstr  ""
 
-#: lxc/main.go:26
+#: lxc/main.go:48
 msgid   "Enables verbose mode."
 msgstr  ""
 
@@ -201,7 +206,7 @@ msgid   "Fingers the LXD instance to check if it is up and working.\n"
         "lxc finger <remote>\n"
 msgstr  ""
 
-#: lxc/main.go:89
+#: lxc/main.go:111
 msgid   "For example: 'lxd-images import lxc ubuntu trusty amd64 --alias "
         "ubuntu/trusty'.\n"
 msgstr  ""
@@ -210,11 +215,11 @@ msgstr  ""
 msgid   "Force the container to shutdown."
 msgstr  ""
 
-#: lxc/main.go:81
+#: lxc/main.go:103
 msgid   "Generating a client certificate. This may take a minute...\n"
 msgstr  ""
 
-#: lxc/main.go:88
+#: lxc/main.go:110
 msgid   "If this is your first run, you will need to import images using the "
         "'lxd-images' script.\n"
 msgstr  ""
@@ -567,7 +572,7 @@ msgstr  ""
 msgid   "Unkonwn config trust command %s"
 msgstr  ""
 
-#: lxc/main.go:57
+#: lxc/main.go:79
 #, c-format
 msgid   "Usage: %s\n"
         "\n"
@@ -630,16 +635,16 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/main.go:17
+#: lxc/main.go:39
 msgid   "error: %v\n"
 msgstr  ""
 
-#: lxc/main.go:94
+#: lxc/main.go:116
 msgid   "error: %v\n"
         "%s"
 msgstr  ""
 
-#: lxc/help.go:40 lxc/main.go:51
+#: lxc/help.go:40 lxc/main.go:73
 #, c-format
 msgid   "error: unknown command: %s\n"
 msgstr  ""
@@ -729,7 +734,7 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:131
+#: lxc/main.go:153
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 


### PR DESCRIPTION
Another attempt at solving https://github.com/lxc/lxd/issues/655 .

It might print "is the server running" when the server is actually running, but at least the user can help himself in the more probable case: the server is not running.

In the case where the error is caused by a connection refused on a local
(unix) socket, ask the user whether the server is running or not,
allowing people to help themselves a little faster.

When run in debug mode, extra information about the error is displayed.

Signed-off-by: Chris Glass <tribaal@gmail.com>