### PR TITLE
lxd-client should not depend on liblxc

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -9,7 +9,6 @@ import (
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
-	"gopkg.in/lxc/go-lxc.v2"
 )
 
 type copyCmd struct {
@@ -62,7 +61,7 @@ func copyContainer(config *lxd.Config, sourceResource string, destResource strin
 
 		baseImage = status.Config["volatile.baseImage"]
 
-		if status.State() == lxc.RUNNING && sourceName != destName {
+		if status.State() == shared.RUNNING && sourceName != destName {
 			return fmt.Errorf(gettext.Gettext("changing hostname of running containers not supported"))
 		}
 

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -6,7 +6,6 @@ import (
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared"
-	"gopkg.in/lxc/go-lxc.v2"
 )
 
 type deleteCmd struct{}
@@ -53,7 +52,7 @@ func (c *deleteCmd) run(config *lxd.Config, args []string) error {
 		return doDelete(d, name)
 	}
 
-	if ct.State() != lxc.STOPPED {
+	if ct.State() != shared.STOPPED {
 		resp, err := d.Action(name, shared.Stop, -1, true)
 		if err != nil {
 			return err

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/gosexy/gettext"
 	"github.com/lxc/lxd"
-	"gopkg.in/lxc/go-lxc.v2"
+	"github.com/lxc/lxd/shared"
 )
 
 type moveCmd struct {
@@ -47,7 +47,7 @@ func (c *moveCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		if status.State() != lxc.RUNNING {
+		if status.State() != shared.RUNNING {
 			rename, err := source.Rename(sourceName, destName)
 			if err != nil {
 				return err

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -89,7 +89,7 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = shared.AddDevices(tx, "profile", id, req.Devices)
+	err = AddDevices(tx, "profile", id, req.Devices)
 	if err != nil {
 		tx.Rollback()
 		return SmartError(err)
@@ -197,7 +197,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = shared.AddDevices(tx, "profile", id, req.Devices)
+	err = AddDevices(tx, "profile", id, req.Devices)
 	if err != nil {
 		tx.Rollback()
 		return SmartError(err)

--- a/test/deps.sh
+++ b/test/deps.sh
@@ -1,0 +1,7 @@
+test_check_deps() {
+  bad=0
+  ldd `which lxc` | grep -q liblxc && bad=1 || true
+  if [ "$bad" -eq 1 ]; then
+    echo "this patchset adds a client dependency on liblxc"
+  fi
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -114,6 +114,7 @@ fi
 . ./basic.sh
 . ./concurrent.sh
 . ./database.sh
+. ./deps.sh
 . ./fuidshift.sh
 . ./migration.sh
 . ./remote.sh
@@ -170,6 +171,9 @@ test_commits_signed_off
 
 echo "==> TEST: doing static analysis of commits"
 static_analysis
+
+echo "==> TEST: checking dependencies"
+test_check_deps
 
 echo "==> TEST: Database schema update"
 test_database_update


### PR DESCRIPTION
(or sqlite3)

The Juju folks are interested in using our go client library, but as we had
things factored they needed to link against liblxc, which they didn't want to
do. This seems fairly reasonable, as liblxc brings in a lot of other deps and
all we really want from it is a few constants.

Also, we don't need to compile sqlite3 into the client, so let's not do that
either.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>