### PR TITLE
Remove state file after the tests are run

### DIFF
--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -69,6 +69,9 @@ test_snap_restore() {
   mkdir dir_only_in_snap1
   cd -
 
+  # Delete the state file we created to prevent leaking.
+  rm state
+
   lxc config set bar limits.cpus 1
 
   lxc snapshot bar snap1


### PR DESCRIPTION
The "state" file was left on the filesystem after the tests finished
running. This plugs the leak.

Signed-off-by: Chris Glass <tribaal@gmail.com>