### PR TITLE
implement config show for server config. fixes #685

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -201,21 +201,35 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 		}
 
 	case "show":
-		if len(args) == 1 {
-			return fmt.Errorf(gettext.Gettext("Show for server is not yet supported\n"))
+		remote := ""
+		container := ""
+		if len(args) > 1 {
+			remote, container = config.ParseRemoteAndContainer(args[1])
+			if container == "" {
+				return fmt.Errorf(gettext.Gettext("Show for remotes is not yet supported\n"))
+			}
 		}
-		remote, container := config.ParseRemoteAndContainer(args[1])
-		if container == "" {
-			return fmt.Errorf(gettext.Gettext("Show for remotes is not yet supported\n"))
-		}
+
 		d, err := lxd.NewClient(config, remote)
 		if err != nil {
 			return err
 		}
-		resp, err := d.GetContainerConfig(container)
-		if err != nil {
-			return err
+
+		var resp []string
+
+		if len(args) == 1 || container == "" {
+			resp, err = d.GetServerConfigString()
+			if err != nil {
+				return err
+			}
+
+		} else {
+			resp, err = d.GetContainerConfig(container)
+			if err != nil {
+				return err
+			}
 		}
+
 		fmt.Printf("%s\n", strings.Join(resp, "\n"))
 		return nil
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-21 10:28+0200\n"
+        "POT-Creation-Date: 2015-05-26 17:49-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -105,7 +105,7 @@ msgstr  ""
 msgid   "Bad image property: %s\n"
 msgstr  ""
 
-#: client.go:1347
+#: client.go:1384
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -138,7 +138,7 @@ msgstr  ""
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/copy.go:25
+#: lxc/copy.go:24
 msgid   "Copy containers within or in between lxd instances.\n"
         "\n"
         "lxc copy <source container> <destination container>\n"
@@ -154,7 +154,7 @@ msgid   "Create a read-only snapshot of a container.\n"
         "lxc snapshot <source> <snapshot name> [--stateful]\n"
 msgstr  ""
 
-#: lxc/delete.go:20
+#: lxc/delete.go:19
 msgid   "Delete a container or container snapshot.\n"
         "\n"
         "Destroy a container (or snapshot) and any attached data "
@@ -162,12 +162,12 @@ msgid   "Delete a container or container snapshot.\n"
         "snapshots, ...).\n"
 msgstr  ""
 
-#: lxc/config.go:369
+#: lxc/config.go:383
 #, c-format
 msgid   "Device %s added to %s\n"
 msgstr  ""
 
-#: lxc/config.go:397
+#: lxc/config.go:411
 #, c-format
 msgid   "Device %s removed from %s\n"
 msgstr  ""
@@ -533,10 +533,6 @@ msgstr  ""
 msgid   "Show for remotes is not yet supported\n"
 msgstr  ""
 
-#: lxc/config.go:205
-msgid   "Show for server is not yet supported\n"
-msgstr  ""
-
 #: lxc/info.go:29
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
@@ -545,7 +541,7 @@ msgstr  ""
 msgid   "Size: %.2vMB\n"
 msgstr  ""
 
-#: lxc/delete.go:68
+#: lxc/delete.go:67
 msgid   "Stopping container failed!"
 msgstr  ""
 
@@ -594,7 +590,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/config.go:325 lxc/profile.go:180
+#: lxc/config.go:339 lxc/profile.go:180
 msgid   "YAML parse error %v\n"
 msgstr  ""
 
@@ -606,7 +602,7 @@ msgstr  ""
 msgid   "bad number of things scanned from image, container or snapshot"
 msgstr  ""
 
-#: client.go:1378
+#: client.go:1415
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -615,11 +611,11 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:1382
+#: client.go:1419
 msgid   "bad version in profile url"
 msgstr  ""
 
-#: lxc/copy.go:81
+#: lxc/copy.go:80
 msgid   "can't copy to the same container name"
 msgstr  ""
 
@@ -627,7 +623,7 @@ msgstr  ""
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
-#: lxc/copy.go:66
+#: lxc/copy.go:65
 msgid   "changing hostname of running containers not supported"
 msgstr  ""
 
@@ -673,7 +669,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1192
+#: client.go:1207
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -695,15 +691,15 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1424 client.go:1478
+#: client.go:1461 client.go:1515
 msgid   "no value found in %q\n"
 msgstr  ""
 
-#: lxc/copy.go:92
+#: lxc/copy.go:91
 msgid   "non-http remotes are not supported for migration right now"
 msgstr  ""
 
-#: lxc/copy.go:107
+#: lxc/copy.go:106
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
@@ -738,6 +734,6 @@ msgstr  ""
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:36
 msgid   "you must specify a source container name"
 msgstr  ""

--- a/shared/server.go
+++ b/shared/server.go
@@ -1,0 +1,8 @@
+package shared
+
+type ServerState struct {
+	APICompat   int                    `json:"api_compat"`
+	Auth        string                 `json:"auth"`
+	Environment map[string]string      `json:"environment"`
+	Config      map[string]interface{} `json:"config"`
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -99,6 +99,7 @@ cleanup() {
     [ -n "${LXD3_DIR}" ] && wipe "${LXD3_DIR}"
     [ -n "${LXD4_DIR}" ] && wipe "${LXD4_DIR}"
     [ -n "${LXD_MIGRATE_DIR}" ] && wipe "${LXD_MIGRATE_DIR}"
+    [ -n "${LXD_SERVERCONFIG_DIR}" ] && wipe "${LXD_SERVERCONFIG_DIR}"
 
     echo ""
     echo ""
@@ -122,6 +123,7 @@ fi
 . ./snapshots.sh
 . ./static_analysis.sh
 . ./config.sh
+. ./serverconfig.sh
 . ./profiling.sh
 . ./fdleak.sh
 . ./database_update.sh
@@ -201,6 +203,9 @@ test_snap_restore
 
 echo "==> TEST: profiles, devices and configuration"
 test_config_profiles
+
+echo "==> TEST: server config"
+test_server_config
 
 if type fuidshift >/dev/null 2>&1; then
     echo "==> TEST: uidshift"

--- a/test/serverconfig.sh
+++ b/test/serverconfig.sh
@@ -1,0 +1,15 @@
+test_server_config() {
+
+    export LXD_SERVERCONFIG_DIR=$(mktemp -d -p $(pwd))
+    spawn_lxd 127.0.0.1:18450 $LXD_SERVERCONFIG_DIR
+
+    lxc config set password 123456
+
+    config=$(lxc config show)
+    echo $config | grep -q "trust-password"
+    echo $config | grep -q -v "123456"
+
+    # test untrusted server GET
+    my_curl -X GET https://127.0.0.1:18450/1.0 | grep -v -q environment
+
+}


### PR DESCRIPTION
Prints local server config for `lxc config show`.

In more detail: 
- adds server.go which contains `ServerState` struct that holds server config values
- adds `Client.ServerStatus` that returns a `ServerState`
- `Client.GetServerConfigString` uses `ServerStatus` to build a string for the CLI
- changes "show" case to support local server status using the above changes, for the command `lxc config show`

Comments appreciated on any part, in particular the format of the user-visible output and what info is included there.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>