### PR TITLE
add 'config set' for server config

### DIFF
--- a/client.go
+++ b/client.go
@@ -1168,11 +1168,6 @@ func (c *Client) PullFile(container string, p string) (int, int, os.FileMode, io
 	return uid, gid, mode, r.Body, nil
 }
 
-func (c *Client) SetRemotePwd(password string) (*Response, error) {
-	body := shared.Jmap{"config": shared.Jmap{"trust-password": password}}
-	return c.put("", body, Sync)
-}
-
 func (c *Client) MigrateTo(container string) (*Response, error) {
 	body := shared.Jmap{"migration": true}
 	return c.post(fmt.Sprintf("containers/%s", container), body, Async)
@@ -1290,6 +1285,11 @@ func (c *Client) GetServerConfigString() ([]string, error) {
 	}
 
 	return resp, nil
+}
+
+func (c *Client) SetServerConfig(key string, value string) (*Response, error) {
+	body := shared.Jmap{"config": shared.Jmap{key: value}}
+	return c.put("", body, Sync)
 }
 
 /*

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -103,27 +103,22 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 		return doSet(config, append(args, ""))
 
 	case "set":
-		if len(args) < 2 {
+		if len(args) < 3 {
 			return errArgs
 		}
 
-		if args[1] == "password" {
-			if len(args) != 3 {
-				return errArgs
+		if len(args) == 3 {
+			key := args[1]
+			if key == "password" {
+				key = "trust-password"
 			}
 
-			password := args[2]
 			c, err := lxd.NewClient(config, "")
 			if err != nil {
 				return err
 			}
-
-			_, err = c.SetRemotePwd(password)
+			_, err = c.SetServerConfig(key, args[2])
 			return err
-		}
-
-		if len(args) < 3 {
-			return errArgs
 		}
 
 		return doSet(config, args)

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-05-26 17:49-0400\n"
+        "POT-Creation-Date: 2015-05-26 18:50-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,12 +162,12 @@ msgid   "Delete a container or container snapshot.\n"
         "snapshots, ...).\n"
 msgstr  ""
 
-#: lxc/config.go:383
+#: lxc/config.go:378
 #, c-format
 msgid   "Device %s added to %s\n"
 msgstr  ""
 
-#: lxc/config.go:411
+#: lxc/config.go:406
 #, c-format
 msgid   "Device %s removed from %s\n"
 msgstr  ""
@@ -440,7 +440,7 @@ msgid   "Move containers within or in between lxd instances.\n"
         "lxc move <source container> <destination container>\n"
 msgstr  ""
 
-#: lxc/config.go:163
+#: lxc/config.go:158
 msgid   "No cert provided to add"
 msgstr  ""
 
@@ -448,7 +448,7 @@ msgstr  ""
 msgid   "No certificate on this connection"
 msgstr  ""
 
-#: lxc/config.go:186
+#: lxc/config.go:181
 msgid   "No fingerprint specified."
 msgstr  ""
 
@@ -529,7 +529,7 @@ msgstr  ""
 msgid   "Show all commands (not just interesting ones)"
 msgstr  ""
 
-#: lxc/config.go:209
+#: lxc/config.go:204
 msgid   "Show for remotes is not yet supported\n"
 msgstr  ""
 
@@ -563,7 +563,7 @@ msgstr  ""
 msgid   "Unknown remote subcommand %s"
 msgstr  ""
 
-#: lxc/config.go:200
+#: lxc/config.go:195
 #, c-format
 msgid   "Unkonwn config trust command %s"
 msgstr  ""
@@ -590,7 +590,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/config.go:339 lxc/profile.go:180
+#: lxc/config.go:334 lxc/profile.go:180
 msgid   "YAML parse error %v\n"
 msgstr  ""
 
@@ -669,7 +669,7 @@ msgstr  ""
 msgid   "invalid argument %s"
 msgstr  ""
 
-#: client.go:1207
+#: client.go:1202
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""

--- a/test/serverconfig.sh
+++ b/test/serverconfig.sh
@@ -4,10 +4,12 @@ test_server_config() {
     spawn_lxd 127.0.0.1:18450 $LXD_SERVERCONFIG_DIR
 
     lxc config set password 123456
+    lxc config set core.foo value
 
     config=$(lxc config show)
     echo $config | grep -q "trust-password"
     echo $config | grep -q -v "123456"
+    echo $config | grep -q "core.foo = value"
 
     # test untrusted server GET
     my_curl -X GET https://127.0.0.1:18450/1.0 | grep -v -q environment


### PR DESCRIPTION
- adds 'config set' to client: adds `setServerConfig` in client.go and changes "set" handling in config.go

- moves password setting code from `api10Put` to a separate func `setTrustPassword`
- adds `setServerConfig` in api10.go, used by both `api10Put` for setting `core.*` values and `setTrustPassword` for setting the scrypted password.

- adds a test for setting a value and seeing it back in the 'config show' output