### PR TITLE
spec says memory limit is in MB

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1439,7 +1439,14 @@ func (d *lxdContainer) applyConfig(config map[string]string, fromProfile bool) e
 			cpuset := fmt.Sprintf("0-%d", vint-1)
 			err = d.c.SetConfigItem("lxc.cgroup.cpuset.cpus", cpuset)
 		case "limits.memory":
-			err = d.c.SetConfigItem("lxc.cgroup.memory.limit_in_bytes", v)
+			megabytes, err := strconv.Atoi(v)
+			if err != nil {
+				return err
+			}
+
+			bytes := strconv.Itoa(megabytes * 1024)
+
+			err = d.c.SetConfigItem("lxc.cgroup.memory.limit_in_bytes", bytes)
 
 		default:
 			if strings.HasPrefix(k, "user.") {

--- a/test/stresstest.sh
+++ b/test/stresstest.sh
@@ -160,7 +160,7 @@ configthread() {
     echo "configthread: I am $$"
     for i in `seq 1 20`; do
         lxc profile create p$i
-        lxc profile set p$i limits.memory 100M
+        lxc profile set p$i limits.memory 100
         lxc profile delete p$i
     done
     exit 0


### PR DESCRIPTION
Since it's in MB but the kernel wants it in bytes, let's multiply!

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>