### PR TITLE
Fix tar args for COMPRESSION_BZ2 in btrfs case

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -178,7 +178,7 @@ func imagesPost(d *Daemon, r *http.Request) Response {
 		case COMPRESSION_GZIP:
 			args = append(args, "-zxf")
 		case COMPRESSION_BZ2:
-			args = append(args, "--jxf")
+			args = append(args, "-jxf")
 		case COMPRESSION_LZMA:
 			args = append(args, "--lzma", "-xf")
 		default:


### PR DESCRIPTION
Just noticed this, bzip2 should be either -j or --bzip2 per the manpage.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>