### PR TITLE
always report no rows returned

### DIFF
--- a/shared/db.go
+++ b/shared/db.go
@@ -143,7 +143,10 @@ func doDbQueryScan(db *sql.DB, q string, args []interface{}, outargs []interface
 	err = rows.Err()
 	if err != nil {
 		return [][]interface{}{}, err
+	} else if len(result) == 0 {
+		return [][]interface{}{}, sql.ErrNoRows
 	}
+
 	return result, nil
 }
 


### PR DESCRIPTION
It seems in some cases (joins?) the driver doesn't report sql.ErrNoRows
when no rows are actually returned. Let's always report it ourselves.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>