### PR TITLE
remember to delete container if container create fails

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -344,6 +344,7 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 
 	c, err := newLxdContainer(name, d)
 	if err != nil {
+		removeContainer(d, name)
 		return SmartError(err)
 	}
 


### PR DESCRIPTION
In this case we won't have extracted the container or anything, so it
doesn't really exist. Let's clean up after ourselves so that when whatever
went wrong gets fixed, people don't get a "this container already exists"
error.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>