### PR TITLE
add host veth to `lxc info` output and API

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -59,7 +59,12 @@ func (c *infoCmd) run(config *lxd.Config, args []string) error {
 		fmt.Printf("Ips:\n")
 		foundone := false
 		for _, ip := range ct.Status.Ips {
-			fmt.Printf("  %s:\t %s\t%s\n", ip.Interface, ip.Protocol, ip.Address)
+			vethStr := ""
+			if ip.HostVeth != "" {
+				vethStr = fmt.Sprintf("\t%s", ip.HostVeth)
+			}
+
+			fmt.Printf("  %s:\t%s\t%s%s\n", ip.Interface, ip.Protocol, ip.Address, vethStr)
 			foundone = true
 		}
 		if !foundone {

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1432,8 +1432,26 @@ func getIps(c *lxc.Container) []shared.Ip {
 		if err != nil {
 			continue
 		}
+
+		veth := ""
+
+		for i := 0; i < len(c.ConfigItem("lxc.network")); i++ {
+			nicName := c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.name", i))[0]
+			if nicName != n {
+				continue
+			}
+
+			interfaceType := c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.type", i))
+			if interfaceType[0] != "veth" {
+				continue
+			}
+
+			veth = c.RunningConfigItem(fmt.Sprintf("lxc.network.%d.veth.pair", i))[0]
+			break
+		}
+
 		for _, a := range addresses {
-			ip := shared.Ip{Interface: n, Address: a}
+			ip := shared.Ip{Interface: n, Address: a, HostVeth: veth}
 			if net.ParseIP(a).To4() == nil {
 				ip.Protocol = "IPV6"
 			} else {

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -918,7 +918,7 @@ func dbGetDevices(db *sql.DB, qName string, isprofile bool) (shared.Devices, err
 		return nil, err
 	}
 
-	devices := shared.Devices{} // That's basically a map[string]map[string]string
+	devices := shared.Devices{}
 	for _, r := range results {
 		id = r[0].(int)
 		name = r[1].(string)

--- a/shared/container.go
+++ b/shared/container.go
@@ -43,6 +43,7 @@ type Ip struct {
 	Interface string `json:"interface"`
 	Protocol  string `json:"protocol"`
 	Address   string `json:"address"`
+	HostVeth  string `json:"host_veth"`
 }
 
 type ContainerStatus struct {

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -371,6 +371,13 @@ Output:
                 'type': "disk",
                 'path': "/",
                 'source': "UUID=8f7fdf5e-dc60-4524-b9fe-634f82ac2fb6"}
+            },
+            "eth0": {
+                "type": "nic"
+                "parent": "lxcbr0",
+                "hwaddr": "00:16:3e:f4:e7:1c",
+                "name": "eth0",
+                "nictype": "bridged",
             }
         },
         'userdata': "SOME BASE64 BLOB",
@@ -379,10 +386,12 @@ Output:
                     'status_code': 103,
                     'ips': [{'interface': "eth0",
                              'protocol': "INET6",
-                             'address': "2001:470:b368:1020:1::2"},
+                             'address': "2001:470:b368:1020:1::2",
+                             'host_veth': "vethGMDIY9"},
                             {'interface': "eth0",
                              'protocol': "INET",
-                             'address': "172.16.15.30"}]},
+                             'address': "172.16.15.30",
+                             'host_veth': "vethGMDIY9"}]},
         'log': "lxc-checkpoint 1430925874.468 DEBUG    lxc_commands - commands.c:lxc_cmd_get_state:574 - 'u2' is in 'RUNNING' state
                 lxc-checkpoint 1430925874.468 ERROR    lxc_criu - criu.c:criu_version_ok:242 - No such file or directory - execing criu failed, is it installed?
                 ...",


### PR DESCRIPTION
Looks like:

Name: foo
Status: RUNNING
Init: 30374
Ips:
  eth0: IPV4  10.0.3.2  vethGMDIY9
  lo: IPV4  127.0.0.1
  lo: IPV6  ::1

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>