### PR TITLE
Send an initial SIGWINCH on exec

### DIFF
--- a/client.go
+++ b/client.go
@@ -1010,11 +1010,6 @@ func (c *Client) Exec(name string, cmd []string, env map[string]string, stdin *o
 				}
 
 				for {
-					ch := make(chan os.Signal)
-					signal.Notify(ch, syscall.SIGWINCH)
-					sig := <-ch
-
-					shared.Debugf("Received '%s signal', updating window geometry.\n", sig)
 					width, height, err := terminal.GetSize(syscall.Stdout)
 					if err != nil {
 						continue
@@ -1046,6 +1041,12 @@ func (c *Client) Exec(name string, cmd []string, env map[string]string, stdin *o
 						shared.Debugf("got err writing %s", err)
 						break
 					}
+
+					ch := make(chan os.Signal)
+					signal.Notify(ch, syscall.SIGWINCH)
+					sig := <-ch
+
+					shared.Debugf("Received '%s signal', updating window geometry.\n", sig)
 				}
 
 				closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")


### PR DESCRIPTION
This makes sure that the terminal on the server side is initialized at
the right size before we start receiving stuff from it.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>