### PR TITLE
Add unset for server config keys

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -55,6 +55,9 @@ func (c *configCmd) usage() string {
 			"lxc config edit <container>                            Edit container configuration in external editor\n" +
 			"lxc config get <container> key                         Get configuration key\n" +
 			"lxc config set <container> key [value]                 Set container configuration key\n" +
+			"lxc config unset <container> key                       Unset container configuration key\n" +
+			"lxc config set key value                               Set server configuration key\n" +
+			"lxc config unset key                                   Unset server configuration key\n" +
 			"lxc config show <container>                            Show container configuration\n" +
 			"lxc config trust list [remote]                         List all trusted certs.\n" +
 			"lxc config trust add [remote] [certfile.crt]           Add certfile.crt to trusted hosts.\n" +
@@ -101,9 +104,20 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 	switch args[0] {
 
 	case "unset":
-		if len(args) < 3 {
+		if len(args) < 2 {
 			return errArgs
 		}
+
+		if len(args) == 2 {
+			key := args[1]
+			c, err := lxd.NewClient(config, "")
+			if err != nil {
+				return err
+			}
+			_, err = c.SetServerConfig(key, "")
+			return err
+		}
+
 		return doSet(config, append(args, ""))
 
 	case "set":

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -108,6 +108,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return errArgs
 		}
 
+		// 2 args means we're unsetting a server key
 		if len(args) == 2 {
 			key := args[1]
 			c, err := lxd.NewClient(config, "")
@@ -118,6 +119,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
+		// 3 args is a container config key
 		return doSet(config, append(args, ""))
 
 	case "set":
@@ -125,6 +127,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return errArgs
 		}
 
+		// 3 args means we're setting a server key
 		if len(args) == 3 {
 			key := args[1]
 			c, err := lxd.NewClient(config, "")
@@ -135,6 +138,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
+		// 4 args is a container config key
 		return doSet(config, args)
 
 	case "trust":

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -54,7 +54,7 @@ func (c *configCmd) usage() string {
 			"lxc config device remove <container> <name>            Remove device from container\n" +
 			"lxc config edit <container>                            Edit container configuration in external editor\n" +
 			"lxc config get <container> key                         Get configuration key\n" +
-			"lxc config set <container> key [value]                 Set container configuration key\n" +
+			"lxc config set <container> key value                   Set container configuration key\n" +
 			"lxc config unset <container> key                       Unset container configuration key\n" +
 			"lxc config set key value                               Set server configuration key\n" +
 			"lxc config unset key                                   Unset server configuration key\n" +

--- a/test/serverconfig.sh
+++ b/test/serverconfig.sh
@@ -9,6 +9,9 @@ test_server_config() {
     echo $config | grep -q "trust_password"
     echo $config | grep -q -v "123456"
 
+    lxc config unset core.trust_password
+    lxc config show | grep -q -v "trust_password"
+
     # test untrusted server GET
     my_curl -X GET https://127.0.0.1:18450/1.0 | grep -v -q environment
 


### PR DESCRIPTION
Implemented by POSTing a config json with empty-string values : `{key: ""}`
The daemon sees that and removes the key from the DB.

Fixes #751.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>