### PR TITLE
add initial implementation of /dev/lxd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ po/*.mo
 po/*.po~
 lxd-*.tar.gz
 .vagrant
+test/devlxd-client

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -933,3 +933,21 @@ func dbGetDevices(db *sql.DB, qName string, isprofile bool) (shared.Devices, err
 
 	return devices, nil
 }
+
+func dbListContainers(d *Daemon) ([]string, error) {
+	q := fmt.Sprintf("SELECT name FROM containers WHERE type=? ORDER BY name")
+	inargs := []interface{}{cTypeRegular}
+	var container string
+	outfmt := []interface{}{container}
+	result, err := shared.DbQueryScan(d.db, q, inargs, outfmt)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]string, 0)
+	for _, container := range result {
+		ret = append(ret, container[0].(string))
+	}
+
+	return ret, nil
+}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -1,0 +1,343 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"unsafe"
+
+	"github.com/gorilla/mux"
+	"gopkg.in/lxc/go-lxc.v2"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func socketPath() string {
+	return shared.VarPath("devlxd")
+}
+
+type DevLxdResponse struct {
+	content interface{}
+	code    int
+}
+
+func OkResponse(ct interface{}) *DevLxdResponse {
+	return &DevLxdResponse{ct, http.StatusOK}
+}
+
+type DevLxdHandler struct {
+	path string
+
+	/*
+	 * This API will have to be changed slightly when we decide to support
+	 * websocket events upgrading, but since we don't have events on the
+	 * server side right now either, I went the simple route to avoid
+	 * needless noise.
+	 */
+	f func(c *lxdContainer, r *http.Request) *DevLxdResponse
+}
+
+var configGet = DevLxdHandler{"/1.0/config", func(c *lxdContainer, r *http.Request) *DevLxdResponse {
+	filtered := map[string]string{}
+	for k, v := range c.config {
+		if strings.HasPrefix(k, "user.") {
+			filtered[k] = v
+		}
+	}
+	return OkResponse(filtered)
+}}
+
+var configKeyGet = DevLxdHandler{"/1.0/config/{key}", func(c *lxdContainer, r *http.Request) *DevLxdResponse {
+	key := mux.Vars(r)["key"]
+	if !strings.HasPrefix(key, "user.") {
+		return &DevLxdResponse{"not authorized", http.StatusForbidden}
+	}
+
+	value, ok := c.config[key]
+	if !ok {
+		return &DevLxdResponse{"not found", http.StatusNotFound}
+	}
+
+	return OkResponse(value)
+}}
+
+var metadataGet = DevLxdHandler{"/1.0/meta-data", func(c *lxdContainer, r *http.Request) *DevLxdResponse {
+	return &DevLxdResponse{"not implemented", http.StatusNotImplemented}
+}}
+
+var handlers = []DevLxdHandler{
+	DevLxdHandler{"/", func(c *lxdContainer, r *http.Request) *DevLxdResponse {
+		return OkResponse([]string{"/1.0"})
+	}},
+	DevLxdHandler{"/1.0", func(c *lxdContainer, r *http.Request) *DevLxdResponse {
+		return OkResponse(shared.Jmap{"api_compat": 0})
+	}},
+	configGet,
+	configKeyGet,
+	metadataGet,
+	/* TODO: events */
+}
+
+func hoistReq(f func(*lxdContainer, *http.Request) *DevLxdResponse, d *Daemon) func(http.ResponseWriter, *http.Request) {
+	return func(w http.ResponseWriter, r *http.Request) {
+		conn := extractUnderlyingConn(w)
+		pid, ok := pidMapper.m[conn]
+		if !ok {
+			http.Error(w, pidNotInContainerErr.Error(), 500)
+			return
+		}
+
+		c, err := findContainerForPid(pid, d)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+
+		resp := f(c, r)
+		if resp.code != http.StatusOK {
+			http.Error(w, fmt.Sprintf("%s", resp.content), resp.code)
+		} else {
+			WriteJson(w, resp.content)
+		}
+	}
+}
+
+func createAndBindDevLxd() (*net.UnixListener, error) {
+	path := socketPath()
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf("couldn't remove old devlxd: %s", err)
+	}
+
+	unixAddr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, err
+	}
+
+	unixl, err := net.ListenUnix("unix", unixAddr)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := os.Chmod(path, 0666); err != nil {
+		return nil, err
+	}
+
+	return unixl, nil
+}
+
+func setupDevLxdMount(c *lxc.Container) error {
+	mtab := fmt.Sprintf("%s dev/lxd none bind,create=file 0 0", socketPath())
+	return c.SetConfigItem("lxc.mount.entry", mtab)
+}
+
+func devLxdServer(d *Daemon) http.Server {
+	m := mux.NewRouter()
+
+	for _, handler := range handlers {
+		m.HandleFunc(handler.path, hoistReq(handler.f, d))
+	}
+
+	return http.Server{
+		Handler:   m,
+		ConnState: pidMapper.ConnStateHandler,
+	}
+}
+
+/*
+ * Everything below here is the guts of the unix socket bits. Unfortunately,
+ * golang's API does not make this easy. What happens is:
+ *
+ * 1. We install a ConnState listener on the http.Server, which does the
+ *    initial unix socket credential exchange. When we get a connection started
+ *    event, we use SO_PEERCRED to extract the creds for the socket.
+ *
+ * 2. We store a map from the connection pointer to the pid for that
+ *    connection, so that once the HTTP negotiation occurrs and we get a
+ *    ResponseWriter, we know (because we negotiated on the first byte) which
+ *    pid the connection belogs to.
+ *
+ * 3. Regular HTTP negotiation and dispatch occurs via net/http.
+ *
+ * 4. When rendering the response via ResponseWriter, we match its underlying
+ *    connection against what we stored in step (2) to figure out which container
+ *    it came from.
+ */
+
+/*
+ * We keep this in a global so that we can reference it from the server and
+ * from our http handlers, since there appears to be no way to pass information
+ * around here.
+ */
+var pidMapper = ConnPidMapper{m: map[*net.UnixConn]int32{}}
+
+type ConnPidMapper struct {
+	m map[*net.UnixConn]int32
+}
+
+func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
+	unixConn := conn.(*net.UnixConn)
+	switch state {
+	case http.StateNew:
+		pid, err := getPid(unixConn)
+		if err != nil {
+			shared.Debugf("error getting pid for conn %s", err)
+		} else {
+			m.m[unixConn] = pid
+		}
+	case http.StateActive:
+		return
+	case http.StateIdle:
+		return
+	case http.StateHijacked:
+		/*
+		 * The "Hijacked" state indicates that the connection has been
+		 * taken over from net/http. This is useful for things like
+		 * developing websocket libraries, who want to upgrade the
+		 * connection to a websocket one, and not use net/http any
+		 * more. Whatever the case, we want to forget about it since we
+		 * won't see it either.
+		 */
+		delete(m.m, unixConn)
+	case http.StateClosed:
+		delete(m.m, unixConn)
+	default:
+		shared.Debugf("unknown state for connection %s", state)
+	}
+}
+
+/*
+ * I also don't see that golang exports an API to get at the underlying FD, but
+ * we need it to get at SO_PEERCRED, so let's grab it.
+ */
+func extractUnderlyingFd(unixConnPtr *net.UnixConn) int {
+
+	conn := reflect.Indirect(reflect.ValueOf(unixConnPtr))
+	netFdPtr := conn.FieldByName("fd")
+	netFd := reflect.Indirect(netFdPtr)
+	fd := netFd.FieldByName("sysfd")
+	return int(fd.Int())
+}
+
+func getPid(conn *net.UnixConn) (int32, error) {
+	fd := extractUnderlyingFd(conn)
+	cred, err := syscall.GetsockoptUcred(fd, syscall.SOL_SOCKET, syscall.SO_PEERCRED)
+	if err != nil {
+		return -1, err
+	}
+
+	return cred.Pid, nil
+}
+
+/*
+ * As near as I can tell, there is no nice way of extracting an underlying
+ * net.Conn (or in our case, net.UnixConn) from an http.Request or
+ * ResponseWriter without hijacking it [1]. Since we want to send and recieve
+ * unix creds to figure out which container this request came from, we need to
+ * do this.
+ *
+ * [1]: https://groups.google.com/forum/#!topic/golang-nuts/_FWdFXJa6QA
+ */
+func extractUnderlyingConn(w http.ResponseWriter) *net.UnixConn {
+	v := reflect.Indirect(reflect.ValueOf(w))
+	connPtr := v.FieldByName("conn")
+	conn := reflect.Indirect(connPtr)
+	rwc := conn.FieldByName("rwc")
+
+	netConnPtr := (*net.Conn)(unsafe.Pointer(rwc.UnsafeAddr()))
+	unixConnPtr := (*netConnPtr).(*net.UnixConn)
+
+	return unixConnPtr
+}
+
+var pidNotInContainerErr = fmt.Errorf("pid not in container?")
+
+func findContainerForPid(pid int32, d *Daemon) (*lxdContainer, error) {
+
+	/*
+	 * Try and figure out which container a pid is in. There is probably a
+	 * better way to do this. Based on rharper's initial performance
+	 * metrics, looping over every container and calling newLxdContainer is
+	 * expensive, so I wanted to avoid that if possible, so this happens in
+	 * a two step process:
+	 *
+	 * 1. Walk up the process tree until you see something that looks like
+	 *    an lxc monitor process and extract its name from there.
+	 *
+	 * 2. If this fails, it may be that someone did an `lxc exec foo bash`,
+	 *    so the process isn't actually a decendant of the container's
+	 *    init. In this case we just look through all the containers until
+	 *    we find an init with a matching pid namespace. This is probably
+	 *    uncommon, so hopefully the slowness won't hurt us.
+	 */
+
+	origpid := pid
+
+	for pid > 1 {
+		cmdline, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid))
+		if err != nil {
+			return nil, err
+		}
+
+		if strings.HasPrefix(string(cmdline), "[lxc monitor]") {
+			// container names can't have spaces
+			parts := strings.Split(string(cmdline), " ")
+			name := parts[len(parts)-1]
+
+			return newLxdContainer(name, d)
+		}
+
+		status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+		if err != nil {
+			return nil, err
+		}
+
+		re := regexp.MustCompile("PPid:\\s*([0-9]*)")
+		for _, line := range strings.Split(string(status), "\n") {
+			m := re.FindStringSubmatch(line)
+			if m != nil && len(m) > 1 {
+				result, err := strconv.Atoi(m[1])
+				if err != nil {
+					return nil, err
+				}
+
+				pid = int32(result)
+				break
+			}
+		}
+	}
+
+	origPidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", origpid))
+	if err != nil {
+		return nil, err
+	}
+
+	containers, err := dbListContainers(d)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, container := range containers {
+		c, err := newLxdContainer(container, d)
+		if err != nil {
+			return nil, err
+		}
+
+		pidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", c.c.InitPid()))
+		if err != nil {
+			return nil, err
+		}
+
+		if origPidNs == pidNs {
+			return c, nil
+		}
+	}
+
+	return nil, pidNotInContainerErr
+}

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+)
+
+type DevLxdDialer struct {
+	Path string
+}
+
+func (d DevLxdDialer) DevLxdDial(network, path string) (net.Conn, error) {
+	addr, err := net.ResolveUnixAddr("unix", d.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, err
+}
+
+func setupDir() error {
+	os.RemoveAll("/tmp/tester")
+	return os.Setenv("LXD_DIR", "/tmp/tester")
+}
+
+func setupSocket() (*net.UnixListener, error) {
+	setupDir()
+
+	os.MkdirAll("/tmp/tester", 0700)
+
+	return createAndBindDevLxd()
+}
+
+func connect(path string) (*net.UnixConn, error) {
+	addr, err := net.ResolveUnixAddr("unix", path)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, nil
+}
+
+func TestCredsSendRecv(t *testing.T) {
+
+	result := make(chan int32, 1)
+
+	listener, err := setupSocket()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer listener.Close()
+	defer os.RemoveAll("/tmp/tester")
+
+	go func() {
+		conn, err := listener.AcceptUnix()
+		if err != nil {
+			t.Log(err)
+			result <- -1
+			return
+		}
+		defer conn.Close()
+
+		pid, err := getPid(conn)
+		if err != nil {
+			t.Log(err)
+			result <- -1
+			return
+		}
+		result <- pid
+	}()
+
+	conn, err := connect("/tmp/tester/devlxd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	pid := <-result
+	if pid != int32(os.Getpid()) {
+		t.Fatal("pid mismatch: ", pid, os.Getpid())
+	}
+}
+
+/*
+ * Here we're not really testing the API functionality (we can't, since it
+ * expects us to be inside a container to work), but it is useful to test that
+ * all the grotty connection extracting stuff works (that is, it gets to the
+ * point where it realizes the pid isn't in a container without crashing).
+ */
+func TestHttpRequest(t *testing.T) {
+
+	if err := setupDir(); err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll("/tmp/tester")
+
+	d, err := StartDaemon("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer d.Stop()
+
+	c := http.Client{Transport: &http.Transport{Dial: DevLxdDialer{Path: "/tmp/tester/devlxd"}.DevLxdDial}}
+
+	raw, err := c.Get("http://1.0")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if raw.StatusCode != 500 {
+		t.Fatal(err)
+	}
+
+	resp, err := ioutil.ReadAll(raw.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !strings.Contains(string(resp), pidNotInContainerErr.Error()) {
+		t.Fatal("resp error not expected: ", string(resp))
+	}
+}

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -83,7 +83,7 @@ func TestCredsSendRecv(t *testing.T) {
 		result <- pid
 	}()
 
-	conn, err := connect("/tmp/tester/devlxd")
+	conn, err := connect("/tmp/tester/devlxd/sock")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -114,7 +114,7 @@ func TestHttpRequest(t *testing.T) {
 	}
 	defer d.Stop()
 
-	c := http.Client{Transport: &http.Transport{Dial: DevLxdDialer{Path: "/tmp/tester/devlxd"}.DevLxdDial}}
+	c := http.Client{Transport: &http.Transport{Dial: DevLxdDialer{Path: "/tmp/tester/devlxd/sock"}.DevLxdDial}}
 
 	raw, err := c.Get("http://1.0")
 	if err != nil {

--- a/specs/dev-lxd.md
+++ b/specs/dev-lxd.md
@@ -5,7 +5,7 @@ configuration options, reporting errors back to the host as well as
 adding support for a range of new features by allowing events to be sent
 in either directions.
 
-In LXD, this feature is implemented through a /dev/lxd node which is
+In LXD, this feature is implemented through a /dev/lxd/sock node which is
 created and setup for all LXD containers.
 
 This file is a Unix socket which processes inside the container can
@@ -13,28 +13,28 @@ connect to. It's multi-threaded so multiple clients can be connected at the
 same time.
 
 # Implementation details
-LXD on the host binds /var/lib/lxd/devlxd.socket and starts listening
-for new connections on it.
+LXD on the host binds /var/lib/lxd/devlxd and starts listening for new
+connections on it.
 
 This socket is then bind-mounted into every single container started by
-LXD at /dev/lxd.
+LXD at /dev/lxd/sock.
 
 The bind-mount is required so we can exceed 4096 containers, otherwise,
 LXD would have to bind a different socket for every container, quickly
 reaching the FD limit.
 
 # Authentication
-Queries on /dev/lxd will only return information related to the
+Queries on /dev/lxd/sock will only return information related to the
 requesting container. To figure out where a request comes from, LXD will
 extract the initial socket ucred and compare that to the list of
 containers it manages.
 
 # Protocol
-The protocol on /dev/lxd is plain-text HTTP with JSON messaging, so very
+The protocol on /dev/lxd/sock is plain-text HTTP with JSON messaging, so very
 similar to the local version of the LXD protocol.
 
 Unlike the main LXD API, there is no background operation and no
-authentication support in the /dev/lxd API.
+authentication support in the /dev/lxd/sock API.
 
 # REST-API
 ## API structure
@@ -69,7 +69,7 @@ Return value:
 
 Note that the configuration key names match those in the container
 config, however not all configuration namespaces will be exported to
-/dev/lxd.
+/dev/lxd/sock.
 We'll initially only support the user namespace (user.\* keys).
 
 At this time, there also aren't any container-writable namespace.

--- a/test/devlxd-client.go
+++ b/test/devlxd-client.go
@@ -1,0 +1,81 @@
+/*
+ * An example of how to use lxd's golang /dev/lxd client. This is intended to
+ * be run from inside a container.
+ */
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+)
+
+type DevLxdDialer struct {
+	Path string
+}
+
+func (d DevLxdDialer) DevLxdDial(network, path string) (net.Conn, error) {
+	addr, err := net.ResolveUnixAddr("unix", d.Path)
+	if err != nil {
+		return nil, err
+	}
+
+	conn, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return conn, err
+}
+
+var DevLxdTransport = &http.Transport{
+	Dial: DevLxdDialer{"/dev/lxd"}.DevLxdDial,
+}
+
+func main() {
+	c := http.Client{Transport: DevLxdTransport}
+	raw, err := c.Get("http://meshuggah-rocks/")
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+
+	if raw.StatusCode != http.StatusOK {
+		fmt.Println("http error", raw.StatusCode)
+		result, err := ioutil.ReadAll(raw.Body)
+		if err == nil {
+			fmt.Println(string(result))
+		}
+		os.Exit(1)
+	}
+
+	result := []string{}
+	if err := json.NewDecoder(raw.Body).Decode(&result); err != nil {
+		fmt.Println("err decoding response", err)
+		os.Exit(1)
+	}
+
+	if result[0] != "/1.0" {
+		fmt.Println("unknown response", result)
+		os.Exit(1)
+	}
+
+	if len(os.Args) > 1 {
+		raw, err := c.Get(fmt.Sprintf("http://meshuggah-rocks/1.0/config/%s", os.Args[1]))
+		if err != nil {
+			fmt.Println(err)
+			os.Exit(1)
+		}
+		key := ""
+		if err := json.NewDecoder(raw.Body).Decode(&key); err != nil {
+			fmt.Println("err decoding response", err)
+			os.Exit(1)
+		}
+		fmt.Println(key)
+	} else {
+		fmt.Println("/dev/lxd ok")
+	}
+}

--- a/test/devlxd-client.go
+++ b/test/devlxd-client.go
@@ -32,7 +32,7 @@ func (d DevLxdDialer) DevLxdDial(network, path string) (net.Conn, error) {
 }
 
 var DevLxdTransport = &http.Transport{
-	Dial: DevLxdDialer{"/dev/lxd"}.DevLxdDial,
+	Dial: DevLxdDialer{"/dev/lxd/sock"}.DevLxdDial,
 }
 
 func main() {

--- a/test/devlxd.sh
+++ b/test/devlxd.sh
@@ -1,0 +1,25 @@
+test_devlxd() {
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    echo "SKIPPING"
+    return
+  fi
+
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
+    if [ -e "$LXD_TEST_IMAGE" ]; then
+        lxc image import $LXD_TEST_IMAGE --alias testimage
+    else
+        ../scripts/lxd-images import busybox --alias testimage
+    fi
+  fi
+
+  go build -tags netgo -a -installsuffix devlxd devlxd-client.go
+  lxc launch testimage devlxd
+
+  lxc file push devlxd-client devlxd/bin/
+  lxc exec devlxd chmod +x /bin/devlxd-client
+
+  lxc config set devlxd user.foo bar
+  lxc exec devlxd devlxd-client user.foo | grep bar
+
+  lxc stop devlxd --force
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -102,6 +102,8 @@ cleanup() {
         [ -n "${dir}" ] && wipe "${dir}"
     done
 
+    rm -f devlxd-client || true
+
     echo ""
     echo ""
     echo "==> Test result: $RESULT"
@@ -128,6 +130,7 @@ fi
 . ./profiling.sh
 . ./fdleak.sh
 . ./database_update.sh
+. ./devlxd.sh
 
 if [ -n "$LXD_DEBUG" ]; then
     debug=--debug
@@ -211,6 +214,9 @@ test_config_profiles
 
 echo "==> TEST: server config"
 test_server_config
+
+echo "==> TEST: devlxd"
+test_devlxd
 
 if type fuidshift >/dev/null 2>&1; then
     echo "==> TEST: uidshift"


### PR DESCRIPTION
Here's an initial implementation of /dev/lxd (it doesn't do events right
now, and the userdata endpoint returns 503 since we haven't implemented it
yet in lxd proper). But, the basics are there, and this is probably enough
for people who want to start working against it to do so.

I haven't added any automated tests yet, but I did include a test program
that exits 0 if /dev/lxd works, and 1 if it doesn't:

$ lxc exec foo devlxd-client
/dev/lxd ok

Also, obviously there are some pretty brutal hacks in here to make things
work. Unfortunately, I'm not sure there's a better way to do some of this
stuff, but am open to suggestions (or better yet, patches :D).

Closes #747
Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>