### PR TITLE
don't pass append() result as argument without storing

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -120,7 +120,8 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		// 3 args is a container config key
-		return doSet(config, append(args, ""))
+		args = append(args, "")
+		return doSet(config, args)
 
 	case "set":
 		if len(args) < 3 {

--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -147,7 +147,8 @@ func setTrustPassword(d *Daemon, password string) error {
 			return err
 		}
 
-		value = hex.EncodeToString(append(salt, hash...))
+		rawvalue := append(salt, hash...)
+		value = hex.EncodeToString(rawvalue)
 	}
 
 	err := setServerConfig(d, "core.trust_password", value)


### PR DESCRIPTION
Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>