### PR TITLE
Fix usage examples for setting the memory limits (again)

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1589,14 +1589,7 @@ func (d *lxdContainer) applyConfig(config map[string]string, fromProfile bool) e
 			cpuset := fmt.Sprintf("0-%d", vint-1)
 			err = d.c.SetConfigItem("lxc.cgroup.cpuset.cpus", cpuset)
 		case "limits.memory":
-			megabytes, err := strconv.Atoi(v)
-			if err != nil {
-				return err
-			}
-
-			bytes := strconv.Itoa(megabytes * 1024)
-
-			err = d.c.SetConfigItem("lxc.cgroup.memory.limit_in_bytes", bytes)
+			err = d.c.SetConfigItem("lxc.cgroup.memory.limit_in_bytes", v)
 
 		default:
 			if strings.HasPrefix(k, "user.") {

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -111,7 +111,7 @@ Command                                                                         
 lxc config show                                                                 | Show the local server's configuration
 lxc config show dakara:                                                         | Show "dakara"'s server' configuration
 lxc config set core.trust\_password new-trust-password                          | Set the local server's trust password to "new-trust-password"
-lxc config set c1 limits.memory 2GB                                             | Set a memory limit of 2GB for container "c1"
+lxc config set c1 limits.memory 2G                                              | Set a memory limit of 2GB for container "c1"
 lxc config show c1                                                              | Show the configuration of the "c1" container, starting by the list of profiles it’s based on, then the container specific settings and finally the resulting overall configuration.
 lxc config trust add new-client-cert.crt                                        | Add new-client-cert.pem to the default remote's trust store (typically local LXD)
 lxc config trust add dakara: new-client-cert.crt                                | Add new-client-cert.pem to the "dakara"'s trust store
@@ -471,7 +471,7 @@ local container still references it.
 Command                                                                  | Result
 :------                                                                  | :-----
 lxc profile create micro                                                 | Create a new "micro" profile.
-lxc profile set micro limits.memory 256MB                                | Restrict memory usage to 256MB
+lxc profile set micro limits.memory 256M                                 | Restrict memory usage to 256MB
 lxc profile set micro limits.cpus 1                                      | Restrict CPU usage to a single core
 lxc profile copy micro dakara:                                           | Copy the resulting profile over to "dakara"
 lxc profile show micro                                                   | Show all the options associated with the "micro" profile and all the containers using it

--- a/test/stresstest.sh
+++ b/test/stresstest.sh
@@ -176,7 +176,7 @@ disturbthread() {
         lxc exec disturb1 -- ps -ef
         lxc stop disturb1
         lxc delete disturb1
-	lxc profile delete empty
+        lxc profile delete empty
     done
     exit 0
 }

--- a/test/stresstest.sh
+++ b/test/stresstest.sh
@@ -160,7 +160,7 @@ configthread() {
     echo "configthread: I am $$"
     for i in `seq 1 20`; do
         lxc profile create p$i
-        lxc profile set p$i limits.memory 100
+        lxc profile set p$i limits.memory 100M
         lxc profile delete p$i
     done
     exit 0


### PR DESCRIPTION
Another pull request, as stated in #736. This one contains the documentation fixes, as well as the revert for 6376638034baf8f371b4caf8461a0bc6c5e4d95d, and a rogue tab removal that I've noticed in `stresstest.sh`.

Hope I've gotten everything right this time. :)