### PR TITLE
exec: do not close fds until we are definately done

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -2532,7 +2532,7 @@ func (s *execWs) Do() shared.OperationResult {
 	}
 
 	controlExit := make(chan bool)
-	stdinEof := make(chan bool)
+	stdEof := make(chan bool)
 
 	if s.interactive {
 		go func() {
@@ -2601,10 +2601,10 @@ func (s *execWs) Do() shared.OperationResult {
 				if i == 0 {
 					<-shared.WebsocketRecvStream(ttys[i], s.conns[i])
 					ttys[i].Close()
-					stdinEof <- true
 				} else {
 					<-shared.WebsocketSendStream(s.conns[i], ptys[i])
 					ptys[i].Close()
+					stdEof <- true
 				}
 			}(i)
 		}
@@ -2617,7 +2617,10 @@ func (s *execWs) Do() shared.OperationResult {
 	)
 
 	if !s.interactive {
-		<-stdinEof
+		ttys[0].Close()
+		ttys[1].Close()
+		ttys[2].Close()
+		<-stdEof
 	}
 
 	for _, tty := range ttys {

--- a/test/exec.sh
+++ b/test/exec.sh
@@ -1,0 +1,34 @@
+test_concurrent_exec() {
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    return
+  fi
+
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
+      if [ -e "$LXD_TEST_IMAGE" ]; then
+          lxc image import $LXD_TEST_IMAGE --alias testimage
+      else
+          ../scripts/lxd-images import busybox --alias testimage
+      fi
+  fi
+
+  name=x1
+  lxc launch testimage x1
+  lxc list ${name} | grep RUNNING
+
+  exec_container() {
+      echo abc$1 | lxc exec ${name} -- cat | grep abc
+  }
+
+  PIDS=""
+  for i in `seq 1 50`; do
+      exec_container $i 2>&1 > $LXD_DIR/exec-$i.out &
+      PIDS="$PIDS $!"
+  done
+
+  for pid in $PIDS; do
+      wait $pid
+  done
+
+  lxc stop ${name} --force
+  lxc delete ${name}
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -115,6 +115,7 @@ fi
 
 . ./basic.sh
 . ./concurrent.sh
+. ./exec.sh
 . ./database.sh
 . ./deps.sh
 . ./fuidshift.sh
@@ -193,6 +194,9 @@ test_remote_admin
 
 echo "==> TEST: basic usage"
 test_basic_usage
+
+echo "==> TEST: concurrent exec"
+test_concurrent_exec
 
 echo "==> TEST: concurrent startup"
 test_concurrent


### PR DESCRIPTION
By closing all fds (in noninteractive case) as soon as RunCommand
is done, we occasionally miss some data still coming from the
container.  Instead, wait until stdin from the container gets an
EOF.

This stops a (on one of my systems, very easy to reproduce) failure
of the concurrency test.  To track this down I also added a simpler
test suggested by stgraber - only doing parallel execs of a single
running container.  In this way it's easy to look for any
exec-$i.out which is missing.  Tha test is also in this request.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>