### PR TITLE
Helpful test tweaks

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -78,6 +78,7 @@ cleanup() {
     set +x
 
     if [ -n "$LXD_INSPECT" ]; then
+        echo "To poke around, use:\n LXD_DIR=$LXD_DIR sudo -E $GOPATH/bin/lxc COMMAND --config ${LXD_CONF}"
         read -p "Tests Completed ($RESULT): hit enter to continue" x
     fi
     echo "==> Cleaning up"
@@ -145,7 +146,7 @@ spawn_lxd() {
   shift
   shift
   echo "==> Spawning lxd on $addr in $lxddir"
-  LXD_DIR=$lxddir lxd $debug --tcp $addr $extraargs $* 2>&1 | tee $lxddir/lxd.log &
+  (LXD_DIR=$lxddir lxd $debug --tcp $addr $extraargs $* 2>&1 & echo $! > $lxddir/lxd.pid) | tee $lxddir/lxd.log &
 
   echo "==> Confirming lxd on $addr is responsive"
   alive=0


### PR DESCRIPTION
Add a message to make postmortem inspection of the LXDs the test spawns
more convenient.

Save the PID of spawned LXDs in their tmpdir to make killing them off
easier in tests that need to spawn isolated LXDs.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>