### PR TITLE
idmap: add ushifting rootfs

### DIFF
--- a/fuidshift/main.go
+++ b/fuidshift/main.go
@@ -8,8 +8,10 @@ import (
 )
 
 func help(me string, status int) {
-	fmt.Printf("Usage: %s directory [-t] <range1> [<range2> ...]\n", me)
+	fmt.Printf("Usage: %s directory [-t] [-r] <range1> [<range2> ...]\n", me)
 	fmt.Printf("  -t implies test mode.  No file ownerships will be changed.\n")
+	fmt.Printf("  -r means reverse, that is shift the uids out of hte container.\n")
+	fmt.Printf("\n")
 	fmt.Printf("  A range is [u|b|g]:<first_container_id:first_host_id:range>.\n")
 	fmt.Printf("  where u means shift uids, g means shift gids, b means shift both.\n")
 	fmt.Printf("  For example: %s directory b:0:100000:65536 u:10000:1000:1\n", me)
@@ -35,10 +37,13 @@ func run() error {
 	directory := os.Args[1]
 	idmap := shared.IdmapSet{}
 	testmode := false
+	reverse := false
 
 	for pos := 2; pos < len(os.Args); pos++ {
 
 		switch os.Args[pos] {
+		case "-r", "--reverse":
+			reverse = true
 		case "t", "-t", "--test", "test":
 			testmode = true
 		default:
@@ -60,5 +65,8 @@ func run() error {
 		os.Exit(1)
 	}
 
+	if reverse {
+		return idmap.UidshiftFromContainer(directory, testmode)
+	}
 	return idmap.UidshiftIntoContainer(directory, testmode)
 }

--- a/test/fuidshift.sh
+++ b/test/fuidshift.sh
@@ -27,6 +27,14 @@ test_nonroot_fuidshift() {
 		echo "==> Wrongly shifted invalid uid to container root"
 		false
 	fi
+
+	# unshift it
+	chown 100000:100000 ${LXD_FUIDMAP_DIR}/x1
+	fuidshift ${LXD_FUIDMAP_DIR}/x1 -r -t u:$u:100000:1 g:$g:100000:1 | tee /dev/stderr | grep "to 0 0" > /dev/null || fail=1
+	if [ $fail -eq 1 ]; then
+		echo "==> Failed to unshift container root back to own uid"
+		false
+	fi
 }
 
 test_root_fuidshift() {


### PR DESCRIPTION
The idmapset currently supports shifting ids into containers, but not
out.  We'll need the latter for publishing containers as images.

Also fix a wrong comment at idmapEntry struct - the hostid field
comment was on the maprange field.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>