### PR TITLE
Move server config functions out of api10.go

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -5,8 +5,9 @@ import (
 	"net/http"
 	"syscall"
 
-	"github.com/lxc/lxd/shared"
 	"gopkg.in/lxc/go-lxc.v2"
+
+	"github.com/lxc/lxd/shared"
 )
 
 var api10 = []Command{

--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -1,17 +1,12 @@
 package main
 
 import (
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"syscall"
 
-	"golang.org/x/crypto/scrypt"
-	"gopkg.in/lxc/go-lxc.v2"
-
 	"github.com/lxc/lxd/shared"
+	"gopkg.in/lxc/go-lxc.v2"
 )
 
 var api10 = []Command{
@@ -39,24 +34,6 @@ var api10 = []Command{
 	certificateFingerprintCmd,
 	profilesCmd,
 	profileCmd,
-}
-
-func getServerConfig(d *Daemon) (map[string]interface{}, error) {
-	config := make(map[string]interface{})
-	q := "SELECT key, value FROM config"
-	rows, err := shared.DbQuery(d.db, q)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var key, value string
-		rows.Scan(&key, &value)
-		config[key] = value
-	}
-
-	return config, nil
 }
 
 func api10Get(d *Daemon, r *http.Request) Response {
@@ -124,82 +101,6 @@ func api10Get(d *Daemon, r *http.Request) Response {
 
 type apiPut struct {
 	Config shared.Jmap `json:"config"`
-}
-
-const (
-	PW_SALT_BYTES = 32
-	PW_HASH_BYTES = 64
-)
-
-func setTrustPassword(d *Daemon, password string) error {
-
-	shared.Debugf("setting new password")
-	var value = password
-	if password != "" {
-		salt := make([]byte, PW_SALT_BYTES)
-		_, err := io.ReadFull(rand.Reader, salt)
-		if err != nil {
-			return err
-		}
-
-		hash, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, PW_HASH_BYTES)
-		if err != nil {
-			return err
-		}
-
-		rawvalue := append(salt, hash...)
-		value = hex.EncodeToString(rawvalue)
-	}
-
-	err := setServerConfig(d, "core.trust_password", value)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func ValidServerConfigKey(k string) bool {
-	switch k {
-	case "core.trust_password":
-		return true
-	}
-
-	return false
-}
-
-func setServerConfig(d *Daemon, key string, value string) error {
-	tx, err := shared.DbBegin(d.db)
-	if err != nil {
-		return err
-	}
-
-	_, err = tx.Exec("DELETE FROM config WHERE key=?", key)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	if value != "" {
-		str := `INSERT INTO config (key, value) VALUES (?, ?);`
-		stmt, err := tx.Prepare(str)
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-		defer stmt.Close()
-		_, err = stmt.Exec(key, value)
-		if err != nil {
-			tx.Rollback()
-			return err
-		}
-	}
-
-	err = shared.TxCommit(tx)
-	if err != nil {
-		return err
-	}
-	return nil
 }
 
 func api10Put(d *Daemon, r *http.Request) Response {

--- a/lxd/serverconfig.go
+++ b/lxd/serverconfig.go
@@ -4,8 +4,9 @@ import (
 	"crypto/rand"
 	"database/sql"
 	"encoding/hex"
-	"golang.org/x/crypto/scrypt"
 	"io"
+
+	"golang.org/x/crypto/scrypt"
 
 	"github.com/lxc/lxd/shared"
 )

--- a/lxd/serverconfig.go
+++ b/lxd/serverconfig.go
@@ -1,0 +1,124 @@
+package main
+
+import (
+	"crypto/rand"
+	"database/sql"
+	"encoding/hex"
+	"golang.org/x/crypto/scrypt"
+	"io"
+
+	"github.com/lxc/lxd/shared"
+)
+
+const (
+	PW_SALT_BYTES = 32
+	PW_HASH_BYTES = 64
+)
+
+func setTrustPassword(d *Daemon, password string) error {
+
+	shared.Debugf("setting new password")
+	var value = password
+	if password != "" {
+		buf := make([]byte, PW_SALT_BYTES)
+		_, err := io.ReadFull(rand.Reader, buf)
+		if err != nil {
+			return err
+		}
+
+		hash, err := scrypt.Key([]byte(password), buf, 1<<14, 8, 1, PW_HASH_BYTES)
+		if err != nil {
+			return err
+		}
+
+		buf = append(buf, hash...)
+		value = hex.EncodeToString(buf)
+	}
+
+	err := setServerConfig(d, "core.trust_password", value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func ValidServerConfigKey(k string) bool {
+	switch k {
+	case "core.trust_password":
+		return true
+	}
+
+	return false
+}
+
+func setServerConfig(d *Daemon, key string, value string) error {
+
+	tx, err := shared.DbBegin(d.db)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec("DELETE FROM config WHERE key=?", key)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	if value != "" {
+		str := `INSERT INTO config (key, value) VALUES (?, ?);`
+		stmt, err := tx.Prepare(str)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+		defer stmt.Close()
+		_, err = stmt.Exec(key, value)
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+	}
+
+	err = shared.TxCommit(tx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// returns value, exists, error
+// Check 'exists' before looking at value. if exists == false, value is meaningless.
+func getServerConfigValue(d *Daemon, key string) (string, bool, error) {
+	var value string
+	q := "SELECT value from config where key=?"
+	arg1 := []interface{}{key}
+	arg2 := []interface{}{&value}
+	err := shared.DbQueryRowScan(d.db, q, arg1, arg2)
+	switch {
+	case err == sql.ErrNoRows:
+		return "", false, nil
+	case err != nil:
+		return "", false, err
+	default:
+		return value, true, nil
+	}
+}
+
+func getServerConfig(d *Daemon) (map[string]interface{}, error) {
+	config := make(map[string]interface{})
+	q := "SELECT key, value FROM config"
+	rows, err := shared.DbQuery(d.db, q)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var key, value string
+		rows.Scan(&key, &value)
+		config[key] = value
+	}
+
+	return config, nil
+}


### PR DESCRIPTION
Adds serverconfig.go to have a better spot for other functions
to be added later, which will do things like perform validation on
server config settings before changing the DB.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>