### PR TITLE
imagesPost: split into smaller functions

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -33,6 +33,7 @@ type Daemon struct {
 	mux         *mux.Router
 	clientCerts []x509.Certificate
 	db          *sql.DB
+	BackingFs   string
 
 	localSockets  []net.Listener
 	remoteSockets []net.Listener
@@ -272,6 +273,11 @@ func StartDaemon(listenAddr string) (*Daemon, error) {
 	err = os.MkdirAll(d.lxcpath, 0755)
 	if err != nil {
 		return nil, err
+	}
+
+	d.BackingFs, err = shared.GetFilesystem(d.lxcpath)
+	if err != nil {
+		shared.Debugf("Error detecting backing fs: %s\n", err)
 	}
 
 	certf, keyf, err := readMyCert()

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"path"
@@ -59,16 +58,7 @@ type network struct {
 func children(iface string) []string {
 	p := path.Join(shared.SYS_CLASS_NET, iface, "brif")
 
-	var ret []string
-
-	ents, err := ioutil.ReadDir(p)
-	if err != nil {
-		return ret
-	}
-
-	for _, ent := range ents {
-		ret = append(ret, ent.Name())
-	}
+	ret, _ := shared.ReadDir(p)
 
 	return ret
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -681,3 +681,16 @@ func SetSize(fd int, width int, height int) (err error) {
 	}
 	return nil
 }
+
+func ReadDir(p string) ([]string, error) {
+	ents, err := ioutil.ReadDir(p)
+	if err != nil {
+		return []string{}, err
+	}
+
+	var ret []string
+	for _, ent := range ents {
+		ret = append(ret, ent.Name())
+	}
+	return ret, nil
+}

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -698,12 +698,13 @@ In the http file upload case, The following headers may be set by the client:
 In the source container case, the following dict must be passed:
 
     {
-        "public": true,             # True or False
+        "public":   true,         # True or False
+        "filename": filename,     # Used for export
         "source": {
-            "type": "container",    # One of "container" or "snapshot"
+            "type": "container",  # One of "container" or "snapshot"
             "name": "abc"
         },
-        "properties": {             # Image properties
+        "properties": {           # Image properties
             "os": "Ubuntu",
         }
     }


### PR DESCRIPTION
Reorganize imagesPost:

  1. keep all working files in a tempdir.  Use a deferred helper to
     remove build files on cleanup rather than calling cleanup by
     hand.
  2. move the backing_fs into Daemon struct and set it on StartDaemon.
  3. use a helper for getting the web request data.  This will handle
     both image posts and container publish requests
  4. split imagesPost into several smaller functions.
  5. write a simple common shared.ReadDir used in both lxd/networks and
     lsd/images.
  6. update the rest api specs to add the image name and the container
     remote.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>