### PR TITLE
Add LVM thin pool support.

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -112,18 +112,30 @@ func api10Put(d *Daemon, r *http.Request) Response {
 	}
 
 	for key, value := range req.Config {
+		if !ValidServerConfigKey(key) {
+			return BadRequest(fmt.Errorf("Bad server config key: '%s'", key))
+		}
+
 		if key == "core.trust_password" {
 			err := setTrustPassword(d, value.(string))
 			if err != nil {
 				return InternalError(err)
 			}
-		} else if ValidServerConfigKey(key) {
-			err := setServerConfig(d, key, value.(string))
+		} else if key == "core.lvm_vg_name" {
+			err := setLVMVolumeGroupNameConfig(d, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
+		} else if key == "core.lvm_thinpool_name" {
+			err := setLVMThinPoolNameConfig(d, value.(string))
 			if err != nil {
 				return InternalError(err)
 			}
 		} else {
-			return BadRequest(fmt.Errorf("Bad server config key: '%s'", key))
+			err := setServerConfig(d, key, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
 		}
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -601,9 +601,7 @@ func imageDelete(d *Daemon, r *http.Request) Response {
 		if err != nil {
 			return InternalError(fmt.Errorf("Failed to remove symlink to deleted image LV: '%s': %v", lvsymlink, err))
 		}
-	}
-
-	if d.BackingFs == "btrfs" {
+	} else if d.BackingFs == "btrfs" {
 		subvol := fmt.Sprintf("%s.btrfs", fname)
 		exec.Command("btrfs", "subvolume", "delete", subvol).Run()
 	}

--- a/shared/lvm.go
+++ b/shared/lvm.go
@@ -1,0 +1,111 @@
+package shared
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+var defaultThinLVSize = "100GiB"
+var defaultThinPoolName = "LXDPool"
+var snapshotCreateTimeout = time.Duration(60) // seconds
+
+func LVMCheckVolumeGroup(vgname string) error {
+
+	output, err := exec.Command("vgdisplay", "-s", vgname).CombinedOutput()
+	if err != nil {
+		Debugf("vgdisplay failed to find vg:\n%s", output)
+		return fmt.Errorf("LVM volume group '%s' not found.", vgname)
+	}
+
+	return nil
+}
+
+func LVMThinPoolLVExists(vgname string, poolname string) (bool, error) {
+	output, err := exec.Command("vgs", "--noheadings", "-o", "lv_attr", fmt.Sprintf("%s/%s", vgname, poolname)).CombinedOutput()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			waitStatus := exitError.Sys().(syscall.WaitStatus)
+			if waitStatus.ExitStatus() == 5 {
+				// pool LV was not found
+				return false, nil
+			}
+		}
+		return false, fmt.Errorf("Error checking for pool '%s'", poolname)
+	}
+	// Found LV named poolname, check type:
+	attrs := strings.TrimSpace(string(output[:]))
+	if strings.HasPrefix(attrs, "t") {
+		return true, nil
+	} else {
+		return false, fmt.Errorf("Pool named '%s' exists but is not a thin pool.", poolname)
+	}
+
+}
+
+func LVMCreateDefaultThinPool(vgname string) (string, error) {
+	output, err := exec.Command("lvcreate", "--poolmetadatasize", "1G", "-l", "100%FREE", "--thinpool", fmt.Sprintf("%s/%s", vgname, defaultThinPoolName)).CombinedOutput()
+	if err != nil {
+		Debugf("could not create thin pool named '%s'. Error:'%s'\nOutput:'%s'", defaultThinPoolName, err, output)
+		return "", fmt.Errorf("Could not create LVM thin pool named %s", defaultThinPoolName)
+	}
+	return defaultThinPoolName, nil
+}
+
+func LVMCreateThinLV(lvname string, poolname string, vgname string) (string, error) {
+	output, err := exec.Command("lvcreate", "--thin", "-n", lvname, "--virtualsize", defaultThinLVSize, fmt.Sprintf("%s/%s", vgname, poolname)).CombinedOutput()
+	if err != nil {
+		Debugf("could not create LV named '%s': '%s'", lvname, output)
+		return "", fmt.Errorf("Could not create thin LV named %s", lvname)
+	}
+	return fmt.Sprintf("/dev/%s/%s", vgname, lvname), nil
+}
+
+func LVMCreateSnapshotLV(lvname string, origlvname string, vgname string) (string, error) {
+	cmd := exec.Command("lvcreate", "-kn", "-n", lvname, "-s", fmt.Sprintf("/dev/%s/%s", vgname, origlvname))
+
+	var errbuf bytes.Buffer
+	cmd.Stderr = &errbuf
+
+	err := cmd.Start()
+	if err != nil {
+		Debugf("could not create LV named '%s' as snapshot of '%s': '%s'", lvname, origlvname, errbuf.String())
+		return "", fmt.Errorf("Could not create snapshot LV named %s", lvname)
+	}
+
+	timer := time.AfterFunc(snapshotCreateTimeout*time.Second, func() {
+		Debugf("Snapshot creation timed out after '%d' seconds, terminating attempt.", snapshotCreateTimeout)
+		cmd.Process.Kill()
+	})
+
+	err = cmd.Wait()
+	timer.Stop()
+	if err != nil {
+		return "", fmt.Errorf("Snapshot LV creation error: '%v'", err)
+	}
+
+	if err != nil {
+		Debugf("could not create LV named '%s' as snapshot of '%s': '%s'", lvname, origlvname, errbuf.String())
+		return "", fmt.Errorf("Could not create snapshot LV named %s", lvname)
+	}
+
+	snapshotFullName := fmt.Sprintf("/dev/%s/%s", vgname, lvname)
+	output, err := exec.Command("lvchange", "-ay", snapshotFullName).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Could not activate new snapshot '%s': %v\noutput:%s", lvname, err, output)
+	}
+
+	return snapshotFullName, nil
+}
+
+func LVMRemoveLV(vgname string, lvname string) error {
+	output, err := exec.Command("lvremove", "-f", fmt.Sprintf("%s/%s", vgname, lvname)).CombinedOutput()
+	if err != nil {
+		Debugf("could not remove LV named '%s': '%s'", lvname, output)
+		return fmt.Errorf("Could not remove LV named %s", lvname)
+	}
+	return nil
+}

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -1,0 +1,109 @@
+create_vg() {
+
+    pvfile=$LXD_DIR/lvm-pv.img
+    truncate -s 10G $pvfile
+    pvloopdev=$(losetup -f)
+    losetup $pvloopdev $pvfile
+
+    #vgcreate will create a PV for us
+    vgcreate lxd_test_vg $pvloopdev
+
+}
+
+cleanup_vg() {
+
+    if [ -n "$LXD_INSPECT_LVM" ]; then
+        echo "To poke around, use:\n LXD_DIR=$LXD_DIR sudo -E $GOPATH/bin/lxc COMMAND --config ${LXD_CONF} "
+        read -p "Pausing to inspect LVM state. Hit Enter to continue cleanup." x
+    fi
+
+    if [ -d "$LXD_DIR"/lxc/testcontainer ]; then
+        echo "unmounting testcontainer LV"
+        umount "$LXD_DIR"/lxc/testcontainer
+    fi
+
+    # -f removes any LVs in the VG
+    vgremove -f lxd_test_vg
+    losetup -d $pvloopdev
+    rm $pvfile
+
+    cleanup
+}
+
+die() {
+    set +x
+    message=$1
+    echo ""
+    echo "\033[1;31m###### Test Failed : $message\033[0m"
+    exit 1
+}
+
+test_lvm() {
+    create_vg
+    trap cleanup_vg EXIT HUP INT TERM
+
+    test_lvm_withpool
+    lvremove -f lxd_test_vg/LXDPool
+
+    lvcreate -l 100%FREE --poolmetadatasize 500M --thinpool lxd_test_vg/test_user_thinpool
+    test_lvm_withpool test_user_thinpool
+}
+
+test_lvm_withpool() {
+    poolname=$1
+    PREV_LXD_DIR=$LXD_DIR
+    export LXD_DIR=$(mktemp -d -p $(pwd))
+    chmod 777 "${LXD_DIR}"
+    spawn_lxd 127.0.0.1:18451 "${LXD_DIR}"
+
+    lxc config set core.lvm_vg_name "zambonirodeo" && die "Shouldn't be able to set nonexistent LVM VG"
+    lxc config show | grep "core.lvm_vg_name" && die "vg_name should not be set after invalid attempt"
+
+    lxc config set core.lvm_vg_name "lxd_test_vg" || die "error setting core.lvm_vg_name config"
+    lxc config show | grep "lxd_test_vg" || die "test_vg not in config show output"
+
+    if [ -n "$poolname" ]; then
+        echo " --> Testing with user-supplied thin pool name '$poolname'"
+        lxc config set core.lvm_thinpool_name $poolname || die "error setting core.lvm_thinpool_name config"
+        lxc config show | grep "$poolname" || die "thin pool name not in config show output."
+    else
+        echo " --> Testing with default thin pool name 'LXDPool'"
+        poolname=LXDPool
+    fi
+
+    ../scripts/lxd-images import busybox --alias testimage
+
+    # get sha of image
+    lxc image info testimage || die "Couldn't find testimage in lxc image info"
+    testimage_sha=$(lxc image info testimage | grep Fingerprint | cut -d' ' -f 2)
+
+    imagelvname=$testimage_sha
+
+    lvs --noheadings -o lv_attr lxd_test_vg/$poolname | grep "^  t" || die "$poolname not found or not a thin pool"
+
+    lvs --noheadings -o lv_attr lxd_test_vg/$imagelvname | grep "^  V" || die "no lv named $imagelvname found or not a thin Vol."
+
+    lvs --noheadings -o pool_lv lxd_test_vg/$imagelvname | grep "$poolname" || die "new LV not member of $poolname"
+
+    # launch a container using that image
+
+    lxc init testimage testcontainer || die "Couldn't init test container"
+
+    # check that we now have a new volume in the pool
+    lvs --noheadings -o pool_lv lxd_test_vg/testcontainer | grep "$poolname" || die "LV for new container not found or not in $poolname"
+
+    lxc start testcontainer || die "Couldn't start testcontainer"
+    lxc list testcontainer | grep RUNNING || die "testcontainer doesn't seem to be running"
+    lxc stop testcontainer --force || die "Couldn't stop testcontainer"
+
+    lxc delete testcontainer || die "Couldn't delete testcontainer"
+    lvs lxd_test_vg/testcontainer && die "testcontainer LV is still there, should've been destroyed"
+    lxc image delete testimage || die "Couldn't delete testimage"
+
+    lvs lxd_test_vg/$imagelvname && die "lv $imagelvname is still there, should be gone"
+
+    kill -9 `cat $LXD_DIR/lxd.pid`
+    sleep 3
+    rm -Rf ${LXD_DIR}
+    LXD_DIR=${PREV_LXD_DIR}
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -133,6 +133,7 @@ fi
 . ./fdleak.sh
 . ./database_update.sh
 . ./devlxd.sh
+. ./lvm.sh
 
 if [ -n "$LXD_DEBUG" ]; then
     debug=--debug
@@ -232,6 +233,13 @@ fi
 
 echo "==> TEST: migration"
 test_migration
+
+if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    echo "===> SKIP: lvm backing (no loop device on Travis)"
+else
+    echo "==> TEST: lvm backing"
+    test_lvm
+fi
 
 curversion=`dpkg -s lxc | awk '/^Version/ { print $2 }'`
 if dpkg --compare-versions "$curversion" gt 1.1.2-0ubuntu3; then


### PR DESCRIPTION
Fixes #683.

Add two server configs: core.lvm_vg_name and core.lvm_thinpool_name.

If lvm_vg_name is set, use thin pool LVs for image and container
storage.

If lvm_thinpool_name is set, use that pool, otherwise create a thin pool
LV named “LXDPool" on image import and create a thin LV for that
image. Because the default setting for lvm is to not auto-extend pools,
that pool will be allocated with 100% of the remaining free space of the
volume group.

Adds test/lvm.sh with a set of tests that are run twice - once for the
default LXDPool creation and once with a pre-created test pool.

On container create, creates a thin snapshot for the container storage.

This branch does not add support for snapshots or migration.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>