### PR TITLE
partially implement container publish

### DIFF
--- a/client.go
+++ b/client.go
@@ -1626,6 +1626,9 @@ func (c *Client) ProfileCopy(name, newname string, dest *Client) error {
 func (c *Client) ImageFromContainer(cname string, public bool, aliases []string, properties map[string]string) (string, error) {
 
 	source := shared.Jmap{"type": "container", "name": cname}
+	if shared.IsSnapshot(cname) {
+		source["type"] = "snapshot"
+	}
 	body := shared.Jmap{"public": public, "source": source, "properties": properties}
 
 	resp, err := c.post("images", body, Sync)

--- a/client.go
+++ b/client.go
@@ -1622,3 +1622,35 @@ func (c *Client) ProfileCopy(name, newname string, dest *Client) error {
 	_, err = dest.post("profiles", body, Sync)
 	return err
 }
+
+func (c *Client) ImageFromContainer(cname string, public bool, aliases []string, properties map[string]string) (string, error) {
+
+	source := shared.Jmap{"type": "container", "name": cname}
+	body := shared.Jmap{"public": public, "source": source, "properties": properties}
+
+	resp, err := c.post("images", body, Sync)
+	if err != nil {
+		return "", err
+	}
+
+	jmap, err := resp.MetadataAsMap()
+	if err != nil {
+		return "", err
+	}
+
+	fingerprint, err := jmap.GetString("fingerprint")
+	if err != nil {
+		return "", err
+	}
+
+	/* add new aliases */
+	for _, alias := range aliases {
+		c.DeleteAlias(alias)
+		err = c.PostAlias(alias, alias, fingerprint)
+		if err != nil {
+			fmt.Printf(gettext.Gettext("Error adding alias %s\n"), alias)
+		}
+	}
+
+	return fingerprint, nil
+}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -142,6 +142,7 @@ var commands = map[string]command{
 	"list":     &listCmd{},
 	"move":     &moveCmd{},
 	"profile":  &profileCmd{},
+	"publish":  &publishCmd{},
 	"remote":   &remoteCmd{},
 	"restart":  &actionCmd{shared.Restart, true},
 	"restore":  &restoreCmd{},

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/gosexy/gettext"
+
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/internal/gnuflag"
+)
+
+type publishCmd struct {
+	httpAddr string
+}
+
+func (c *publishCmd) showByDefault() bool {
+	return true
+}
+
+func (c *publishCmd) usage() string {
+	return gettext.Gettext(
+		"Publish containers as images.\n" +
+			"\n" +
+			"lxc publish [remote:]container [remote:] [--alias=ALIAS]... [prop-key=prop-value]...\n")
+}
+
+var pAliases aliasList // aliasList defined in lxc/image.go
+var makePublic bool
+
+func (c *publishCmd) flags() {
+	gnuflag.BoolVar(&makePublic, "public", false, gettext.Gettext("Make the image public"))
+	gnuflag.Var(&pAliases, "alias", "New alias to define at target")
+}
+
+func (c *publishCmd) run(config *lxd.Config, args []string) error {
+	var cRemote string
+	var cName string
+	iName := ""
+	iRemote := ""
+	properties := map[string]string{}
+	firstprop := 1 // first property is arg[2] if arg[1] is image remote, else arg[1]
+
+	if len(args) < 1 {
+		return errArgs
+	}
+
+	cRemote, cName = config.ParseRemoteAndContainer(args[0])
+	if len(args) >= 2 && !strings.Contains(args[1], "=") {
+		firstprop = 2
+		iRemote, iName = config.ParseRemoteAndContainer(args[1])
+	}
+
+	if cName == "" {
+		return fmt.Errorf(gettext.Gettext("Container name is mandatory"))
+	}
+	if iName != "" {
+		return fmt.Errorf(gettext.Gettext("There is no \"image name\".  Did you want an alias?"))
+	}
+
+	if cRemote != iRemote {
+		/*
+		 * Get the source remote to export the container over a websocket,
+		 * pass that ws to the dest remote, and have it import it as an
+		 * image
+		 */
+		return fmt.Errorf(gettext.Gettext("Publish to remote server is not supported yet"))
+	}
+
+	d, err := lxd.NewClient(config, iRemote)
+	if err != nil {
+		return err
+	}
+
+	for i := firstprop; i < len(args); i++ {
+		entry := strings.SplitN(args[i], "=", 2)
+		if len(entry) < 2 {
+			return errArgs
+		}
+		properties[entry[0]] = entry[1]
+	}
+
+	fp, err := d.ImageFromContainer(cName, makePublic, pAliases, properties)
+
+	if err == nil {
+		fmt.Printf("Container published with fingerprint %s\n", fp)
+	}
+	return err
+}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -2777,8 +2777,8 @@ func startContainer(args []string) error {
  *     metadata.yaml
  *     rootfs/
  */
-func (d *lxdContainer) exportToDir(dir string) error {
-	if d.c.Running() {
+func (d *lxdContainer) exportToDir(snap, dir string) error {
+	if snap != "" && d.c.Running() {
 		return fmt.Errorf("Cannot export a running container as image")
 	}
 
@@ -2790,7 +2790,11 @@ func (d *lxdContainer) exportToDir(dir string) error {
 		}
 	}
 
-	source = shared.VarPath("lxc", d.name, "rootfs")
+	if snap != "" {
+		source = snapshotRootfsDir(d, snap)
+	} else {
+		source = shared.VarPath("lxc", d.name, "rootfs")
+	}
 	dest = fmt.Sprintf("%s/rootfs", dir)
 
 	// rsync the rootfs

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -71,7 +72,7 @@ func detectCompression(fname string) (int, string, error) {
 }
 
 type imageFromContainerPostReq struct {
-	Name       string            `json:"name"`
+	Filename   string            `json:"filename"`
 	Public     bool              `json:"public"`
 	Source     map[string]string `json:"source"`
 	Properties map[string]string `json:"properties"`
@@ -84,14 +85,89 @@ type imageMetadata struct {
 	Templates     map[string]*TemplateEntry
 }
 
-func imgPostContInfo(r *http.Request, req imageFromContainerPostReq, builddir string) (public int,
-	fingerprint string, arch int,
-	filename string, size int64,
-	properties map[string]string, err error) {
-	return 0, "", 0, "", 0, properties, fmt.Errorf("Not implemented")
+/*
+ * This function takes a container or snapshot from the local image server and
+ * exports it as an image.
+ */
+func imgPostContInfo(d *Daemon, r *http.Request, req imageFromContainerPostReq,
+	builddir string) (public int, fingerprint string, arch int,
+	filename string, size int64, properties map[string]string, err error) {
+
+	properties = map[string]string{}
+	name := req.Source["name"]
+	ctype := req.Source["type"]
+	if ctype == "" || name == "" {
+		return 0, "", 0, "", 0, properties, fmt.Errorf("No source provided")
+	}
+
+	if ctype == "snapshot" {
+		// we'll ned to get metadata from the container itself
+		// figure that out later
+		return 0, "", 0, "", 0, properties, fmt.Errorf("Snapshot export not yet implemnted")
+	}
+
+	filename = req.Filename
+	switch req.Public {
+	case true:
+		public = 1
+	case false:
+		public = 0
+	}
+
+	// Get the container to export itself
+	c, err := newLxdContainer(name, d)
+	if err != nil {
+		return 0, "", 0, "", 0, properties, err
+	}
+
+	if err := c.exportToDir(builddir); err != nil {
+		return 0, "", 0, "", 0, properties, err
+	}
+	// Build the actual image file
+	tarfname := fmt.Sprintf("%s.tar.xz", name)
+	tarpath := filepath.Join(builddir, tarfname)
+	args := []string{"-C", builddir, "--numeric-owner", "-Jcf", tarpath}
+	if shared.PathExists(filepath.Join(builddir, "metadata.yaml")) {
+		args = append(args, "metadata.yaml")
+	}
+	args = append(args, "rootfs")
+	output, err := exec.Command("tar", args...).CombinedOutput()
+	if err != nil {
+		shared.Debugf("image packing failed\n")
+		shared.Debugf("command was: tar %q\n", args)
+		shared.Debugf(string(output))
+		return 0, "", 0, "", 0, properties, err
+	}
+
+	// get the size and fingerprint
+	sha256 := sha256.New()
+	tarf, err := os.Open(tarpath)
+	if err != nil {
+		return 0, "", 0, "", 0, properties, err
+	}
+	size, err = io.Copy(sha256, tarf)
+	tarf.Close()
+	if err != nil {
+		return 0, "", 0, "", 0, properties, err
+	}
+	fingerprint = fmt.Sprintf("%x", sha256.Sum(nil))
+
+	/* rename the the file to the expected name so our caller can use it */
+	imagefname := filepath.Join(builddir, fingerprint)
+	err = os.Rename(tarpath, imagefname)
+	if err != nil {
+		return 0, "", 0, "", 0, properties, err
+	}
+
+	arch = c.architecture
+	for key, value := range req.Properties {
+		properties[key] = value
+	}
+
+	return
 }
 
-func getImgPostInfo(r *http.Request, builddir string) (public int,
+func getImgPostInfo(d *Daemon, r *http.Request, builddir string) (public int,
 	fingerprint string, arch int,
 	filename string, size int64,
 	properties map[string]string, err error) {
@@ -100,7 +176,7 @@ func getImgPostInfo(r *http.Request, builddir string) (public int,
 	decoder := json.NewDecoder(r.Body)
 	req := imageFromContainerPostReq{}
 	if err = decoder.Decode(&req); err == nil {
-		return imgPostContInfo(r, req, builddir)
+		return imgPostContInfo(d, r, req, builddir)
 	}
 
 	// ok we've got an image in the body
@@ -145,7 +221,7 @@ func getImgPostInfo(r *http.Request, builddir string) (public int,
 		return 0, "", 0, "", 0, properties, err
 	}
 
-	imagefname := fmt.Sprintf("%s/%s", builddir, fingerprint)
+	imagefname := filepath.Join(builddir, fingerprint)
 	err = os.Rename(tarfname, imagefname)
 	if err != nil {
 		return 0, "", 0, "", 0, properties, err
@@ -207,7 +283,7 @@ func removeImgWorkdir(d *Daemon, builddir string) {
 		/* todo: find the .btrfs file under dir */
 		fnamelist, _ := shared.ReadDir(builddir)
 		for _, fname := range fnamelist {
-			subvol := fmt.Sprintf("%s/%s", builddir, fname)
+			subvol := filepath.Join(builddir, fname)
 			exec.Command("btrfs", "subvolume", "delete", subvol).Run()
 		}
 	}
@@ -220,7 +296,7 @@ func removeImgWorkdir(d *Daemon, builddir string) {
 func buildOtherFs(d *Daemon, builddir string, fp string) error {
 	switch d.BackingFs {
 	case "btrfs":
-		imagefname := fmt.Sprintf("%s/%s", builddir, fp)
+		imagefname := filepath.Join(builddir, fp)
 		subvol := fmt.Sprintf("%s.btrfs", imagefname)
 		if err := makeBtrfsSubvol(imagefname, subvol); err != nil {
 			return err
@@ -231,7 +307,7 @@ func buildOtherFs(d *Daemon, builddir string, fp string) error {
 
 // Copy imagefile and btrfs file out of the tmpdir
 func pullOutImagefiles(d *Daemon, builddir string, fp string) error {
-	imagefname := fmt.Sprintf("%s/%s", builddir, fp)
+	imagefname := filepath.Join(builddir, fp)
 	finalName := shared.VarPath("images", fp)
 	subvol := fmt.Sprintf("%s.btrfs", imagefname)
 
@@ -324,7 +400,7 @@ func imagesPost(d *Daemon, r *http.Request) Response {
 	defer removeImgWorkdir(d, builddir)
 
 	/* Grab all info from the web request */
-	public, fingerprint, arch, filename, size, properties, err := getImgPostInfo(r, builddir)
+	public, fingerprint, arch, filename, size, properties, err := getImgPostInfo(d, r, builddir)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-06-23 17:56-0400\n"
+        "POT-Creation-Date: 2015-06-25 16:42-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -130,6 +130,10 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
+#: lxc/publish.go:55
+msgid   "Container name is mandatory"
+msgstr  ""
+
 #: lxc/image.go:81
 msgid   "Copy aliases from source"
 msgstr  ""
@@ -182,7 +186,7 @@ msgstr  ""
 msgid   "Ephemeral container"
 msgstr  ""
 
-#: client.go:543 client.go:553 client.go:695
+#: client.go:543 client.go:553 client.go:695 client.go:1651
 #, c-format
 msgid   "Error adding alias %s\n"
 msgstr  ""
@@ -284,6 +288,10 @@ msgstr  ""
 
 #: lxc/image.go:80
 msgid   "Make image public"
+msgstr  ""
+
+#: lxc/publish.go:32
+msgid   "Make the image public"
 msgstr  ""
 
 #: lxc/profile.go:48
@@ -494,6 +502,17 @@ msgstr  ""
 msgid   "Public: %s\n"
 msgstr  ""
 
+#: lxc/publish.go:23
+msgid   "Publish containers as images.\n"
+        "\n"
+        "lxc publish [remote:]container [remote:] [--alias=ALIAS]... [prop-"
+        "key=prop-value]...\n"
+msgstr  ""
+
+#: lxc/publish.go:67
+msgid   "Publish to remote server is not supported yet"
+msgstr  ""
+
 #: lxc/remote.go:42
 msgid   "Remote admin password"
 msgstr  ""
@@ -549,6 +568,10 @@ msgstr  ""
 
 #: lxc/delete.go:70
 msgid   "Stopping container failed!"
+msgstr  ""
+
+#: lxc/publish.go:58
+msgid   "There is no \"image name\".  Did you want an alias?"
 msgstr  ""
 
 #: lxc/action.go:34
@@ -732,7 +755,7 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:154
+#: lxc/main.go:155
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -41,6 +41,11 @@ test_basic_usage() {
   # Test container copy
   lxc copy bar foo
   lxc delete foo
+
+  # Test container publish
+  lxc publish bar --alias=foo prop1=val1
+  lxc image show foo | grep val1
+  lxc image delete foo
   lxc delete bar
 
   # Test randomly named container creation


### PR DESCRIPTION
This implements
	lxc publish --public c1 c1image
	lxc publish r1:c1 r1:c1image

It does not support publishing a container from one lxd server
to an image on another lxd server.

It also does not support snapshots, though that should be a trivial
patch on top of this.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>