### PR TITLE
use setns() in file push/pull

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -32,7 +32,8 @@ func (c *fileCmd) usage() string {
 			"lxc file pull <source> [<source>...] <target>\n" +
 			"lxc file push [--uid=UID] [--gid=GID] [--mode=MODE] <source> [<source>...] <target>\n" +
 			"\n" +
-			"<source> in the case of pull and <target> in the case of push are <container name>/<path>\n")
+			"<source> in the case of pull and <target> in the case of push are <container name>/<path>\n" +
+			"This operation is only supported on containers that are currently running\n")
 }
 
 func (c *fileCmd) flags() {

--- a/lxd/copyfile.go
+++ b/lxd/copyfile.go
@@ -135,7 +135,8 @@ __attribute__((constructor)) void init(void) {
 		_exit(232);
 	}
 
-	if ((size = read(cmdline, buf, sizeof(buf))) < 0) {
+	memset(buf, 0, sizeof(buf));
+	if ((size = read(cmdline, buf, sizeof(buf)-1)) < 0) {
 		close(cmdline);
 		perror("read");
 		_exit(232);

--- a/lxd/copyfile.go
+++ b/lxd/copyfile.go
@@ -1,0 +1,212 @@
+/*
+ * This file is a bit funny. The goal here is to use setns() to manipulate
+ * files inside the container, so we don't have to reason about the paths to
+ * make sure they don't escape (we can simply rely on the kernel for
+ * correctness). Unfortunately, you can't setns() to a mount namespace with a
+ * multi-threaded program, which every golang binary is. However, by declaring
+ * our init as an initializer, we can capture process control before it is
+ * transferred to the golang runtime, so we can then setns() as we'd like
+ * before golang has a chance to set up any threads. So, we implement two new
+ * lxd fork* commands which are captured here, and take a file on the host fs
+ * and copy it into the container ns.
+ *
+ * An alternative to this would be to move this code into a separate binary,
+ * which of course has problems of its own when it comes to packaging (how do
+ * we find the binary, what do we do if someone does file push and it is
+ * missing, etc.). After some discussion, even though the embedded method is
+ * somewhat convoluted, it was preferred.
+ */
+package main
+
+/*
+#include <string.h>
+#include <stdio.h>
+#include <sys/mount.h>
+#include <sched.h>
+#include <linux/sched.h>
+#include <linux/limits.h>
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <unistd.h>
+
+// This expects:
+//  ./lxd forkputfile /source/path <pid> /target/path
+// or
+//  ./lxd forkgetfile /target/path <pid> /soruce/path <uid> <gid> <mode>
+// i.e. 8 arguments, each which have a max length of PATH_MAX.
+// Unfortunately, lseek() and fstat() both fail (EINVAL and 0 size) for
+// procfs. Also, we can't mmap, because procfs doesn't support that, either.
+//
+#define CMDLINE_SIZE (8 * PATH_MAX)
+
+int copy(int target, int source)
+{
+	ssize_t n;
+	char buf[1024];
+
+	while ((n = read(source, buf, 1024)) > 0) {
+		if (write(target, buf, n) != n) {
+			perror("write");
+			return -1;
+		}
+	}
+
+	if (n < 0) {
+		perror("read");
+		return -1;
+	}
+
+	return 0;
+}
+
+int manip_file_in_ns(char *host, int pid, char *container, bool is_put, uid_t uid, gid_t gid, mode_t mode) {
+	int host_fd, container_fd, mntns;
+	char buf[PATH_MAX];
+	int ret = -1;
+	int container_open_flags;
+
+	host_fd = open(host, O_RDWR);
+	if (host_fd < 0) {
+		perror("open host");
+		return -1;
+	}
+
+	sprintf(buf, "/proc/%d/ns/mnt", pid);
+	fprintf(stderr, "mntns dir: %s\n", buf);
+	mntns = open(buf, O_RDONLY);
+	if (mntns < 0) {
+		perror("open mntns");
+		goto close_host;
+	}
+
+	if (setns(mntns, 0) < 0) {
+		perror("setns");
+		goto close_mntns;
+	}
+
+	container_open_flags = O_RDWR;
+	if (is_put)
+		container_open_flags |= O_CREAT;
+
+	container_fd = open(container, container_open_flags, mode);
+	if (container_fd < 0) {
+		perror("open container");
+		goto close_mntns;
+	}
+
+	if (is_put) {
+		if (copy(container_fd, host_fd) < 0)
+			goto close_container;
+
+		if (fchown(container_fd, uid, gid) < 0) {
+			perror("fchown");
+			goto close_container;
+		}
+
+		ret = 0;
+	} else
+		ret = copy(host_fd, container_fd);
+
+close_container:
+	close(container_fd);
+close_mntns:
+	close(mntns);
+close_host:
+	close(host_fd);
+	return ret;
+}
+
+__attribute__((constructor)) void init(void) {
+	int cmdline;
+	char *command = NULL, *source = NULL, *target = NULL;
+	pid_t pid;
+	char buf[CMDLINE_SIZE];
+	char *cur;
+	bool is_put;
+	ssize_t size;
+	uid_t uid = 0;
+	gid_t gid = 0;
+	mode_t mode = 0;
+
+	cmdline = open("/proc/self/cmdline", O_RDONLY);
+	if (cmdline < 0) {
+		perror("open");
+		_exit(232);
+	}
+
+	if ((size = read(cmdline, buf, sizeof(buf))) < 0) {
+		close(cmdline);
+		perror("read");
+		_exit(232);
+	}
+
+	cur = buf;
+	// skip argv[0]
+	while (*cur != 0) {
+		cur++;
+	}
+	cur++;
+	if (size <= cur - buf) {
+		close(cmdline);
+		return;
+	}
+
+	command = cur;
+	if (strcmp(command, "forkputfile") == 0) {
+		is_put = true;
+	} else if (strcmp(command, "forkgetfile") == 0) {
+		is_put = false;
+	} else {
+		// This isn't one of our special commands, let's just continue
+		// normally with execution.
+		close(cmdline);
+		return;
+	}
+
+#define ADVANCE_ARG_REQUIRED()					\
+	do {							\
+		while (*cur != 0)				\
+			cur++;					\
+		cur++;						\
+		if (size <= cur - buf) {			\
+			close(cmdline);				\
+			printf("not enough arguments\n");	\
+			_exit(1);				\
+		}						\
+	} while(0)
+
+	ADVANCE_ARG_REQUIRED();
+	source = cur;
+
+	ADVANCE_ARG_REQUIRED();
+	pid = atoi(cur);
+
+	ADVANCE_ARG_REQUIRED();
+	target = cur;
+
+	if (is_put) {
+		ADVANCE_ARG_REQUIRED();
+		uid = atoi(cur);
+
+		ADVANCE_ARG_REQUIRED();
+		gid = atoi(cur);
+
+		ADVANCE_ARG_REQUIRED();
+		mode = atoi(cur);
+	}
+
+	printf("command: %s\n", command);
+	printf("source: %s\n", source);
+	printf("pid: %d\n", pid);
+	printf("target: %s\n", target);
+	printf("uid: %d\n", uid);
+	printf("gid: %d\n", gid);
+	printf("mode: %d\n", mode);
+
+	close(cmdline);
+
+	_exit(manip_file_in_ns(source, pid, target, is_put, uid, gid, mode));
+}
+*/
+import "C"

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -930,7 +930,7 @@ func imageExport(d *Daemon, r *http.Request) Response {
 		"Content-Disposition": fmt.Sprintf("inline;filename=%s", filename),
 	}
 
-	return FileResponse(r, path, filename, headers)
+	return FileResponse(r, path, filename, headers, false)
 }
 
 func imageSecret(d *Daemon, r *http.Request) Response {

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -51,6 +51,9 @@ func run() error {
 			return startContainer(os.Args[1:])
 		case "forkmigrate":
 			return migration.MigrateContainer(os.Args[1:])
+			/*
+				case "forkputfile" and "forkgetfile" handled specially in copyfile.go
+			*/
 		}
 	}
 

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -36,14 +36,15 @@ type syncResponse struct {
   headers: any other headers that should be set in the response
 */
 type fileResponse struct {
-	req      *http.Request
-	path     string
-	filename string
-	headers  map[string]string
+	req              *http.Request
+	path             string
+	filename         string
+	headers          map[string]string
+	removeAfterServe bool
 }
 
-func FileResponse(r *http.Request, path string, filename string, headers map[string]string) Response {
-	return &fileResponse{r, path, filename, headers}
+func FileResponse(r *http.Request, path string, filename string, headers map[string]string, removeAfterServe bool) Response {
+	return &fileResponse{r, path, filename, headers, removeAfterServe}
 }
 
 func (r *fileResponse) Render(w http.ResponseWriter) error {
@@ -67,6 +68,10 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 	}
 
 	http.ServeContent(w, r.req, r.filename, fi.ModTime(), f)
+	if r.removeAfterServe {
+		os.Remove(r.filename)
+	}
+
 	return nil
 }
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-06-23 17:56-0400\n"
+        "POT-Creation-Date: 2015-06-26 11:56-0600\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -231,12 +231,12 @@ msgstr  ""
 msgid   "Information about remotes not yet supported\n"
 msgstr  ""
 
-#: lxc/file.go:158
+#: lxc/file.go:159
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:53
+#: lxc/file.go:54
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -379,6 +379,8 @@ msgid   "Manage files on a container.\n"
         "\n"
         "<source> in the case of pull and <target> in the case of push are "
         "<container name>/<path>\n"
+        "This operation is only supported on containers that are currently "
+        "running\n"
 msgstr  ""
 
 #: lxc/remote.go:29
@@ -436,7 +438,7 @@ msgstr  ""
 msgid   "Missing summary."
 msgstr  ""
 
-#: lxc/file.go:144
+#: lxc/file.go:145
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
@@ -519,15 +521,15 @@ msgid   "Set the current state of a resource back to what it was when it was "
         "lxc restore <resource> <snapshot name> [--stateful]\n"
 msgstr  ""
 
-#: lxc/file.go:40
+#: lxc/file.go:41
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:41
+#: lxc/file.go:42
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:39
+#: lxc/file.go:40
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -666,7 +668,7 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: lxc/file.go:205
+#: lxc/file.go:206
 #, c-format
 msgid   "invalid argument %s"
 msgstr  ""

--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -194,7 +194,8 @@ tar cf - /opt/myapp \| lxc exec dakara:c2 -- tar xvf -    | Make a tarball of /o
     file pull <source> [<source>...] <target>
 
 **Description**
-Copies file to or from the container. Supports rewriting the uid/gid/mode.
+Copies file to or from the container. Supports rewriting the uid/gid/mode. This
+is only allowed for containers that are currently running.
 
 **Examples**
 

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -501,7 +501,8 @@ The following headers will be set (on top of standard size and mimetype headers)
  * X-LXD-gid: 0
  * X-LXD-mode: 0700
 
-This is designed to be easily usable from the command line or even a web browser.
+This is designed to be easily usable from the command line or even a web
+browser. This is only supported for currently running contianers.
 
 ### POST
  * Description: upload a file to the container
@@ -517,7 +518,8 @@ The following headers may be set by the client:
  * X-LXD-gid: 0
  * X-LXD-mode: 0700
 
-This is designed to be easily usable from the command line or even a web browser.
+This is designed to be easily usable from the command line or even a web
+browser. This is only supported for currently running containers.
 
 ## /1.0/containers/\<name\>/snapshots
 ### GET

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -502,7 +502,7 @@ The following headers will be set (on top of standard size and mimetype headers)
  * X-LXD-mode: 0700
 
 This is designed to be easily usable from the command line or even a web
-browser. This is only supported for currently running contianers.
+browser. This is only supported for currently running containers.
 
 ### POST
  * Description: upload a file to the container

--- a/test/filemanip.sh
+++ b/test/filemanip.sh
@@ -1,0 +1,27 @@
+test_filemanip() {
+  if [ -n "$TRAVIS_PULL_REQUEST" ]; then
+    return
+  fi
+
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
+    if [ -e "$LXD_TEST_IMAGE" ]; then
+        lxc image import $LXD_TEST_IMAGE --alias testimage
+    else
+        ../scripts/lxd-images import busybox --alias testimage
+    fi
+  fi
+
+  # Check that symlinks are interpreted relative to the container's root
+  mkdir -p /tmp/outside
+
+  lxc launch testimage filemanip
+  lxc exec filemanip -- mkdir /tmp/outside
+  lxc exec filemanip -- ln -s /tmp/outside /tmp/inside
+  lxc file push main.sh filemanip/tmp/inside/
+
+  [ ! -f /tmp/outside/main.sh ]
+  [ -f ${LXD_DIR}/lxc/filemanip/rootfs/tmp/outside/main.sh ]
+
+  rm -rf /tmp/outside
+  lxc delete filemanip
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -121,6 +121,7 @@ fi
 . ./exec.sh
 . ./database.sh
 . ./deps.sh
+. ./filemanip.sh
 . ./fuidshift.sh
 . ./migration.sh
 . ./remote.sh
@@ -220,6 +221,9 @@ test_config_profiles
 
 echo "==> TEST: server config"
 test_server_config
+
+echo "==> TEST: filemanip"
+test_filemanip
 
 echo "==> TEST: devlxd"
 test_devlxd

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -37,7 +37,7 @@ test_snap_restore() {
     return
   fi
 
-  lxc init testimage bar
+  lxc launch testimage bar
 
   ##########################################################
   # PREPARATION  
@@ -49,6 +49,7 @@ test_snap_restore() {
   echo snap0 > state 
   lxc file push state bar/root/state
   lxc file push state bar/root/file_only_in_snap0
+  lxc stop bar
   mkdir "$LXD_DIR/lxc/bar/rootfs/root/dir_only_in_snap0"
   cd "$LXD_DIR/lxc/bar/rootfs/root/"
   ln -s ./file_only_in_snap0 statelink
@@ -58,8 +59,10 @@ test_snap_restore() {
 
   ## prepare snap1
   echo snap1 > state 
+  lxc start bar
   lxc file push state bar/root/state
   lxc file push state bar/root/file_only_in_snap1
+  lxc stop bar
   cd "$LXD_DIR/lxc/bar/rootfs/root/"
 
   rmdir dir_only_in_snap0


### PR DESCRIPTION
This prevents a security issue with interpreting symlink paths, as well as
avoids any such other issues by simply setns()ing into the container's
namespace to manipulate files.

Closes #789

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>