### PR TITLE
2015 06 29/untrustedimage.2

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -659,7 +659,7 @@ func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 	}
 }
 
-var imagesCmd = Command{name: "images", post: imagesPost, get: imagesGet}
+var imagesCmd = Command{name: "images", post: imagesPost, untrustedGet: true, get: imagesGet}
 
 func imageDelete(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]


### PR DESCRIPTION
'lxc image list remote:' from an untrusted client should succeed and show the public images.  It should not show private images.  Fix the current behavior (by allowing untrusted gets) and add a testcase.
