### PR TITLE
Use lvm/btrfs for images imported via launch remote

### DIFF
--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -4,7 +4,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 
 	"github.com/lxc/lxd/shared"
 )
@@ -79,7 +81,16 @@ func ensureLocalImage(d *Daemon, server, fp string, secret string) error {
 	if err != nil {
 		return err
 	}
-	destName := shared.VarPath("images", fp)
+
+	builddir, err := ioutil.TempDir(destDir, "lxd_build_")
+	if err != nil {
+		return err
+	}
+
+	/* remove the builddir when done */
+	defer removeImgWorkdir(d, builddir)
+
+	destName := filepath.Join(builddir, fp)
 	if _, err := os.Stat(destName); err == nil {
 		os.Remove(destName)
 	}
@@ -98,26 +109,9 @@ func ensureLocalImage(d *Daemon, server, fp string, secret string) error {
 		return err
 	}
 
-	q := `INSERT INTO images (fingerprint, filename, size, architecture, creation_date, expiry_date, upload_date) VALUES (?, ?, ?, ?, ?, ?, strftime("%s"))`
-
-	result, err := shared.DbExec(d.db, q, fp, info.Filename, info.Size, info.Architecture, info.CreationDate, info.ExpiryDate)
-	if err != nil {
-		os.Remove(destName)
-		return err
-	}
-
-	id64, err := result.LastInsertId()
+	_, err = buildImageFromInfo(d, info, builddir)
 	if err != nil {
 		return err
-	}
-	id := int(id64)
-
-	for k, v := range info.Properties {
-		q := `INSERT INTO images_properties (image_id, type, key, value) VALUES (?, 0, ?, ?)`
-		_, err = shared.DbExec(d.db, q, id, k, v)
-		if err != nil {
-			return err
-		}
 	}
 
 	return nil

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -39,7 +39,10 @@ die() {
 }
 
 test_lvm() {
-    which vgcreate || echo "===> SKIPPING lvm backing: vgcreate not found" && return
+    if [ ! `which vgcreate` ]; then
+        echo "===> SKIPPING lvm backing: vgcreate not found"
+        return
+    fi
     create_vg
     trap cleanup_vg EXIT HUP INT TERM
 
@@ -48,6 +51,9 @@ test_lvm() {
 
     lvcreate -l 100%FREE --poolmetadatasize 500M --thinpool lxd_test_vg/test_user_thinpool
     test_lvm_withpool test_user_thinpool
+
+    lvremove -f lxd_test_vg/test_user_thinpool
+    test_remote_launch_imports_lvm
 }
 
 test_lvm_withpool() {
@@ -106,5 +112,50 @@ test_lvm_withpool() {
     kill -9 `cat $LXD_DIR/lxd.pid`
     sleep 3
     rm -Rf ${LXD_DIR}
+    LXD_DIR=${PREV_LXD_DIR}
+}
+
+test_remote_launch_imports_lvm() {
+    PREV_LXD_DIR=$LXD_DIR
+    export LXD_DIR=$(mktemp -d -p $(pwd))
+    chmod 777 "${LXD_DIR}"
+    spawn_lxd 127.0.0.1:18466 "${LXD_DIR}"
+
+    # import busybox as a regular file-backed image
+    ../scripts/lxd-images import busybox --alias testimage
+
+    export LXD_REMOTE_DIR=$(mktemp -d -p $(pwd))
+    chmod 777 "${LXD_REMOTE_DIR}"
+
+    spawn_lxd 127.0.0.1:18467 "${LXD_REMOTE_DIR}"
+
+    # swap env so 'lxc' will point at the new LXD
+    TEMPLXDDIR=$LXD_DIR
+    LXD_DIR=$LXD_REMOTE_DIR
+    LXD_REMOTE_DIR=$TEMPLXDDIR
+
+    lxc config set core.lvm_vg_name "lxd_test_vg" || die "couldn't set vg_name"
+    (echo y; sleep 3; echo foo) | lxc remote add testremote 127.0.0.1:18466
+
+    testimage_sha=$(lxc image info testremote:testimage | grep Fingerprint | cut -d' ' -f 2)
+    lxc launch testremote:testimage remote-test || die "Couldn't launch from remote"
+
+    lxc image show $testimage_sha || die "Didn't import image from remote"
+    lvs --noheadings -o lv_attr lxd_test_vg/$testimage_sha | grep "^  V" || die "no lv named $testimage_sha or not a thin Vol."
+
+    lxc list | grep remote-test | grep RUNNING || die "remote-test is not RUNNING"
+    lvs --noheadings -o pool_lv lxd_test_vg/remote-test | grep LXDPool || die "LV for remote-test not found or not in LXDPool"
+    lxc stop remote-test --force || die "Couldn't stop remote-test"
+    lxc delete remote-test
+
+    lvs lxd_test_vg/remote-test && die "remote-test LV is still there, should have been removed."
+    lxc image delete $testimage_sha
+    lvs lxd_test_vg/$testimage_sha && die "LV $testimage_sha is still there, should have been removed."
+
+    kill -9 `cat $LXD_DIR/lxd.pid`
+    kill -9 `cat $LXD_REMOTE_DIR/lxd.pid`
+    sleep 3
+    rm -Rf ${LXD_DIR}
+    rm -Rf ${LXD_REMOTE_DIR}
     LXD_DIR=${PREV_LXD_DIR}
 }

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -39,7 +39,7 @@ die() {
 }
 
 test_lvm() {
-    if [ ! `which vgcreate` ]; then
+    if ! which vgcreate >/dev/null; then
         echo "===> SKIPPING lvm backing: vgcreate not found"
         return
     fi


### PR DESCRIPTION
Fixes #805

Ensure that images imported as a result of 'lxc launch remote:imagename'
are using the correct storage backend by sharing a new function
'buildImageFromInfo' with imagesPost.

Adds a test for this to test_lvm

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>