### PR TITLE
2015 07 02/tarreader.gzipcmd

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -369,6 +369,9 @@ func (d *lxdContainer) tarStoreFile(linkmap map[uint64]string, offset int, tw *t
 	// unshift the id under /rootfs/ for unpriv containers
 	if !d.isPrivileged() && strings.HasPrefix(hdr.Name, "/rootfs") {
 		hdr.Uid, hdr.Gid = d.idmapset.ShiftFromNs(hdr.Uid, hdr.Gid)
+		if hdr.Uid == -1 || hdr.Gid == -1 {
+			return nil
+		}
 	}
 	if major != -1 {
 		hdr.Devmajor = int64(major)

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"archive/tar"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 	"time"
 
@@ -334,41 +338,122 @@ func startContainer(args []string) error {
 	return c.Start()
 }
 
+func (d *lxdContainer) tarStoreFile(linkmap map[uint64]string, offset int, tw *tar.Writer, path string, fi os.FileInfo) error {
+	var err error
+	var major, minor, nlink int
+	var ino uint64
+
+	link := ""
+	if fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		link, err = os.Readlink(path)
+		if err != nil {
+			return err
+		}
+	}
+	hdr, err := tar.FileInfoHeader(fi, link)
+	if err != nil {
+		return err
+	}
+	hdr.Name = path[offset:]
+	if fi.IsDir() || fi.Mode()&os.ModeSymlink == os.ModeSymlink {
+		hdr.Size = 0
+	} else {
+		hdr.Size = fi.Size()
+	}
+
+	hdr.Uid, hdr.Gid, major, minor, ino, nlink, err = shared.GetFileStat(path)
+	if err != nil {
+		return fmt.Errorf("error getting file info: %s\n", err)
+	}
+
+	// unshift the id under /rootfs/ for unpriv containers
+	if !d.isPrivileged() && strings.HasPrefix(hdr.Name, "/rootfs") {
+		hdr.Uid, hdr.Gid = d.idmapset.ShiftFromNs(hdr.Uid, hdr.Gid)
+	}
+	if major != -1 {
+		hdr.Devmajor = int64(major)
+		hdr.Devminor = int64(minor)
+	}
+
+	// If it's a hardlink we've already seen use the old name
+	if fi.Mode().IsRegular() && nlink > 1 {
+		if firstpath, found := linkmap[ino]; found {
+			hdr.Typeflag = tar.TypeLink
+			hdr.Linkname = firstpath
+			hdr.Size = 0
+		} else {
+			linkmap[ino] = hdr.Name
+		}
+	}
+
+	// todo - handle xattrs
+
+	if err := tw.WriteHeader(hdr); err != nil {
+		return fmt.Errorf("error writing header: %s\n", err)
+	}
+
+	if hdr.Typeflag == tar.TypeReg {
+		f, err := os.Open(path)
+		if err != nil {
+			return fmt.Errorf("tarStoreFile: error opening file: %s\n", err)
+		}
+		defer f.Close()
+		if _, err := io.Copy(tw, f); err != nil {
+			return fmt.Errorf("error copying file %s\n", err)
+		}
+	}
+	return nil
+}
+
 /*
- * Export the container under @dir.  It will look like:
+ * Export the container to a unshifted tarfile containing:
  * dir/
  *     metadata.yaml
  *     rootfs/
  */
-func (d *lxdContainer) exportToDir(snap, dir string) error {
+func (d *lxdContainer) exportToTar(snap string, w io.Writer) error {
 	if snap != "" && d.c.Running() {
 		return fmt.Errorf("Cannot export a running container as image")
 	}
 
-	source := shared.VarPath("lxc", d.name, "metadata.yaml")
-	dest := fmt.Sprintf("%s/metadata.yaml", dir)
-	if shared.PathExists(source) {
-		if err := shared.CopyFile(dest, source); err != nil {
+	tw := tar.NewWriter(w)
+
+	// keep track of the first path we saw for each path with nlink>1
+	linkmap := map[uint64]string{}
+
+	cDir := shared.VarPath("lxc", d.name)
+
+	// Path inside the tar image is the pathname starting after cDir
+	offset := len(cDir)
+
+	fnam := filepath.Join(cDir, "metadata.yaml")
+	writeToTar := func(path string, fi os.FileInfo, err error) error {
+		if err := d.tarStoreFile(linkmap, offset, tw, path, fi); err != nil {
+			shared.Debugf("error tarring up %s: %s\n", path, err)
+			return err
+		}
+		return nil
+	}
+
+	fnam = filepath.Join(cDir, "metadata.yaml")
+	if shared.PathExists(fnam) {
+		fi, err := os.Lstat(fnam)
+		if err != nil {
+			shared.Debugf("Error statting %s during exportToTar\n", fnam)
+			tw.Close()
+			return err
+		}
+		if err := d.tarStoreFile(linkmap, offset, tw, fnam, fi); err != nil {
+			shared.Debugf("exportToTar: error writing to tarfile: %s\n", err)
+			tw.Close()
 			return err
 		}
 	}
-
-	if snap != "" {
-		source = snapshotRootfsDir(d, snap)
-	} else {
-		source = shared.VarPath("lxc", d.name, "rootfs")
+	fnam = filepath.Join(cDir, "rootfs")
+	filepath.Walk(fnam, writeToTar)
+	fnam = filepath.Join(cDir, "templates")
+	if shared.PathExists(fnam) {
+		filepath.Walk(fnam, writeToTar)
 	}
-
-	// rsync the rootfs
-	err := exec.Command("rsync", "-a", "--devices", source, dir).Run()
-	if err != nil {
-		return err
-	}
-
-	// unshift
-	if !d.isPrivileged() {
-		rootfs := fmt.Sprintf("%s/rootfs", dir)
-		err = d.idmapset.UnshiftRootfs(rootfs)
-	}
-	return err
+	return tw.Close()
 }

--- a/shared/idmapset.go
+++ b/shared/idmapset.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 /*
@@ -218,20 +217,14 @@ func (m IdmapSet) ShiftFromNs(uid int, gid int) (int, int) {
 	return m.doShiftIntoNs(uid, gid, "out")
 }
 
-func getOwner(path string) (int, int, error) {
-	var stat syscall.Stat_t
-	err := syscall.Lstat(path, &stat)
-	if err != nil {
-		return 0, 0, err
-	}
-	uid := int(stat.Uid)
-	gid := int(stat.Gid)
-	return uid, gid, nil
+func GetOwner(path string) (int, int, error) {
+	uid, gid, _, _, _, _, err := GetFileStat(path)
+	return uid, gid, err
 }
 
 func (set *IdmapSet) doUidshiftIntoContainer(dir string, testmode bool, how string) error {
 	convert := func(path string, fi os.FileInfo, err error) (e error) {
-		uid, gid, err := getOwner(path)
+		uid, gid, err := GetOwner(path)
 		if err != nil {
 			return err
 		}

--- a/shared/util.go
+++ b/shared/util.go
@@ -694,3 +694,24 @@ func ReadDir(p string) ([]string, error) {
 	}
 	return ret, nil
 }
+
+func GetFileStat(p string) (uid int, gid int, major int, minor int,
+	inode uint64, nlink int, err error) {
+	var stat syscall.Stat_t
+	err = syscall.Lstat(p, &stat)
+	if err != nil {
+		return
+	}
+	uid = int(stat.Uid)
+	gid = int(stat.Gid)
+	inode = uint64(stat.Ino)
+	nlink = int(stat.Nlink)
+	major = -1
+	minor = -1
+	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
+		major = int(stat.Rdev / 256)
+		minor = int(stat.Rdev % 256)
+	}
+
+	return
+}


### PR DESCRIPTION
Skip the rsync before calling tar, and use archive/tar for creating the tarfile.

This won't yet handle xattrs, which rsync+tar presumably did.