### PR TITLE
Add support for "lxc copy" and btrfs filesystem, see issue #485.

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -527,7 +527,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 		if btrfsIsSubvolume(subvol) {
 			/*
 			 * Copy by using btrfs snapshot
-		   */
+			 */
 			output, err := btrfsSnapshot(subvol, dpath, false)
 			if err != nil {
 				shared.Debugf("Failed to create a BTRFS Snapshot of '%s' to '%s'.", subvol, dpath)
@@ -537,7 +537,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 		} else {
 			/*
 			 * Copy by using rsync
-		   */
+			 */
 			output, err := exec.Command("rsync", "-a", "--devices", oldPath, newPath).CombinedOutput()
 			if err != nil {
 				shared.Debugf("rsync failed:\n%s", output)

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -20,7 +20,7 @@ func btrfsCmdIsInstalled() bool {
 	 *
 	 * TODO: Move this to the main code somewhere and call it once?
 	 */
-	out, err := exec.Command("which", "btrfs").Output()
+	out, err := exec.LookPath("btrfs")
 	if err != nil || len(out) == 0 {
 		return false
 	}


### PR DESCRIPTION
This patch uses **btrfs subvolume snapshot &lt;source&gt;> &lt;target&gt;** instead
of **rsync** if the source container is a btrfs container and everything
is on the same host.

I use **btrfs subvolume show &lt;source&gt;** to detect if the source
container is on btrfs.