### PR TITLE
Remove error timeout for lvcreate

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -256,7 +256,7 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 
 			snapshotLVPath, err := shared.LVMCreateSnapshotLV(name, hash, vgname)
 			if err != nil {
-				return fmt.Errorf("Error creating snapshot of source volume '%s'", srcLVPath)
+				return fmt.Errorf("Error creating snapshot of source volume '%s': %v", srcLVPath, err)
 			}
 
 			destPath := shared.VarPath("lxc", name)

--- a/shared/lvm.go
+++ b/shared/lvm.go
@@ -74,14 +74,8 @@ func LVMCreateSnapshotLV(lvname string, origlvname string, vgname string) (strin
 		Debugf("could not create LV named '%s' as snapshot of '%s': '%s'", lvname, origlvname, errbuf.String())
 		return "", fmt.Errorf("Could not create snapshot LV named %s", lvname)
 	}
-
-	timer := time.AfterFunc(snapshotCreateTimeout*time.Second, func() {
-		Debugf("Snapshot creation timed out after '%d' seconds, terminating attempt.", snapshotCreateTimeout)
-		cmd.Process.Kill()
-	})
-
 	err = cmd.Wait()
-	timer.Stop()
+
 	if err != nil {
 		return "", fmt.Errorf("Snapshot LV creation error: '%v'", err)
 	}


### PR DESCRIPTION
The timer was intended to catch cases where lvcreate hangs due to error
conditions such as a full thin pool, but contention for the thin pool
lock can cause lvcreate to take arbitrarily long before completing
successfully, so a timeout is not a good idea here.

Also logs actual error from snapshot creation.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>