### PR TITLE
move mounting of lvm vols to container start/stop

### DIFF
--- a/lxd/container_delete.go
+++ b/lxd/container_delete.go
@@ -29,11 +29,6 @@ func removeContainerPath(d *Daemon, name string) error {
 	}
 
 	if vgnameIsSet {
-		output, err := exec.Command("umount", cpath).CombinedOutput()
-		if err != nil {
-			return fmt.Errorf("failed to unmount container path '%s'.\nError: %v\nOutput: %s", cpath, err, output)
-		}
-
 		err = shared.LVMRemoveLV(vgname, name)
 		if err != nil {
 			return fmt.Errorf("failed to remove deleted container LV: %v", err)

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -222,6 +222,9 @@ func containersRestart(d *Daemon) error {
 			return err
 		}
 
+		if err = activateStorage(d, container); err != nil {
+			return err
+		}
 		container.c.Start()
 	}
 
@@ -257,6 +260,9 @@ func containersShutdown(d *Daemon) error {
 			go func() {
 				container.c.Shutdown(time.Second * 30)
 				container.c.Stop()
+				if err = deactivateStorage(d, container); err != nil {
+					shared.Logf("Error deactivating storage after container stop: %v", err)
+				}
 				wg.Done()
 			}()
 		}


### PR DESCRIPTION
Instead of mounting a container's LV on create and unmounting it
on destroy, mount on start/stop, ensuring that we do not have
unused images mounted, and that LV-backed containers restarted
after a reboot have their mounts restored.

Adds tests for unmounting after force-stopping, but due to
busybox not working with lxc shutdown, only includes
commented-out tests for unmounting after shutdown.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>