### PR TITLE
fix lvm testcase on new wily systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ To run the testsuite, you'll also need:
 
     sudo apt-get install curl gettext jq sqlite3
 
+To use LVM backing stores, you'll need:
+
+    sudo apt-get install lvm2 thin-provisioning-tools
+
 ### Building the tools
 
 LXD consists of two binaries, a client called `lxc` and a server called `lxd`.

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -5,8 +5,8 @@ create_vg() {
     pvloopdev=$(losetup -f)
     losetup $pvloopdev $pvfile
 
-    #vgcreate will create a PV for us
-    vgcreate lxd_test_vg $pvloopdev
+    pvcreate $pvloopdev
+    vgcreate -vv lxd_test_vg $pvloopdev
 
 }
 

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -6,7 +6,11 @@ create_vg() {
     losetup $pvloopdev $pvfile
 
     pvcreate $pvloopdev
-    vgcreate -vv lxd_test_vg $pvloopdev
+    VGDEBUG=""
+    if [ -n "$LXD_DEBUG" ]; then
+        VGDEBUG="-vv"
+    fi
+    vgcreate $VGDEBUG lxd_test_vg $pvloopdev
 
 }
 


### PR DESCRIPTION
For some reason, vgcreate has stopped auto-calling pvcreate, so do
it by hand.

Also comment that lvm and thin-provisioning-tools are needed.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>