### PR TITLE
Switch storage drivers on lvm config set

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -140,6 +140,9 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err != nil {
 				return InternalError(err)
 			}
+			if err = d.SetupStorageDriver(); err != nil {
+				return InternalError(err)
+			}
 		} else if key == "core.lvm_thinpool_name" {
 			err := setLVMThinPoolNameConfig(d, value.(string))
 			if err != nil {


### PR DESCRIPTION
Restores earlier behavior in which setting 'core.lvm_vg_name' to a valid
value is sufficient to get lxd to start using lvm.

It had been changed to only check that value on daemon startup.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>