### PR TITLE
Show image name in 'not found' error for launch

### DIFF
--- a/client.go
+++ b/client.go
@@ -1052,7 +1052,7 @@ func (c *Client) Init(name string, imgremote string, image string, profiles *[]s
 
 		imageinfo, err := c.GetImageInfo(fingerprint)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("can't get info for image '%s': %s", image, err)
 		}
 
 		if !shared.IntInSlice(imageinfo.Architecture, architectures) {

--- a/client.go
+++ b/client.go
@@ -1052,7 +1052,7 @@ func (c *Client) Init(name string, imgremote string, image string, profiles *[]s
 
 		imageinfo, err := c.GetImageInfo(fingerprint)
 		if err != nil {
-			return nil, fmt.Errorf("can't get info for image '%s': %s", image, err)
+			return nil, fmt.Errorf(gettext.Gettext("can't get info for image '%s': %s"), image, err)
 		}
 
 		if !shared.IntInSlice(imageinfo.Architecture, architectures) {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: PACKAGE VERSION\n"
         "Report-Msgid-Bugs-To: \n"
-        "POT-Creation-Date: 2015-07-22 22:40-0500\n"
+        "POT-Creation-Date: 2015-07-27 14:56-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -670,6 +670,11 @@ msgstr  ""
 
 #: lxc/copy.go:81
 msgid   "can't copy to the same container name"
+msgstr  ""
+
+#: client.go:1055
+#, c-format
+msgid   "can't get info for image '%s': %s"
 msgstr  ""
 
 #: client.go:419 client.go:424


### PR DESCRIPTION
When you forget to include an image name in 'lxc launch', it's nice to
see the name of the image that wasn't found, to jog your memory that
there probably isn't an image named 'testcontainer' or whatever.

Prior to this, `lxc launch foo` (assuming there's no image named foo) gives this:
```
Creating container...error: not found
```

With this you get the more useful:
```
Creating container...error: can't get info for image 'foo': not found
```

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>