### PR TITLE
Detect container and image storage.

### DIFF
--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -65,7 +65,9 @@ func containerPost(d *Daemon, r *http.Request) Response {
 			return err
 		}
 
-		removeContainer(d, c)
+		if err = removeContainer(d, c); err != nil {
+			return fmt.Errorf("error removing container after rename: %v", err)
+		}
 		return nil
 	}
 

--- a/lxd/container_state.go
+++ b/lxd/container_state.go
@@ -43,11 +43,16 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
+	s, err := storageForContainer(d, c)
+	if err != nil {
+		return SmartError(fmt.Errorf("Couldn't detect storage: %v", err))
+	}
+
 	var do func() error
 	switch shared.ContainerAction(raw.Action) {
 	case shared.Start:
 		do = func() error {
-			if err = d.Storage.ContainerStart(c); err != nil {
+			if err = s.ContainerStart(c); err != nil {
 				return err
 			}
 			if err = c.Start(); err != nil {
@@ -61,7 +66,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 				if err = c.Stop(); err != nil {
 					return err
 				}
-				if err = d.Storage.ContainerStop(c); err != nil {
+				if err = s.ContainerStop(c); err != nil {
 					return err
 				}
 				return nil
@@ -71,7 +76,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 				if err = c.Shutdown(time.Duration(raw.Timeout) * time.Second); err != nil {
 					return err
 				}
-				if err = d.Storage.ContainerStop(c); err != nil {
+				if err = s.ContainerStop(c); err != nil {
 					return err
 				}
 				return nil

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -224,7 +224,14 @@ func containersRestart(d *Daemon) error {
 			return err
 		}
 
-		if err = d.Storage.ContainerStart(container); err != nil {
+		s, err := storageForContainer(d, container)
+		if err != nil {
+			shared.Log.Error(
+				"Error getting storage driver for container",
+				log.Ctx{"err": err})
+			return fmt.Errorf("Couldn't detect storage: %v", err)
+		}
+		if err = s.ContainerStart(container); err != nil {
 			return err
 		}
 		container.c.Start()
@@ -262,7 +269,14 @@ func containersShutdown(d *Daemon) error {
 			go func() {
 				container.c.Shutdown(time.Second * 30)
 				container.c.Stop()
-				if err = d.Storage.ContainerStop(container); err != nil {
+				s, err := storageForContainer(d, container)
+				if err != nil {
+					shared.Log.Error(
+						"Error getting storage driver for container",
+						log.Ctx{"err": err})
+				}
+
+				if err = s.ContainerStop(container); err != nil {
 					shared.Log.Error(
 						"Error deactivating storage after container stop",
 						log.Ctx{"err": err})

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -353,7 +353,11 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 			return shared.OperationError(err)
 		}
 
-		if err := d.Storage.ContainerCopy(c, source); err != nil {
+		s, err := storageForContainer(d, source)
+		if err != nil {
+			return shared.OperationError(err)
+		}
+		if err := s.ContainerCopy(c, source); err != nil {
 			removeContainer(d, c)
 			return shared.OperationError(err)
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -721,13 +721,20 @@ func imageDelete(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
+	// get storage before deleting images/$fp because we need to
+	// look at the path
+	s, err := storageForImage(d, imgInfo)
+	if err != nil {
+		return InternalError(err)
+	}
+
 	fname := shared.VarPath("images", imgInfo.Fingerprint)
 	err = os.Remove(fname)
 	if err != nil {
 		shared.Debugf("Error deleting image file %s: %s\n", fname, err)
 	}
 
-	if err = d.Storage.ImageDelete(imgInfo.Fingerprint); err != nil {
+	if err = s.ImageDelete(imgInfo.Fingerprint); err != nil {
 		return InternalError(err)
 	}
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -63,7 +63,7 @@ func storageTypeToString(sType storageType) string {
 }
 
 type storage interface {
-	Init() (storage, error)
+	Init(config map[string]interface{}) (storage, error)
 
 	GetStorageType() storageType
 	GetStorageTypeName() string
@@ -82,6 +82,11 @@ type storage interface {
 }
 
 func newStorage(d *Daemon, sType storageType) (storage, error) {
+	var nilmap map[string]interface{}
+	return newStorageWithConfig(d, sType, nilmap)
+}
+
+func newStorageWithConfig(d *Daemon, sType storageType, config map[string]interface{}) (storage, error) {
 	var s storage
 
 	switch sType {
@@ -93,7 +98,7 @@ func newStorage(d *Daemon, sType storageType) (storage, error) {
 		s = &storageLogWrapper{w: &storageDir{d: d, sType: sType}}
 	}
 
-	return s.Init()
+	return s.Init(config)
 }
 
 type storageShared struct {
@@ -134,8 +139,8 @@ type storageLogWrapper struct {
 	log log.Logger
 }
 
-func (lw *storageLogWrapper) Init() (storage, error) {
-	_, err := lw.w.Init()
+func (lw *storageLogWrapper) Init(config map[string]interface{}) (storage, error) {
+	_, err := lw.w.Init(config)
 	lw.log = shared.Log.New(
 		log.Ctx{"driver": fmt.Sprintf("storage/%s", lw.w.GetStorageTypeName())},
 	)

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -18,7 +18,7 @@ type storageBtrfs struct {
 	storageShared
 }
 
-func (s *storageBtrfs) Init() (storage, error) {
+func (s *storageBtrfs) Init(config map[string]interface{}) (storage, error) {
 	s.sTypeName = storageTypeToString(s.sType)
 	if err := s.initShared(); err != nil {
 		return s, err

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -15,7 +15,7 @@ type storageDir struct {
 	storageShared
 }
 
-func (s *storageDir) Init() (storage, error) {
+func (s *storageDir) Init(config map[string]interface{}) (storage, error) {
 	s.sTypeName = storageTypeToString(s.sType)
 	if err := s.initShared(); err != nil {
 		return s, err

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -90,7 +90,7 @@ func (s *storageLvm) GetStorageType() storageType {
 func (s *storageLvm) ContainerCreate(
 	container *lxdContainer, imageFingerprint string) error {
 
-	lvPath, err := s.createSnapshotLV(container.NameGet(), imageFingerprint)
+	lvpath, err := s.createSnapshotLV(container.NameGet(), imageFingerprint)
 	if err != nil {
 		return err
 	}
@@ -100,8 +100,14 @@ func (s *storageLvm) ContainerCreate(
 		return fmt.Errorf("Error creating container directory: %v", err)
 	}
 
+	dst := shared.VarPath("lxc", fmt.Sprintf("%s.lv", container.NameGet()))
+	err = os.Symlink(lvpath, dst)
+	if err != nil {
+		return err
+	}
+
 	if !container.isPrivileged() {
-		output, err := exec.Command("mount", "-o", "discard", lvPath, destPath).CombinedOutput()
+		output, err := exec.Command("mount", "-o", "discard", lvpath, destPath).CombinedOutput()
 		if err != nil {
 			os.RemoveAll(destPath)
 			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, output)

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -57,25 +57,28 @@ type storageLvm struct {
 	storageShared
 }
 
-func (s *storageLvm) Init() (storage, error) {
+func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 	s.sTypeName = storageTypeToString(s.sType)
 	if err := s.initShared(); err != nil {
 		return s, err
 	}
 
-	vgName, vgNameIsSet, err := getServerConfigValue(s.d, "core.lvm_vg_name")
-	if err != nil {
-		return s, fmt.Errorf("Error checking server config: %v", err)
-	}
-	if !vgNameIsSet {
-		return s, fmt.Errorf("LVM isn't enabled")
-	}
+	if config["vgName"] == nil {
+		vgName, vgNameIsSet, err := getServerConfigValue(s.d, "core.lvm_vg_name")
+		if err != nil {
+			return s, fmt.Errorf("Error checking server config: %v", err)
+		}
+		if !vgNameIsSet {
+			return s, fmt.Errorf("LVM isn't enabled")
+		}
 
-	if err := storageLVMCheckVolumeGroup(vgName); err != nil {
-		return s, err
+		if err := storageLVMCheckVolumeGroup(vgName); err != nil {
+			return s, err
+		}
+		s.vgName = vgName
+	} else {
+		s.vgName = config["vgName"].(string)
 	}
-
-	s.vgName = vgName
 
 	return s, nil
 }

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -48,6 +48,8 @@ test_basic_usage() {
 
   # Test container rename
   lxc move foo bar
+  lxc list | grep -v foo
+  lxc list | grep bar
 
   # Test container copy
   lxc copy bar foo


### PR DESCRIPTION
Fixes #827 

Two separate commits - the first modifies storage backend to allow creating them for temporary usage. The second uses that to handle different storage configs per container.

Use existence of the .lv symlink to detect if a container or image is
backed by an LVM LV. Use appropriate storage driver based on the storage
of the container being deleted, snapshotted or copied-from.

Also modifies delete behavior so that an error from the storage driver
does not stop the container from being deleted in the db.
