### PR TITLE
only fail fdleak test if the leaked fds are > 0

### DIFF
--- a/test/fdleak.sh
+++ b/test/fdleak.sh
@@ -17,5 +17,12 @@ test_fdleak() {
     lxc delete leaktest1
     afterfds=`/bin/ls /proc/$lxd1_pid/fd | wc -l`
     leakedfds=$((afterfds - beforefds))
-    [ $leakedfds -lt 1 ] || { echo "$leakedfds FDS leaked"; ls /proc/$lxd1_pid/fd -al; false; }
+
+    bad=0
+    [ $leakedfds -gt 0 ] && bad=1 || true
+    if [ $bad -eq 1 ]; then
+      echo "$leakedfds FDS leaked"
+      ls /proc/$lxd1_pid/fd -al
+      false
+    fi
 }


### PR DESCRIPTION
In some cases, somehow we're getting fdsleaked=-1, which is fine and we
shouldn't fail the test.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>