### PR TITLE
containers POST: don't allow '/' in container names

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -380,8 +380,8 @@ func containersPost(d *Daemon, r *http.Request) Response {
 		shared.Debugf("no name provided, creating %s", req.Name)
 	}
 
-	if strings.Contains(req.Name, "/") {
-		return BadRequest(fmt.Errorf("Invalid container name: '/' is reserved for snapshots"))
+	if strings.Contains(req.Name, shared.SnapshotDelimiter) {
+		return BadRequest(fmt.Errorf("Invalid container name: '%s' is reserved for snapshots", shared.SnapshotDelimiter))
 	}
 
 	switch req.Source.Type {

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -380,6 +380,10 @@ func containersPost(d *Daemon, r *http.Request) Response {
 		shared.Debugf("no name provided, creating %s", req.Name)
 	}
 
+	if strings.Contains(req.Name, "/") {
+		return BadRequest(fmt.Errorf("Invalid container name: '/' is reserved for snapshots"))
+	}
+
 	switch req.Source.Type {
 	case "image":
 		return createFromImage(d, &req)


### PR DESCRIPTION
Otherwise:

$ lxc init 9468e75eb8f2 a/1
$ lxc delete a/1
  error: not found

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>