### PR TITLE
shmounts: only bind-mount if really needed

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -313,8 +313,9 @@ func (d *Daemon) SetupStorageDriver() error {
 
 func setupSharedMounts() error {
 	path := shared.VarPath("shmounts")
-	if shared.IsSharedMount(path) {
-		// mounted by previous lxd run which must have crashed
+	if shared.IsOnSharedMount(path) {
+		// / may already be ms-shared, or shmounts may have
+		// been mounted by a previous lxd run
 		return nil
 	}
 	if !shared.PathExists(path) {


### PR DESCRIPTION
If $lxdpath is on a MS_SHARED mount, then we don't need to remount
$lxddir/shmounts itself.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>