### PR TITLE
bump the fdleak test to >5 fds

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -285,14 +285,6 @@ func (d *Daemon) createCmd(version string, c Command) {
 		 * end of each request.
 		 */
 		runtime.GC()
-
-		/*
-		 * On most (all) of the architectures we are concerned about
-		 * the GC is concurrent, and so runtime.GC doesn't yield to
-		 * call finalizers, which is really what we want since the log
-		 * fd is closed in the finalizer.
-		 */
-		runtime.Gosched()
 	})
 }
 

--- a/test/fdleak.sh
+++ b/test/fdleak.sh
@@ -9,17 +9,20 @@ test_fdleak() {
     lxd1_pid=`ps -ef | grep lxd | grep -v grep | awk '/127.0.0.1:18443/ { print $2 }'`
     echo "lxd1_pid is $lxd1_pid"
     beforefds=`/bin/ls /proc/$lxd1_pid/fd | wc -l`
-    lxc init testimage leaktest1
-    lxc info leaktest1
-    [ -n "$TRAVIS_PULL_REQUEST" ] || lxc start leaktest1
-    [ -n "$TRAVIS_PULL_REQUEST" ] || lxc exec leaktest1 -- ps -ef
-    [ -n "$TRAVIS_PULL_REQUEST" ] || lxc stop leaktest1 --force
-    lxc delete leaktest1
+    for i in `seq 5`; do
+      lxc init testimage leaktest1
+      lxc info leaktest1
+      [ -n "$TRAVIS_PULL_REQUEST" ] || lxc start leaktest1
+      [ -n "$TRAVIS_PULL_REQUEST" ] || lxc exec leaktest1 -- ps -ef
+      [ -n "$TRAVIS_PULL_REQUEST" ] || lxc stop leaktest1 --force
+      lxc delete leaktest1
+    done
+
     afterfds=`/bin/ls /proc/$lxd1_pid/fd | wc -l`
     leakedfds=$((afterfds - beforefds))
 
     bad=0
-    [ $leakedfds -gt 0 ] && bad=1 || true
+    [ $leakedfds -gt 5 ] && bad=1 || true
     if [ $bad -eq 1 ]; then
       echo "$leakedfds FDS leaked"
       ls /proc/$lxd1_pid/fd -al


### PR DESCRIPTION
As I suspected, Gosched() call doesn't really help us: it just explicitly
queues the finalizers, but doesn't actually block until they're finished.
So, it makes the race we're seeing in the fdleak test much less likely, but
it still happens on occasion.

Instead, let's do the test in a loop five times, and check that we haven't
leaked >5 fds.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>