### PR TITLE
Move snapshots to $LXD_DIR/snapshots.

### DIFF
--- a/lxd/container_new.go
+++ b/lxd/container_new.go
@@ -196,8 +196,7 @@ func (c *lxdContainer) NameGet() string {
 
 func (c *lxdContainer) PathGet() string {
 	if c.IsSnapshot() {
-		snappieces := strings.SplitN(c.NameGet(), shared.SnapshotDelimiter, 2)
-		return shared.VarPath("containers", snappieces[0], "snapshots", snappieces[1])
+		return shared.VarPath("snapshots", c.NameGet())
 	}
 
 	return shared.VarPath("containers", c.NameGet())

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -13,10 +13,12 @@ import (
 	"gopkg.in/lxc/go-lxc.v2"
 
 	"github.com/lxc/lxd/shared"
+
+	log "gopkg.in/inconshreveable/log15.v2"
 )
 
 func snapshotsDir(c *lxdContainer) string {
-	return shared.VarPath("containers", c.name, "snapshots")
+	return shared.VarPath("snapshots", c.name)
 }
 
 func snapshotDir(c *lxdContainer, name string) string {
@@ -147,6 +149,11 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 	fullName := fmt.Sprintf("%s/%s", name, snapshotName)
 	snapDir := snapshotDir(c, snapshotName)
 	if shared.PathExists(snapDir) {
+		shared.Log.Error(
+			"Snapshot exists on disk",
+			log.Ctx{
+				"name": fullName,
+				"path": snapDir})
 		return Conflict
 	}
 
@@ -254,6 +261,12 @@ func snapshotPost(r *http.Request, c *lxdContainer, oldName string) Response {
 	newDir := snapshotDir(c, newName)
 
 	if shared.PathExists(newDir) {
+		shared.Log.Error(
+			"Cant rename snapshot, the new path exists",
+			log.Ctx{
+				"oldName": oldName,
+				"newName": newName,
+				"path":    newDir})
 		return Conflict
 	}
 

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -322,7 +322,7 @@ func containerDeleteSnapshots(d *Daemon, cname string) error {
 		sname = r[0].(string)
 		id = r[1].(int)
 		ids = append(ids, id)
-		cdir := shared.VarPath("containers", cname, "snapshots", sname)
+		cdir := shared.VarPath("snapshots", sname)
 
 		if backingFs == "btrfs" {
 			btrfsDeleteSubvol(cdir)

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -27,7 +27,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 }
 
 func doContainersGet(d *Daemon, recursion bool) (interface{}, error) {
-	result, err := dbContainersList(d.db)
+	result, err := dbContainersList(d.db, cTypeRegular)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -375,6 +375,9 @@ func StartDaemon(listenAddr string) (*Daemon, error) {
 	if err := os.MkdirAll(shared.VarPath("images"), 0700); err != nil {
 		return nil, err
 	}
+	if err := os.MkdirAll(shared.VarPath("snapshots"), 0700); err != nil {
+		return nil, err
+	}
 	if err := os.MkdirAll(shared.VarPath("devlxd"), 0755); err != nil {
 		return nil, err
 	}

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -252,7 +253,7 @@ func dbUpdateFromV11(d *Daemon) error {
 
 			// Remove /var/lib/lxd/containers/<container>/snapshots
 			// if its empty.
-			cPathParent := shared.PathParent(oldPath)
+			cPathParent := filepath.Dir(oldPath)
 			if ok, _ := shared.PathIsEmpty(cPathParent); ok {
 				os.Remove(cPathParent)
 			}

--- a/lxd/db_container.go
+++ b/lxd/db_container.go
@@ -302,9 +302,9 @@ func dbContainerConfigGet(db *sql.DB, containerID int) (map[string]string, error
 	return config, nil
 }
 
-func dbContainersList(db *sql.DB) ([]string, error) {
+func dbContainersList(db *sql.DB, cType containerType) ([]string, error) {
 	q := fmt.Sprintf("SELECT name FROM containers WHERE type=? ORDER BY name")
-	inargs := []interface{}{cTypeRegular}
+	inargs := []interface{}{cType}
 	var container string
 	outfmt := []interface{}{container}
 	result, err := dbQueryScan(db, q, inargs, outfmt)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -342,7 +342,7 @@ func findContainerForPid(pid int32, d *Daemon) (*lxdContainer, error) {
 		return nil, err
 	}
 
-	containers, err := dbContainersList(d.db)
+	containers, err := dbContainersList(d.db, cTypeRegular)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -97,7 +97,7 @@ func (s *storageBtrfs) ContainerCopy(container *lxdContainer, sourceContainer *l
 		/*
 		 * Copy by using rsync
 		 */
-		output, err := s.rsyncCopy(
+		output, err := storageRsyncCopy(
 			sourceContainer.RootfsPathGet(),
 			container.RootfsPathGet())
 		if err != nil {

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -78,7 +78,7 @@ func (s *storageDir) ContainerCopy(
 	/*
 	 * Copy by using rsync
 	 */
-	output, err := s.rsyncCopy(oldPath, newPath)
+	output, err := storageRsyncCopy(oldPath, newPath)
 	if err != nil {
 		s.ContainerDelete(container)
 		s.log.Error("ContainerCopy: rsync failed", log.Ctx{"output": output})

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -196,7 +196,7 @@ func (s *storageLvm) ContainerCopy(container *lxdContainer, sourceContainer *lxd
 	/*
 	 * Copy by using rsync
 	 */
-	output, err := s.rsyncCopy(oldPath, newPath)
+	output, err := storageRsyncCopy(oldPath, newPath)
 	if err != nil {
 		os.RemoveAll(container.PathGet())
 		s.log.Error("ContainerCopy: rsync failed", log.Ctx{"output": output})

--- a/shared/util.go
+++ b/shared/util.go
@@ -61,16 +61,6 @@ func PathExists(name string) bool {
 	return true
 }
 
-// PathParent returns the parent path of "path"
-// For example:
-//   /var/lib/lxd/snapshots/test/snap0
-// turns to:
-//   /var/lib/lxd/snapshots/test
-func PathParent(path string) string {
-	parent, _ := filepath.Abs(AddSlash(path) + "..")
-	return parent
-}
-
 // PathIsEmpty checks if the given path is empty.
 func PathIsEmpty(path string) (bool, error) {
 	f, err := os.Open(path)

--- a/shared/util.go
+++ b/shared/util.go
@@ -61,6 +61,35 @@ func PathExists(name string) bool {
 	return true
 }
 
+// PathParent returns the parent path of "path"
+// For example:
+//   /var/lib/lxd/snapshots/test/snap0
+// turns to:
+//   /var/lib/lxd/snapshots/test
+func PathParent(path string) string {
+	parent, _ := filepath.Abs(AddSlash(path) + "..")
+	return parent
+}
+
+// PathIsEmpty checks if the given path is empty.
+func PathIsEmpty(path string) (bool, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	// read in ONLY one file
+	_, err = f.Readdir(1)
+
+	// and if the file is EOF... well, the dir is empty.
+	if err == io.EOF {
+		return true, nil
+	}
+	return false, err
+}
+
+// IsDir returns true if the given path is a directory.
 func IsDir(name string) bool {
 	stat, err := os.Lstat(name)
 	if err != nil {


### PR DESCRIPTION
Moves snapshots from: 

    $LXD_DIR/containers/<container>/snapshots/<snapshotname>

to 

    $LX_DIR/snapshots/<container>/<snapshotname>


Also:
- makes storage.rsyncCopy available as storageRsyncCopy
- adds some error log messages, i needed them while debugging.
- extends `dbContainersList` to list either Containers or Snapshots.

Did multiple tests, including the full testsuite seems to work fine.