### PR TITLE
Print container names for init and launch

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/chai2010/gettext-go/gettext"
 
@@ -135,7 +136,11 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 	}
 
 	var resp *lxd.Response
-
+	if name == "" {
+		fmt.Printf("Creating ")
+	} else {
+		fmt.Printf("Creating %s ", name)
+	}
 	if !requested_empty_profiles && len(profiles) == 0 {
 		resp, err = d.Init(name, iremote, image, nil, ephem)
 	} else {
@@ -146,5 +151,19 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 		return err
 	}
 
-	return d.WaitForSuccess(resp.Operation)
+	err = d.WaitForSuccess(resp.Operation)
+	if err != nil {
+		fmt.Println("error.")
+		return err
+	} else {
+		containers := resp.Resources["containers"]
+
+		if len(containers) == 1 && name == "" {
+			cname := path.Base(containers[0])
+			fmt.Println(cname, "done.")
+		} else {
+			fmt.Println("done.")
+		}
+	}
+	return nil
 }

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -56,7 +56,6 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 		remote = ""
 	}
 
-	fmt.Printf("Creating container...")
 	d, err := lxd.NewClient(config, remote)
 	if err != nil {
 		return err
@@ -105,20 +104,25 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 			return fmt.Errorf(gettext.Gettext("got bad version"))
 		}
 	}
+	fmt.Printf("Creating %s ", name)
 
 	if err = d.WaitForSuccess(resp.Operation); err != nil {
 		return err
 	}
-	fmt.Println("done")
+	fmt.Println("done.")
 
-	fmt.Printf("Starting container...")
+	fmt.Printf("Starting %s ", name)
 	resp, err = d.Action(name, shared.Start, -1, false)
 	if err != nil {
 		return err
 	}
 
 	err = d.WaitForSuccess(resp.Operation)
-	fmt.Println("done")
+	if err != nil {
+		fmt.Println("error.")
+	} else {
+		fmt.Println("done.")
+	}
 
 	return err
 }


### PR DESCRIPTION
Fixes #884.

Prints container name as soon as we know it, which may be after hearing
back from the server if the user didn't specify a name.

Also prints 'error' instead of 'done' in case of error.

Modified 'lxc launch' as per #884, and also went ahead and modified
'lxc init'.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>