### PR TITLE
lxd-images: Use trusty by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ LXD has two parts, the daemon (the `lxd` binary), and the client (the `lxc`
 binary). Now that the daemon is all configured and running (either via the
 packaging or via the from-source instructions above), you can import some images:
 
-    $GOPATH/src/github.com/lxc/lxd/scripts/lxd-images import lxc ubuntu trusty amd64 --alias ubuntu --alias ubuntu/trusty --alias ubuntu/trusty/amd64
+    $GOPATH/src/github.com/lxc/lxd/scripts/lxd-images import ubuntu --alias ubuntu
     $GOPATH/src/github.com/lxc/lxd/scripts/lxd-images import lxc debian wheezy amd64 --alias debian --alias debian/wheezy --alias debian/wheezy/amd64
 
 With those two images imported into LXD, you can now start containers:

--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -423,8 +423,7 @@ class Ubuntu(object):
 
     def image_download(self, release=None, architecture=None, version=None):
         if not release:
-            # FIXME: We should default to latest LTS once available
-            release = "wily"
+            release = "trusty"
 
         if not architecture:
             architecture = local_architecture()


### PR DESCRIPTION
And also start recommending the cloud images as the default.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>