### PR TITLE
Drop lxc_path from the config options

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -20,7 +20,6 @@ Key                             | Type          | Default                   | De
 :--                             | :---          | :------                   | :----------
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed
-lxc.lxc\_path                   | string        | /var/lib/lxd/lxc          | LXC path used for the container control socket
 
 Those keys can be set using the lxc tool with:
 


### PR DESCRIPTION
We've never supported it and now we really want to stick with
/var/lib/lxd/containers.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>