### PR TITLE
Drop --tcp and make the https port configurable

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -79,7 +79,7 @@ func addServer(config *lxd.Config, server string, addr string, acceptCert bool, 
 		r_host = host
 		r_port = port
 	} else {
-		r_port = "8443"
+		r_port = shared.DefaultPort
 	}
 
 	if r_scheme == "unix" {

--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -148,6 +148,21 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err != nil {
 				return InternalError(err)
 			}
+		} else if key == "core.https_address" {
+			old_address, err := d.ConfigValueGet("core.https_address")
+			if err != nil {
+				return InternalError(err)
+			}
+
+			d.UpdateHTTPsPort(old_address, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
+
+			err = d.ConfigValueSet(key, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
 		} else {
 			err := d.ConfigValueSet(key, value.(string))
 			if err != nil {

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -106,7 +106,7 @@ func TestHttpRequest(t *testing.T) {
 	}
 	defer os.RemoveAll("/tmp/tester")
 
-	d, err := StartDaemon("")
+	d, err := StartDaemon()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -27,7 +27,6 @@ var verbose = gnuflag.Bool("v", false, "Enables verbose mode.")
 var syslogFlag = gnuflag.Bool("syslog", false, "Enables syslog logging.")
 var logfile = gnuflag.String("logfile", "", "Logfile to log to (e.g., /var/log/lxd/lxd.log).")
 var debug = gnuflag.Bool("debug", false, "Enables debug mode.")
-var listenAddr = gnuflag.String("tcp", "", "TCP address <addr:port> to listen on in addition to the unix socket (e.g., 127.0.0.1:8443).")
 var group = gnuflag.String("group", "", "Group which owns the shared socket.")
 var help = gnuflag.Bool("help", false, "Print this help message.")
 var version = gnuflag.Bool("version", false, "Print LXD's version number and exit.")
@@ -125,7 +124,7 @@ func run() error {
 		}()
 	}
 
-	d, err := StartDaemon(*listenAddr)
+	d, err := StartDaemon()
 
 	if err != nil {
 		if d != nil && d.db != nil {

--- a/scripts/vagrant/install-lxd.sh
+++ b/scripts/vagrant/install-lxd.sh
@@ -32,7 +32,7 @@ stop on shutdown
 
 script
 
-    exec /home/vagrant/go/bin/lxd --group vagrant --tcp 0.0.0.0:443
+    exec /home/vagrant/go/bin/lxd --group vagrant
 
 end script
 

--- a/shared/util.go
+++ b/shared/util.go
@@ -21,6 +21,9 @@ import (
 	"unsafe"
 )
 
+const SnapshotDelimiter = "/"
+const DefaultPort = "8443"
+
 func GetFileStat(p string) (uid int, gid int, major int, minor int,
 	inode uint64, nlink int, err error) {
 	var stat syscall.Stat_t
@@ -314,8 +317,6 @@ func (r BytesReadCloser) Close() error {
 	/* no-op since we're in memory */
 	return nil
 }
-
-const SnapshotDelimiter = "/"
 
 func IsSnapshot(name string) bool {
 	return strings.Contains(name, SnapshotDelimiter)

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -18,6 +18,7 @@ currently supported:
 
 Key                             | Type          | Default                   | Description
 :--                             | :---          | :------                   | :----------
+core.https\_address             | string        | -                         | Address to bind for the remote API
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed
 lxc.lxc\_path                   | string        | /var/lib/lxd/lxc          | LXC path used for the container control socket

--- a/test/main.sh
+++ b/test/main.sh
@@ -174,7 +174,7 @@ spawn_lxd() {
   cp server.key $lxddir
 
   echo "==> Spawning lxd on $addr in $lxddir"
-  (LXD_DIR=$lxddir lxd $debug --tcp $addr $extraargs $* 2>&1 & echo $! > $lxddir/lxd.pid) | tee $lxddir/lxd.log &
+  (LXD_DIR=$lxddir lxd $debug $extraargs $* 2>&1 & echo $! > $lxddir/lxd.pid) | tee $lxddir/lxd.log &
 
   echo "==> Confirming lxd on $addr is responsive"
   alive=0
@@ -182,6 +182,9 @@ spawn_lxd() {
     [ -e "${lxddir}/unix.socket" ] && LXD_DIR=$lxddir lxc finger && alive=1
     sleep 1s
   done
+
+  echo "==> Binding to network"
+  LXD_DIR=$lxddir lxc config set core.https_address $addr
 
   echo "==> Setting trust password"
   LXD_DIR=$lxddir lxc config set core.trust_password foo

--- a/test/stresstest.sh
+++ b/test/stresstest.sh
@@ -95,7 +95,7 @@ spawn_lxd() {
   shift
   shift
   echo "==> Spawning lxd on $addr in $lxddir"
-  LXD_DIR=$lxddir lxd ${DEBUG} --tcp $addr $extraargs $* 2>&1 > $lxddir/lxd.log &
+  LXD_DIR=$lxddir lxd ${DEBUG} $extraargs $* 2>&1 > $lxddir/lxd.log &
 
   echo "==> Confirming lxd on $addr is responsive"
   alive=0
@@ -103,6 +103,9 @@ spawn_lxd() {
     [ -e "${lxddir}/unix.socket" ] && LXD_DIR=$lxddir lxc finger && alive=1
     sleep 1s
   done
+
+  echo "==> Binding to network"
+  LXD_DIR=$lxddir lxc config set core.https_address $addr
 
   echo "==> Setting trust password"
   LXD_DIR=$lxddir lxc config set core.trust_password foo


### PR DESCRIPTION
This makes it possible to set/unset the https address and port over the
API and drops the old --tcp option.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>