### PR TITLE
Unset removes config key from cached map

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -685,6 +685,10 @@ func (d *Daemon) ConfigValueSet(key string, value string) error {
 		if _, err := d.ConfigValuesGet(); err != nil {
 			return err
 		}
+	}
+
+	if value == "" {
+		delete(d.configValues, key)
 	} else {
 		d.configValues[key] = value
 	}

--- a/lxd/daemon_test.go
+++ b/lxd/daemon_test.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func Test_config_value_set_empty_removes_val(t *testing.T) {
+	d := &Daemon{}
+
+	err := shared.SetLogger("", "", true, true)
+	if err != nil {
+		t.Error("logging")
+	}
+
+	err = initializeDbObject(d, ":memory:")
+	defer d.db.Close()
+
+	if err != nil {
+		t.Error("failed to init db")
+	}
+	if err = d.ConfigValueSet("core.lvm_vg_name", "foo"); err != nil {
+		t.Error("couldn't set value", err)
+	}
+
+	val, err := d.ConfigValueGet("core.lvm_vg_name")
+	if err != nil {
+		t.Error("Error getting val")
+	}
+	if val != "foo" {
+		t.Error("Expected foo, got ", val)
+	}
+
+	err = d.ConfigValueSet("core.lvm_vg_name", "")
+	if err != nil {
+		t.Error("error setting to ''")
+	}
+
+	val, err = d.ConfigValueGet("core.lvm_vg_name")
+	if err != nil {
+		t.Error("Error getting val")
+	}
+	if val != "" {
+		t.Error("Expected '', got ", val)
+	}
+
+	valMap, err := d.ConfigValuesGet()
+	if err != nil {
+		t.Error("Error getting val")
+	}
+	if key, present := valMap["core.lvm_vg_name"]; present {
+		t.Errorf("un-set key should not be in values map, it is '%v'", key)
+	}
+
+}


### PR DESCRIPTION
The unset command translates into setting key="", which just removes the
key from the db in dbConfigValueSet. This behavior wasn't reproduced
when the in-memory cache was added. This commit returns that behavior
and adds a unit test for it.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>