### PR TITLE
Implement recursion requests for profiles, fixes issue #476.

### DIFF
--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -27,6 +27,25 @@ func dbProfileIDGet(db *sql.DB, profile string) (int64, error) {
 	return id, nil
 }
 
+// dbProfilesGet returns a string list of profiles.
+func dbProfilesGet(db *sql.DB) ([]string, error) {
+	q := fmt.Sprintf("SELECT name FROM profiles")
+	inargs := []interface{}{}
+	var name string
+	outfmt := []interface{}{name}
+	result, err := dbQueryScan(db, q, inargs, outfmt)
+	if err != nil {
+		return []string{}, err
+	}
+
+	response := []string{}
+	for _, r := range result {
+		response = append(response, r[0].(string))
+	}
+
+	return response, nil
+}
+
 func dbProfileCreate(db *sql.DB, profile string, config map[string]string,
 	devices shared.Devices) (int64, error) {
 


### PR DESCRIPTION
This is what it looks like:

    $ curl -s -k --cert ~/.config/lxc/client.crt --key ~/.config/lxc/client.key https://127.0.0.1:8443/1.0/profiles | jq .
    {
      "type": "sync",
      "status": "Success",
      "status_code": 200,
      "metadata": [
        "/1.0/profiles/default"
      ]
    }
    $ curl -s -k --cert ~/.config/lxc/client.crt --key ~/.config/lxc/client.key https://127.0.0.1:8443/1.0/profiles?recursion=1 | jq .
    {
      "type": "sync",
      "status": "Success",
      "status_code": 200,
      "metadata": [
        {
          "name": "default",
          "config": {},
          "devices": {
            "eth0": {
              "nictype": "bridged",
              "parent": "lxcbr0",
              "type": "nic"
            }
          }
        },
        {
          "name": "unconfined",
          "config": {},
          "devices": {}
        },
        {
          "name": "privileged",
          "config": {
            "security.privileged": "true"
          },
          "devices": {}
        }
      ]
    }


Signed-off-by: René Jochum <rene@jochums.at>