### PR TITLE
Daemon now survives storage init errors at startup

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -294,11 +294,22 @@ func (d *Daemon) SetupStorageDriver() error {
 	}
 	if vgName != "" {
 		d.Storage, err = newStorage(d, storageTypeLvm)
+		if err != nil {
+			shared.Logf("Could not initialize storage type LVM: %s - falling back to dir", err)
+		} else {
+			return nil
+		}
 	} else if d.BackingFs == "btrfs" {
 		d.Storage, err = newStorage(d, storageTypeBtrfs)
-	} else {
-		d.Storage, err = newStorage(d, -1)
+		if err != nil {
+			shared.Logf("Could not initialize storage type btrfs: %s - falling back to dir", err)
+		} else {
+			return nil
+		}
 	}
+
+	d.Storage, err = newStorage(d, storageTypeDir)
+
 	return err
 }
 


### PR DESCRIPTION
If the daemon is configured to use e.g. a particuarl LVM VG, and that VG
is not available when the daemon starts, the daemon needs to be able to
still start in order to fix the relevant config.

Adds a test.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>