### PR TITLE
Add helper func for testimage import

### DIFF
--- a/test/basic.sh
+++ b/test/basic.sh
@@ -10,13 +10,8 @@ gen_third_cert() {
 }
 
 test_basic_usage() {
-  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
-    if [ -e "$LXD_TEST_IMAGE" ]; then
-        lxc image import $LXD_TEST_IMAGE --alias testimage
-    else
-        ../scripts/lxd-images import busybox --alias testimage
-    fi
-  fi
+
+  ensure_import_testimage
 
   # Test image export
   sum=$(lxc image info testimage | grep ^Fingerprint | cut -d' ' -f2)

--- a/test/main.sh
+++ b/test/main.sh
@@ -193,6 +193,16 @@ spawn_lxd() {
   fi
 }
 
+ensure_import_testimage() {
+  if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
+    if [ -e "$LXD_TEST_IMAGE" ]; then
+        lxc image import $LXD_TEST_IMAGE --alias testimage
+    else
+        ../scripts/lxd-images import busybox --alias testimage
+    fi
+  fi
+}
+
 spawn_lxd 127.0.0.1:18443 $LXD_DIR
 
 export LXD2_DIR=$(mktemp -d -p $(pwd))

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -1,4 +1,5 @@
 test_migration() {
+  ensure_import_testimage
   (echo y;  sleep 3;  echo foo) | lxc remote add l1 127.0.0.1:18443 $debug
   (echo y;  sleep 3;  echo foo) | lxc remote add l2 127.0.0.1:18444 $debug
 


### PR DESCRIPTION
Allows migration tests to be run by themselves

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>