### PR TITLE
Rename MigrateTo to GetMigrationSourceWS

### DIFF
--- a/client.go
+++ b/client.go
@@ -1346,7 +1346,7 @@ func (c *Client) PullFile(container string, p string) (int, int, os.FileMode, io
 	return uid, gid, mode, r.Body, nil
 }
 
-func (c *Client) MigrateTo(container string) (*Response, error) {
+func (c *Client) GetMigrationSourceWS(container string) (*Response, error) {
 	body := shared.Jmap{"migration": true}
 	return c.post(fmt.Sprintf("containers/%s", container), body, Async)
 }

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -107,7 +107,7 @@ func copyContainer(config *lxd.Config, sourceResource string, destResource strin
 			return fmt.Errorf(gettext.Gettext("not all the profiles from the source exist on the target"))
 		}
 
-		to, err := source.MigrateTo(sourceName)
+		to, err := source.GetMigrationSourceWS(sourceName)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
sourceremote.MigrateTo(sourcecontainer) posts a GET to
sourceremote/containers/sourcecontainer with body {migration: True},
which returns a websocket in an asyncResponse. The name "MigrateTo" was
confusing (me).

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>