### PR TITLE
remove --checksum for storageRsyncCopy

### DIFF
--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -62,7 +62,6 @@ func storageRsyncCopy(source string, dest string) (string, error) {
 	output, err := exec.Command(
 		"rsync",
 		"-a",
-		"--checksum", // TODO: Not sure we need this option
 		"-HAX",
 		"--devices",
 		"--delete",


### PR DESCRIPTION
--checksum is not likely to be necessary, causes significant IO, and we
don't use it in the other places where we call rsync.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>