### PR TITLE
Remove -z compression option for migration rsync

### DIFF
--- a/lxd/migration/rsync.go
+++ b/lxd/migration/rsync.go
@@ -74,7 +74,7 @@ func rsyncSendSetup(path string) (*exec.Cmd, net.Conn, error) {
 	 * hardcoding that at the other end, so we can just ignore it.
 	 */
 	rsyncCmd := fmt.Sprintf("sh -c \"nc -U %s\"", f.Name())
-	cmd := exec.Command("rsync", "-arvPz", "--devices", "--partial", path, "localhost:/tmp/foo", "-e", rsyncCmd)
+	cmd := exec.Command("rsync", "-arvP", "--devices", "--partial", path, "localhost:/tmp/foo", "-e", rsyncCmd)
 	if err := cmd.Start(); err != nil {
 		return nil, nil, err
 	}
@@ -105,7 +105,7 @@ func RsyncSend(path string, conn *websocket.Conn) error {
 }
 
 func rsyncRecvCmd(path string) *exec.Cmd {
-	return exec.Command("rsync", "--server", "-vlogDtprze.iLsfx", "--devices", "--partial", ".", path)
+	return exec.Command("rsync", "--server", "-vlogDtpre.iLsfx", "--devices", "--partial", ".", path)
 }
 
 // RsyncRecv sets up the receiving half of the websocket to rsync (the other


### PR DESCRIPTION
Over fast connections, this is slower due to cpu overhead.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>