### PR TITLE
Use go race detector for make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,9 @@ protobuf:
 
 .PHONY: check
 check: default
-	go test ./...
-	cd test && ./main.sh
+	go test -race ./...
+	-cd test && GORACE="halt_on_error=1" ./main.sh
+	go install -v -a ./...	# rebuild all without race detector
 
 gccgo:
 	go build -compiler gccgo ./...


### PR DESCRIPTION
NOTE: 'go install -race' will rebuild all with the instrumentation, but
a subsequent 'go install' will not rebuild everything, so we force it
with a 'go install -a' after every test suite run.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>