### PR TITLE
Decouple snapshot and basic from remote tests

### DIFF
--- a/test/basic.sh
+++ b/test/basic.sh
@@ -12,6 +12,7 @@ gen_third_cert() {
 test_basic_usage() {
 
   ensure_import_testimage
+  ensure_has_localhost_remote
 
   # Test image export
   sum=$(lxc image info testimage | grep ^Fingerprint | cut -d' ' -f2)

--- a/test/main.sh
+++ b/test/main.sh
@@ -194,6 +194,12 @@ spawn_lxd() {
   fi
 }
 
+ensure_has_localhost_remote() {
+    if ! lxc remote list | grep -q "localhost"; then
+        (echo y; sleep 3) | lxc remote add localhost $BASEURL $debug --password foo
+    fi
+}
+
 ensure_import_testimage() {
   if ! lxc image alias list | grep -q "^| testimage\s*|.*$"; then
     if [ -e "$LXD_TEST_IMAGE" ]; then

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -1,5 +1,6 @@
 test_snapshots() {
   ensure_import_testimage
+  ensure_has_localhost_remote
 
   lxc init testimage foo
 
@@ -37,6 +38,9 @@ test_snap_restore() {
     echo "SKIPPING"
     return
   fi
+
+  ensure_import_testimage
+  ensure_has_localhost_remote
 
   lxc launch testimage bar
 


### PR DESCRIPTION
this lets you do 
`main.sh snapshots`, `main.sh snap_restore`, `main.sh basic_usage`
by themselves.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>