### PR TITLE
Use ContainerSnapshotDelete to delete snapshots

### DIFF
--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -249,6 +249,9 @@ func containersShutdown(d *Daemon) error {
 }
 
 func containerDeleteSnapshots(d *Daemon, cname string) error {
+	shared.Log.Debug("containerDeleteSnapshots",
+		log.Ctx{"container": cname})
+
 	results, err := dbContainerGetSnapshots(d.db, cname)
 	if err != nil {
 		return err
@@ -266,8 +269,8 @@ func containerDeleteSnapshots(d *Daemon, cname string) error {
 
 		if err := sc.Delete(); err != nil {
 			shared.Log.Error(
-				"containerDeleteSnapshots: Failed to load delete a snapshotcontainer",
-				log.Ctx{"container": cname, "snapshot": sname})
+				"containerDeleteSnapshots: Failed to delete a snapshotcontainer",
+				log.Ctx{"container": cname, "snapshot": sname, "err": err})
 		}
 	}
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -103,23 +103,6 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 		return fmt.Errorf("Error cleaning up %s: %s", cPath, err)
 	}
 
-	// If its name contains a "/" also remove the parent,
-	// this should only happen with snapshot containers
-	if strings.Contains(container.NameGet(), "/") {
-		oldPathParent := filepath.Dir(container.PathGet(""))
-		shared.Log.Debug(
-			"Trying to remove the parent path",
-			log.Ctx{"container": container.NameGet(), "parent": oldPathParent})
-
-		if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
-			os.Remove(oldPathParent)
-		} else {
-			shared.Log.Debug(
-				"Cannot remove the parent of this container its not empty",
-				log.Ctx{"container": container.NameGet(), "parent": oldPathParent})
-		}
-	}
-
 	return nil
 }
 
@@ -271,7 +254,20 @@ func (s *storageBtrfs) ContainerSnapshotCreate(
 func (s *storageBtrfs) ContainerSnapshotDelete(
 	snapshotContainer container) error {
 
-	return s.ContainerDelete(snapshotContainer)
+	err := s.ContainerDelete(snapshotContainer)
+	if err != nil {
+		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.NameGet(), err)
+	}
+
+	oldPathParent := filepath.Dir(snapshotContainer.PathGet(""))
+	shared.Log.Debug(
+		"Trying to remove the parent path",
+		log.Ctx{"container": snapshotContainer.NameGet(), "parent": oldPathParent})
+
+	if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
+		os.Remove(oldPathParent)
+	}
+	return nil
 }
 
 // ContainerSnapshotRename renames a snapshot of a container.

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -260,10 +260,6 @@ func (s *storageBtrfs) ContainerSnapshotDelete(
 	}
 
 	oldPathParent := filepath.Dir(snapshotContainer.PathGet(""))
-	shared.Log.Debug(
-		"Trying to remove the parent path",
-		log.Ctx{"container": snapshotContainer.NameGet(), "parent": oldPathParent})
-
 	if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
 		os.Remove(oldPathParent)
 	}


### PR DESCRIPTION
Moves snapshot-specific code into the separate function in the storage
drivers that was already there but unused.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>