### PR TITLE
Re-add --checksum for local rsync

### DIFF
--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -65,6 +65,7 @@ func storageRsyncCopy(source string, dest string) (string, error) {
 		"-HAX",
 		"--devices",
 		"--delete",
+		"--checksum",
 		rsyncVerbosity,
 		shared.AddSlash(source),
 		dest).CombinedOutput()


### PR DESCRIPTION
Rsync 3.1.1 ignores sub-second timestamp differences, so we need
checksums for correctness. This will hopefully change in upstream soon.

This will make the snapshot_restore test case work more reliably on ext4 systems.
Currently, if you run it with LXD_DEBUG un-set, it will frequently fail, and will fail less often if LXD_DEBUG is set (because that's sometimes slow enough to cross a second border in the snapshots)

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>