### PR TITLE
Fix 599

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -112,7 +112,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			}
 		}
 
-		expiry, err := dbGetImageExpiry(d)
+		expiry, err := dbImageExpiryGet(d.db)
 		if err != nil || expiry == "" {
 			expiry = "10"
 		}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -184,7 +184,7 @@ func containerLXDCreateFromImage(d *Daemon, name string,
 		return nil, err
 	}
 
-	if err := dbUpdateImageLastAccess(d, hash); err != nil {
+	if err := dbImageLastAccessUpdate(d.db, hash); err != nil {
 		return nil, fmt.Errorf("Error updating image last use date: %s", err)
 	}
 

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -37,7 +37,7 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 	}
 
 	if req.Source.Server != "" {
-		err := ensureLocalImage(d, req.Source.Server, hash, req.Source.Secret, true)
+		err := d.ImageDownload(req.Source.Server, hash, req.Source.Secret, true)
 		if err != nil {
 			return InternalError(err)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -15,6 +15,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -60,7 +61,10 @@ type Daemon struct {
 
 	configValues map[string]string
 
-	IsMock bool
+	IsMock                bool
+
+	imagesDownloading     map[string]*sync.Mutex
+	imagesDownloadingLock sync.RWMutex
 }
 
 // Command is the basic structure for every API call.
@@ -473,7 +477,9 @@ SELECT fingerprint FROM images WHERE cached=1 AND last_use_date<=strftime('%s', 
 // StartDaemon starts the shared daemon with the provided configuration.
 func startDaemon() (*Daemon, error) {
 	d := &Daemon{
-		IsMock: false,
+		IsMock:                false,
+		imagesDownloading:     map[string]*sync.Mutex{},
+		imagesDownloadingLock: sync.RWMutex{},
 	}
 
 	if err := d.Init(); err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -61,9 +61,9 @@ type Daemon struct {
 
 	configValues map[string]string
 
-	IsMock                bool
+	IsMock bool
 
-	imagesDownloading     map[string]*sync.Mutex
+	imagesDownloading     map[string]chan bool
 	imagesDownloadingLock sync.RWMutex
 }
 
@@ -478,7 +478,7 @@ SELECT fingerprint FROM images WHERE cached=1 AND last_use_date<=strftime('%s', 
 func startDaemon() (*Daemon, error) {
 	d := &Daemon{
 		IsMock:                false,
-		imagesDownloading:     map[string]*sync.Mutex{},
+		imagesDownloading:     map[string]chan bool{},
 		imagesDownloadingLock: sync.RWMutex{},
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -447,7 +447,7 @@ func (d *Daemon) UpdateHTTPsPort(oldAddress string, newAddress string) error {
 
 func (d *Daemon) pruneExpiredImages() {
 	shared.Debugf("Pruning expired images\n")
-	expiry, err := dbGetImageExpiry(d)
+	expiry, err := dbImageExpiryGet(d.db)
 	if err != nil { // no expiry
 		shared.Debugf("Failed getting the cached image expiry timeout\n")
 		return
@@ -584,7 +584,7 @@ func (d *Daemon) Init() error {
 	d.pruneChan = make(chan bool)
 	go func() {
 		for {
-			expiryStr, err := dbGetImageExpiry(d)
+			expiryStr, err := dbImageExpiryGet(d.db)
 			var expiry int
 			if err != nil {
 				expiry = 10

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -1,0 +1,277 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"mime/multipart"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/lxc/lxd/shared"
+
+	log "gopkg.in/inconshreveable/log15.v2"
+)
+
+// ImageDownload checks if we have that Image Fingerprint else
+// downloads the image from a remote server.
+func (d *Daemon) ImageDownload(
+	server, fp string, secret string, forContainer bool) error {
+
+	if _, err := dbImageGet(d.db, fp, false, true); err == nil {
+		// already have it
+		return nil
+	}
+
+	// Now check if we already downloading the image
+	d.imagesDownloadingLock.RLock()
+	if lock, ok := d.imagesDownloading[fp]; ok {
+		// We already download the image
+		d.imagesDownloadingLock.RUnlock()
+
+		shared.Log.Info(
+			"Already downloading the image, waiting for it to succeed",
+			log.Ctx{"image": fp})
+
+		// Now we use a little trick
+		// we wait until we can lock the download once
+		// we are able to lock it we return we have it on succeed.
+		lock.Lock()
+		lock.Unlock()
+
+		// Somehow dbImageGet fails here so i use dbImagesGet.
+		{
+			results, err := dbImagesGet(d.db, false)
+			if err != nil {
+				shared.Log.Error("Failed to get the image list")
+				return fmt.Errorf("Failed to get the image list")
+			}
+
+			found := false
+			for _, imagesFP := range results {
+				if imagesFP == fp {
+					found = true
+					break
+				}
+			}
+
+			if !found {
+				shared.Log.Error(
+					"Previous download didn't succeed",
+					log.Ctx{"image": fp, "err": err})
+
+				return fmt.Errorf("Previous download didn't succeed")
+			}
+		}
+
+		shared.Log.Info(
+			"Previous download succeeded",
+			log.Ctx{"image": fp})
+
+		return nil
+	}
+
+	d.imagesDownloadingLock.RUnlock()
+
+	shared.Log.Info(
+		"Downloading the image",
+		log.Ctx{"image": fp})
+
+	// Add the download to the queue
+	lock := sync.Mutex{}
+	lock.Lock()
+	d.imagesDownloadingLock.Lock()
+	d.imagesDownloading[fp] = &lock
+	d.imagesDownloadingLock.Unlock()
+
+	// Unlock once this func ends.
+	defer func() {
+		if lock, ok := d.imagesDownloading[fp]; ok {
+			d.imagesDownloadingLock.Lock()
+			lock.Unlock()
+
+			delete(d.imagesDownloading, fp)
+
+			d.imagesDownloadingLock.Unlock()
+		}
+	}()
+
+	/* grab the metadata from /1.0/images/%s */
+	var url string
+	if secret != "" {
+		url = fmt.Sprintf(
+			"%s/%s/images/%s?secret=%s",
+			server, shared.APIVersion, fp, secret)
+
+	} else {
+		url = fmt.Sprintf("%s/%s/images/%s", server, shared.APIVersion, fp)
+	}
+
+	resp, err := d.httpGetSync(url)
+	if err != nil {
+		shared.Log.Error(
+			"Failed to download image metadata",
+			log.Ctx{"image": fp, "err": err})
+
+		return nil
+	}
+
+	info := shared.ImageInfo{}
+	if err := json.Unmarshal(resp.Metadata, &info); err != nil {
+		return err
+	}
+
+	/* now grab the actual file from /1.0/images/%s/export */
+	var exporturl string
+	if secret != "" {
+		exporturl = fmt.Sprintf(
+			"%s/%s/images/%s/export?secret=%s",
+			server, shared.APIVersion, fp, secret)
+
+	} else {
+		exporturl = fmt.Sprintf(
+			"%s/%s/images/%s/export",
+			server, shared.APIVersion, fp)
+	}
+
+	raw, err := d.httpGetFile(exporturl)
+	if err != nil {
+		shared.Log.Error(
+			"Failed to download image",
+			log.Ctx{"image": fp, "err": err})
+		return err
+	}
+
+	destDir := shared.VarPath("images")
+	destName := filepath.Join(destDir, fp)
+	if shared.PathExists(destName) {
+		d.Storage.ImageDelete(fp)
+	}
+
+	ctype, ctypeParams, err := mime.ParseMediaType(raw.Header.Get("Content-Type"))
+	if err != nil {
+		ctype = "application/octet-stream"
+	}
+
+	if ctype == "multipart/form-data" {
+		// Parse the POST data
+		mr := multipart.NewReader(raw.Body, ctypeParams["boundary"])
+
+		// Get the metadata tarball
+		part, err := mr.NextPart()
+		if err != nil {
+			shared.Log.Error(
+				"Invalid multipart image",
+				log.Ctx{"image": fp, "err": err})
+
+			return err
+		}
+
+		if part.FormName() != "metadata" {
+			shared.Log.Error(
+				"Invalid multipart image",
+				log.Ctx{"image": fp, "err": err})
+
+			return fmt.Errorf("Invalid multipart image")
+		}
+
+		destName := filepath.Join(destDir, info.Fingerprint)
+		f, err := os.Create(destName)
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+
+			return err
+		}
+
+		_, err = io.Copy(f, part)
+		f.Close()
+
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+
+			return err
+		}
+
+		// Get the rootfs tarball
+		part, err = mr.NextPart()
+		if err != nil {
+			shared.Log.Error(
+				"Invalid multipart image",
+				log.Ctx{"image": fp, "err": err})
+
+			return err
+		}
+
+		if part.FormName() != "rootfs" {
+			shared.Log.Error(
+				"Invalid multipart image",
+				log.Ctx{"image": fp})
+			return fmt.Errorf("Invalid multipart image")
+		}
+
+		destName = filepath.Join(destDir, info.Fingerprint+".rootfs")
+		f, err = os.Create(destName)
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+			return err
+		}
+
+		_, err = io.Copy(f, part)
+		f.Close()
+
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+			return err
+		}
+	} else {
+		destName := filepath.Join(destDir, info.Fingerprint)
+
+		f, err := os.Create(destName)
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+
+			return err
+		}
+
+		_, err = io.Copy(f, raw.Body)
+		f.Close()
+
+		if err != nil {
+			shared.Log.Error(
+				"Failed to save image",
+				log.Ctx{"image": fp, "err": err})
+			return err
+		}
+	}
+
+	_, err = imageBuildFromInfo(d, info)
+	if err != nil {
+		shared.Log.Error(
+			"Failed to create image",
+			log.Ctx{"image": fp, "err": err})
+
+		return err
+	}
+
+	if forContainer {
+		return dbInitImageLastAccess(d, fp)
+	}
+
+	shared.Log.Info(
+		"Download succeeded",
+		log.Ctx{"image": fp})
+
+	return nil
+}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -19,7 +19,7 @@ import (
 func (d *Daemon) ImageDownload(
 	server, fp string, secret string, forContainer bool) error {
 
-	if id := dbImageIDGet(d.db, fp); id != -1 {
+	if _, err := dbImageGet(d.db, fp, false, true); err == nil {
 		shared.Log.Debug("Image already exists in the db", log.Ctx{"image": fp})
 		// already have it
 		return nil
@@ -44,7 +44,7 @@ func (d *Daemon) ImageDownload(
 			shared.Log.Warn("Value transmitted over image lock semaphore?")
 		}
 
-		if id := dbImageIDGet(d.db, fp); id == -1 {
+		if _, err := dbImageGet(d.db, fp, false, true); err != nil {
 			shared.Log.Error(
 				"Previous download didn't succeed",
 				log.Ctx{"image": fp})

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -266,7 +266,7 @@ func (d *Daemon) ImageDownload(
 	}
 
 	if forContainer {
-		return dbInitImageLastAccess(d, fp)
+		return dbImageLastAccessInit(d.db, fp)
 	}
 
 	shared.Log.Info(

--- a/lxd/daemon_test.go
+++ b/lxd/daemon_test.go
@@ -1,10 +1,15 @@
 package main
 
-import "testing"
+import (
+	"sync"
+	"testing"
+)
 
 func mockStartDaemon() (*Daemon, error) {
 	d := &Daemon{
-		IsMock: true,
+		IsMock:                true,
+		imagesDownloading:     map[string]*sync.Mutex{},
+		imagesDownloadingLock: sync.RWMutex{},
 	}
 
 	if err := d.Init(); err != nil {

--- a/lxd/daemon_test.go
+++ b/lxd/daemon_test.go
@@ -8,7 +8,7 @@ import (
 func mockStartDaemon() (*Daemon, error) {
 	d := &Daemon{
 		IsMock:                true,
-		imagesDownloading:     map[string]*sync.Mutex{},
+		imagesDownloading:     map[string]chan bool{},
 		imagesDownloadingLock: sync.RWMutex{},
 	}
 

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -417,31 +417,3 @@ func dbExec(db *sql.DB, q string, args ...interface{}) (sql.Result, error) {
 		time.Sleep(1 * time.Second)
 	}
 }
-
-func dbUpdateImageLastAccess(d *Daemon, fingerprint string) error {
-	stmt := `UPDATE images SET last_use_date=strftime("%s") WHERE fingerprint=?`
-	_, err := dbExec(d.db, stmt, fingerprint)
-	return err
-}
-
-func dbInitImageLastAccess(d *Daemon, fingerprint string) error {
-	stmt := `UPDATE images SET cached=1, last_use_date=strftime("%s") WHERE fingerprint=?`
-	_, err := dbExec(d.db, stmt, fingerprint)
-	return err
-}
-
-func dbGetImageExpiry(d *Daemon) (string, error) {
-	q := `SELECT value FROM config WHERE key='images.remote_cache_expiry'`
-	arg1 := []interface{}{}
-	var expiry string
-	arg2 := []interface{}{&expiry}
-	err := dbQueryRowScan(d.db, q, arg1, arg2)
-	switch err {
-	case sql.ErrNoRows:
-		return "10", nil
-	case nil:
-		return expiry, nil
-	default:
-		return "", err
-	}
-}

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -2,44 +2,12 @@ package main
 
 import (
 	"database/sql"
-	"fmt"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/lxc/lxd/shared"
 )
-
-func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
-	results, err := dbImagesGet(d.db, public)
-	if err != nil {
-		return []string{}, err
-	}
-
-	resultString := make([]string, len(results))
-	resultMap := make([]shared.ImageInfo, len(results))
-	i := 0
-	for _, name := range results {
-		if !recursion {
-			url := fmt.Sprintf("/%s/images/%s", shared.APIVersion, name)
-			resultString[i] = url
-		} else {
-			image, response := doImageGet(d, name, public)
-			if response != nil {
-				continue
-			}
-			resultMap[i] = image
-		}
-
-		i++
-	}
-
-	if !recursion {
-		return resultString, nil
-	}
-
-	return resultMap, nil
-}
 
 func dbImagesGet(db *sql.DB, public bool) ([]string, error) {
 	q := "SELECT fingerprint FROM images"

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -10,18 +10,6 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func dbImageIDGet(db *sql.DB, fp string) int {
-	q := `SELECT id FROM images WHERE fingerprint=?`
-	id := -1
-	arg1 := []interface{}{fp}
-	arg2 := []interface{}{&id}
-	err := dbQueryRowScan(db, q, arg1, arg2)
-	if err != nil {
-		return -1
-	}
-	return id
-}
-
 func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 	resultString := []string{}
 	resultMap := []shared.ImageInfo{}

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -10,6 +10,18 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
+func dbImageIDGet(db *sql.DB, fp string) int {
+	q := `SELECT id FROM images WHERE fingerprint=?`
+	id := -1
+	arg1 := []interface{}{fp}
+	arg2 := []interface{}{&id}
+	err := dbQueryRowScan(db, q, arg1, arg2)
+	if err != nil {
+		return -1
+	}
+	return id
+}
+
 func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 	resultString := []string{}
 	resultMap := []shared.ImageInfo{}

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -64,7 +64,7 @@ func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 // pass a shortform and will get the full fingerprint.
 // There can never be more than one image with a given fingerprint, as it is
 // enforced by a UNIQUE constraint in the schema.
-func dbImageGet(db *sql.DB, fingerprint string, public bool, strict_matching bool) (*shared.ImageBaseInfo, error) {
+func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool) (*shared.ImageBaseInfo, error) {
 	var err error
 	var create, expire, upload *time.Time // These hold the db-returned times
 
@@ -79,7 +79,7 @@ func dbImageGet(db *sql.DB, fingerprint string, public bool, strict_matching boo
 
 	var query string
 
-	if strict_matching {
+	if strictMatching {
 		query = `
         SELECT
             id, fingerprint, filename, size, public, architecture,

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -174,3 +174,31 @@ func dbImageAliasAdd(db *sql.DB, name string, imageID int, desc string) error {
 	_, err := dbExec(db, stmt, name, imageID, desc)
 	return err
 }
+
+func dbImageLastAccessUpdate(db *sql.DB, fingerprint string) error {
+	stmt := `UPDATE images SET last_use_date=strftime("%s") WHERE fingerprint=?`
+	_, err := dbExec(db, stmt, fingerprint)
+	return err
+}
+
+func dbImageLastAccessInit(db *sql.DB, fingerprint string) error {
+	stmt := `UPDATE images SET cached=1, last_use_date=strftime("%s") WHERE fingerprint=?`
+	_, err := dbExec(db, stmt, fingerprint)
+	return err
+}
+
+func dbImageExpiryGet(db *sql.DB) (string, error) {
+	q := `SELECT value FROM config WHERE key='images.remote_cache_expiry'`
+	arg1 := []interface{}{}
+	var expiry string
+	arg2 := []interface{}{&expiry}
+	err := dbQueryRowScan(db, q, arg1, arg2)
+	switch err {
+	case sql.ErrNoRows:
+		return "10", nil
+	case nil:
+		return expiry, nil
+	default:
+		return "", err
+	}
+}

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -9,6 +9,18 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
+func dbImageIDGet(db *sql.DB, fp string) int {
+	q := `SELECT id FROM images WHERE fingerprint=?`
+	id := -1
+	arg1 := []interface{}{fp}
+	arg2 := []interface{}{&id}
+	err := dbQueryRowScan(db, q, arg1, arg2)
+	if err != nil {
+		return -1
+	}
+	return id
+}
+
 func dbImagesGet(db *sql.DB, public bool) ([]string, error) {
 	q := "SELECT fingerprint FROM images"
 	if public == true {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -239,7 +239,9 @@ func imgPostRemoteInfo(d *Daemon, req imagePostReq) Response {
 		return BadRequest(fmt.Errorf("must specify one of alias or fingerprint for init from image"))
 	}
 
-	err = ensureLocalImage(d, req.Source["server"], hash, req.Source["secret"], false)
+	err = d.ImageDownload(
+		req.Source["server"], hash, req.Source["secret"], false)
+
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -644,6 +644,37 @@ func getImageMetadata(fname string) (*imageMetadata, error) {
 	return metadata, nil
 }
 
+func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
+	results, err := dbImagesGet(d.db, public)
+	if err != nil {
+		return []string{}, err
+	}
+
+	resultString := make([]string, len(results))
+	resultMap := make([]shared.ImageInfo, len(results))
+	i := 0
+	for _, name := range results {
+		if !recursion {
+			url := fmt.Sprintf("/%s/images/%s", shared.APIVersion, name)
+			resultString[i] = url
+		} else {
+			image, response := doImageGet(d, name, public)
+			if response != nil {
+				continue
+			}
+			resultMap[i] = image
+		}
+
+		i++
+	}
+
+	if !recursion {
+		return resultString, nil
+	}
+
+	return resultMap, nil
+}
+
 func imagesGet(d *Daemon, r *http.Request) Response {
 	public := !d.isTrustedClient(r)
 

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -27,23 +27,11 @@ func remoteGetImageFingerprint(d *Daemon, server string, alias string) (string, 
 	return result.Name, nil
 }
 
-func (d *Daemon) dbGetimage(fp string) int {
-	q := `SELECT id FROM images WHERE fingerprint=?`
-	id := -1
-	arg1 := []interface{}{fp}
-	arg2 := []interface{}{&id}
-	err := dbQueryRowScan(d.db, q, arg1, arg2)
-	if err != nil {
-		return -1
-	}
-	return id
-}
-
 func ensureLocalImage(d *Daemon, server, fp string, secret string, forContainer bool) error {
 	var url string
 	var exporturl string
 
-	if d.dbGetimage(fp) != -1 {
+	if dbImageIDGet(d.db, fp) != -1 {
 		// already have it
 		return nil
 	}

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -3,17 +3,16 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io"
-	"mime"
-	"mime/multipart"
-	"os"
-	"path/filepath"
 
 	"github.com/lxc/lxd/shared"
 )
 
-func remoteGetImageFingerprint(d *Daemon, server string, alias string) (string, error) {
-	url := fmt.Sprintf("%s/%s/images/aliases/%s", server, shared.APIVersion, alias)
+func remoteGetImageFingerprint(
+	d *Daemon, server string, alias string) (string, error) {
+
+	url := fmt.Sprintf(
+		"%s/%s/images/aliases/%s",
+		server, shared.APIVersion, alias)
 
 	resp, err := d.httpGetSync(url)
 	if err != nil {
@@ -25,134 +24,4 @@ func remoteGetImageFingerprint(d *Daemon, server string, alias string) (string, 
 		return "", fmt.Errorf("Error reading alias\n")
 	}
 	return result.Name, nil
-}
-
-func ensureLocalImage(d *Daemon, server, fp string, secret string, forContainer bool) error {
-	var url string
-	var exporturl string
-
-	if _, err := dbImageGet(d.db, fp, false, true); err == nil {
-		// already have it
-		return nil
-	}
-
-	/* grab the metadata from /1.0/images/%s */
-	if secret != "" {
-		url = fmt.Sprintf("%s/%s/images/%s?secret=%s", server, shared.APIVersion, fp, secret)
-	} else {
-		url = fmt.Sprintf("%s/%s/images/%s", server, shared.APIVersion, fp)
-	}
-
-	resp, err := d.httpGetSync(url)
-	if err != nil {
-		return nil
-	}
-
-	info := shared.ImageInfo{}
-	if err := json.Unmarshal(resp.Metadata, &info); err != nil {
-		return err
-	}
-
-	/* now grab the actual file from /1.0/images/%s/export */
-	if secret != "" {
-		exporturl = fmt.Sprintf("%s/%s/images/%s/export?secret=%s", server, shared.APIVersion, fp, secret)
-	} else {
-		exporturl = fmt.Sprintf("%s/%s/images/%s/export", server, shared.APIVersion, fp)
-	}
-
-	raw, err := d.httpGetFile(exporturl)
-	if err != nil {
-		return err
-	}
-
-	destDir := shared.VarPath("images")
-	err = os.MkdirAll(destDir, 0700)
-	if err != nil {
-		return err
-	}
-	destName := filepath.Join(destDir, fp)
-	if shared.PathExists(destName) {
-		os.Remove(destName)
-	}
-
-	ctype, ctypeParams, err := mime.ParseMediaType(raw.Header.Get("Content-Type"))
-	if err != nil {
-		ctype = "application/octet-stream"
-	}
-
-	if ctype == "multipart/form-data" {
-		// Parse the POST data
-		mr := multipart.NewReader(raw.Body, ctypeParams["boundary"])
-
-		// Get the metadata tarball
-		part, err := mr.NextPart()
-		if err != nil {
-			return err
-		}
-
-		if part.FormName() != "metadata" {
-			return fmt.Errorf("Invalid multipart image")
-		}
-
-		destName := filepath.Join(destDir, info.Fingerprint)
-		f, err := os.Create(destName)
-		if err != nil {
-			return err
-		}
-
-		_, err = io.Copy(f, part)
-		f.Close()
-
-		if err != nil {
-			return err
-		}
-
-		// Get the rootfs tarball
-		part, err = mr.NextPart()
-		if err != nil {
-			return err
-		}
-
-		if part.FormName() != "rootfs" {
-			return fmt.Errorf("Invalid multipart image")
-		}
-
-		destName = filepath.Join(destDir, info.Fingerprint+".rootfs")
-		f, err = os.Create(destName)
-		if err != nil {
-			return err
-		}
-
-		_, err = io.Copy(f, part)
-		f.Close()
-
-		if err != nil {
-			return err
-		}
-	} else {
-		destName := filepath.Join(destDir, info.Fingerprint)
-
-		f, err := os.Create(destName)
-		if err != nil {
-			return err
-		}
-
-		_, err = io.Copy(f, raw.Body)
-		f.Close()
-
-		if err != nil {
-			return err
-		}
-	}
-
-	_, err = imageBuildFromInfo(d, info)
-	if err != nil {
-		return err
-	}
-
-	if forContainer {
-		return dbInitImageLastAccess(d, fp)
-	}
-
-	return nil
 }

--- a/lxd/remote.go
+++ b/lxd/remote.go
@@ -31,7 +31,7 @@ func ensureLocalImage(d *Daemon, server, fp string, secret string, forContainer 
 	var url string
 	var exporturl string
 
-	if dbImageIDGet(d.db, fp) != -1 {
+	if _, err := dbImageGet(d.db, fp, false, true); err == nil {
 		// already have it
 		return nil
 	}

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -111,6 +111,13 @@ test_remote_usage() {
 
   lxc image alias create localhost:testimage $sum
 
+  # Double launch to test if the image downloads only once.
+  lxc init localhost:testimage lxd2:c1 &
+  lxc init localhost:testimage lxd2:c2
+
+  lxc delete lxd2:c1
+  lxc delete lxd2:c2
+
   if [ -n "$TRAVIS_PULL_REQUEST" ]; then
     return
   fi
@@ -123,11 +130,4 @@ test_remote_usage() {
   lxc info lxd2:c1
   lxc stop lxd2:c1 --force
   lxc delete lxd2:c1
-
-  # Double launch to test if the image downloads only once.
-  lxc launch localhost:testimage lxd2:c1 &
-  lxc launch localhost:testimage lxd2:c2
-
-  lxc delete lxd2:c1
-  lxc delete lxd2:c2
 }

--- a/test/remote.sh
+++ b/test/remote.sh
@@ -123,4 +123,11 @@ test_remote_usage() {
   lxc info lxd2:c1
   lxc stop lxd2:c1 --force
   lxc delete lxd2:c1
+
+  # Double launch to test if the image downloads only once.
+  lxc launch localhost:testimage lxd2:c1 &
+  lxc launch localhost:testimage lxd2:c2
+
+  lxc delete lxd2:c1
+  lxc delete lxd2:c2
 }


### PR DESCRIPTION
This branch implements a per image lock for downloading images, this makes the following possible:

    lxc remote add images images.linuxcontainers.org
    lxc launch images:ubuntu/trusty/amd64 c1 &
    lxc launch images:ubuntu/trusty/amd64 c2

The image will be downloaded only once and c2 waits for the download on c1.

This should also work but is untested:

    lxc remote add images images.linuxcontainers.org
    lxc launch images:ubuntu/trusty/amd64 c1 &
    lxc launch images:ubuntu/trusty/amd64 c2 &
    lxc launch images:ubuntu/vivid/amd64 c3 &
    lxc launch images:ubuntu/vivid/amd64 c4

The above should download trusty and vivid at the same time.