### PR TITLE
Show the https_address in 'lxc config'.

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -72,6 +72,8 @@ func (c *configCmd) usage() string {
 			"\tlxc config device add [remote:]container1 <device-name> disk source=/share/c1 path=opt\n" +
 			"To set an lxc config value:\n" +
 			"\tlxc config set [remote:]<container> raw.lxc 'lxc.aa_allow_incomplete = 1'\n" +
+			"To listen on IPv4 and IPv6 port 8443 (you can omit the 8443 its the default):\n" +
+			"\tlxc config set core.https_address [::]:8443\n" +
 			"To set the server trust password:\n" +
 			"\tlxc config set core.trust_password blah\n")
 }


### PR DESCRIPTION
Now the users know about https_address when they call `lxc config`.

Signed-off-by: René Jochum <rene@jochums.at>