### PR TITLE
Config clarity improvements and profile config override fixes

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -106,9 +106,8 @@ type containerLXD struct {
 	idmapset     *shared.IdmapSet
 	cType        containerType
 
-	// These two will contain the containers data without profiles
-	myConfig  map[string]string
-	myDevices shared.Devices
+	baseConfig  map[string]string
+	baseDevices shared.Devices
 
 	Storage storage
 }
@@ -137,6 +136,9 @@ type container interface {
 	IDGet() int
 	NameGet() string
 	ArchitectureGet() int
+	ConfigGet() map[string]string
+	DevicesGet() shared.Devices
+	ProfilesGet() []string
 	PathGet(newName string) string
 	RootfsPathGet() string
 	TemplatesPathGet() string
@@ -145,7 +147,6 @@ type container interface {
 	LogPathGet() string
 	InitPidGet() (int, error)
 	IdmapSetGet() (*shared.IdmapSet, error)
-	ConfigGet() containerLXDArgs
 
 	TemplateApply(trigger string) error
 	ExportToTar(snap string, w io.Writer) error
@@ -200,14 +201,12 @@ func containerLXDCreateFromImage(d *Daemon, name string,
 func containerLXDCreateAsCopy(d *Daemon, name string,
 	args containerLXDArgs, sourceContainer container) (container, error) {
 
-	// Create the container
 	c, err := containerLXDCreateInternal(d, name, args)
 	if err != nil {
 		return nil, err
 	}
 
-	// Replace the config
-	if err := c.ConfigReplace(sourceContainer.ConfigGet()); err != nil {
+	if err := c.ConfigReplace(args); err != nil {
 		c.Delete()
 		return nil, err
 	}
@@ -340,12 +339,12 @@ func containerLXDCreateInternal(
 		"Container created in the DB",
 		log.Ctx{"container": name, "id": id})
 
-	myConfig := map[string]string{}
-	if err := shared.DeepCopy(&args.Config, &myConfig); err != nil {
+	baseConfig := map[string]string{}
+	if err := shared.DeepCopy(&args.Config, &baseConfig); err != nil {
 		return nil, err
 	}
-	myDevices := shared.Devices{}
-	if err := shared.DeepCopy(&args.Devices, &myDevices); err != nil {
+	baseDevices := shared.Devices{}
+	if err := shared.DeepCopy(&args.Devices, &baseDevices); err != nil {
 		return nil, err
 	}
 
@@ -359,8 +358,8 @@ func containerLXDCreateInternal(
 		profiles:     args.Profiles,
 		devices:      args.Devices,
 		cType:        args.Ctype,
-		myConfig:     myConfig,
-		myDevices:    myDevices}
+		baseConfig:   baseConfig,
+		baseDevices:  baseDevices}
 
 	// No need to detect storage here, its a new container.
 	c.Storage = d.Storage
@@ -381,12 +380,12 @@ func containerLXDLoad(d *Daemon, name string) (container, error) {
 		return nil, err
 	}
 
-	myConfig := map[string]string{}
-	if err := shared.DeepCopy(&args.Config, &myConfig); err != nil {
+	baseConfig := map[string]string{}
+	if err := shared.DeepCopy(&args.Config, &baseConfig); err != nil {
 		return nil, err
 	}
-	myDevices := shared.Devices{}
-	if err := shared.DeepCopy(&args.Devices, &myDevices); err != nil {
+	baseDevices := shared.Devices{}
+	if err := shared.DeepCopy(&args.Devices, &baseDevices); err != nil {
 		return nil, err
 	}
 
@@ -400,8 +399,8 @@ func containerLXDLoad(d *Daemon, name string) (container, error) {
 		profiles:     args.Profiles,
 		devices:      args.Devices,
 		cType:        args.Ctype,
-		myConfig:     myConfig,
-		myDevices:    myDevices}
+		baseConfig:   baseConfig,
+		baseDevices:  baseDevices}
 
 	s, err := storageForFilename(d, c.PathGet(""))
 	if err != nil {
@@ -478,15 +477,14 @@ func (c *containerLXD) init() error {
 		return err
 	}
 
-	/* apply profiles */
 	for _, p := range c.profiles {
 		if err := c.applyProfile(p); err != nil {
 			return err
 		}
 	}
 
-	// Apply the config of this container over the profile(s) above.
-	if err := c.applyConfig(c.myConfig, false); err != nil {
+	// base per-container config should override profile config, so we apply it second
+	if err := c.applyConfig(c.baseConfig, false); err != nil {
 		return err
 	}
 
@@ -495,7 +493,7 @@ func (c *containerLXD) init() error {
 	}
 
 	// Allow overwrites of devices
-	for k, v := range c.myDevices {
+	for k, v := range c.baseDevices {
 		c.devices[k] = v
 	}
 
@@ -531,11 +529,11 @@ func (c *containerLXD) RenderState() (*shared.ContainerState, error) {
 	return &shared.ContainerState{
 		Name:            c.name,
 		Profiles:        c.profiles,
-		Config:          c.myConfig,
+		Config:          c.baseConfig,
 		ExpandedConfig:  c.config,
 		Userdata:        []byte{},
 		Status:          status,
-		Devices:         c.myDevices,
+		Devices:         c.baseDevices,
 		ExpandedDevices: c.devices,
 		Ephemeral:       c.ephemeral,
 	}, nil
@@ -714,8 +712,15 @@ func (c *containerLXD) Restore(sourceContainer container) error {
 		return err
 	}
 
-	// Replace the config
-	err = c.ConfigReplace(sourceContainer.ConfigGet())
+	args := containerLXDArgs{
+		Ctype:        cTypeRegular,
+		Config:       sourceContainer.ConfigGet(),
+		Profiles:     sourceContainer.ProfilesGet(),
+		Ephemeral:    sourceContainer.IsEphemeral(),
+		Architecture: sourceContainer.ArchitectureGet(),
+		Devices:      sourceContainer.DevicesGet(),
+	}
+	err = c.ConfigReplace(args)
 	if err != nil {
 		shared.Log.Error("RESTORE => Restore of the configuration failed",
 			log.Ctx{
@@ -914,21 +919,22 @@ func (c *containerLXD) ConfigReplace(newConfig containerLXDArgs) error {
 		return err
 	}
 
-	c.myConfig = newConfig.Config
-	c.myDevices = newConfig.Devices
+	c.baseConfig = newContainerArgs.Config
+	c.baseDevices = newContainerArgs.Devices
 
 	return nil
 }
 
-func (c *containerLXD) ConfigGet() containerLXDArgs {
-	newConfig := containerLXDArgs{
-		Config:    c.myConfig,
-		Devices:   c.myDevices,
-		Profiles:  c.profiles,
-		Ephemeral: c.ephemeral,
-	}
+func (c *containerLXD) ConfigGet() map[string]string {
+	return c.config
+}
 
-	return newConfig
+func (c *containerLXD) DevicesGet() shared.Devices {
+	return c.devices
+}
+
+func (c *containerLXD) ProfilesGet() []string {
+	return c.profiles
 }
 
 /*
@@ -1340,7 +1346,7 @@ func (c *containerLXD) setupMacAddresses() error {
 				d["hwaddr"] = hwaddr
 				key := fmt.Sprintf("volatile.%s.hwaddr", name)
 				c.config[key] = hwaddr
-				c.myConfig[key] = hwaddr
+				c.baseConfig[key] = hwaddr
 				newConfigEntries[key] = hwaddr
 			}
 		}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -234,7 +234,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 	opts.ClearEnv = true
 	opts.Env = []string{}
 
-	for k, v := range c.ConfigGet().Config {
+	for k, v := range c.ConfigGet() {
 		if strings.HasPrefix(k, "environment.") {
 			opts.Env = append(opts.Env, fmt.Sprintf("%s=%s", strings.TrimPrefix(k, "environment."), v))
 		}

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -138,9 +138,17 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		snapshotName
 
 	snapshot := func() error {
+		config := c.ConfigGet()
+		args := containerLXDArgs{
+			Ctype:        cTypeSnapshot,
+			Config:       config,
+			Profiles:     c.ProfilesGet(),
+			Ephemeral:    c.IsEphemeral(),
+			BaseImage:    config["volatile.base_image"],
+			Architecture: c.ArchitectureGet(),
+			Devices:      c.DevicesGet(),
+		}
 
-		args := c.ConfigGet()
-		args.Ctype = cTypeSnapshot
 		_, err := containerLXDCreateAsSnapshot(d, fullName, args, c, stateful)
 		if err != nil {
 			return err

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -14,15 +14,15 @@ func (suite *lxdTestSuite) TestContainer_ProfilesDefault() {
 	suite.Req.Nil(err)
 	defer c.Delete()
 
-	config := c.ConfigGet()
+	profiles := c.ProfilesGet()
 	suite.Len(
-		config.Profiles,
+		profiles,
 		1,
 		"No default profile created on containerLXDCreateInternal.")
 
 	suite.Equal(
 		"default",
-		config.Profiles[0],
+		profiles[0],
 		"First profile should be the default profile.")
 }
 
@@ -49,9 +49,9 @@ func (suite *lxdTestSuite) TestContainer_ProfilesMulti() {
 	suite.Req.Nil(err)
 	defer c.Delete()
 
-	config := c.ConfigGet()
+	profiles := c.ProfilesGet()
 	suite.Len(
-		config.Profiles,
+		profiles,
 		2,
 		"Didn't get both profiles in containerLXDCreateInternal.")
 

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -189,7 +189,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 
 	if req.Config == nil {
 		config := make(map[string]string)
-		for key, value := range sourceConfig.Config {
+		for key, value := range sourceConfig {
 			if key[0:8] == "volatile" {
 				shared.Debugf("Skipping configuration key: %s\n", key)
 				continue
@@ -200,7 +200,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 	}
 
 	if req.Profiles == nil {
-		req.Profiles = sourceConfig.Profiles
+		req.Profiles = source.ProfilesGet()
 	}
 
 	args := containerLXDArgs{

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -47,7 +47,7 @@ type devLxdHandler struct {
 
 var configGet = devLxdHandler{"/1.0/config", func(c container, r *http.Request) *devLxdResponse {
 	filtered := []string{}
-	for k, _ := range c.ConfigGet().Config {
+	for k, _ := range c.ConfigGet() {
 		if strings.HasPrefix(k, "user.") {
 			filtered = append(filtered, fmt.Sprintf("/1.0/config/%s", k))
 		}
@@ -61,7 +61,7 @@ var configKeyGet = devLxdHandler{"/1.0/config/{key}", func(c container, r *http.
 		return &devLxdResponse{"not authorized", http.StatusForbidden, "raw"}
 	}
 
-	value, ok := c.ConfigGet().Config[key]
+	value, ok := c.ConfigGet()[key]
 	if !ok {
 		return &devLxdResponse{"not found", http.StatusNotFound, "raw"}
 	}
@@ -70,7 +70,7 @@ var configKeyGet = devLxdHandler{"/1.0/config/{key}", func(c container, r *http.
 }}
 
 var metadataGet = devLxdHandler{"/1.0/meta-data", func(c container, r *http.Request) *devLxdResponse {
-	value := c.ConfigGet().Config["user.meta-data"]
+	value := c.ConfigGet()["user.meta-data"]
 	return okResponse(fmt.Sprintf("#cloud-config\ninstance-id: %s\nlocal-hostname: %s\n%s", c.NameGet(), c.NameGet(), value), "raw")
 }}
 

--- a/shared/devices.go
+++ b/shared/devices.go
@@ -11,13 +11,23 @@ func (list Devices) ContainsName(k string) bool {
 }
 
 func nicEqual(d1 Device, d2 Device) bool {
+	if !nicSettingsEqual(d1, d2) {
+		return false
+	}
+	if d1.get("hwaddr") != d2.get("hwaddr") {
+		return false
+	}
+	return true
+}
+
+func nicSettingsEqual(d1 Device, d2 Device) bool {
 	if d1.get("nictype") != d2.get("nictype") {
 		return false
 	}
 	if d1.get("name") != d2.get("name") || d1.get("parent") != d2.get("parent") {
 		return false
 	}
-	if d1.get("mtu") != d2.get("mtu") || d1.get("hwaddr") != d2.get("hwaddr") {
+	if d1.get("mtu") != d2.get("mtu") {
 		return false
 	}
 	return true
@@ -89,4 +99,29 @@ func (old Devices) Update(newlist Devices) (map[string]Device, map[string]Device
 		}
 	}
 	return rmlist, addlist
+}
+
+func (newBaseDevices Devices) ExtendFromProfile(currentFullDevices Devices, newDevicesFromProfile Devices) error {
+
+	// Add devices from profile to a list of new devices. If a nic
+	// is already in currentFullDevices and only differs by
+	// hwaddr, keep the existing one instead of overwriting it
+	// with the one from the profile
+	for name, newDev := range newDevicesFromProfile {
+		if newDev["type"] == "nic" {
+			if curDev, ok := currentFullDevices[name]; ok {
+				if nicSettingsEqual(newDev, curDev) {
+					newBaseDevices[name] = curDev
+				} else {
+					newBaseDevices[name] = newDev
+				}
+			} else {
+				newBaseDevices[name] = newDev
+			}
+		} else {
+			newBaseDevices[name] = newDev
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
May be better viewed as individual commits.

Fixes test failures introduced by #997.

Some refactoring to clarify container.config - full config with profile config applied - and container.baseConfig, just the per-container config.

Repurposes GetConfig to only return the actual config map instead of a containerLXDArgs struct, which was being populated using the base config only, causing issues with re-applying config on containers PUT.