### PR TITLE
Copy volatile fixes

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -211,7 +211,6 @@ func containerLXDCreateAsCopy(d *Daemon, name string,
 		return nil, err
 	}
 
-	// Now copy the source
 	sourceContainer.StorageStart()
 	defer sourceContainer.StorageStop()
 

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -83,18 +83,6 @@ func dbContainerCreate(db *sql.DB, name string, args containerLXDArgs) (int, err
 		return 0, DbErrAlreadyDefined
 	}
 
-	if args.Profiles == nil {
-		args.Profiles = []string{"default"}
-	}
-
-	if args.BaseImage != "" {
-		if args.Config == nil {
-			args.Config = map[string]string{}
-		}
-
-		args.Config["volatile.base_image"] = args.BaseImage
-	}
-
 	tx, err := dbBegin(db)
 	if err != nil {
 		return 0, err

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -18,6 +18,8 @@ test_migration() {
 
   lxc copy l2:nonlive l2:nonlive2
   lxc config get l2:nonlive2 volatile.base_image | grep -q base_image
+  # check that nonlive2 has a new addr in volatile
+  [ "`lxc config get l2:nonlive volatile.eth0.hwaddr`" != "`lxc config get l2:nonlive2 volatile.eth0.hwaddr`" ]
 
   lxc config unset l2:nonlive volatile.base_image
   lxc copy l2:nonlive l1:nobase

--- a/test/migration.sh
+++ b/test/migration.sh
@@ -17,7 +17,8 @@ test_migration() {
   [ -d "$LXD2_DIR/containers/nonlive/rootfs" ]
 
   lxc copy l2:nonlive l2:nonlive2
-  lxc config get l2:nonlive2 volatile.base_image | grep -q base_image
+  # should have the same base image tag
+  [ "`lxc config get l2:nonlive volatile.base_image`" = "`lxc config get l2:nonlive2 volatile.base_image`" ]
   # check that nonlive2 has a new addr in volatile
   [ "`lxc config get l2:nonlive volatile.eth0.hwaddr`" != "`lxc config get l2:nonlive2 volatile.eth0.hwaddr`" ]
 


### PR DESCRIPTION

clear volatile config keys in containerLXDCreateAsCopy to e.g. avoid duplicate mac addrs.
keep around volatile.base_image though.

fixes/adds tests for the above.