### PR TITLE
Don't copy profile settings to container in start

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -623,16 +623,15 @@ func (c *containerLXD) Start() error {
 		}
 	}
 
-	config := c.ConfigGet()
 	c.config["volatile.last_state.idmap"] = jsonIdmap
 
 	args := containerLXDArgs{
 		Ctype:        c.cType,
-		Config:       config,
+		Config:       c.baseConfig,
 		Profiles:     c.profiles,
 		Ephemeral:    c.ephemeral,
 		Architecture: c.architecture,
-		Devices:      c.devices,
+		Devices:      c.baseDevices,
 	}
 	err = c.ConfigReplace(args)
 

--- a/test/config.sh
+++ b/test/config.sh
@@ -39,7 +39,10 @@ test_config_profiles() {
   if [ -z "$TRAVIS_PULL_REQUEST" ]; then
     # test live-adding a nic
     lxc start foo
+    lxc config show foo | grep -q "raw.lxc" && false
+    lxc config show foo | grep -v "volatile.eth0.hwaddr" | grep -q "eth0" && false
     lxc config device add foo eth2 nic nictype=bridged parent=lxcbr0 name=eth10
+    lxc exec foo -- /sbin/ifconfig -a | grep eth0
     lxc exec foo -- /sbin/ifconfig -a | grep eth10
     lxc config device list foo | grep eth2
     lxc config device remove foo eth2


### PR DESCRIPTION
Fixes #1014.

Profiles are applied in container.init. The config and devices sent
to ConfigReplace in Start() should be just the base.

Adds tests to check this - NOTE these tests depend on 'config show' and
'device list' not showing extended config/device info, which should
probably change.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>