### PR TITLE
Allow unsetting lvm_thinpool_name after vg_name

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -53,11 +53,12 @@ func storageLVMSetThinPoolNameConfig(d *Daemon, poolname string) error {
 	if err != nil {
 		return fmt.Errorf("Error getting lvm_vg_name config")
 	}
-	if vgname == "" {
-		return fmt.Errorf("Can not set lvm_thinpool_name without lvm_vg_name set.")
-	}
 
 	if poolname != "" {
+		if vgname == "" {
+			return fmt.Errorf("Can not set lvm_thinpool_name without lvm_vg_name set.")
+		}
+
 		poolExists, err := storageLVMThinpoolExists(vgname, poolname)
 		if err != nil {
 			return fmt.Errorf("Error checking for thin pool '%s' in '%s': %v", poolname, vgname, err)

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -159,6 +159,11 @@ test_lvm_withpool() {
         lxc config show | grep "$poolname" || die "thin pool name not in config show output."
         echo " --> only doing minimal image import subtest with user pool name"
         do_image_import_subtest $poolname
+
+        # check that we can unset configs in this order
+        lxc config unset core.lvm_vg_name
+        lxc config unset core.lvm_thinpool_name
+
         do_kill_lxd `cat $LXD_DIR/lxd.pid`
         sleep 3
         wipe ${LXD_DIR}


### PR DESCRIPTION
Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>