### PR TITLE
Vagrant box also for vmware

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 Vagrant.configure('2') do |config|
-    # grab Ubuntu 14.04 official image
-    config.vm.box = "ubuntu/trusty64" # Ubuntu 14.04
+    # grab Ubuntu 14.04 boxcutter image: https://atlas.hashicorp.com/boxcutter
+    config.vm.box = "boxcutter/ubuntu1404" # Ubuntu 14.04
 
     # fix issues with slow dns https://www.virtualbox.org/ticket/13002
     config.vm.provider :virtualbox do |vb, override|

--- a/scripts/vagrant/install-go.sh
+++ b/scripts/vagrant/install-go.sh
@@ -3,7 +3,7 @@
 set -xe
 export DEBIAN_FRONTEND=noninteractive
 
-which add-apt-repository || sudo apt-get install -y software-properties-common
+which add-apt-repository || (sudo apt-get update ; sudo apt-get install -y software-properties-common)
 sudo add-apt-repository ppa:ubuntu-lxc/lxd-git-master
 sudo apt-get update
 which go || sudo apt-get install -y golang


### PR DESCRIPTION
Use a different vagrant base box which supports vbox/vmware/parallels
and has guest tools.

update package lists before installing packages since this base box
does not have any package lists pre-fetched.

Signed-off-by: Ragnar Rova <ragnar.rova@gmail.com>