### PR TITLE
Add support for LVM native snapshot and copy

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -129,6 +129,7 @@ type container interface {
 
 	StorageStart() error
 	StorageStop() error
+	StorageGet() storage
 
 	IsPrivileged() bool
 	IsRunning() bool
@@ -234,6 +235,7 @@ func containerLXDCreateAsSnapshot(d *Daemon, name string,
 		return nil, err
 	}
 
+	c.Storage = sourceContainer.StorageGet()
 	if err := c.Storage.ContainerSnapshotCreate(c, sourceContainer); err != nil {
 		c.Delete()
 		return nil, err
@@ -723,6 +725,10 @@ func (c *containerLXD) StorageStart() error {
 
 func (c *containerLXD) StorageStop() error {
 	return c.Storage.ContainerStop(c)
+}
+
+func (c *containerLXD) StorageGet() storage {
+	return c.Storage
 }
 
 func (c *containerLXD) Restore(sourceContainer container) error {

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -232,7 +232,6 @@ func containerLXDCreateAsSnapshot(d *Daemon, name string,
 	args containerLXDArgs, sourceContainer container,
 	stateful bool) (container, error) {
 
-	// Create the container
 	c, err := containerLXDCreateInternal(d, name, args)
 	if err != nil {
 		return nil, err
@@ -758,9 +757,7 @@ func (c *containerLXD) Restore(sourceContainer container) error {
 	// Restore the FS.
 	// TODO: I switched the FS and config restore, think thats the correct way
 	// (pcdummy)
-	sourceContainer.StorageStart()
 	err := c.Storage.ContainerRestore(c, sourceContainer)
-	sourceContainer.StorageStop()
 
 	if err != nil {
 		shared.Log.Error("RESTORE => Restoring the filesystem failed",

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -217,9 +217,6 @@ func containerLXDCreateAsCopy(d *Daemon, name string,
 		return nil, err
 	}
 
-	sourceContainer.StorageStart()
-	defer sourceContainer.StorageStop()
-
 	if err := c.Storage.ContainerCopy(c, sourceContainer); err != nil {
 		c.Delete()
 		return nil, err

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -36,7 +36,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 15
+const DB_CURRENT_VERSION int = 16
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -5,6 +5,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -12,6 +13,61 @@ import (
 
 	log "gopkg.in/inconshreveable/log15.v2"
 )
+
+func dbUpdateFromV15(d *Daemon) error {
+	// munge all LVM-backed containers' LV names to match what is
+	// required for snapshot support
+
+	cNames, err := dbContainersList(d.db, cTypeRegular)
+	if err != nil {
+		return err
+	}
+
+	vgName, err := d.ConfigValueGet("core.lvm_vg_name")
+	if err != nil {
+		return fmt.Errorf("Error checking server config: %v", err)
+	}
+
+	for _, cName := range cNames {
+		var lvLinkPath string
+		if strings.Contains(cName, shared.SnapshotDelimiter) {
+			lvLinkPath = shared.VarPath("snapshots", fmt.Sprintf("%s.lv", cName))
+		} else {
+			lvLinkPath = shared.VarPath("containers", fmt.Sprintf("%s.lv", cName))
+		}
+
+		if !shared.PathExists(lvLinkPath) {
+			continue
+		}
+
+		newLVName := strings.Replace(cName, "-", "--", -1)
+		newLVName = strings.Replace(newLVName, shared.SnapshotDelimiter, "-", -1)
+
+		if cName == newLVName {
+			shared.Log.Debug("no need to rename, skipping", log.Ctx{"cName": cName, "newLVName": newLVName})
+			continue
+		}
+
+		shared.Log.Debug("about to rename cName in lv upgrade", log.Ctx{"lvLinkPath": lvLinkPath, "cName": cName, "newLVName": newLVName})
+
+		output, err := exec.Command("lvrename", vgName, cName, newLVName).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Could not rename LV '%s' to 's': %v\noutput:%s", cName, newLVName, err, output)
+		}
+
+		if err := os.Remove(lvLinkPath); err != nil {
+			return fmt.Errorf("Couldn't remove lvLinkPath '%s'", lvLinkPath)
+		}
+		newLinkDest := fmt.Sprintf("/dev/%s/%s", vgName, newLVName)
+		if err := os.Symlink(newLinkDest, lvLinkPath); err != nil {
+			return fmt.Errorf("Couldn't recreate symlink '%s'->'%s'", lvLinkPath, newLinkDest)
+		}
+	}
+	stmt := `
+INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
+	_, err = d.db.Exec(stmt, 16)
+	return err
+}
 
 func dbUpdateFromV14(db *sql.DB) error {
 	stmt := `
@@ -635,6 +691,12 @@ func dbUpdate(d *Daemon, prevVersion int) error {
 	}
 	if prevVersion < 15 {
 		err = dbUpdateFromV14(db)
+		if err != nil {
+			return err
+		}
+	}
+	if prevVersion < 16 {
+		err = dbUpdateFromV15(d)
 		if err != nil {
 			return err
 		}

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -52,7 +52,7 @@ func dbUpdateFromV15(d *Daemon) error {
 
 		output, err := exec.Command("lvrename", vgName, cName, newLVName).CombinedOutput()
 		if err != nil {
-			return fmt.Errorf("Could not rename LV '%s' to 's': %v\noutput:%s", cName, newLVName, err, output)
+			return fmt.Errorf("Could not rename LV '%s' to '%s': %v\noutput:%s", cName, newLVName, err, output)
 		}
 
 		if err := os.Remove(lvLinkPath); err != nil {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -188,12 +188,13 @@ func newStorageWithConfig(d *Daemon, sType storageType, config map[string]interf
 func storageForFilename(d *Daemon, filename string) (storage, error) {
 	config := make(map[string]interface{})
 	storageType := storageTypeDir
-	lvLinkPath := filename + ".lv"
+
 	filesystem, err := filesystemDetect(filename)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't detect filesystem for '%s': %v", filename, err)
 	}
 
+	lvLinkPath := filename + ".lv"
 	if shared.PathExists(lvLinkPath) {
 		storageType = storageTypeLvm
 		lvPath, err := os.Readlink(lvLinkPath)

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -264,9 +264,9 @@ func (s *storageLvm) ContainerCopy(container container, sourceContainer containe
 
 func (s *storageLvm) ContainerStart(container container) error {
 	lvName := containerNameToLVName(container.NameGet())
-	lvPath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvName)
+	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvName)
 	output, err := exec.Command(
-		"mount", "-o", "discard", lvPath, container.PathGet("")).CombinedOutput()
+		"mount", "-o", "discard", lvpath, container.PathGet("")).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf(
 			"Error mounting snapshot LV path='%s': %v\noutput:'%s'",

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -228,8 +228,7 @@ func (s *storageLvm) ContainerDelete(container container) error {
 
 func (s *storageLvm) ContainerCopy(container container, sourceContainer container) error {
 	if s.isLVMContainer(sourceContainer) {
-		readonly := false
-		if err := s.createSnapshotContainer(container, sourceContainer, readonly); err != nil {
+		if err := s.createSnapshotContainer(container, sourceContainer, false); err != nil {
 			s.log.Error("Error creating snapshot LV for copy", log.Ctx{"err": err})
 			return err
 		}
@@ -323,8 +322,7 @@ func (s *storageLvm) ContainerRestore(
 
 func (s *storageLvm) ContainerSnapshotCreate(
 	snapshotContainer container, sourceContainer container) error {
-	readonly := true
-	return s.createSnapshotContainer(snapshotContainer, sourceContainer, readonly)
+	return s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
 }
 
 func (s *storageLvm) createSnapshotContainer(

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -10,10 +10,11 @@ import (
 	"syscall"
 
 	"github.com/lxc/lxd/shared"
-	"golang.org/x/sys/unix"
 
 	log "gopkg.in/inconshreveable/log15.v2"
 )
+
+var sysSyncfsTrapNum uintptr = 306
 
 var storageLvmDefaultThinLVSize = "100GiB"
 var storageLvmDefaultThinPoolName = "LXDPool"
@@ -344,7 +345,7 @@ func (s *storageLvm) createSnapshotContainer(
 			return fmt.Errorf("Error opening mounted sourceContainer path for syncfs: '%v'", err)
 		}
 		defer srcDir.Close()
-		_, _, errno := unix.Syscall(unix.SYS_SYNCFS, srcDir.Fd(), 0, 0)
+		_, _, errno := syscall.Syscall(sysSyncfsTrapNum, srcDir.Fd(), 0, 0)
 		if errno != 0 {
 			return fmt.Errorf("Error syncing fs of frozen source container: '%s'", err)
 		}

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -208,7 +208,7 @@ test_lvm_withpool() {
     lxc copy test-container test-container-copy
     lxc start test-container-copy
     lxc stop test-container --force
-    lxc exec test-container -- ls /tmp/unchill || die "should find unchill in copy of unchillbro"
+    lxc exec test-container-copy -- ls /tmp/unchill || die "should find unchill in copy of unchillbro"
     lxc stop test-container-copy --force
 
     # TODO can't do this because busybox ignores SIGPWR, breaking restart:

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -204,7 +204,13 @@ test_lvm_withpool() {
     lxc restore test-container unchillbro
     lxc start test-container
     lxc exec test-container -- ls /tmp/unchill || die "should find unchill in unchillbro"
+
+    lxc copy test-container test-container-copy
+    lxc start test-container-copy
     lxc stop test-container --force
+    lxc exec test-container -- ls /tmp/unchill || die "should find unchill in copy of unchillbro"
+    lxc stop test-container-copy --force
+
     # TODO can't do this because busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:
     # lxc start test-container || die "Couldn't re-start test-container"


### PR DESCRIPTION
Both snapshot and copy are implemented using LVM thin snapshots.
LXD snapshots are read-only LVM thin snapshots.
Because of LVM naming limitations, we must munge snapshot names, replacing / with - and - with --.

Handles situations where a dir-backed container is copied after setting the LVM config, we copy into an LVM container.
When a dir-backed container is snapshotted, it gets a dir-backed snapshot (this change is in container.go, containerLXDCreateAsSnapshot().)

Adds tests to verify that these situations work well.

This includes some code from @pcdummy's PR #1000. I commented there with more details about what was used.