### PR TITLE
Add container rename to LVM driver

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -304,7 +304,7 @@ func (s *storageLvm) ContainerRename(
 				"err":     err,
 				"output":  output})
 
-		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'",			oldName, newName, err)
+		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'", oldName, newName, err)
 	}
 
 	// Rename the Symlink
@@ -606,7 +606,6 @@ func (s *storageLvm) createSnapshotLV(lvname string, origlvname string, readonly
 func (s *storageLvm) isLVMContainer(container container) bool {
 	return shared.PathExists(fmt.Sprintf("%s.lv", container.PathGet("")))
 }
-
 
 func (s *storageLvm) renameLV(oldName string, newName string) (string, error) {
 	output, err := exec.Command("lvrename", s.vgName, oldName, newName).CombinedOutput()

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -218,6 +218,10 @@ test_lvm_withpool() {
     lxc exec test-container-copy -- ls /tmp/unchill || die "should find unchill in copy of unchillbro"
     lxc stop test-container-copy --force
 
+    lxc move test-container-copy test-cc
+    lvs lxd_test_vg/test--container--copy && die "test-container-copy should not exist"
+    lvs lxd_test_vg/test--cc || die "test--cc should exist"
+
     # TODO can't do this because busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:
     # lxc start test-container || die "Couldn't re-start test-container"


### PR DESCRIPTION
Uses lvrename, adds tests.

Code almost entirely from @pcdummy's #1000, except for the name munging.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>