### PR TITLE
Allow renaming snapshots on same system

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -43,12 +43,18 @@ func (c *moveCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		status, err := source.ContainerStatus(sourceName, false)
-		if err != nil {
-			return err
+		canRename := false
+		if shared.IsSnapshot(sourceName) {
+			canRename = true
+		} else {
+			status, err := source.ContainerStatus(sourceName, false)
+			if err != nil {
+				return err
+			}
+			canRename = status.State() != shared.RUNNING
 		}
 
-		if status.State() != shared.RUNNING {
+		if canRename {
 			rename, err := source.Rename(sourceName, destName)
 			if err != nil {
 				return err

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -23,8 +23,9 @@ test_snapshots() {
   wait_for my_curl -X POST $BASEURL/1.0/containers/foo/snapshots/tester -d "{\"name\":\"tester2\"}"
   [ ! -d "$LXD_DIR/snapshots/foo/tester" ]
 
-  lxc delete foo/tester2
-  [ ! -d "$LXD_DIR/snapshots/foo/tester2" ]
+  lxc move foo/tester2 foo/tester-two
+  lxc delete foo/tester-two
+  [ ! -d "$LXD_DIR/snapshots/foo/tester-two" ]
 
   lxc delete foo
   lxc delete foosnap1


### PR DESCRIPTION
The optimization to use rename instead of copy for 'lxc move' did not
work with snapshots.

Fixes #1038 

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>