### PR TITLE
Disallow changing LVM config if pool is in use.

### DIFF
--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -21,6 +21,8 @@ Key                             | Type          | Default                   | De
 :--                             | :---          | :------                   | :----------
 core.https\_address             | string        | -                         | Address to bind for the remote API
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
+core.lvm\_vg\_name              | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `core.lvm_thinpool_name` is set.
+core.lvm\_thinpool\_name        | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `core.lvm_vg_name`, if the default pool parameters are undesirable.
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed
 
 Those keys can be set using the lxc tool with:

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -114,12 +114,13 @@ test_mixing_storage() {
     lxc snapshot reg-container-sticks-around regsnap || die "Couldn't snapshot"
     lvs lxd_test_vg/reg--container--sticks--around-regsnap && die "we should NOT have a snap lv for a reg container"
 
-    lxc config unset core.lvm_vg_name || die "couldn't unset config"
-    lxc stop lvm-container --force || die "couldn't stop lvm-container"
-    lxc start lvm-container || die "couldn't start lvm-container"
-    lxc stop lvm-container --force || die "couldn't stop lvm-container"
+    lxc config unset core.lvm_vg_name && die "shouldn't be able to unset config with existing lv containers"
     lxc delete lvm-container || die "couldn't delete container"
     lxc image delete testimage || die "couldn't delete lvm-backed image"
+
+    lxc delete lvm-from-reg || die "couldn't delete lvm-from-reg"
+    lxc config unset core.lvm_vg_name || die "should be able to unset config after delete all"
+
     exit 0
     )
 
@@ -172,6 +173,9 @@ test_lvm_withpool() {
         echo " --> only doing minimal image import subtest with user pool name"
         do_image_import_subtest $poolname
 
+        lxc config unset core.lvm_vg_name && die "should not be allowed to unset without deleting"
+        lxc image delete testimage
+        
         # check that we can unset configs in this order
         lxc config unset core.lvm_vg_name
         lxc config unset core.lvm_thinpool_name


### PR DESCRIPTION
Checks for containers or images in the db that are using the
currently-configured thin pool, and would hence be broken if the config
was changed.

Includes the names of the offending images/containers in the error message.

Updates tests.

Fixes #953.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>