### PR TITLE
Snapshot Renaming Fixes - general and LVM

### DIFF
--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -227,6 +227,10 @@ test_lvm_withpool() {
     lvs lxd_test_vg/test--container--copy && die "test-container-copy should not exist"
     lvs lxd_test_vg/test--cc || die "test--cc should exist"
 
+    lxc move test-container/chillbro test-container/superchill
+    lvs lxd_test_vg/test--container-superchill || die "superchill should exist"
+    lvs lxd_test_vg/test--container-chillbro && die "chillbro should not exist"
+
     # TODO busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:
     # lxc start test-container || die "Couldn't re-start test-container"

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -27,9 +27,18 @@ test_snapshots() {
   lxc delete foo/tester-two
   [ ! -d "$LXD_DIR/snapshots/foo/tester-two" ]
 
-  lxc delete foo
-  lxc delete foosnap1
+  lxc snapshot foo namechange
+  [ -d "$LXD_DIR/snapshots/foo/namechange" ]
+  lxc move foo foople
   [ ! -d "$LXD_DIR/containers/foo" ]
+  [ -d "$LXD_DIR/containers/foople" ]
+  [ -d "$LXD_DIR/snapshots/foople/namechange" ]
+  [ -d "$LXD_DIR/snapshots/foople/namechange" ]
+
+  lxc delete foople
+  lxc delete foosnap1
+  [ ! -d "$LXD_DIR/containers/foople" ]
+  [ ! -d "$LXD_DIR/containers/foosnap1" ]
 }
 
 test_snap_restore() {


### PR DESCRIPTION
Use storage.ContainerSnapshotRename to rename snapshot storage, allowing snapshot-dir-specific cleanup.

Also fix a TODO: rename snapshots of renamed containers, and add tests for this.

Finally implement ContainerSnapshotRename for the LVM storage backend.