### PR TITLE
LVM version info

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -179,6 +179,12 @@ func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 		return s, err
 	}
 
+	output, err := exec.Command("lvm", "version").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting LVM version: %v\noutput:'%s'", err, string(output))
+	}
+	s.sTypeVersion = strings.TrimSpace(string(output))
+
 	if config["vgName"] == nil {
 		vgName, err := s.d.ConfigValueGet("core.lvm_vg_name")
 		if err != nil {

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -227,6 +227,10 @@ test_lvm_withpool() {
     lvs lxd_test_vg/test--container--copy && die "test-container-copy should not exist"
     lvs lxd_test_vg/test--cc || die "test--cc should exist"
 
+    lxc move test-container/chillbro test-container/superchill
+    lvs lxd_test_vg/test--container-superchill || die "superchill should exist"
+    lvs lxd_test_vg/test--container-chillbro && die "chillbro should not exist"
+
     # TODO busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:
     # lxc start test-container || die "Couldn't re-start test-container"

--- a/test/snapshots.sh
+++ b/test/snapshots.sh
@@ -27,9 +27,18 @@ test_snapshots() {
   lxc delete foo/tester-two
   [ ! -d "$LXD_DIR/snapshots/foo/tester-two" ]
 
-  lxc delete foo
-  lxc delete foosnap1
+  lxc snapshot foo namechange
+  [ -d "$LXD_DIR/snapshots/foo/namechange" ]
+  lxc move foo foople
   [ ! -d "$LXD_DIR/containers/foo" ]
+  [ -d "$LXD_DIR/containers/foople" ]
+  [ -d "$LXD_DIR/snapshots/foople/namechange" ]
+  [ -d "$LXD_DIR/snapshots/foople/namechange" ]
+
+  lxc delete foople
+  lxc delete foosnap1
+  [ ! -d "$LXD_DIR/containers/foople" ]
+  [ ! -d "$LXD_DIR/containers/foosnap1" ]
 }
 
 test_snap_restore() {


### PR DESCRIPTION
This includes two commits from #1052.

Simply sets s.sTypeVersion to all three lines of "lvm version" output, since they all seem potentially useful.

Here's an example:
```
ubuntu@canonical-lxd:~$ sudo lvm version
  LVM version:     2.02.111(2) (2014-09-01)
  Library version: 1.02.90 (2014-09-01)
  Driver version:  4.29.0
```