### PR TITLE
Add version output to LVM storage driver

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -179,6 +179,12 @@ func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 		return s, err
 	}
 
+	output, err := exec.Command("lvm", "version").CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("Error getting LVM version: %v\noutput:'%s'", err, string(output))
+	}
+	s.sTypeVersion = strings.TrimSpace(string(output))
+
 	if config["vgName"] == nil {
 		vgName, err := s.d.ConfigValueGet("core.lvm_vg_name")
 		if err != nil {

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -183,7 +183,19 @@ func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Error getting LVM version: %v\noutput:'%s'", err, string(output))
 	}
-	s.sTypeVersion = strings.TrimSpace(string(output))
+	lines := strings.Split(string(output), "\n")
+
+	s.sTypeVersion = ""
+	for idx, line := range lines {
+		fields := strings.SplitAfterN(line, ":", 2)
+		if len(fields) < 2 {
+			continue
+		}
+		if idx > 0 {
+			s.sTypeVersion += " / "
+		}
+		s.sTypeVersion += strings.TrimSpace(fields[1])
+	}
 
 	if config["vgName"] == nil {
 		vgName, err := s.d.ConfigValueGet("core.lvm_vg_name")


### PR DESCRIPTION
Simply sets s.sTypeVersion to all three lines of "lvm version" output, since they all seem potentially useful.

Here's an example:
```
ubuntu@canonical-lxd:~$ sudo lvm version
  LVM version:     2.02.111(2) (2014-09-01)
  Library version: 1.02.90 (2014-09-01)
  Driver version:  4.29.0
```

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>