### PR TITLE
Implement shutdown command (and some cleanup)

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"syscall"
 
 	"gopkg.in/lxc/go-lxc.v2"
@@ -96,7 +97,9 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"kernel_version":      kernelVersion,
 			"storage":             d.Storage.GetStorageTypeName(),
 			"storage_version":     d.Storage.GetStorageTypeVersion(),
-			"version":             shared.Version}
+			"server":              "lxd",
+			"server_pid":          os.Getpid(),
+			"server_version":      shared.Version}
 
 		body["environment"] = env
 

--- a/shared/server.go
+++ b/shared/server.go
@@ -8,9 +8,11 @@ type ServerStateEnvironment struct {
 	Kernel             string   `json:"kernel"`
 	KernelArchitecture string   `json:"kernel_architecture"`
 	KernelVersion      string   `json:"kernel_version"`
+	Server             string   `json:"server"`
+	ServerPid          int      `json:"server_pid"`
+	ServerVersion      string   `json:"server_version"`
 	Storage            string   `json:"storage"`
 	StorageVersion     string   `json:"storage_version"`
-	Version            string   `json:"version"`
 }
 
 type ServerState struct {

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -194,12 +194,16 @@ Return value (if trusted):
         'environment': {                                # Various information about the host (OS, kernel, ...)
                         'addresses': ["1.2.3.4:8443", "[1234::1234]:8443"],
                         'architectures': [1, 2],
-                        'backing_fs': "ext4",
-                        'kernel': "Linux",
-                        'kernel_version': "3.16",
                         'driver': "lxc",
                         'driver_version': "1.0.6",
-                        'version': "0.8.1"}
+                        'kernel': "Linux",
+                        'kernel_architecture': "x86_64",
+                        'kernel_version': "3.16",
+                        'storage': "btrfs",
+                        'storage_version': "3.19",
+                        'server': "lxd",
+                        'server_pid': 10224,
+                        'server_version': "0.8.1"}
     }
 
 Return value (if guest or untrusted):


### PR DESCRIPTION
This implements the shutdown command as a lxd argument.

When called, SIGPWR is sent to LXD by fetching the daemon's PID over the
API, we then wait for LXD to stop responding before returning.

This is meant to be used by init systems to perform a clean shutdown of
LXD on host shutdown.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>