### PR TITLE
Rename core.lvm to storage.lvm (and fix testsuite)

### DIFF
--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -153,7 +153,7 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err != nil {
 				return InternalError(err)
 			}
-		} else if key == "core.lvm_vg_name" {
+		} else if key == "storage.lvm_vg_name" {
 			err := storageLVMSetVolumeGroupNameConfig(d, value.(string))
 			if err != nil {
 				return InternalError(err)
@@ -161,7 +161,7 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err = d.SetupStorageDriver(); err != nil {
 				return InternalError(err)
 			}
-		} else if key == "core.lvm_thinpool_name" {
+		} else if key == "storage.lvm_thinpool_name" {
 			err := storageLVMSetThinPoolNameConfig(d, value.(string))
 			if err != nil {
 				return InternalError(err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -300,7 +300,7 @@ func (d *Daemon) createCmd(version string, c Command) {
 }
 
 func (d *Daemon) SetupStorageDriver() error {
-	vgName, err := d.ConfigValueGet("core.lvm_vg_name")
+	vgName, err := d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		return fmt.Errorf("Couldn't read config: %s", err)
 	}
@@ -861,9 +861,9 @@ func (d *Daemon) ConfigKeyIsValid(key string) bool {
 		return true
 	case "core.trust_password":
 		return true
-	case "core.lvm_vg_name":
+	case "storage.lvm_vg_name":
 		return true
-	case "core.lvm_thinpool_name":
+	case "storage.lvm_thinpool_name":
 		return true
 	case "images.remote_cache_expiry":
 		return true

--- a/lxd/daemon_test.go
+++ b/lxd/daemon_test.go
@@ -33,11 +33,11 @@ func Test_config_value_set_empty_removes_val(t *testing.T) {
 	}
 	defer d.Stop()
 
-	if err = d.ConfigValueSet("core.lvm_vg_name", "foo"); err != nil {
+	if err = d.ConfigValueSet("storage.lvm_vg_name", "foo"); err != nil {
 		t.Error("couldn't set value", err)
 	}
 
-	val, err := d.ConfigValueGet("core.lvm_vg_name")
+	val, err := d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		t.Error("Error getting val")
 	}
@@ -45,12 +45,12 @@ func Test_config_value_set_empty_removes_val(t *testing.T) {
 		t.Error("Expected foo, got ", val)
 	}
 
-	err = d.ConfigValueSet("core.lvm_vg_name", "")
+	err = d.ConfigValueSet("storage.lvm_vg_name", "")
 	if err != nil {
 		t.Error("error setting to ''")
 	}
 
-	val, err = d.ConfigValueGet("core.lvm_vg_name")
+	val, err = d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		t.Error("Error getting val")
 	}
@@ -62,7 +62,7 @@ func Test_config_value_set_empty_removes_val(t *testing.T) {
 	if err != nil {
 		t.Error("Error getting val")
 	}
-	if key, present := valMap["core.lvm_vg_name"]; present {
+	if key, present := valMap["storage.lvm_vg_name"]; present {
 		t.Errorf("un-set key should not be in values map, it is '%v'", key)
 	}
 

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -36,7 +36,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 16
+const DB_CURRENT_VERSION int = 17
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -14,6 +14,15 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
+func dbUpdateFromV16(db *sql.DB) error {
+	stmt := `
+UPDATE config SET key='storage.lvm_vg_name' WHERE key = 'core.lvm_vg_name';
+UPDATE config SET key='storage.lvm_thinpool_name' WHERE key = 'core.lvm_thinpool_name';
+INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
+	_, err := db.Exec(stmt, 17)
+	return err
+}
+
 func dbUpdateFromV15(d *Daemon) error {
 	// munge all LVM-backed containers' LV names to match what is
 	// required for snapshot support
@@ -23,7 +32,7 @@ func dbUpdateFromV15(d *Daemon) error {
 		return err
 	}
 
-	vgName, err := d.ConfigValueGet("core.lvm_vg_name")
+	vgName, err := d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		return fmt.Errorf("Error checking server config: %v", err)
 	}
@@ -697,6 +706,12 @@ func dbUpdate(d *Daemon, prevVersion int) error {
 	}
 	if prevVersion < 16 {
 		err = dbUpdateFromV15(d)
+		if err != nil {
+			return err
+		}
+	}
+	if prevVersion < 17 {
+		err = dbUpdateFromV16(db)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -52,14 +52,14 @@ func storageLVMThinpoolExists(vgName string, poolName string) (bool, error) {
 
 func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 	results := []string{}
-	vgname, err := d.ConfigValueGet("core.lvm_vg_name")
+	vgname, err := d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		return results, fmt.Errorf("Error getting lvm_vg_name config")
 	}
 	if vgname == "" {
 		return results, nil
 	}
-	poolname, err := d.ConfigValueGet("core.lvm_thinpool_name")
+	poolname, err := d.ConfigValueGet("storage.lvm_thinpool_name")
 	if err != nil {
 		return results, fmt.Errorf("Error getting lvm_thinpool_name config")
 	}
@@ -109,7 +109,7 @@ func storageLVMSetThinPoolNameConfig(d *Daemon, poolname string) error {
 		return fmt.Errorf("Can not change LVM config. Images or containers are still using LVs: %v", users)
 	}
 
-	vgname, err := d.ConfigValueGet("core.lvm_vg_name")
+	vgname, err := d.ConfigValueGet("storage.lvm_vg_name")
 	if err != nil {
 		return fmt.Errorf("Error getting lvm_vg_name config: %v", err)
 	}
@@ -128,7 +128,7 @@ func storageLVMSetThinPoolNameConfig(d *Daemon, poolname string) error {
 		}
 	}
 
-	err = d.ConfigValueSet("core.lvm_thinpool_name", poolname)
+	err = d.ConfigValueSet("storage.lvm_thinpool_name", poolname)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func storageLVMSetVolumeGroupNameConfig(d *Daemon, vgname string) error {
 		}
 	}
 
-	err = d.ConfigValueSet("core.lvm_vg_name", vgname)
+	err = d.ConfigValueSet("storage.lvm_vg_name", vgname)
 	if err != nil {
 		return err
 	}
@@ -198,7 +198,7 @@ func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 	}
 
 	if config["vgName"] == nil {
-		vgName, err := s.d.ConfigValueGet("core.lvm_vg_name")
+		vgName, err := s.d.ConfigValueGet("storage.lvm_vg_name")
 		if err != nil {
 			return s, fmt.Errorf("Error checking server config: %v", err)
 		}
@@ -605,7 +605,7 @@ func (s *storageLvm) createDefaultThinPool() (string, error) {
 
 func (s *storageLvm) createThinLV(lvname string) (string, error) {
 
-	poolname, err := s.d.ConfigValueGet("core.lvm_thinpool_name")
+	poolname, err := s.d.ConfigValueGet("storage.lvm_thinpool_name")
 	if err != nil {
 		return "", fmt.Errorf("Error checking server config, err=%v", err)
 	}

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -14,15 +14,15 @@ for devices, network interfaces and storage volumes.
 The key/value configuration is namespaced with the following namespaces
 currently supported:
  - core (core daemon configuration)
- - lxc (LXC configuration)
  - images (image configuration)
+ - storage (storage configuration)
 
 Key                             | Type          | Default                   | Description
 :--                             | :---          | :------                   | :----------
 core.https\_address             | string        | -                         | Address to bind for the remote API
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
-core.lvm\_vg\_name              | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `core.lvm_thinpool_name` is set.
-core.lvm\_thinpool\_name        | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `core.lvm_vg_name`, if the default pool parameters are undesirable.
+storage.lvm\_vg\_name           | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
+storage.lvm\_thinpool\_name     | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed
 
 Those keys can be set using the lxc tool with:

--- a/test/basic.sh
+++ b/test/basic.sh
@@ -164,7 +164,7 @@ test_basic_usage() {
   # unloaded on stop, and that it is deleted when the container is deleted
   lxc launch testimage lxd-apparmor-test
   aa-status | grep lxd-apparmor-test
-  lxc stop lxd-apparmor-test
+  lxc stop lxd-apparmor-test --force
   bad=0
   aa-status | grep lxd-apparmor-test && bad=1 || true
   if [ "$bad" -eq 1 ]; then

--- a/test/lvm.sh
+++ b/test/lvm.sh
@@ -96,7 +96,7 @@ test_mixing_storage() {
     ../scripts/lxd-images import busybox --alias testimage || die "couldn't import image"
     lxc launch testimage reg-container || die "couldn't launch regular container"
     lxc copy reg-container reg-container-sticks-around || die "Couldn't copy reg"
-    lxc config set core.lvm_vg_name "lxd_test_vg" || die "error setting core.lvm_vg_name config"
+    lxc config set storage.lvm_vg_name "lxd_test_vg" || die "error setting storage.lvm_vg_name config"
     lxc config show | grep "lxd_test_vg" || die "test_vg not in config show output"
     lxc stop reg-container --force || die "couldn't stop reg-container"
     lxc start reg-container || die "couldn't start reg-container"
@@ -114,12 +114,12 @@ test_mixing_storage() {
     lxc snapshot reg-container-sticks-around regsnap || die "Couldn't snapshot"
     lvs lxd_test_vg/reg--container--sticks--around-regsnap && die "we should NOT have a snap lv for a reg container"
 
-    lxc config unset core.lvm_vg_name && die "shouldn't be able to unset config with existing lv containers"
+    lxc config unset storage.lvm_vg_name && die "shouldn't be able to unset config with existing lv containers"
     lxc delete lvm-container || die "couldn't delete container"
     lxc image delete testimage || die "couldn't delete lvm-backed image"
 
     lxc delete lvm-from-reg || die "couldn't delete lvm-from-reg"
-    lxc config unset core.lvm_vg_name || die "should be able to unset config after delete all"
+    lxc config unset storage.lvm_vg_name || die "should be able to unset config after delete all"
 
     exit 0
     )
@@ -160,25 +160,25 @@ test_lvm_withpool() {
     (
     set -e
     LXD_DIR=$LXD5_DIR
-    lxc config set core.lvm_vg_name "zambonirodeo" && die "Shouldn't be able to set nonexistent LVM VG"
-    lxc config show | grep "core.lvm_vg_name" && die "vg_name should not be set after invalid attempt"
+    lxc config set storage.lvm_vg_name "zambonirodeo" && die "Shouldn't be able to set nonexistent LVM VG"
+    lxc config show | grep "storage.lvm_vg_name" && die "vg_name should not be set after invalid attempt"
 
-    lxc config set core.lvm_vg_name "lxd_test_vg" || die "error setting core.lvm_vg_name config"
+    lxc config set storage.lvm_vg_name "lxd_test_vg" || die "error setting storage.lvm_vg_name config"
     lxc config show | grep "lxd_test_vg" || die "test_vg not in config show output"
 
     if [ -n "$poolname" ]; then
         echo " --> Testing with user-supplied thin pool name '$poolname'"
-        lxc config set core.lvm_thinpool_name $poolname || die "error setting core.lvm_thinpool_name config"
+        lxc config set storage.lvm_thinpool_name $poolname || die "error setting storage.lvm_thinpool_name config"
         lxc config show | grep "$poolname" || die "thin pool name not in config show output."
         echo " --> only doing minimal image import subtest with user pool name"
         do_image_import_subtest $poolname
 
-        lxc config unset core.lvm_vg_name && die "should not be allowed to unset without deleting"
+        lxc config unset storage.lvm_vg_name && die "should not be allowed to unset without deleting"
         lxc image delete testimage
         
         # check that we can unset configs in this order
-        lxc config unset core.lvm_vg_name
-        lxc config unset core.lvm_thinpool_name
+        lxc config unset storage.lvm_vg_name
+        lxc config unset storage.lvm_thinpool_name
 
         return
     else
@@ -275,7 +275,7 @@ test_remote_launch_imports_lvm() {
     LXD_DIR=$LXD6_DIR
     LXD_REMOTE_DIR=$LXD5_DIR
 
-    lxc config set core.lvm_vg_name "lxd_test_vg" || die "couldn't set vg_name"
+    lxc config set storage.lvm_vg_name "lxd_test_vg" || die "couldn't set vg_name"
     (echo y; sleep 3; echo foo) | lxc remote add testremote 127.0.0.1:18466
 
     testimage_sha=$(lxc image info testremote:testimage | grep Fingerprint | cut -d' ' -f 2)
@@ -310,7 +310,7 @@ test_init_with_missing_vg() {
     set -e
     LXD_DIR=$LXD5_DIR
     create_vg red_shirt_yeoman_vg
-    lxc config set core.lvm_vg_name "red_shirt_yeoman_vg" || die "error setting core.lvm_vg_name config"
+    lxc config set storage.lvm_vg_name "red_shirt_yeoman_vg" || die "error setting storage.lvm_vg_name config"
     exit 0
     )
 
@@ -323,7 +323,7 @@ test_init_with_missing_vg() {
     set -e
     LXD_DIR=$LXD5_DIR
     lxc config show | grep "red_shirt_yeoman_vg" || die "should show config even if it is broken"
-    lxc config unset core.lvm_vg_name || die "should be able to un set config to un break"
+    lxc config unset storage.lvm_vg_name || die "should be able to un set config to un break"
     exit 0
     )
 


### PR DESCRIPTION
This is in preparation for ZFS support. I think it makes sense to move the storage configuration stuff to its own namespace.