### PR TITLE
Support nested lxd [RFC]

### DIFF
--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -338,6 +338,8 @@ func ValidContainerConfigKey(k string) bool {
 		return true
 	case "security.privileged":
 		return true
+	case "security.nesting":
+		return true
 	case "raw.apparmor":
 		return true
 	case "raw.lxc":

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -142,6 +142,9 @@ func run() error {
 		shared.Log.Warn("apparmor_parser binary not found. AppArmor disabled.")
 	}
 
+	/* Can we create devices? */
+	checkCanMknod()
+
 	if *printGoroutines > 0 {
 		go func() {
 			for {


### PR DESCRIPTION
Closes #1002 

This suffices to allow me to run lxd containers within lxd containers.

When running lxd inside a lxd container, a few things must be done differently.

First, we cannot create devices.  This means when init'ing a container we have
to avoid extracting the devices as that will fail.

Secondly, we need some extra permissions from apparmor for mounting and
pivot_root.

Thirdly, we cannot load new apparmor policies, so avoid that.  Intead, tell
lxc to use the same policy we are currently in.  (There is no way to tell
lxc "don't switch apparmor profiles at all")  We support running lxd
containers under a lxc-container-default-with-nesting profile, as well
as supporting lxc-container-default containers under lxd containers.

HOWTO

To tell lxd that a container should allow nesting containers inside itself,
you should

1. set 'security.nesting = 1' in the container configuration or profile
2. make sure that root has a wide enough uidgid allocation to support the
   nesting.  If the allocated subuids in the nested containers will be
   the default '100000:65536', then you must have a range of at least
   165537 uids.  I usually just use
	   root:200000:200000
   in the host's subuid and subgid files.

TODO: instead of just excluding /dev/* in tar, use archive/tar by hand and
      skip all devices
TODO: figure out a way to not need 'mount,' apparmor rule.  As far as we know
      this is currently still needed because of a bug in apparmor which
      doesn't allow a mount rule combining 'remount' with other permissions,
      so we cannot allow 'remount -o remount,bind,ro'.

sidenote: I did also try to support the archive extraction using seccomp.
	  Simply using seccomp_errno to return errno 0 for mknod and mknodat
	  without creating the device does not suffice, because tar then
	  checks the utime of the created node.  Using seccomp_trap doesn't
	  work because we cannot catch sigsys for the tar we spawn.  However,
	  we should be able to (1) start the tar under seccomp and ptrace,
	  (2) use seccomp_ret_trace for mknod and mknodat, create a file
	  in place of the device, then continue the task.  This would
	  require us to be able to use ptrace to find the path to be
	  created.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>