### PR TITLE
apparmor: also stat kernel security path

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -136,10 +136,11 @@ func run() error {
 	}
 
 	_, err = exec.LookPath("apparmor_parser")
-	if err == nil {
+	if err == nil && shared.IsDir("/sys/kernel/security/apparmor") {
 		aaEnabled = true
 	} else {
-		shared.Log.Warn("apparmor_parser binary not found. AppArmor disabled.")
+		shared.Log.Warn("apparmor_parser binary not found or apparmor " +
+			"fs not mounted. AppArmor disabled.")
 	}
 
 	if *printGoroutines > 0 {


### PR DESCRIPTION
apparmor_parser won't do anything if the apparmor fs isn't mounted, so let's
check that too.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>