### PR TITLE
copy: fix idmap shifting

### DIFF
--- a/lxd/migration/migrate.go
+++ b/lxd/migration/migrate.go
@@ -434,6 +434,10 @@ func (c *migrationSink) do() error {
 		srcIdmap := new(shared.IdmapSet)
 		dstIdmap := c.IdmapSet
 
+		if dstIdmap == nil {
+			dstIdmap = new(shared.IdmapSet)
+		}
+
 		if c.live {
 			var err error
 			imagesDir, err = ioutil.TempDir("", "lxd_migration_")


### PR DESCRIPTION
In particular, srcIdmap is created via new(IdmapSet), so it'll never be nil
when dstIdmap is. Instead, let's make an actual object, since the actual empty
object means the same thing as nil (i.e. "don't uidmapshift anything"), the
resulting reflective deep comparison works and we get the expected behavior,
instead of this giant stack trace:

panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x0 pc=0x5c77eb]

goroutine 59 [running]:
runtime.panic(0x9eb400, 0x11003d3)
  /usr/lib/go/src/pkg/runtime/panic.c:279 +0xf5
github.com/lxc/lxd/shared.func·002(0xc20806a300, 0x1d, 0x7fb709518b98, 0xc20820b5e0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/shared/idmapset.go:234 +0x47b
path/filepath.walk(0xc20806a300, 0x1d, 0x7fb709518b98, 0xc20820b5e0, 0x7fb709389c18, 0x0, 0x0)
  /usr/lib/go/src/pkg/path/filepath/path.go:343 +0x8c
path/filepath.Walk(0xc20806a300, 0x1d, 0x7fb709389c18, 0x0, 0x0)
  /usr/lib/go/src/pkg/path/filepath/path.go:390 +0xe5
github.com/lxc/lxd/shared.(*IdmapSet).doUidshiftIntoContainer(0x0, 0xc20806a300, 0x1d, 0x0, 0xa789d0, 0x2, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/shared/idmapset.go:258 +0x1c5
github.com/lxc/lxd/shared.(*IdmapSet).ShiftRootfs(0x0, 0xc20806a300, 0x1d, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/shared/idmapset.go:270 +0x66
github.com/lxc/lxd/lxd/migration.func·003(0xc2081fd5c0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:506 +0xa18
created by github.com/lxc/lxd/lxd/migration.(*migrationSink).do
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:551 +0x5ae

goroutine 16 [semacquire, 2 minutes]:
sync.runtime_Semacquire(0xc2080f4c28)
  /usr/lib/go/src/pkg/runtime/sema.goc:199 +0x30
sync.(*WaitGroup).Wait(0xc2080ed8e0)
  /usr/lib/go/src/pkg/sync/waitgroup.go:129 +0x14b
main.run(0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:194 +0xaaf
main.main()
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:42 +0x26

goroutine 19 [finalizer wait]:
runtime.park(0x533390, 0x11f39e8, 0x1103709)
  /usr/lib/go/src/pkg/runtime/proc.c:1369 +0x89
runtime.parkunlock(0x11f39e8, 0x1103709)
  /usr/lib/go/src/pkg/runtime/proc.c:1385 +0x3b
runfinq()
  /usr/lib/go/src/pkg/runtime/mgc0.c:2644 +0xcf
runtime.goexit()
  /usr/lib/go/src/pkg/runtime/proc.c:1445

goroutine 20 [syscall, 2 minutes]:
os/signal.loop()
  /usr/lib/go/src/pkg/os/signal/signal_unix.go:21 +0x1e
created by os/signal.init·1
  /usr/lib/go/src/pkg/os/signal/signal_unix.go:27 +0x32

goroutine 17 [syscall, 2 minutes]:
runtime.goexit()
  /usr/lib/go/src/pkg/runtime/proc.c:1445

goroutine 21 [chan receive, 2 minutes]:
database/sql.(*DB).connectionOpener(0xc20803e400)
  /usr/lib/go/src/pkg/database/sql/sql.go:583 +0x48
created by database/sql.Open
  /usr/lib/go/src/pkg/database/sql/sql.go:442 +0x27c

goroutine 22 [select, 2 minutes]:
main.func·031()
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:607 +0x156
created by main.(*Daemon).Init
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:615 +0xf1d

goroutine 50 [IO wait]:
net.runtime_pollWait(0x7fb709519ba0, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc2080d8220, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc2080d8220, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).Read(0xc2080d81c0, 0xc208076c00, 0x400, 0x400, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:242 +0x34c
net.(*conn).Read(0xc208032098, 0xc208076c00, 0x400, 0x400, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/net.go:122 +0xe7
crypto/tls.(*block).readFromUntil(0xc2081226f0, 0x7fb709520bf0, 0xc208032098, 0x5, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:451 +0xd9
crypto/tls.(*Conn).readRecord(0xc208075600, 0x17, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:536 +0x1ff
crypto/tls.(*Conn).Read(0xc208075600, 0xc20819e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:901 +0x16a
net/http.(*liveSwitchReader).Read(0xc2080d2028, 0xc20819e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:206 +0xaf
io.(*LimitedReader).Read(0xc2080ec060, 0xc20819e000, 0x1000, 0x1000, 0xc208149800, 0x0, 0x0)
  /usr/lib/go/src/pkg/io/io.go:399 +0xd0
bufio.(*Reader).fill(0xc2080e4060)
  /usr/lib/go/src/pkg/bufio/bufio.go:97 +0x1b3
bufio.(*Reader).ReadSlice(0xc2080e4060, 0x74070a, 0x0, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/bufio/bufio.go:298 +0x22c
bufio.(*Reader).ReadLine(0xc2080e4060, 0x0, 0x0, 0x0, 0x1210700, 0x0, 0x0)
  /usr/lib/go/src/pkg/bufio/bufio.go:326 +0x69
net/textproto.(*Reader).readLineSlice(0xc2081228a0, 0x0, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/textproto/reader.go:55 +0x9d
net/textproto.(*Reader).ReadLine(0xc2081228a0, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/textproto/reader.go:36 +0x4e
net/http.ReadRequest(0xc2080e4060, 0xc20815a1a0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/request.go:556 +0xc7
net/http.(*conn).readRequest(0xc2080d2000, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:577 +0x276
net/http.(*conn).serve(0xc2080d2000)
  /usr/lib/go/src/pkg/net/http/server.go:1132 +0x61e
created by net/http.(*Server).Serve
  /usr/lib/go/src/pkg/net/http/server.go:1721 +0x313

goroutine 25 [chan receive, 2 minutes]:
main.func·043()
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:171 +0x134
created by main.run
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:180 +0xa54

goroutine 26 [chan receive, 2 minutes]:
main.func·044()
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:187 +0x26c
created by main.run
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/main.go:192 +0xa9c

goroutine 27 [IO wait, 1 minutes]:
net.runtime_pollWait(0x7fb709519d00, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc208071e20, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc208071e20, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).accept(0xc208071dc0, 0xd29d80, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:419 +0x343
net.(*UnixListener).AcceptUnix(0xc2080ed820, 0x57dc03, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/unixsock_posix.go:293 +0x73
net.(*UnixListener).Accept(0xc2080ed820, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/unixsock_posix.go:304 +0x4b
net/http.(*Server).Serve(0xc2080e59e0, 0x7fb709520128, 0xc2080ed820, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:1698 +0x91
net/http.Serve(0x7fb709520128, 0xc2080ed820, 0x7fb709520318, 0xc20810e6e0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:1576 +0x7c
main.func·034(0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:766 +0x88
gopkg.in/tomb%2ev2.(*Tomb).run(0xc20803a808, 0xc2080ed9e0)
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:153 +0x23
created by gopkg.in/tomb%2ev2.(*Tomb).Go
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:149 +0x110

goroutine 28 [IO wait]:
net.runtime_pollWait(0x7fb709519c50, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc208071e90, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc208071e90, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).accept(0xc208071e30, 0xd29d60, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:419 +0x343
net.(*TCPListener).AcceptTCP(0xc208032380, 0xc20816b680, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/tcpsock_posix.go:234 +0x5d
net.(*TCPListener).Accept(0xc208032380, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/tcpsock_posix.go:244 +0x4b
crypto/tls.(*listener).Accept(0xc2080ed8c0, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/tls.go:46 +0x6a
net/http.(*Server).Serve(0xc2080e5a40, 0x7fb709520240, 0xc2080ed8c0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:1698 +0x91
net/http.Serve(0x7fb709520240, 0xc2080ed8c0, 0x7fb709520318, 0xc20810e6e0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:1576 +0x7c
main.func·034(0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:766 +0x88
gopkg.in/tomb%2ev2.(*Tomb).run(0xc20803a808, 0xc2080eda80)
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:153 +0x23
created by gopkg.in/tomb%2ev2.(*Tomb).Go
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:149 +0x110

goroutine 29 [IO wait, 2 minutes]:
net.runtime_pollWait(0x7fb709519db0, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc208070a70, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc208070a70, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).accept(0xc208070a10, 0xd29d80, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:419 +0x343
net.(*UnixListener).AcceptUnix(0xc2080b2360, 0x18, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/unixsock_posix.go:293 +0x73
net.(*UnixListener).Accept(0xc2080b2360, 0x0, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/unixsock_posix.go:304 +0x4b
net/http.(*Server).Serve(0xc2080e5aa0, 0x7fb709520128, 0xc2080b2360, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/http/server.go:1698 +0x91
main.func·035(0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:771 +0xdb
gopkg.in/tomb%2ev2.(*Tomb).run(0xc20803a808, 0xc2080f4e40)
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:153 +0x23
created by gopkg.in/tomb%2ev2.(*Tomb).Go
  /home/ubuntu/packages/go/src/gopkg.in/tomb.v2/tomb.go:149 +0x110

goroutine 51 [chan receive]:
main.operationWaitGet(0xc20803a780, 0xc20815a270, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:194 +0x575
main.func·029(0x7fb709520498, 0xc2080eee60, 0xc20815a270)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/daemon.go:263 +0x6be
net/http.HandlerFunc.ServeHTTP(0xc2080ec880, 0x7fb709520498, 0xc2080eee60, 0xc20815a270)
  /usr/lib/go/src/pkg/net/http/server.go:1235 +0x40
github.com/gorilla/mux.(*Router).ServeHTTP(0xc20810e6e0, 0x7fb709520498, 0xc2080eee60, 0xc20815a270)
  /home/ubuntu/packages/go/src/github.com/gorilla/mux/mux.go:98 +0x292
net/http.serverHandler.ServeHTTP(0xc2080e5a40, 0x7fb709520498, 0xc2080eee60, 0xc20815a270)
  /usr/lib/go/src/pkg/net/http/server.go:1673 +0x19f
net/http.(*conn).serve(0xc2080d2080)
  /usr/lib/go/src/pkg/net/http/server.go:1174 +0xa7e
created by net/http.(*Server).Serve
  /usr/lib/go/src/pkg/net/http/server.go:1721 +0x313

goroutine 38 [chan receive, 2 minutes]:
github.com/lxc/lxd/lxd/migration.(*migrationSourceWs).Do(0xc208108a80, 0x0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:228 +0x5a
github.com/lxc/lxd/shared.OperationWebsocket.Do·fm(0x0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/response.go:220 +0x50
main.func·045(0xc2080efc20)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:69 +0x32
created by main.startOperation
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:76 +0x1b7

goroutine 52 [IO wait]:
net.runtime_pollWait(0x7fb709519990, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc208108c30, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc208108c30, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).Read(0xc208108bd0, 0xc208064000, 0x400, 0x400, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:242 +0x34c
net.(*conn).Read(0xc2080321a0, 0xc208064000, 0x400, 0x400, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/net.go:122 +0xe7
crypto/tls.(*block).readFromUntil(0xc208123470, 0x7fb709520bf0, 0xc2080321a0, 0x5, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:451 +0xd9
crypto/tls.(*Conn).readRecord(0xc20817e000, 0x17, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:536 +0x1ff
crypto/tls.(*Conn).Read(0xc20817e000, 0xc208064c00, 0x400, 0x400, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:901 +0x16a
bufio.(*Reader).fill(0xc2080e5680)
  /usr/lib/go/src/pkg/bufio/bufio.go:97 +0x1b3
bufio.(*Reader).Read(0xc2080e5680, 0xc208155fe8, 0x2, 0x8, 0x2, 0x0, 0x0)
  /usr/lib/go/src/pkg/bufio/bufio.go:175 +0x230
github.com/gorilla/websocket.(*Conn).readFull(0xc2080cc2d0, 0xc208155fe8, 0x2, 0x8, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:542 +0xb0
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc2080cc2d0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:566 +0x162
github.com/gorilla/websocket.(*Conn).NextReader(0xc2080cc2d0, 0x7fb7095203a0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:706 +0x77
github.com/lxc/lxd/lxd/migration.(*migrationFields).recv(0xc2080d0930, 0x7fb70952e128, 0xc2080d5e00, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:62 +0x43
github.com/lxc/lxd/lxd/migration.(*migrationSourceWs).Do(0xc2080d0930, 0x0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:326 +0x1629
github.com/lxc/lxd/shared.OperationWebsocket.Do·fm(0x0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/response.go:220 +0x50
main.func·045(0xc2080e0000)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:69 +0x32
created by main.startOperation
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:76 +0x1b7

goroutine 53 [select]:
github.com/lxc/lxd/lxd/migration.(*migrationSink).do(0xc2081fd5c0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:556 +0x936
github.com/lxc/lxd/lxd/migration.*migrationSink.(github.com/lxc/lxd/lxd/migration.do)·fm(0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:378 +0x38
main.func·027(0x0, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/containers_post.go:159 +0x7ea
main.func·045(0xc2080ee8c0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:69 +0x32
created by main.startOperation
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/operations.go:76 +0x1b7

goroutine 60 [IO wait]:
net.runtime_pollWait(0x7fb709519a40, 0x72, 0x0)
  /usr/lib/go/src/pkg/runtime/netpoll.goc:146 +0x66
net.(*pollDesc).Wait(0xc208108a70, 0x72, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:84 +0x46
net.(*pollDesc).WaitRead(0xc208108a70, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/fd_poll_runtime.go:89 +0x42
net.(*netFD).Read(0xc208108a10, 0xc208064800, 0x400, 0x400, 0x0, 0x7fb7095182b8, 0xb)
  /usr/lib/go/src/pkg/net/fd_unix.go:242 +0x34c
net.(*conn).Read(0xc208032158, 0xc208064800, 0x400, 0x400, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/net/net.go:122 +0xe7
crypto/tls.(*block).readFromUntil(0xc208159950, 0x7fb709520bf0, 0xc208032158, 0x5, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:451 +0xd9
crypto/tls.(*Conn).readRecord(0xc208075b80, 0x17, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:536 +0x1ff
crypto/tls.(*Conn).Read(0xc208075b80, 0xc20811a000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
  /usr/lib/go/src/pkg/crypto/tls/conn.go:901 +0x16a
bufio.(*Reader).fill(0xc2080e55c0)
  /usr/lib/go/src/pkg/bufio/bufio.go:97 +0x1b3
bufio.(*Reader).Read(0xc2080e55c0, 0xc208156d00, 0x2, 0x8, 0x2, 0x0, 0x0)
  /usr/lib/go/src/pkg/bufio/bufio.go:175 +0x230
github.com/gorilla/websocket.(*Conn).readFull(0xc2080cc1e0, 0xc208156d00, 0x2, 0x8, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:542 +0xb0
github.com/gorilla/websocket.(*Conn).advanceFrame(0xc2080cc1e0, 0xc200000000, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:566 +0x162
github.com/gorilla/websocket.(*Conn).NextReader(0xc2080cc1e0, 0x7fb70952e128, 0x0, 0x0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/gorilla/websocket/conn.go:706 +0x77
github.com/lxc/lxd/lxd/migration.(*migrationFields).recv(0xc2081fd5c0, 0x7fb70952e128, 0xc2081589c0, 0x0, 0x0)
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:62 +0x43
github.com/lxc/lxd/lxd/migration.func·001()
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:115 +0xbb
created by github.com/lxc/lxd/lxd/migration.(*migrationFields).controlChannel
  /home/ubuntu/packages/go/src/github.com/lxc/lxd/lxd/migration/migrate.go:122 +0xa7

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>