### PR TITLE
Make it possible to force AppArmor off

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -434,7 +434,7 @@ func containerLXDLoad(d *Daemon, name string) (container, error) {
 //       we might be able to split this is up into c.Start().
 func (c *containerLXD) init() error {
 	templateConfBase := "ubuntu"
-	templateConfDir := os.Getenv("LXC_TEMPLATE_CONFIG")
+	templateConfDir := os.Getenv("LXD_LXC_TEMPLATE_CONFIG")
 	if templateConfDir == "" {
 		templateConfDir = "/usr/share/lxc/config"
 	}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -143,6 +143,11 @@ func run() error {
 			"fs not mounted. AppArmor disabled.")
 	}
 
+	if aaEnabled && os.Getenv("LXD_SECURITY_APPARMOR") == "false" {
+		aaEnabled = false
+		shared.Log.Warn("apparmor has been manually disabled")
+	}
+
 	/* Can we create devices? */
 	checkCanMknod()
 

--- a/specs/environment.md
+++ b/specs/environment.md
@@ -1,0 +1,19 @@
+# Introduction
+The LXD client and daemon respect some environment variables to adapt to
+the user's environment and to turn some advanced features on and off.
+
+# Common
+LXD\_DIR                        | The LXD data directory
+PATH                            | List of paths to look into when resolving binaries
+
+# Client environment variable
+Name                            | Description
+:---                            | :----
+EDITOR                          | What text editor to use
+VISUAL                          | What text editor to use (if EDITOR isn't set)
+
+# Server environment variable
+Name                            | Description
+:---                            | :----
+LXD\_SECURITY\_APPARMOR         | If set to "false", forces AppArmor off
+LXD\_LXC\_TEMPLATE\_CONFIG      | Path to the LXC template configuration directory


### PR DESCRIPTION
This is currently needed for Snappy until we figure out how to load all
the LXC profiles. This isn't a regression since Snappy never had
AppArmor support.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>