### PR TITLE
Move unused IsMountPoint to OS-specific util_linux.go

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -338,17 +338,6 @@ func ReadLastNLines(f *os.File, lines int) (string, error) {
 	return string(data), nil
 }
 
-func SetSize(fd int, width int, height int) (err error) {
-	var dimensions [4]uint16
-	dimensions[0] = uint16(height)
-	dimensions[1] = uint16(width)
-
-	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(&dimensions)), 0, 0, 0); err != 0 {
-		return err
-	}
-	return nil
-}
-
 func ReadDir(p string) ([]string, error) {
 	ents, err := ioutil.ReadDir(p)
 	if err != nil {

--- a/shared/util.go
+++ b/shared/util.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
-	"unsafe"
 )
 
 const SnapshotDelimiter = "/"

--- a/shared/util.go
+++ b/shared/util.go
@@ -92,20 +92,6 @@ func IsDir(name string) bool {
 	return stat.IsDir()
 }
 
-func IsMountPoint(name string) bool {
-	stat, err := os.Stat(name)
-	if err != nil {
-		return false
-	}
-
-	rootStat, err := os.Lstat(name + "/..")
-	if err != nil {
-		return false
-	}
-	// If the directory has the same device as parent, then it's not a mountpoint.
-	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev
-}
-
 // VarPath returns the provided path elements joined by a slash and
 // appended to the end of $LXD_DIR, which defaults to /var/lib/lxd.
 func VarPath(path ...string) string {

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -220,3 +220,14 @@ func IsMountPoint(name string) bool {
 	// If the directory has the same device as parent, then it's not a mountpoint.
 	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev
 }
+
+func SetSize(fd int, width int, height int) (err error) {
+	var dimensions [4]uint16
+	dimensions[0] = uint16(height)
+	dimensions[1] = uint16(width)
+
+	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, uintptr(fd), uintptr(syscall.TIOCSWINSZ), uintptr(unsafe.Pointer(&dimensions)), 0, 0, 0); err != 0 {
+		return err
+	}
+	return nil
+}

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"syscall"
+	"unsafe"
 
 	"github.com/chai2010/gettext-go/gettext"
 )

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -206,3 +206,17 @@ func GroupId(name string) (int, error) {
 
 	return int(C.int(result.gr_gid)), nil
 }
+
+func IsMountPoint(name string) bool {
+	stat, err := os.Stat(name)
+	if err != nil {
+		return false
+	}
+
+	rootStat, err := os.Lstat(name + "/..")
+	if err != nil {
+		return false
+	}
+	// If the directory has the same device as parent, then it's not a mountpoint.
+	return stat.Sys().(*syscall.Stat_t).Dev != rootStat.Sys().(*syscall.Stat_t).Dev
+}


### PR DESCRIPTION
This brings LXD client closer to be built on Windows (#825)

Signed-off-by: anatoly techtonik <techtonik@gmail.com>