### PR TITLE
delay check for subuids

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -560,6 +560,9 @@ func (c *containerLXD) init() error {
 	}
 
 	if !c.IsPrivileged() {
+		if c.daemon.IdmapSet == nil {
+			return fmt.Errorf("user has no subuids")
+		}
 		c.idmapset = c.daemon.IdmapSet // TODO - per-tenant idmaps
 	}
 

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -219,10 +219,6 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 func containersPost(d *Daemon, r *http.Request) Response {
 	shared.Debugf("Responding to container create")
 
-	if d.IdmapSet == nil {
-		return BadRequest(fmt.Errorf("shared's user has no subuids"))
-	}
-
 	req := containerPostReq{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		return BadRequest(err)


### PR DESCRIPTION
if we are creating a privileged container, we shouldn't fail
creation because of there being no subuids.  But we can't
easily know at the start of containers_post whether the container
is privileged.  So delay the check until we have the info, and
until we definately need it.

As a downside, an error message won't be seen until we've
downloaded the image.  To change that we'd have to do c.init()
before checking for and downloading the image.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>