### PR TITLE
Fix missing original idmap

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -377,6 +377,26 @@ func containerLXDCreateInternal(
 		return nil, err
 	}
 
+	idmap := c.IdmapSetGet()
+
+	var jsonIdmap string
+	if idmap != nil {
+		idmapBytes, err := json.Marshal(idmap.Idmap)
+		if err != nil {
+			c.Delete()
+			return nil, err
+		}
+		jsonIdmap = string(idmapBytes)
+	} else {
+		jsonIdmap = "[]"
+	}
+
+	err = c.ConfigKeySet("volatile.last_state.idmap", jsonIdmap)
+	if err != nil {
+		c.Delete()
+		return nil, err
+	}
+
 	return c, nil
 }
 


### PR DESCRIPTION
Without this, the following would end up with invalid permissions:
    lxc init ubuntu blah
    lxc config set blah security.privileged true
    lxc start blah

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>