### PR TITLE
2015 09 19/nest

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -509,7 +509,7 @@ func (c *containerLXD) init() error {
 		return err
 	}
 
-	if !c.IsPrivileged() {
+	if !c.IsPrivileged() || shared.RunningInUserNS() {
 		err = c.c.SetConfigItem("lxc.include", fmt.Sprintf("%s/%s.userns.conf", templateConfDir, templateConfBase))
 		if err != nil {
 			return err

--- a/shared/util.go
+++ b/shared/util.go
@@ -489,3 +489,25 @@ func DeepCopy(src, dest interface{}) error {
 
 	return nil
 }
+
+func RunningInUserNS() bool {
+	file, err := os.Open("/proc/self/uid_map")
+	if err != nil {
+		return false
+	}
+	defer file.Close()
+
+	buf := bufio.NewReader(file)
+	l, _, err := buf.ReadLine()
+	if err != nil {
+		return false
+	}
+
+	line := string(l)
+	var a, b, c int
+	fmt.Sscanf(line, "%d %d %d", &a, &b, &c)
+	if a == 0 && b == 0 && c == 4294967295 {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
This pair fixes the problems when starting privileged containers nested inside a container.  It probably also fixes some other problems.

The first problem was that we were making some decisions based on c.IsNesting and c.IsPrivileged before we had applied profiles and configuration to c.

The second was that we were only adding ubuntu.userns.conf for an unprivileged container, but we also need to do so when we are starting a nested container.