### PR TITLE
use http rather than https for ubuntu cloud images.

### DIFF
--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -334,8 +334,7 @@ class Ubuntu(Image):
     server = None
     stream = None
 
-    # FIXME: We should default to the released stream once available
-    def __init__(self, server="https://cloud-images.ubuntu.com",
+    def __init__(self, server="http://cloud-images.ubuntu.com",
                  stream="releases",
                  gpgkey="7FF3F408476CF100"):
 


### PR DESCRIPTION
using http by default means benefit of caching proxies.

Also here, remove FIXME comment that is now fixed.