### PR TITLE
config: allow '-' argument to set value from stdin

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -95,6 +95,15 @@ func doSet(config *lxd.Config, args []string) error {
 
 	key := args[2]
 	value := args[3]
+
+	if value == "-" {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("Can't read from stdin: %u", err)
+		}
+		value = string(buf[:])
+	}
+
 	return d.SetContainerConfig(container, key, value)
 }
 

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -99,7 +99,7 @@ func doSet(config *lxd.Config, args []string) error {
 	if value == "-" {
 		buf, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return fmt.Errorf("Can't read from stdin: %u", err)
+			return fmt.Errorf("Can't read from stdin: %s", err)
 		}
 		value = string(buf[:])
 	}

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -321,7 +321,7 @@ func doProfileSet(client *lxd.Client, p string, args []string) error {
 	if value == "-" {
 		buf, err := ioutil.ReadAll(os.Stdin)
 		if err != nil {
-			return fmt.Errorf("Can't read from stdin: %u", err)
+			return fmt.Errorf("Can't read from stdin: %s", err)
 		}
 		value = string(buf[:])
 	}

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -317,6 +317,15 @@ func doProfileSet(client *lxd.Client, p string, args []string) error {
 	} else {
 		value = args[1]
 	}
+
+	if value == "-" {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("Can't read from stdin: %u", err)
+		}
+		value = string(buf[:])
+	}
+
 	err := client.SetProfileConfigItem(p, key, value)
 	return err
 }

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -16,6 +16,15 @@ test_config_profiles() {
     false
   fi
 
+  lxc profile create stdintest
+  echo "BADCONF" | lxc profile set stdintest user.user_data -
+  lxc profile show stdintest | grep BADCONF
+  lxc profile delete stdintest
+
+  echo "BADCONF" | lxc config set foo user.user_data -
+  lxc config show foo | grep BADCONF
+  lxc config unset foo user.user_data
+
   lxc config device add foo home disk source=/mnt path=/mnt readonly=true
   lxc profile create onenic
   lxc profile device add onenic eth0 nic nictype=bridged parent=lxcbr0


### PR DESCRIPTION
for profile set and config set, a value of '-' results in reading from
stdin for the real value.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>