### PR TITLE
tests: Don't chown stdin when it's not a tty

### DIFF
--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -144,7 +144,7 @@ test_basic_usage() {
   lxc exec foo -- /bin/rm -f root/in1
 
   # make sure stdin is chowned to our container root uid (Issue #590)
-  lxc exec foo -- chown 1000:1000 /proc/self/fd/0
+  [ -t 0 ] && lxc exec foo -- chown 1000:1000 /proc/self/fd/0
 
   echo foo | lxc exec foo tee /tmp/foo
 


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>