### PR TITLE
Last couple of 0.19 features

### DIFF
--- a/client.go
+++ b/client.go
@@ -559,7 +559,7 @@ func (c *Client) CopyImage(image string, dest *Client, copy_aliases bool, aliase
 		"server":      c.BaseURL,
 		"fingerprint": fingerprint}
 
-	if info.Public == 0 {
+	if !shared.InterfaceToBool(info.Public) {
 		var operation string
 
 		resp, err := c.post("images/"+fingerprint+"/secret", nil, Async)
@@ -889,8 +889,11 @@ func (c *Client) GetImageInfo(image string) (*shared.ImageInfo, error) {
 	return &info, nil
 }
 
-func (c *Client) PutImageProperties(name string, p shared.ImageProperties) error {
-	body := shared.Jmap{"properties": p}
+func (c *Client) PutImageInfo(name string, p shared.BriefImageInfo) error {
+	body := shared.Jmap{}
+	body["public"] = p.Public
+	body["properties"] = p.Properties
+
 	_, err := c.put(fmt.Sprintf("images/%s", name), body, Sync)
 	return err
 }
@@ -1088,7 +1091,7 @@ func (c *Client) Init(name string, imgremote string, image string, profiles *[]s
 			return nil, fmt.Errorf(gettext.Gettext("The image architecture is incompatible with the target server"))
 		}
 
-		if imageinfo.Public == 0 {
+		if !shared.InterfaceToBool(imageinfo.Public) {
 			resp, err := tmpremote.post("images/"+fingerprint+"/secret", nil, Async)
 			if err != nil {
 				return nil, err

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -213,7 +213,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		}
 		fmt.Printf(gettext.Gettext("Fingerprint: %s")+"\n", info.Fingerprint)
 		public := gettext.Gettext("no")
-		if info.Public == 1 {
+		if shared.InterfaceToBool(info) {
 			public = gettext.Gettext("yes")
 		}
 		fmt.Printf(gettext.Gettext("Size: %.2vMB")+"\n", float64(info.Size)/1024.0/1024.0)
@@ -329,12 +329,12 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 				return err
 			}
 
-			newdata := shared.ImageProperties{}
+			newdata := shared.BriefImageInfo{}
 			err = yaml.Unmarshal(contents, &newdata)
 			if err != nil {
 				return err
 			}
-			return d.PutImageProperties(image, newdata)
+			return d.PutImageInfo(image, newdata)
 		}
 
 		info, err := d.GetImageInfo(image)
@@ -342,7 +342,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		properties := info.Properties
+		properties := info.BriefInfo()
 		editor := os.Getenv("VISUAL")
 		if editor == "" {
 			editor = os.Getenv("EDITOR")
@@ -380,7 +380,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			if err != nil {
 				return err
 			}
-			newdata := shared.ImageProperties{}
+			newdata := shared.BriefImageInfo{}
 			err = yaml.Unmarshal(contents, &newdata)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, gettext.Gettext("YAML parse error %v")+"\n", err)
@@ -392,7 +392,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 
 				continue
 			}
-			err = d.PutImageProperties(image, newdata)
+			err = d.PutImageInfo(image, newdata)
 			break
 		}
 
@@ -447,7 +447,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
-		properties := info.Properties
+		properties := info.BriefInfo()
 
 		data, err := yaml.Marshal(&properties)
 		fmt.Printf("%s", data)
@@ -500,7 +500,7 @@ func showImages(images []shared.ImageInfo) error {
 		fp := image.Fingerprint[0:12]
 		public := gettext.Gettext("no")
 		description := findDescription(image.Properties)
-		if image.Public == 1 {
+		if shared.InterfaceToBool(image.Public) {
 			public = gettext.Gettext("yes")
 		}
 		const layout = "Jan 2, 2006 at 3:04pm (MST)"

--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -22,6 +22,7 @@ import uuid
 
 _ = gettext.gettext
 gettext.textdomain("lxd")
+quiet = False
 
 
 class FriendlyParser(argparse.ArgumentParser):
@@ -29,6 +30,11 @@ class FriendlyParser(argparse.ArgumentParser):
         sys.stderr.write('error: %s\n' % message)
         self.print_help()
         sys.exit(2)
+
+
+def msg(content, end=None):
+    if not quiet:
+        print(content, end=end)
 
 
 def find_on_path(command):
@@ -52,7 +58,7 @@ def report_download(blocks_read, block_size, total_size):
     if percent > 100:
         return
 
-    print(_("Progress: %.0f %%") % percent, end='\r')
+    msg(_("Progress: %.0f %%") % percent, end='\r')
 
 
 def local_architecture():
@@ -123,15 +129,29 @@ class LXD(object):
         return [alias.split("/1.0/images/aliases/")[-1]
                 for alias in data['metadata']]
 
-    def images_list(self):
-        status, data = self.rest_call("/1.0/images")
+    def images_remove(self, name):
+        status, data = self.rest_call("/1.0/images/%s" % name,
+                                      method="DELETE")
 
-        return [image.split("/1.0/images/")[-1] for image in data['metadata']]
+        if status != 200:
+            raise Exception("Failed to remove alias: %s" % name)
 
-    def images_upload(self, path, filename, public):
+    def images_list(self, recursive=False):
+        if recursive:
+            status, data = self.rest_call("/1.0/images?recursion=1")
+            return data['metadata']
+        else:
+            status, data = self.rest_call("/1.0/images")
+            return [image.split("/1.0/images/")[-1]
+                    for image in data['metadata']]
+
+    def images_upload(self, path, filename, public, sync=False):
         headers = {}
         if public:
             headers['X-LXD-public'] = "1"
+
+        if sync:
+            headers['X-LXD-properties'] = "lxd-images.sync=%s" % sync
 
         if isinstance(path, str):
             headers['Content-Type'] = "application/octet-stream"
@@ -179,7 +199,7 @@ class Image(object):
     """ Class for reuse of various functionality """
 
     def gpg_update(self):
-        print(_("Downloading the GPG key for %s" % self.server))
+        msg(_("Downloading the GPG key for %s" % self.server))
         gpg_environ = dict(os.environ)
         gpg_environ["GNUPGHOME"] = self.gpgdir
 
@@ -195,7 +215,7 @@ class Image(object):
             raise Exception("Failed to retrieve the GPG key")
 
     def gpg_verify(self, path):
-        print(_("Validating the GPG signature of %s" % path))
+        msg(_("Validating the GPG signature of %s" % path))
         gpg_environ = dict(os.environ)
         gpg_environ["GNUPGHOME"] = self.gpgdir
 
@@ -355,7 +375,7 @@ class Ubuntu(Image):
         if self.workdir:
             shutil.rmtree(self.workdir)
 
-    def image_download(self, release=None, architecture=None, version=None):
+    def image_lookup(self, release=None, architecture=None, version=None):
         if not release:
             release = "trusty"
 
@@ -412,12 +432,15 @@ class Ubuntu(Image):
         if not image:
             raise Exception("The requested image doesn't exist.")
 
-        print(_("Downloading the image."))
+        return image
+
+    def image_download(self, image):
+        msg(_("Downloading the image."))
         try:
-            print(_("Image manifest: %s") % "%s/%s" %
-                  (self.server, image['items']['manifest']['path']))
+            msg(_("Image manifest: %s") % "%s/%s" %
+                (self.server, image['items']['manifest']['path']))
         except KeyError:
-            print(_("No image manifest provided."))
+            msg(_("No image manifest provided."))
 
         def download_and_verify(file_to_download, prefix, pubname):
             """
@@ -465,14 +488,14 @@ if __name__ == "__main__":
         sys.exit(1)
     lxd = LXD(lxd_socket)
 
-    def setup_alias(parser, args, fingerprint):
+    def setup_alias(aliases, fingerprint):
         existing = lxd.aliases_list()
 
-        for alias in args.alias:
+        for alias in aliases:
             if alias in existing:
                 lxd.aliases_remove(alias)
             lxd.aliases_create(alias, fingerprint)
-            print(_("Setup alias: %s" % alias))
+            msg(_("Setup alias: %s" % alias))
 
     def import_busybox(parser, args):
         busybox = Busybox()
@@ -490,7 +513,7 @@ if __name__ == "__main__":
 
             r = lxd.images_upload((meta_path, rootfs_path),
                                   meta_path.split("/")[-1], args.public)
-            print(_("Image imported as: %s" % r['fingerprint']))
+            msg(_("Image imported as: %s" % r['fingerprint']))
         else:
             path = busybox.create_tarball()
 
@@ -501,30 +524,103 @@ if __name__ == "__main__":
                 parser.exit(1, _("This image is already in the store.\n"))
 
             r = lxd.images_upload(path, path.split("/")[-1], args.public)
-            print(_("Image imported as: %s" % r['fingerprint']))
+            msg(_("Image imported as: %s" % r['fingerprint']))
 
-        setup_alias(parser, args, fingerprint)
+        setup_alias(args.alias, fingerprint)
 
     def import_ubuntu(parser, args):
         ubuntu = Ubuntu(stream=args.stream)
 
-        meta_path, rootfs_path = ubuntu.image_download(args.release,
-                                                       args.architecture,
-                                                       args.version)
+        sync = False
+        if args.sync:
+            sync = "ubuntu:%s:%s:%s" % (args.stream, args.release,
+                                        args.architecture)
 
-        with open(meta_path, "rb") as meta_fd:
-            with open(rootfs_path, "rb") as rootfs_fd:
-                fingerprint = hashlib.sha256(meta_fd.read() +
-                                             rootfs_fd.read()).hexdigest()
+        image = ubuntu.image_lookup(args.release, args.architecture,
+                                    args.version)
+
+        fingerprint = \
+            image['items']['lxd.tar.xz']['combined_sha256'].split(" ")[0]
 
         if fingerprint in lxd.images_list():
-            parser.exit(1, _("This image is already in the store.\n"))
+            msg(_("Image already in the store, only setting up aliases."))
+            setup_alias(args.alias, fingerprint)
+            return
+
+        meta_path, rootfs_path = ubuntu.image_download(image)
 
         r = lxd.images_upload((meta_path, rootfs_path),
-                              meta_path.split("/")[-1], args.public)
-        print(_("Image imported as: %s" % r['fingerprint']))
+                              meta_path.split("/")[-1], args.public, sync)
 
-        setup_alias(parser, args, fingerprint)
+        msg(_("Image imported as: %s" % r['fingerprint']))
+
+        setup_alias(args.alias, fingerprint)
+
+    def sync(parser, args):
+        # Look for images that have been marked for syncing
+        for image in lxd.images_list(recursive=True):
+            if "lxd-images.sync" not in image['properties']:
+                continue
+
+            # Get the main image properties
+            image_hash = image['fingerprint']
+            image_public = image['public']
+            image_source = image['properties']['lxd-images.sync']
+            image_aliases = [alias['target'] for alias in image['aliases']]
+
+            # Extract the serialized lxd-images config
+            source_parts = image_source.split(":")
+            if not source_parts:
+                continue
+
+            # Only Ubuntu is supported right now
+            if source_parts[0] != "ubuntu":
+                continue
+
+            # Extract the serialized fields
+            if len(source_parts) != 4:
+                continue
+
+            source_stream, source_series, \
+                source_arch = source_parts[1:]
+
+            # Deal with cases where the user didn't provide a series or arch
+            if source_series == "None":
+                source_series = None
+
+            if source_arch == "None":
+                source_arch = None
+
+            # Look for a new image
+            ubuntu = Ubuntu(stream=source_stream)
+
+            try:
+                new_image = ubuntu.image_lookup(source_series, source_arch)
+            except:
+                msg(_("The latest image for \"%s\" couldn't be found.")
+                    % image_source)
+                continue
+
+            new_image_hash = \
+                new_image['items']['lxd.tar.xz']['combined_sha256'] \
+                .split(" ")[0]
+
+            if new_image_hash == image_hash:
+                continue
+
+            if new_image_hash in lxd.images_list():
+                continue
+
+            # Download the new image
+            meta_path, rootfs_path = ubuntu.image_download(new_image)
+
+            r = lxd.images_upload((meta_path, rootfs_path),
+                                  meta_path.split("/")[-1], image_public,
+                                  image_source)
+
+            lxd.images_remove(image_hash)
+            setup_alias(image_aliases, r['fingerprint'])
+            msg("Updated %s to %s" % (image_source, r['fingerprint']))
 
     parser = FriendlyParser(
         description=_("LXD: image store helper"),
@@ -535,7 +631,17 @@ if __name__ == "__main__":
 
  To import a basic busybox image:
     %s import busybox --alias busybox
-""" % (sys.argv[0], sys.argv[0])))
+
+
+ Some images can be kept in sync for you, use --sync for that:
+    %s import ubuntu --alias ubuntu --sync
+
+ Then make sure the following command is executed regularly (e.g. crontab):
+    %s sync
+""" % (sys.argv[0], sys.argv[0], sys.argv[0], sys.argv[0])))
+
+    parser.add_argument("--quiet", action="store_true",
+                        default=False, help=_("Silence all non-error output"))
 
     parser_subparsers = parser.add_subparsers(dest="action")
     parser_subparsers.required = True
@@ -576,10 +682,22 @@ if __name__ == "__main__":
     parser_import_ubuntu.add_argument("--public", action="store_true",
                                       default=False,
                                       help=_("Make the image public"))
+    parser_import_ubuntu.add_argument("--sync", action="store_true",
+                                      default=False,
+                                      help=_("Keep this image up to date"))
     parser_import_ubuntu.set_defaults(func=import_ubuntu)
+
+    # Image sync
+    parser_import = parser_subparsers.add_parser(
+        "sync", help=_("Sync images"))
+    parser_import.set_defaults(func=sync)
 
     # Call the function
     args = parser.parse_args()
+
+    if args.quiet:
+        quiet = True
+
     try:
         args.func(parser, args)
     except Exception as e:

--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -620,7 +620,7 @@ if __name__ == "__main__":
 
             lxd.images_remove(image_hash)
             setup_alias(image_aliases, r['fingerprint'])
-            msg("Updated %s to %s" % (image_source, r['fingerprint']))
+            msg(_("Updated %s to %s") % (image_source, r['fingerprint']))
 
     parser = FriendlyParser(
         description=_("LXD: image store helper"),

--- a/shared/image.go
+++ b/shared/image.go
@@ -15,11 +15,27 @@ type ImageInfo struct {
 	Fingerprint  string            `json:"fingerprint"`
 	Filename     string            `json:"filename"`
 	Properties   map[string]string `json:"properties"`
-	Public       int               `json:"public"`
+	Public       interface{}       `json:"public"`
 	Size         int64             `json:"size"`
 	CreationDate int64             `json:"created_at"`
 	ExpiryDate   int64             `json:"expires_at"`
 	UploadDate   int64             `json:"uploaded_at"`
+}
+
+/*
+ * BriefImageInfo contains a subset of the fields in
+ * ImageInfo, namely those which a user may update
+ */
+type BriefImageInfo struct {
+	Properties map[string]string `json:"properties"`
+	Public     interface{}       `json:"public"`
+}
+
+func (i *ImageInfo) BriefInfo() BriefImageInfo {
+	retstate := BriefImageInfo{
+		Properties: i.Properties,
+		Public:     i.Public}
+	return retstate
 }
 
 type ImageBaseInfo struct {
@@ -27,7 +43,7 @@ type ImageBaseInfo struct {
 	Fingerprint  string
 	Filename     string
 	Size         int64
-	Public       int
+	Public       interface{}
 	Architecture int
 	CreationDate int64
 	ExpiryDate   int64

--- a/shared/util.go
+++ b/shared/util.go
@@ -541,3 +541,18 @@ func ValidHostname(name string) bool {
 
 	return true
 }
+
+func InterfaceToBool(value interface{}) bool {
+	switch t := value.(type) {
+	case bool:
+		return t
+	case float32:
+		return t == 1
+	case float64:
+		return t == 1
+	case int:
+		return t == 1
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
This does the following:
 - Introduce new --quiet global switch
   When passed, all non-error output will be hidden.

 - Introduce new --sync ubuntu importer switch
   When passed, an image property will be set, this property is what the
   sync command looks for.

 - Introduce new "sync" command
   This command will look for any image which was imported with --sync,
   check if a newer version of the image is available and if so, update the
   image to it.

 - Drops redundant image hashing
   Instead of locally hashing the downloaded files, just forward the
   fingerprint that's available in the simplestream data.

 - Improves pre-existing image detection
   When importing an Ubuntu image that's already in the store, no
   download will occur, instead, any extra alias passed on the command line
   will be set.

Closes #1161

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>