### PR TITLE
Add needed apparmor permissions for nesting

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -42,6 +42,10 @@ const NESTING_AA_PROFILE = `
   mount,
   mount options=bind /var/lib/lxd/shmounts/** -> /var/lib/lxd/**,
   change_profile -> lxc-container-default,
+  # lxc-container-default-with-nesting also inherited these
+  # from start-container, and seems to need them.
+  ptrace,
+  signal,
 `
 
 const DEFAULT_AA_PROFILE = `


### PR DESCRIPTION
In order to attach to a container (nested), we need 'ptrace'.

In order for lxc-stop to work, we need 'signal'.

The stock lxc nesting profile provides these by inheriting them
from the 'start-container' profile.  We hadn't added them to the
apparmor code for containers with security.nesting=1.  Add them.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>