### PR TITLE
Start container storage before publish

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1257,6 +1257,11 @@ func (c *containerLXD) ExportToTar(snap string, w io.Writer) error {
 		return fmt.Errorf("Cannot export a running container as image")
 	}
 
+	if err := c.StorageStart(); err != nil {
+		return err
+	}
+	defer c.StorageStop()
+
 	idmap, err := c.LastIdmapSetGet()
 	if err != nil {
 		return err

--- a/test/suites/lvm.sh
+++ b/test/suites/lvm.sh
@@ -225,6 +225,9 @@ test_lvm_withpool() {
     lvs ${VGNAME}/test--container-superchill || die "superchill should exist"
     lvs ${VGNAME}/test--container-chillbro && die "chillbro should not exist"
 
+    lxc publish test-container || die "Couldn't publish test-container"
+    lxc publish test-container/unchillbro || die "Couldn't publish snapshot"
+
     # TODO busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:
     # lxc start test-container || die "Couldn't re-start test-container"


### PR DESCRIPTION
Fixes publishing LVM-backed snaps and containers.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>