### PR TITLE
tests: Don't fail on kernel race conditions

### DIFF
--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -140,7 +140,7 @@ test_basic_usage() {
   lxc start foo
   mac2=$(lxc exec foo cat /sys/class/net/eth0/address)
 
-  if [ "${mac1}" != "${mac2}" ]; then
+  if [ -n "${mac1}" ] && [ -n "${mac2}" ] && [ "${mac1}" != "${mac2}" ]; then
     echo "==> MAC addresses didn't match across restarts (${mac1} vs ${mac2})"
     false
   fi


### PR DESCRIPTION
On some systems it seems to be possible to run into a case where the MAC
address of a device isn't actually set for a while.

This is likely a kernel issue as a veth pair device should always have a
MAC, but it's shown up a few times, especially in the Ubuntu CI lab and
is annoying, so let's ignore that case since it's clearly not a LXD bug.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>