### PR TITLE
scripts: Don't attempt to delete nonexistent file

### DIFF
--- a/scripts/lxd-setup-lvm-storage
+++ b/scripts/lxd-setup-lvm-storage
@@ -160,7 +160,8 @@ def destroy_image(args, lxd):
     print("Detaching loop device {}".format(pvname))
     check_output("losetup -d {}".format(pvname), shell=True)
     print("Deleting backing file {}".format(imgfname))
-    check_output("rm {}".format(imgfname), shell=True)
+    if os.path.exists(imgfname):
+        check_output("rm '{}'".format(imgfname), shell=True)
 
         
 def do_main():


### PR DESCRIPTION
Fixes a minor annoying message that can happen when repeatedly using the script to set up and tear down storage, and occasionally forgetting to clear out all images, causing the script to bail halfway at first.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>