### PR TITLE
zfs: Force an unmount ahead of destroy

### DIFF
--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -578,6 +578,19 @@ func (s *storageZfs) zfsCreate(path string) error {
 }
 
 func (s *storageZfs) zfsDestroy(path string) error {
+	mountpoint, err := s.zfsGet(path, "mountpoint")
+	if err != nil {
+		return err
+	}
+
+	if mountpoint != "none" {
+		output, err := exec.Command("umount", "-l", mountpoint).CombinedOutput()
+		if err != nil {
+			s.log.Error("umount failed", log.Ctx{"output": string(output)})
+			return err
+		}
+	}
+
 	output, err := exec.Command(
 		"zfs",
 		"destroy",


### PR DESCRIPTION
It looks like in some cases we have a stopped container that still holds
some fs reference in the kernel, causing some problems at destroy time.
So let's do a lazy unmount ahead of time which seems to help the kernel
clean things up, making zfs succeed.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>