### PR TITLE
Implement unix char and block devices.

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -191,6 +192,8 @@ type container interface {
 
 	DetachMount(m shared.Device) error
 	AttachMount(m shared.Device) error
+	AttachUnixDev(dev shared.Device) error
+	DetachUnixDev(dev shared.Device) error
 }
 
 func containerLXDCreateAsEmpty(d *Daemon, name string,
@@ -594,11 +597,6 @@ func (c *containerLXD) init() error {
 		c.devices[k] = v
 	}
 
-	/* now add the lxc.* entries for the configured devices */
-	if err := c.applyDevices(); err != nil {
-		return err
-	}
-
 	if !c.IsPrivileged() {
 		if c.daemon.IdmapSet == nil {
 			return fmt.Errorf("LXD doesn't have a uid/gid allocation. In this mode, only privileged containers are supported.")
@@ -642,6 +640,146 @@ func (c *containerLXD) RenderState() (*shared.ContainerState, error) {
 	}, nil
 }
 
+func (c *containerLXD) insertMount(source, target, fstype string, flags int, options string) error {
+	pid := c.c.InitPid()
+	if pid == -1 { // container not running - we're done
+		return nil
+	}
+
+	// now live-mount
+	var tmpMount string
+	var err error
+	if shared.IsDir(source) {
+		tmpMount, err = ioutil.TempDir(shared.VarPath("shmounts", c.name), "lxdmount_")
+	} else {
+		f, err := ioutil.TempFile(shared.VarPath("shmounts", c.name), "lxdmount_")
+		if err == nil {
+			tmpMount = f.Name()
+			f.Close()
+		}
+	}
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Mount(source, tmpMount, fstype, uintptr(flags), "")
+	if err != nil {
+		return err
+	}
+
+	mntsrc := filepath.Join("/dev/.lxd-mounts", filepath.Base(tmpMount))
+	// finally we need to move-mount this in the container
+	pidstr := fmt.Sprintf("%d", pid)
+	err = exec.Command(os.Args[0], "forkmount", pidstr, mntsrc, target).Run()
+	syscall.Unmount(tmpMount, syscall.MNT_DETACH) // in case forkmount failed
+	os.Remove(tmpMount)
+
+	return nil
+}
+
+func (c *containerLXD) createUnixDevice(m shared.Device) (string, string, error) {
+	devname := m["path"]
+	if !filepath.IsAbs(devname) {
+		devname = filepath.Join("/", devname)
+	}
+
+	// target must be a relative path, so that lxc will DTRT
+	tgtname := m["path"]
+	for len(tgtname) > 0 && filepath.IsAbs(tgtname) {
+		tgtname = tgtname[1:]
+	}
+	if len(tgtname) == 0 {
+		return "", "", fmt.Errorf("Failed to interpret path: %s", devname)
+	}
+
+	var err error
+	var major, minor int
+	if m["major"] == "" && m["minor"] == "" {
+		major, minor, err = getDev(devname)
+		if err != nil {
+			return "", "", fmt.Errorf("Device does not exist: %s", devname)
+		}
+	} else if m["major"] == "" || m["minor"] == "" {
+		return "", "", fmt.Errorf("Both major and minor must be supplied for devices")
+	} else {
+		/* ok we have a major:minor and need to create it */
+		major, err = strconv.Atoi(m["major"])
+		if err != nil {
+			return "", "", fmt.Errorf("Bad major %s in device %s", m["major"], m["path"])
+		}
+		minor, err = strconv.Atoi(m["minor"])
+		if err != nil {
+			return "", "", fmt.Errorf("Bad minor %s in device %s", m["minor"], m["path"])
+		}
+	}
+
+	name := strings.Replace(m["path"], "/", "-", -1)
+	devpath := path.Join(c.PathGet(""), name)
+	fmt.Printf("c.PathGet is %s, m[name] %s, name %s, devpath %s\n", c.PathGet(""), m["path"], name, devpath)
+	fmt.Printf("m is %v\n", m)
+	mode := os.FileMode(0660)
+	if m["type"] == "unix-block" {
+		mode |= syscall.S_IFBLK
+	} else {
+		mode |= syscall.S_IFCHR
+	}
+
+	if m["mode"] != "" {
+		tmp, err := devModeOct(m["mode"])
+		if err != nil {
+			return "", "", fmt.Errorf("Bad mode %s in device %s", m["mode"], m["path"])
+		}
+		mode = os.FileMode(tmp)
+	}
+
+	os.Remove(devpath)
+	if err := syscall.Mknod(devpath, uint32(mode), minor|(major<<8)); err != nil {
+		if shared.PathExists(devname) {
+			return devname, tgtname, nil
+		}
+		return "", "", fmt.Errorf("Failed to create device %s for %s: %s", devpath, m["path"], err)
+	}
+
+	if err := c.idmapset.ShiftFile(devpath); err != nil {
+		// uidshift failing is weird, but not a big problem.  Log and proceed
+		shared.Debugf("Failed to uidshift device %s: %s\n", m["path"], err)
+	}
+
+	return devpath, tgtname, nil
+}
+
+func (c *containerLXD) setupUnixDev(m shared.Device) error {
+	source, target, err := c.createUnixDevice(m)
+	if err != nil {
+		return fmt.Errorf("Failed to setup device %s: %s", m["path"], err)
+	}
+
+	options, err := devGetOptions(m)
+	if err != nil {
+		return err
+	}
+
+	if c.c.Running() {
+		// TODO - insert mount from 'source' to 'target'
+		err := c.insertMount(source, target, "none", syscall.MS_BIND, options)
+		if err != nil {
+			return fmt.Errorf("Failed to add mount for device %s: %s", m["path"], err)
+		}
+
+		// add the new device cgroup rule
+		entry, err := deviceCgroupInfo(m)
+		if err != nil {
+			return fmt.Errorf("Failed to add cgroup rule for device %s: %s", m["path"], err)
+		}
+		if err := c.c.SetCgroupItem("devices.allow", entry); err != nil {
+			return fmt.Errorf("Failed to add cgroup rule %s for device %s: %s", entry, m["path"], err)
+		}
+	}
+
+	entry := fmt.Sprintf("%s %s none %s", source, target, options)
+	return c.c.SetConfigItem("lxc.mount.entry", entry)
+}
+
 func (c *containerLXD) Start() error {
 	if c.IsRunning() {
 		return fmt.Errorf("the container is already running")
@@ -666,6 +804,14 @@ func (c *containerLXD) Start() error {
 	}
 
 	if err := c.mountShared(); err != nil {
+		return err
+	}
+
+	/*
+	 * add the lxc.* entries for the configured devices,
+	 * and create if necessary
+	 */
+	if err := c.applyDevices(); err != nil {
 		return err
 	}
 
@@ -1484,29 +1630,7 @@ func (c *containerLXD) AttachMount(m shared.Device) error {
 		return err
 	}
 
-	pid := c.c.InitPid()
-	if pid == -1 { // container not running - we're done
-		return nil
-	}
-
-	// now live-mount
-	tmpMount, err := ioutil.TempDir(shared.VarPath("shmounts", c.name), "lxdmount_")
-	if err != nil {
-		return err
-	}
-
-	err = syscall.Mount(m["source"], tmpMount, fstype, uintptr(flags), "")
-	if err != nil {
-		return err
-	}
-
-	mntsrc := filepath.Join("/dev/.lxd-mounts", filepath.Base(tmpMount))
-	// finally we need to move-mount this in the container
-	pidstr := fmt.Sprintf("%d", pid)
-	err = exec.Command(os.Args[0], "forkmount", pidstr, mntsrc, m["path"]).Run()
-	syscall.Unmount(tmpMount, syscall.MNT_DETACH) // in case forkmount failed
-	os.Remove(tmpMount)
-
+	err = c.insertMount(m["source"], m["path"], fstype, flags, opts)
 	if err != nil && !optional {
 		return err
 	}
@@ -1786,6 +1910,11 @@ func (c *containerLXD) applyDevices() error {
 			err := setConfigItem(c, line[0], line[1])
 			if err != nil {
 				return fmt.Errorf("Failed configuring device %s: %s\n", name, err)
+			}
+		}
+		if d["type"] == "unix-block" || d["type"] == "unix-char" {
+			if err := c.setupUnixDev(d); err != nil {
+				return fmt.Errorf("Failed creating device %s: %s", d["name"], err)
 			}
 		}
 	}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -14,6 +16,8 @@ import (
 
 	"github.com/lxc/lxd/shared"
 	"gopkg.in/lxc/go-lxc.v2"
+
+	log "gopkg.in/inconshreveable/log15.v2"
 )
 
 func addBlockDev(dev string) ([]string, error) {
@@ -28,12 +32,117 @@ func addBlockDev(dev string) ([]string, error) {
 	return line, err
 }
 
+func devGetOptions(d shared.Device) (string, error) {
+	opts := []string{"bind", "create=file"}
+	if d["uid"] != "" {
+		u, err := strconv.Atoi(d["uid"])
+		if err != nil {
+			return "", err
+		}
+		opts = append(opts, fmt.Sprintf("uid=%d", u))
+	}
+	if d["gid"] != "" {
+		g, err := strconv.Atoi(d["gid"])
+		if err != nil {
+			return "", err
+		}
+		opts = append(opts, fmt.Sprintf("gid=%d", g))
+	}
+	if d["mode"] != "" {
+		m, err := devModeOct(d["mode"])
+		if err != nil {
+			return "", err
+		}
+		opts = append(opts, fmt.Sprintf("mode=%0d", m))
+	} else {
+		opts = append(opts, "mode=0660")
+	}
+
+	return strings.Join(opts, ","), nil
+}
+
+func devModeOct(strmode string) (int, error) {
+	// todo - parse strmode
+	return 0660, nil
+}
+
+func devModeString(strmode string) string {
+	// todo - parse strmode
+	return "rwm"
+}
+
+func getDev(path string) (int, int, error) {
+	stat := syscall.Stat_t{}
+	err := syscall.Stat(path, &stat)
+	if err != nil {
+		return 0, 0, err
+	}
+	major := int(stat.Rdev / 256)
+	minor := int(stat.Rdev % 256)
+	return major, minor, nil
+}
+
+func deviceCgroupInfo(dev shared.Device) (string, error) {
+	var err error
+
+	t := dev["type"]
+	switch t {
+	case "unix-char":
+		t = "c"
+	case "unix-block":
+		t = "b"
+	default: // internal error - look at how we were called
+		return "", fmt.Errorf("BUG: bad device type %s", dev["type"])
+	}
+
+	var major, minor int
+	if dev["major"] == "" && dev["minor"] == "" {
+		devname := dev["path"]
+		if !filepath.IsAbs(devname) {
+			devname = filepath.Join("/", devname)
+		}
+		major, minor, err = getDev(devname)
+		if err != nil {
+			return "", err
+		}
+	} else if dev["major"] != "" && dev["minor"] != "" {
+		major, err = strconv.Atoi(dev["major"])
+		if err != nil {
+			return "", err
+		}
+		minor, err = strconv.Atoi(dev["minor"])
+		if err != nil {
+			return "", err
+		}
+	} else {
+		return "", fmt.Errorf("Both major and minor must be supplied for devices")
+	}
+
+	devcg := fmt.Sprintf("%s %d:%d %s", t, major, minor, devModeString(dev["mode"]))
+	return devcg, nil
+}
+
+/*
+ * unixDevCgroup only grabs the cgroup devices.allow statement
+ * we need.  We'll add a mount.entry to bind mount the actual
+ * device later.
+ */
+func unixDevCgroup(dev shared.Device) ([][]string, error) {
+	devcg, err := deviceCgroupInfo(dev)
+	if err != nil {
+		return [][]string{}, err
+	}
+	entry := []string{"lxc.cgroup.devices.allow", devcg}
+	return [][]string{entry}, nil
+}
+
 func deviceToLxc(d shared.Device) ([][]string, error) {
 	switch d["type"] {
 	case "unix-char":
-		return nil, fmt.Errorf("Not implemented")
+		return unixDevCgroup(d)
 	case "unix-block":
-		return nil, fmt.Errorf("Not implemented")
+		return unixDevCgroup(d)
+
 	case "nic":
 		if d["nictype"] != "bridged" && d["nictype"] != "" {
 			return nil, fmt.Errorf("Bad nic type: %s\n", d["nictype"])
@@ -370,6 +479,33 @@ func txUpdateNic(tx *sql.Tx, cId int, devname string, nicname string) error {
 	return err
 }
 
+func (c *containerLXD) DetachUnixDev(dev shared.Device) error {
+	cginfo, err := deviceCgroupInfo(dev)
+	if err != nil {
+		return err
+	}
+	c.c.SetCgroupItem("devices.remove", cginfo)
+	pid := c.c.InitPid()
+	if pid == -1 { // container not running
+		return nil
+	}
+	pidstr := fmt.Sprintf("%d", pid)
+	if err := exec.Command(os.Args[0], "forkumount", pidstr, dev["path"]).Run(); err != nil {
+		shared.Log.Warn("Error unmounting device", log.Ctx{"Error": err})
+		return err
+	}
+	if err := os.Remove(fmt.Sprintf("/proc/%d/root/%s", pid, dev["path"])); err != nil {
+		shared.Log.Warn("Error removing device", log.Ctx{"Error": err})
+		return err
+	}
+
+	return nil
+}
+
+func (c *containerLXD) AttachUnixDev(dev shared.Device) error {
+	return c.setupUnixDev(dev)
+}
+
 /*
  * Given a running container and a list of devices before and after a
  * config change, update the devices in the container.
@@ -392,6 +528,10 @@ func devicesApplyDeltaLive(tx *sql.Tx, c container, preDevList shared.Devices, p
 			}
 		case "disk":
 			return c.DetachMount(dev)
+		case "unix-block":
+			return c.DetachUnixDev(dev)
+		case "unix-char":
+			return c.DetachUnixDev(dev)
 		}
 	}
 
@@ -418,6 +558,10 @@ func devicesApplyDeltaLive(tx *sql.Tx, c container, preDevList shared.Devices, p
 				return fmt.Errorf("no source or destination given")
 			}
 			return c.AttachMount(dev)
+		case "unix-block":
+			return c.AttachUnixDev(dev)
+		case "unix-char":
+			return c.AttachUnixDev(dev)
 		}
 	}
 

--- a/shared/devices.go
+++ b/shared/devices.go
@@ -74,6 +74,10 @@ func liveUpdateable(devtype string) bool {
 		return true
 	case "disk":
 		return true
+	case "unix-block":
+		return true
+	case "unix-char":
+		return true
 	default:
 		return false
 	}

--- a/shared/idmapset_linux.go
+++ b/shared/idmapset_linux.go
@@ -275,6 +275,10 @@ func (set *IdmapSet) UnshiftRootfs(p string) error {
 	return set.doUidshiftIntoContainer(p, false, "out")
 }
 
+func (set *IdmapSet) ShiftFile(p string) error {
+	return set.ShiftRootfs(p)
+}
+
 const (
 	minIDRange = 65536
 )

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -135,7 +135,7 @@ The currently supported device types and their properties are:
     - path (path relative to the container's root)
     - major (optional, if not specified, the same path on the host is mirrored)
     - minor (optional, if not specified, the same path on the host is mirrored)
-    - uid (optional, if not specified, defaults t0 0)
+    - uid (optional, if not specified, defaults to 0)
     - gid (optional, if not specified, defaults to 0)
     - mode (optional, if not specified, defaults to 0660)
 


### PR DESCRIPTION
Closes #1200
Closes #483

If we have the ability to mknod, then we create a device in the
containerdir and bind mount that into the container.  This allows
us to uidshift the device to the container root.  If we can not
mknod, then we try to bind mount the provided device pathname
from the host into the container.  This supports nested containers.

Create a helper for inserting a mount into a container, since
we need it both for adding disk and unix block/char devices.

Add a testcase.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>