### PR TITLE
Fix 1212

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -147,7 +147,7 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 		if err != nil {
 			c.StorageStop()
 			c.Delete()
-			return shared.OperationError(err)
+			return shared.OperationError(fmt.Errorf("Error transferring container data: %s", err))
 		}
 
 		defer c.StorageStop()

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -141,14 +141,16 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 
 		// Start the storage for this container (LVM mount/umount)
 		c.StorageStart()
-		defer c.StorageStop()
 
 		// And finaly run the migration.
 		err = sink()
 		if err != nil {
+			c.StorageStop()
 			c.Delete()
 			return shared.OperationError(err)
 		}
+
+		defer c.StorageStop()
 
 		err = c.TemplateApply("copy")
 		if err != nil {


### PR DESCRIPTION
This is a partial fix for #1212. 

The issue is that for LVM, container storage needs to be stopped before we can delete the container, or else it gives an error that the LV is busy.

However, in the context of #1212, there's a websocket error that's breaking the actual transfer, causing a retry somewhere, and this only fixes the cleanup from the error.