### PR TITLE
Start LVM storage at source before migration

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -174,6 +174,8 @@ func NewMigrationSource(c container) (shared.OperationWebsocket, error) {
 		if err != nil {
 			return nil, err
 		}
+	} else {
+		c.StorageStart()
 	}
 
 	return &ret, nil
@@ -228,6 +230,7 @@ func (s *migrationSourceWs) Do() shared.OperationResult {
 	criuType := CRIUType_CRIU_RSYNC.Enum()
 	if !s.live {
 		criuType = nil
+		defer s.container.StorageStop()
 	}
 
 	idmaps := make([]*IDMapType, 0)

--- a/lxd/rsync_test.go
+++ b/lxd/rsync_test.go
@@ -36,7 +36,7 @@ func TestRsyncSendRecv(t *testing.T) {
 	f.Write([]byte(helloWorld))
 	f.Close()
 
-	send, sendConn, err := rsyncSendSetup(shared.AddSlash(source))
+	send, sendConn, _, err := rsyncSendSetup(shared.AddSlash(source))
 	if err != nil {
 		t.Error(err)
 		return


### PR DESCRIPTION
Fixes #1212 

Also includes extra support for debugging rsync, but doesn't do anything verbose by default.