### PR TITLE
Reduce default LV size

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -16,7 +16,7 @@ import (
 
 var sysSyncfsTrapNum uintptr = 306
 
-var storageLvmDefaultThinLVSize = "100GiB"
+var storageLvmDefaultThinLVSize = "10GiB"
 var storageLvmDefaultThinPoolName = "LXDPool"
 
 func storageLVMCheckVolumeGroup(vgName string) error {


### PR DESCRIPTION
Greatly reduces amount of time it takes to mkfs for newly created LVs,
for images and copy targets.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>