### PR TITLE
Move GetFileStat into shared/util_linux.go

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -19,32 +19,10 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"syscall"
 )
 
 const SnapshotDelimiter = "/"
 const DefaultPort = "8443"
-
-func GetFileStat(p string) (uid int, gid int, major int, minor int,
-	inode uint64, nlink int, err error) {
-	var stat syscall.Stat_t
-	err = syscall.Lstat(p, &stat)
-	if err != nil {
-		return
-	}
-	uid = int(stat.Uid)
-	gid = int(stat.Gid)
-	inode = uint64(stat.Ino)
-	nlink = int(stat.Nlink)
-	major = -1
-	minor = -1
-	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
-		major = int(stat.Rdev / 256)
-		minor = int(stat.Rdev % 256)
-	}
-
-	return
-}
 
 // AddSlash adds a slash to the end of paths if they don't already have one.
 // This can be useful for rsyncing things, since rsync has behavior present on

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -13,6 +13,27 @@ import (
 	"github.com/chai2010/gettext-go/gettext"
 )
 
+func GetFileStat(p string) (uid int, gid int, major int, minor int,
+	inode uint64, nlink int, err error) {
+	var stat syscall.Stat_t
+	err = syscall.Lstat(p, &stat)
+	if err != nil {
+		return
+	}
+	uid = int(stat.Uid)
+	gid = int(stat.Gid)
+	inode = uint64(stat.Ino)
+	nlink = int(stat.Nlink)
+	major = -1
+	minor = -1
+	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
+		major = int(stat.Rdev / 256)
+		minor = int(stat.Rdev % 256)
+	}
+
+	return
+}
+
 // #cgo LDFLAGS: -lutil -lpthread
 /*
 #define _GNU_SOURCE

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -13,27 +13,6 @@ import (
 	"github.com/chai2010/gettext-go/gettext"
 )
 
-func GetFileStat(p string) (uid int, gid int, major int, minor int,
-	inode uint64, nlink int, err error) {
-	var stat syscall.Stat_t
-	err = syscall.Lstat(p, &stat)
-	if err != nil {
-		return
-	}
-	uid = int(stat.Uid)
-	gid = int(stat.Gid)
-	inode = uint64(stat.Ino)
-	nlink = int(stat.Nlink)
-	major = -1
-	minor = -1
-	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
-		major = int(stat.Rdev / 256)
-		minor = int(stat.Rdev % 256)
-	}
-
-	return
-}
-
 // #cgo LDFLAGS: -lutil -lpthread
 /*
 #define _GNU_SOURCE
@@ -309,6 +288,29 @@ func GroupId(name string) (int, error) {
 	}
 
 	return int(C.int(result.gr_gid)), nil
+}
+
+// --- pure Go functions ---
+
+func GetFileStat(p string) (uid int, gid int, major int, minor int,
+	inode uint64, nlink int, err error) {
+	var stat syscall.Stat_t
+	err = syscall.Lstat(p, &stat)
+	if err != nil {
+		return
+	}
+	uid = int(stat.Uid)
+	gid = int(stat.Gid)
+	inode = uint64(stat.Ino)
+	nlink = int(stat.Nlink)
+	major = -1
+	minor = -1
+	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
+		major = int(stat.Rdev / 256)
+		minor = int(stat.Rdev % 256)
+	}
+
+	return
 }
 
 func IsMountPoint(name string) bool {


### PR DESCRIPTION
This function is not available on Windows and is not used
in lxc client. After this is merged `go get ...` should work ok
on this platform (#825).

Signed-off-by: anatoly techtonik <techtonik@gmail.com>