### PR TITLE
nuke *Get postfix from orbit

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -238,7 +238,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 	opts.ClearEnv = true
 	opts.Env = []string{}
 
-	for k, v := range c.ConfigGet() {
+	for k, v := range c.Config() {
 		if strings.HasPrefix(k, "environment.") {
 			opts.Env = append(opts.Env, fmt.Sprintf("%s=%s", strings.TrimPrefix(k, "environment."), v))
 		}
@@ -256,7 +256,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 	if post.WaitForWS {
 		ws := &execWs{}
 		ws.fds = map[int]string{}
-		idmapset := c.IdmapSetGet()
+		idmapset := c.IdmapSet()
 		if idmapset != nil {
 			ws.rootUid, ws.rootGid = idmapset.ShiftIntoNs(0, 0)
 		}

--- a/lxd/container_file.go
+++ b/lxd/container_file.go
@@ -33,13 +33,13 @@ func containerFileHandler(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("container is not running"))
 	}
 
-	initPid := c.InitPidGet()
+	initPid := c.InitPID()
 
 	switch r.Method {
 	case "GET":
 		return containerFileGet(initPid, r, targetPath)
 	case "POST":
-		idmapset, err := c.LastIdmapSetGet()
+		idmapset, err := c.LastIdmapSet()
 		if err != nil {
 			return InternalError(err)
 		}

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -55,7 +55,7 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 			url := fmt.Sprintf("/%s/containers/%s/snapshots/%s", shared.APIVersion, cname, snapName)
 			resultString = append(resultString, url)
 		} else {
-			body := shared.Jmap{"name": snapName, "stateful": shared.PathExists(sc.StateDirGet())}
+			body := shared.Jmap{"name": snapName, "stateful": shared.PathExists(sc.StateDir())}
 			resultMap = append(resultMap, body)
 		}
 	}
@@ -139,15 +139,15 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		snapshotName
 
 	snapshot := func() error {
-		config := c.ConfigGet()
+		config := c.Config()
 		args := containerLXDArgs{
 			Ctype:        cTypeSnapshot,
 			Config:       config,
-			Profiles:     c.ProfilesGet(),
+			Profiles:     c.Profiles(),
 			Ephemeral:    c.IsEphemeral(),
 			BaseImage:    config["volatile.base_image"],
-			Architecture: c.ArchitectureGet(),
-			Devices:      c.DevicesGet(),
+			Architecture: c.Architecture(),
+			Devices:      c.Devices(),
 		}
 
 		_, err := containerLXDCreateAsSnapshot(d, fullName, args, c, stateful)
@@ -187,7 +187,7 @@ func snapshotHandler(d *Daemon, r *http.Request) Response {
 }
 
 func snapshotGet(sc container, name string) Response {
-	body := shared.Jmap{"name": name, "stateful": shared.PathExists(sc.StateDirGet())}
+	body := shared.Jmap{"name": name, "stateful": shared.PathExists(sc.StateDir())}
 	return SyncResponse(true, body)
 }
 

--- a/lxd/container_state.go
+++ b/lxd/container_state.go
@@ -10,7 +10,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func containerStateGet(d *Daemon, r *http.Request) Response {
+func containerState(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 	c, err := containerLXDLoad(d, name)
 	if err != nil {

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -14,7 +14,7 @@ func (suite *lxdTestSuite) TestContainer_ProfilesDefault() {
 	suite.Req.Nil(err)
 	defer c.Delete()
 
-	profiles := c.ProfilesGet()
+	profiles := c.Profiles()
 	suite.Len(
 		profiles,
 		1,
@@ -49,7 +49,7 @@ func (suite *lxdTestSuite) TestContainer_ProfilesMulti() {
 	suite.Req.Nil(err)
 	defer c.Delete()
 
-	profiles := c.ProfilesGet()
+	profiles := c.Profiles()
 	suite.Len(
 		profiles,
 		2,
@@ -110,7 +110,7 @@ func (suite *lxdTestSuite) TestContainer_LoadFromDB() {
 		"The loaded container isn't excactly the same as the created one.")
 }
 
-func (suite *lxdTestSuite) TestContainer_PathGet_Regular() {
+func (suite *lxdTestSuite) TestContainer_Path_Regular() {
 	// Regular
 	args := containerLXDArgs{
 		Ctype:     cTypeRegular,
@@ -122,11 +122,11 @@ func (suite *lxdTestSuite) TestContainer_PathGet_Regular() {
 	defer c.Delete()
 
 	suite.Req.False(c.IsSnapshot(), "Shouldn't be a snapshot.")
-	suite.Req.Equal(shared.VarPath("containers", "testFoo"), c.PathGet(""))
-	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.PathGet("testFoo2"))
+	suite.Req.Equal(shared.VarPath("containers", "testFoo"), c.Path(""))
+	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.Path("testFoo2"))
 }
 
-func (suite *lxdTestSuite) TestContainer_PathGet_Snapshot() {
+func (suite *lxdTestSuite) TestContainer_Path_Snapshot() {
 	// Snapshot
 	args := containerLXDArgs{
 		Ctype:     cTypeSnapshot,
@@ -140,13 +140,13 @@ func (suite *lxdTestSuite) TestContainer_PathGet_Snapshot() {
 	suite.Req.True(c.IsSnapshot(), "Should be a snapshot.")
 	suite.Req.Equal(
 		shared.VarPath("snapshots", "test", "snap0"),
-		c.PathGet(""))
+		c.Path(""))
 	suite.Req.Equal(
 		shared.VarPath("snapshots", "test", "snap1"),
-		c.PathGet("test/snap1"))
+		c.Path("test/snap1"))
 }
 
-func (suite *lxdTestSuite) TestContainer_LogPathGet() {
+func (suite *lxdTestSuite) TestContainer_LogPath() {
 	args := containerLXDArgs{
 		Ctype:     cTypeRegular,
 		Ephemeral: false,
@@ -156,7 +156,7 @@ func (suite *lxdTestSuite) TestContainer_LogPathGet() {
 	suite.Req.Nil(err)
 	defer c.Delete()
 
-	suite.Req.Equal(shared.VarPath("logs", "testFoo"), c.LogPathGet())
+	suite.Req.Equal(shared.VarPath("logs", "testFoo"), c.LogPath())
 }
 
 func (suite *lxdTestSuite) TestContainer_IsPrivileged_Privileged() {
@@ -200,5 +200,5 @@ func (suite *lxdTestSuite) TestContainer_Rename() {
 	defer c.Delete()
 
 	suite.Req.Nil(c.Rename("testFoo2"), "Failed to rename the container.")
-	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.PathGet(""))
+	suite.Req.Equal(shared.VarPath("containers", "testFoo2"), c.Path(""))
 }

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -107,7 +107,7 @@ var containerCmd = Command{
 
 var containerStateCmd = Command{
 	name: "containers/{name}/state",
-	get:  containerStateGet,
+	get:  containerState,
 	put:  containerStatePut,
 }
 
@@ -143,7 +143,7 @@ func containerWatchEphemeral(d *Daemon, c container) {
 		lxContainer.Wait(lxc.RUNNING, 1*time.Second)
 		lxContainer.Wait(lxc.STOPPED, -1*time.Second)
 
-		_, err := dbContainerIDGet(d.db, c.NameGet())
+		_, err := dbContainerID(d.db, c.Name())
 		if err != nil {
 			return
 		}
@@ -240,7 +240,7 @@ func containersShutdown(d *Daemon) error {
 			return err
 		}
 
-		err = c.ConfigKeySet("volatile.last_state.power", c.StateGet())
+		err = c.ConfigKeySet("volatile.last_state.power", c.State())
 
 		if err != nil {
 			return err

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -176,7 +176,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 		return SmartError(err)
 	}
 
-	sourceConfig := source.ConfigGet()
+	sourceConfig := source.Config()
 
 	if req.Config == nil {
 		req.Config = make(map[string]string)
@@ -192,7 +192,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 	}
 
 	if req.Profiles == nil {
-		req.Profiles = source.ProfilesGet()
+		req.Profiles = source.Profiles()
 	}
 
 	args := containerLXDArgs{

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -22,7 +22,7 @@ func dbContainerRemove(db *sql.DB, name string) error {
 	return err
 }
 
-func dbContainerIDGet(db *sql.DB, name string) (int, error) {
+func dbContainerID(db *sql.DB, name string) (int, error) {
 	q := "SELECT id FROM containers WHERE name=?"
 	id := -1
 	arg1 := []interface{}{name}
@@ -52,13 +52,13 @@ func dbContainerGet(db *sql.DB, name string) (*containerLXDArgs, error) {
 		args.Ephemeral = true
 	}
 
-	config, err := dbContainerConfigGet(db, args.ID)
+	config, err := dbContainerConfig(db, args.ID)
 	if err != nil {
 		return nil, err
 	}
 	args.Config = config
 
-	profiles, err := dbContainerProfilesGet(db, args.ID)
+	profiles, err := dbContainerProfiles(db, args.ID)
 	if err != nil {
 		return nil, err
 	}
@@ -66,7 +66,7 @@ func dbContainerGet(db *sql.DB, name string) (*containerLXDArgs, error) {
 
 	args.Devices = shared.Devices{}
 	/* get container_devices */
-	newdevs, err := dbDevicesGet(db, name, false)
+	newdevs, err := dbDevices(db, name, false)
 	if err != nil {
 		return nil, err
 	}
@@ -82,7 +82,7 @@ func dbContainerCreate(db *sql.DB, name string, args containerLXDArgs) (int, err
 		return 0, fmt.Errorf("Invalid container name")
 	}
 
-	id, err := dbContainerIDGet(db, name)
+	id, err := dbContainerID(db, name)
 	if err == nil {
 		return 0, DbErrAlreadyDefined
 	}
@@ -209,7 +209,7 @@ func dbContainerProfilesInsert(tx *sql.Tx, id int, profiles []string) error {
 }
 
 // Get a list of profiles for a given container id.
-func dbContainerProfilesGet(db *sql.DB, containerID int) ([]string, error) {
+func dbContainerProfiles(db *sql.DB, containerID int) ([]string, error) {
 	var name string
 	var profiles []string
 
@@ -235,8 +235,8 @@ func dbContainerProfilesGet(db *sql.DB, containerID int) ([]string, error) {
 	return profiles, nil
 }
 
-// dbContainerConfigGet gets the container configuration map from the DB
-func dbContainerConfigGet(db *sql.DB, containerID int) (map[string]string, error) {
+// dbContainerConfig gets the container configuration map from the DB
+func dbContainerConfig(db *sql.DB, containerID int) (map[string]string, error) {
 	var key, value string
 	q := `SELECT key, value FROM containers_config WHERE container_id=?`
 

--- a/lxd/db_devices.go
+++ b/lxd/db_devices.go
@@ -54,7 +54,7 @@ func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices shared.Devices) error
 	return nil
 }
 
-func dbDeviceConfigGet(db *sql.DB, id int, isprofile bool) (shared.Device, error) {
+func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (shared.Device, error) {
 	var query string
 	var key, value string
 	newdev := shared.Device{} // That's a map[string]string
@@ -82,7 +82,7 @@ func dbDeviceConfigGet(db *sql.DB, id int, isprofile bool) (shared.Device, error
 	return newdev, nil
 }
 
-func dbDevicesGet(db *sql.DB, qName string, isprofile bool) (shared.Devices, error) {
+func dbDevices(db *sql.DB, qName string, isprofile bool) (shared.Devices, error) {
 	var q string
 	if isprofile {
 		q = `SELECT profiles_devices.id, profiles_devices.name, profiles_devices.type
@@ -112,7 +112,7 @@ func dbDevicesGet(db *sql.DB, qName string, isprofile bool) (shared.Devices, err
 		if err != nil {
 			return nil, err
 		}
-		newdev, err := dbDeviceConfigGet(db, id, isprofile)
+		newdev, err := dbDeviceConfig(db, id, isprofile)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -9,7 +9,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func dbProfileIDGet(db *sql.DB, profile string) (int64, error) {
+func dbProfileID(db *sql.DB, profile string) (int64, error) {
 	id := int64(-1)
 
 	rows, err := dbQuery(db, "SELECT id FROM profiles WHERE name=?", profile)
@@ -27,8 +27,8 @@ func dbProfileIDGet(db *sql.DB, profile string) (int64, error) {
 	return id, nil
 }
 
-// dbProfilesGet returns a string list of profiles.
-func dbProfilesGet(db *sql.DB) ([]string, error) {
+// dbProfiles returns a string list of profiles.
+func dbProfiles(db *sql.DB) ([]string, error) {
 	q := fmt.Sprintf("SELECT name FROM profiles")
 	inargs := []interface{}{}
 	var name string
@@ -85,7 +85,7 @@ func dbProfileCreate(db *sql.DB, profile string, config map[string]string,
 }
 
 func dbProfileCreateDefault(db *sql.DB) error {
-	id, err := dbProfileIDGet(db, "default")
+	id, err := dbProfileID(db, "default")
 	if err != nil {
 		return err
 	}
@@ -110,7 +110,7 @@ func dbProfileCreateDefault(db *sql.DB) error {
 }
 
 func dbProfileCreateMigratable(db *sql.DB) error {
-	id, err := dbProfileIDGet(db, "migratable")
+	id, err := dbProfileID(db, "migratable")
 	if err != nil {
 		return err
 	}
@@ -132,7 +132,7 @@ lxc.seccomp =`,
 }
 
 // Get the profile configuration map from the DB
-func dbProfileConfigGet(db *sql.DB, name string) (map[string]string, error) {
+func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 	var key, value string
 	query := `
         SELECT

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -497,7 +497,7 @@ func Test_dbImageAliasAdd(t *testing.T) {
 	}
 }
 
-func Test_dbContainerConfigGet(t *testing.T) {
+func Test_dbContainerConfig(t *testing.T) {
 	var db *sql.DB
 	var err error
 	var result map[string]string
@@ -508,7 +508,7 @@ func Test_dbContainerConfigGet(t *testing.T) {
 
 	_, err = db.Exec("INSERT INTO containers_config (container_id, key, value) VALUES (1, 'something', 'something else');")
 
-	result, err = dbContainerConfigGet(db, 1)
+	result, err = dbContainerConfig(db, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -522,7 +522,7 @@ func Test_dbContainerConfigGet(t *testing.T) {
 	}
 }
 
-func Test_dbProfileConfigGet(t *testing.T) {
+func Test_dbProfileConfig(t *testing.T) {
 	var db *sql.DB
 	var err error
 	var result map[string]string
@@ -533,7 +533,7 @@ func Test_dbProfileConfigGet(t *testing.T) {
 
 	_, err = db.Exec("INSERT INTO profiles_config (profile_id, key, value) VALUES (3, 'something', 'something else');")
 
-	result, err = dbProfileConfigGet(db, "theprofile")
+	result, err = dbProfileConfig(db, "theprofile")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func Test_dbProfileConfigGet(t *testing.T) {
 	}
 }
 
-func Test_dbContainerProfilesGet(t *testing.T) {
+func Test_dbContainerProfiles(t *testing.T) {
 	var db *sql.DB
 	var err error
 	var result []string
@@ -557,7 +557,7 @@ func Test_dbContainerProfilesGet(t *testing.T) {
 	defer db.Close()
 
 	expected = []string{"theprofile"}
-	result, err = dbContainerProfilesGet(db, 1)
+	result, err = dbContainerProfiles(db, 1)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -569,7 +569,7 @@ func Test_dbContainerProfilesGet(t *testing.T) {
 	}
 }
 
-func Test_dbDevicesGet_profiles(t *testing.T) {
+func Test_dbDevices_profiles(t *testing.T) {
 	var db *sql.DB
 	var err error
 	var result shared.Devices
@@ -579,7 +579,7 @@ func Test_dbDevicesGet_profiles(t *testing.T) {
 	db = createTestDb(t)
 	defer db.Close()
 
-	result, err = dbDevicesGet(db, "theprofile", true)
+	result, err = dbDevices(db, "theprofile", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -595,7 +595,7 @@ func Test_dbDevicesGet_profiles(t *testing.T) {
 
 }
 
-func Test_dbDevicesGet_containers(t *testing.T) {
+func Test_dbDevices_containers(t *testing.T) {
 	var db *sql.DB
 	var err error
 	var result shared.Devices
@@ -605,7 +605,7 @@ func Test_dbDevicesGet_containers(t *testing.T) {
 	db = createTestDb(t)
 	defer db.Close()
 
-	result, err = dbDevicesGet(db, "thename", false)
+	result, err = dbDevices(db, "thename", false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -46,7 +46,7 @@ type devLxdHandler struct {
 
 var configGet = devLxdHandler{"/1.0/config", func(c container, r *http.Request) *devLxdResponse {
 	filtered := []string{}
-	for k, _ := range c.ConfigGet() {
+	for k, _ := range c.Config() {
 		if strings.HasPrefix(k, "user.") {
 			filtered = append(filtered, fmt.Sprintf("/1.0/config/%s", k))
 		}
@@ -60,7 +60,7 @@ var configKeyGet = devLxdHandler{"/1.0/config/{key}", func(c container, r *http.
 		return &devLxdResponse{"not authorized", http.StatusForbidden, "raw"}
 	}
 
-	value, ok := c.ConfigGet()[key]
+	value, ok := c.Config()[key]
 	if !ok {
 		return &devLxdResponse{"not found", http.StatusNotFound, "raw"}
 	}
@@ -69,8 +69,8 @@ var configKeyGet = devLxdHandler{"/1.0/config/{key}", func(c container, r *http.
 }}
 
 var metadataGet = devLxdHandler{"/1.0/meta-data", func(c container, r *http.Request) *devLxdResponse {
-	value := c.ConfigGet()["user.meta-data"]
-	return okResponse(fmt.Sprintf("#cloud-config\ninstance-id: %s\nlocal-hostname: %s\n%s", c.NameGet(), c.NameGet(), value), "raw")
+	value := c.Config()["user.meta-data"]
+	return okResponse(fmt.Sprintf("#cloud-config\ninstance-id: %s\nlocal-hostname: %s\n%s", c.Name(), c.Name(), value), "raw")
 }}
 
 var handlers = []devLxdHandler{
@@ -352,7 +352,7 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 			return nil, err
 		}
 
-		initpid := c.InitPidGet()
+		initpid := c.InitPID()
 		pidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", initpid))
 		if err != nil {
 			return nil, err

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -219,7 +219,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req imagePostReq,
 		return info, err
 	}
 
-	info.Architecture = c.ArchitectureGet()
+	info.Architecture = c.Architecture()
 	info.Properties = req.Properties
 
 	return info, nil

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -21,7 +21,7 @@ type profilesPostReq struct {
 }
 
 func profilesGet(d *Daemon, r *http.Request) Response {
-	results, err := dbProfilesGet(d.db)
+	results, err := dbProfiles(d.db)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -78,12 +78,12 @@ var profilesCmd = Command{
 	post: profilesPost}
 
 func doProfileGet(d *Daemon, name string) (*shared.ProfileConfig, error) {
-	config, err := dbProfileConfigGet(d.db, name)
+	config, err := dbProfileConfig(d.db, name)
 	if err != nil {
 		return nil, err
 	}
 
-	devices, err := dbDevicesGet(d.db, name, true)
+	devices, err := dbDevices(d.db, name, true)
 	if err != nil {
 		return nil, err
 	}
@@ -133,13 +133,13 @@ func profilePut(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	preDevList, err := dbDevicesGet(d.db, name, true)
+	preDevList, err := dbDevices(d.db, name, true)
 	if err != nil {
 		return InternalError(err)
 	}
 	clist := getRunningContainersWithProfile(d, name)
 
-	id, err := dbProfileIDGet(d.db, name)
+	id, err := dbProfileID(d.db, name)
 	if err != nil {
 		return InternalError(fmt.Errorf("Failed to retrieve profile='%s'", name))
 	}
@@ -174,9 +174,9 @@ func profilePut(d *Daemon, r *http.Request) Response {
 		if !c.IsRunning() {
 			continue
 		}
-		fmt.Printf("Updating profile device list for %s\n", c.NameGet())
+		fmt.Printf("Updating profile device list for %s\n", c.Name())
 		if err := devicesApplyDeltaLive(tx, c, preDevList, postDevList); err != nil {
-			shared.Debugf("Warning: failed to update device list for container %s (profile %s updated)", c.NameGet(), name)
+			shared.Debugf("Warning: failed to update device list for container %s (profile %s updated)", c.Name(), name)
 		}
 	}
 

--- a/lxd/profiles_test.go
+++ b/lxd/profiles_test.go
@@ -35,7 +35,7 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 	}
 
 	// Make sure there are 0 profiles_devices entries left.
-	devices, err := dbDevicesGet(d.db, "theprofile", true)
+	devices, err := dbDevices(d.db, "theprofile", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +44,7 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 	}
 
 	// Make sure there are 0 profiles_config entries left.
-	config, err := dbProfileConfigGet(d.db, "theprofile")
+	config, err := dbProfileConfig(d.db, "theprofile")
 	if err == nil {
 		t.Fatal("found the profile!")
 	}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -233,16 +233,16 @@ func (ss *storageShared) GetStorageTypeVersion() string {
 }
 
 func (ss *storageShared) shiftRootfs(c container) error {
-	dpath := c.PathGet("")
-	rpath := c.RootfsPathGet()
+	dpath := c.Path("")
+	rpath := c.RootfsPath()
 
 	shared.Log.Debug("Shifting root filesystem",
-		log.Ctx{"container": c.NameGet(), "rootfs": rpath})
+		log.Ctx{"container": c.Name(), "rootfs": rpath})
 
-	idmapset := c.IdmapSetGet()
+	idmapset := c.IdmapSet()
 
 	if idmapset == nil {
-		return fmt.Errorf("IdmapSet of container '%s' is nil", c.NameGet())
+		return fmt.Errorf("IdmapSet of container '%s' is nil", c.Name())
 	}
 
 	err := idmapset.ShiftRootfs(rpath)
@@ -258,7 +258,7 @@ func (ss *storageShared) shiftRootfs(c container) error {
 }
 
 func (ss *storageShared) setUnprivUserAcl(c container, destPath string) error {
-	idmapset := c.IdmapSetGet()
+	idmapset := c.IdmapSet()
 
 	// Skip for privileged containers
 	if idmapset == nil {
@@ -318,7 +318,7 @@ func (lw *storageLogWrapper) ContainerCreate(container container) error {
 	lw.log.Debug(
 		"ContainerCreate",
 		log.Ctx{
-			"name":         container.NameGet(),
+			"name":         container.Name(),
 			"isPrivileged": container.IsPrivileged()})
 	return lw.w.ContainerCreate(container)
 }
@@ -330,13 +330,13 @@ func (lw *storageLogWrapper) ContainerCreateFromImage(
 		"ContainerCreateFromImage",
 		log.Ctx{
 			"imageFingerprint": imageFingerprint,
-			"name":             container.NameGet(),
+			"name":             container.Name(),
 			"isPrivileged":     container.IsPrivileged()})
 	return lw.w.ContainerCreateFromImage(container, imageFingerprint)
 }
 
 func (lw *storageLogWrapper) ContainerDelete(container container) error {
-	lw.log.Debug("ContainerDelete", log.Ctx{"container": container.NameGet()})
+	lw.log.Debug("ContainerDelete", log.Ctx{"container": container.Name()})
 	return lw.w.ContainerDelete(container)
 }
 
@@ -346,18 +346,18 @@ func (lw *storageLogWrapper) ContainerCopy(
 	lw.log.Debug(
 		"ContainerCopy",
 		log.Ctx{
-			"container": container.NameGet(),
-			"source":    sourceContainer.NameGet()})
+			"container": container.Name(),
+			"source":    sourceContainer.Name()})
 	return lw.w.ContainerCopy(container, sourceContainer)
 }
 
 func (lw *storageLogWrapper) ContainerStart(container container) error {
-	lw.log.Debug("ContainerStart", log.Ctx{"container": container.NameGet()})
+	lw.log.Debug("ContainerStart", log.Ctx{"container": container.Name()})
 	return lw.w.ContainerStart(container)
 }
 
 func (lw *storageLogWrapper) ContainerStop(container container) error {
-	lw.log.Debug("ContainerStop", log.Ctx{"container": container.NameGet()})
+	lw.log.Debug("ContainerStop", log.Ctx{"container": container.Name()})
 	return lw.w.ContainerStop(container)
 }
 
@@ -367,7 +367,7 @@ func (lw *storageLogWrapper) ContainerRename(
 	lw.log.Debug(
 		"ContainerRename",
 		log.Ctx{
-			"container": container.NameGet(),
+			"container": container.Name(),
 			"newName":   newName})
 	return lw.w.ContainerRename(container, newName)
 }
@@ -378,8 +378,8 @@ func (lw *storageLogWrapper) ContainerRestore(
 	lw.log.Debug(
 		"ContainerRestore",
 		log.Ctx{
-			"container": container.NameGet(),
-			"source":    sourceContainer.NameGet()})
+			"container": container.Name(),
+			"source":    sourceContainer.Name()})
 	return lw.w.ContainerRestore(container, sourceContainer)
 }
 
@@ -388,8 +388,8 @@ func (lw *storageLogWrapper) ContainerSnapshotCreate(
 
 	lw.log.Debug("ContainerSnapshotCreate",
 		log.Ctx{
-			"snapshotContainer": snapshotContainer.NameGet(),
-			"sourceContainer":   sourceContainer.NameGet()})
+			"snapshotContainer": snapshotContainer.Name(),
+			"sourceContainer":   sourceContainer.Name()})
 
 	return lw.w.ContainerSnapshotCreate(snapshotContainer, sourceContainer)
 }
@@ -397,7 +397,7 @@ func (lw *storageLogWrapper) ContainerSnapshotDelete(
 	snapshotContainer container) error {
 
 	lw.log.Debug("ContainerSnapshotDelete",
-		log.Ctx{"snapshotContainer": snapshotContainer.NameGet()})
+		log.Ctx{"snapshotContainer": snapshotContainer.Name()})
 	return lw.w.ContainerSnapshotDelete(snapshotContainer)
 }
 
@@ -406,7 +406,7 @@ func (lw *storageLogWrapper) ContainerSnapshotRename(
 
 	lw.log.Debug("ContainerSnapshotRename",
 		log.Ctx{
-			"snapshotContainer": snapshotContainer.NameGet(),
+			"snapshotContainer": snapshotContainer.Name(),
 			"newName":           newName})
 	return lw.w.ContainerSnapshotRename(snapshotContainer, newName)
 }

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -45,7 +45,7 @@ func (s *storageBtrfs) Init(config map[string]interface{}) (storage, error) {
 }
 
 func (s *storageBtrfs) ContainerCreate(container container) error {
-	cPath := container.PathGet("")
+	cPath := container.Path("")
 
 	// MkdirAll the pardir of the BTRFS Subvolume.
 	if err := os.MkdirAll(filepath.Dir(cPath), 0755); err != nil {
@@ -82,7 +82,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(
 	}
 
 	// Now make a snapshot of the image subvol
-	err := s.subvolsSnapshot(imageSubvol, container.PathGet(""), false)
+	err := s.subvolsSnapshot(imageSubvol, container.Path(""), false)
 	if err != nil {
 		return err
 	}
@@ -93,7 +93,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(
 			return err
 		}
 	} else {
-		if err := os.Chmod(container.PathGet(""), 0700); err != nil {
+		if err := os.Chmod(container.Path(""), 0700); err != nil {
 			return err
 		}
 	}
@@ -102,7 +102,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(
 }
 
 func (s *storageBtrfs) ContainerDelete(container container) error {
-	cPath := container.PathGet("")
+	cPath := container.Path("")
 
 	// First remove the subvol (if it was one).
 	if s.isSubvolume(cPath) {
@@ -122,8 +122,8 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 }
 
 func (s *storageBtrfs) ContainerCopy(container container, sourceContainer container) error {
-	subvol := sourceContainer.PathGet("")
-	dpath := container.PathGet("")
+	subvol := sourceContainer.Path("")
+	dpath := container.Path("")
 
 	if s.isSubvolume(subvol) {
 		// Snapshot the sourcecontainer
@@ -141,8 +141,8 @@ func (s *storageBtrfs) ContainerCopy(container container, sourceContainer contai
 		 * Copy by using rsync
 		 */
 		output, err := storageRsyncCopy(
-			sourceContainer.PathGet(""),
-			container.PathGet(""))
+			sourceContainer.Path(""),
+			container.Path(""))
 		if err != nil {
 			s.ContainerDelete(container)
 
@@ -170,8 +170,8 @@ func (s *storageBtrfs) ContainerStop(container container) error {
 func (s *storageBtrfs) ContainerRename(
 	container container, newName string) error {
 
-	oldPath := container.PathGet("")
-	newPath := container.PathGet(newName)
+	oldPath := container.Path("")
+	newPath := container.Path(newName)
 
 	if err := os.Rename(oldPath, newPath); err != nil {
 		return err
@@ -184,12 +184,12 @@ func (s *storageBtrfs) ContainerRename(
 func (s *storageBtrfs) ContainerRestore(
 	container container, sourceContainer container) error {
 
-	targetSubVol := container.PathGet("")
-	sourceSubVol := sourceContainer.PathGet("")
-	sourceBackupPath := container.PathGet("") + ".back"
+	targetSubVol := container.Path("")
+	sourceSubVol := sourceContainer.Path("")
+	sourceBackupPath := container.Path("") + ".back"
 
 	// Create a backup of the container
-	err := os.Rename(container.PathGet(""), sourceBackupPath)
+	err := os.Rename(container.Path(""), sourceBackupPath)
 	if err != nil {
 		return err
 	}
@@ -228,7 +228,7 @@ func (s *storageBtrfs) ContainerRestore(
 	if failure != nil {
 		// Restore original container
 		s.ContainerDelete(container)
-		os.Rename(sourceBackupPath, container.PathGet(""))
+		os.Rename(sourceBackupPath, container.Path(""))
 	} else {
 		// Remove the backup, we made
 		if s.isSubvolume(sourceBackupPath) {
@@ -243,8 +243,8 @@ func (s *storageBtrfs) ContainerRestore(
 func (s *storageBtrfs) ContainerSnapshotCreate(
 	snapshotContainer container, sourceContainer container) error {
 
-	subvol := sourceContainer.PathGet("")
-	dpath := snapshotContainer.PathGet("")
+	subvol := sourceContainer.Path("")
+	dpath := snapshotContainer.Path("")
 
 	if s.isSubvolume(subvol) {
 		// Create a readonly snapshot of the source.
@@ -277,10 +277,10 @@ func (s *storageBtrfs) ContainerSnapshotDelete(
 
 	err := s.ContainerDelete(snapshotContainer)
 	if err != nil {
-		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.NameGet(), err)
+		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.Name(), err)
 	}
 
-	oldPathParent := filepath.Dir(snapshotContainer.PathGet(""))
+	oldPathParent := filepath.Dir(snapshotContainer.Path(""))
 	if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
 		os.Remove(oldPathParent)
 	}
@@ -291,8 +291,8 @@ func (s *storageBtrfs) ContainerSnapshotDelete(
 func (s *storageBtrfs) ContainerSnapshotRename(
 	snapshotContainer container, newName string) error {
 
-	oldPath := snapshotContainer.PathGet("")
-	newPath := snapshotContainer.PathGet(newName)
+	oldPath := snapshotContainer.Path("")
+	newPath := snapshotContainer.Path(newName)
 
 	// Create the new parent.
 	if !shared.PathExists(filepath.Dir(newPath)) {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -77,8 +77,8 @@ func (s *storageZfs) ContainerStop(container container) error {
 
 // Things we do have to care about
 func (s *storageZfs) ContainerCreate(container container) error {
-	cPath := container.PathGet("")
-	fs := fmt.Sprintf("containers/%s", container.NameGet())
+	cPath := container.Path("")
+	fs := fmt.Sprintf("containers/%s", container.Name())
 
 	err := s.zfsCreate(fs)
 	if err != nil {
@@ -106,10 +106,10 @@ func (s *storageZfs) ContainerCreate(container container) error {
 }
 
 func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint string) error {
-	cPath := container.PathGet("")
+	cPath := container.Path("")
 	imagePath := shared.VarPath("images", fingerprint)
 	subvol := fmt.Sprintf("%s.zfs", imagePath)
-	fs := fmt.Sprintf("containers/%s", container.NameGet())
+	fs := fmt.Sprintf("containers/%s", container.Name())
 	fsImage := fmt.Sprintf("images/%s", fingerprint)
 
 	if !shared.PathExists(subvol) {
@@ -152,7 +152,7 @@ func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint s
 }
 
 func (s *storageZfs) ContainerDelete(container container) error {
-	fs := fmt.Sprintf("containers/%s", container.NameGet())
+	fs := fmt.Sprintf("containers/%s", container.Name())
 
 	removable := true
 	snaps, err := s.zfsListSnapshots(fs)
@@ -221,10 +221,10 @@ func (s *storageZfs) ContainerCopy(container container, sourceContainer containe
 	var sourceFs string
 	var sourceSnap string
 
-	sourceFields := strings.SplitN(sourceContainer.NameGet(), shared.SnapshotDelimiter, 2)
+	sourceFields := strings.SplitN(sourceContainer.Name(), shared.SnapshotDelimiter, 2)
 	sourceName := sourceFields[0]
 
-	destName := container.NameGet()
+	destName := container.Name()
 	destFs := fmt.Sprintf("containers/%s", destName)
 
 	if len(sourceFields) == 2 {
@@ -258,13 +258,13 @@ func (s *storageZfs) ContainerCopy(container container, sourceContainer containe
 			return err
 		}
 
-		output, err := storageRsyncCopy(sourceContainer.PathGet(""), container.PathGet(""))
+		output, err := storageRsyncCopy(sourceContainer.Path(""), container.Path(""))
 		if err != nil {
 			return fmt.Errorf("rsync failed: %s", string(output))
 		}
 	}
 
-	cPath := container.PathGet("")
+	cPath := container.Path("")
 	err := os.Symlink(cPath+".zfs", cPath)
 	if err != nil {
 		return err
@@ -286,7 +286,7 @@ func (s *storageZfs) ContainerCopy(container container, sourceContainer containe
 }
 
 func (s *storageZfs) ContainerRename(container container, newName string) error {
-	oldName := container.NameGet()
+	oldName := container.Name()
 
 	err := s.zfsRename(fmt.Sprintf("containers/%s", oldName), fmt.Sprintf("containers/%s", newName))
 	if err != nil {
@@ -312,7 +312,7 @@ func (s *storageZfs) ContainerRename(container container, newName string) error 
 }
 
 func (s *storageZfs) ContainerRestore(container container, sourceContainer container) error {
-	fields := strings.SplitN(sourceContainer.NameGet(), shared.SnapshotDelimiter, 2)
+	fields := strings.SplitN(sourceContainer.Name(), shared.SnapshotDelimiter, 2)
 	cName := fields[0]
 	snapName := fmt.Sprintf("snapshot-%s", fields[1])
 
@@ -325,7 +325,7 @@ func (s *storageZfs) ContainerRestore(container container, sourceContainer conta
 }
 
 func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
-	fields := strings.SplitN(snapshotContainer.NameGet(), shared.SnapshotDelimiter, 2)
+	fields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
 	cName := fields[0]
 	snapName := fmt.Sprintf("snapshot-%s", fields[1])
 
@@ -350,7 +350,7 @@ func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, source
 }
 
 func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error {
-	fields := strings.SplitN(snapshotContainer.NameGet(), shared.SnapshotDelimiter, 2)
+	fields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
 	cName := fields[0]
 	snapName := fmt.Sprintf("snapshot-%s", fields[1])
 
@@ -384,7 +384,7 @@ func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error 
 }
 
 func (s *storageZfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
-	oldFields := strings.SplitN(snapshotContainer.NameGet(), shared.SnapshotDelimiter, 2)
+	oldFields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
 	oldcName := oldFields[0]
 	oldName := fmt.Sprintf("snapshot-%s", oldFields[1])
 


### PR DESCRIPTION
Mostly this is just sed, but there is also a slight refactoring in that
containerLXD had a single public member named Storage, which collided with
Storage() once you remove the Get postifx. This commit switches that and
its usage to a private member. Also:

1. Go is not Java.
2. Go is not Java.
3. Go is not Java.
4. Go is not Java.
5. Go is not Java.
6. Go is not Java.
7. Go is not Java.
8. Go is not Java.
9. Go is not Java.
10. Go is not Java.
11. Go is not Java.
12. Go is not Java.
13. Go is not Java.
14. Go is not Java.
15. Go is not Java.
16. Go is not Java.
17. Go is not Java.
18. Go is not Java.
19. Go is not Java.
20. Go is not Java.
21. Go is not Java.
22. Go is not Java.
23. Go is not Java.
24. Go is not Java.
25. Go is not Java.
26. Go is not Java.
27. Go is not Java.
28. Go is not Java.
29. Go is not Java.
30. Go is not Java.
31. Go is not Java.
32. Go is not Java.
33. Go is not Java.
34. Go is not Java.
35. Go is not Java.
36. Go is not Java.
37. Go is not Java.
38. Go is not Java.
39. Go is not Java.
40. Go is not Java.
41. Go is not Java.
42. Go is not Java.
43. Go is not Java.
44. Go is not Java.
45. Go is not Java.
46. Go is not Java.
47. Go is not Java.
48. Go is not Java.
49. Go is not Java.
50. Go is not Java.
51. Go is not Java.
52. Go is not Java.
53. Go is not Java.
54. Go is not Java.
55. Go is not Java.
56. Go is not Java.
57. Go is not Java.
58. Go is not Java.
59. Go is not Java.
60. Go is not Java.
61. Go is not Java.
62. Go is not Java.
63. Go is not Java.
64. Go is not Java.
65. Go is not Java.
66. Go is not Java.
67. Go is not Java.
68. Go is not Java.
69. Go is not Java.
70. Go is not Java.
71. Go is not Java.
72. Go is not Java.
73. Go is not Java.
74. Go is not Java.
75. Go is not Java.
76. Go is not Java.
77. Go is not Java.
78. Go is not Java.
79. Go is not Java.
80. Go is not Java.
81. Go is not Java.
82. Go is not Java.
83. Go is not Java.
84. Go is not Java.
85. Go is not Java.
86. Go is not Java.
87. Go is not Java.
88. Go is not Java.
89. Go is not Java.
90. Go is not Java.
91. Go is not Java.
92. Go is not Java.
93. Go is not Java.
94. Go is not Java.
95. Go is not Java.
96. Go is not Java.
97. Go is not Java.
98. Go is not Java.
99. Go is not Java.
100. Go is not Java.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>