### PR TITLE
Update CLI documentation for profiles to show that edit accepts STDIN.

### DIFF
--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -50,10 +50,13 @@ func (c *profileCmd) usage() string {
 lxc profile list [filters]                     List available profiles.
 lxc profile show <profile>                     Show details of a profile.
 lxc profile create <profile>                   Create a profile.
-lxc profile edit <profile>                     Edit profile in external editor.
 lxc profile copy <profile> <remote>            Copy the profile to the specified remote.
 lxc profile set <profile> <key> <value>        Set profile configuration.
 lxc profile delete <profile>                   Delete a profile.
+lxc profile edit <profile>                     
+    Edit profile, either by launching external editor or reading STDIN.
+    Example: lxc profile edit <profile> # launch editor
+             cat profile.yml | lxc profile edit <profile> # read from profile.yml
 lxc profile apply <container> <profiles>
     Apply a comma-separated list of profiles to a container, in order.
     All profiles passed in this call (and only those) will be applied


### PR DESCRIPTION
When the fix for issue #573 "Nice to have: write out config files and read it back in" was merged, the CLI usage documentation was not updated.  This commit clarifies that 'lxc profile edit' now accepts stdin.  I've not yet done the equivalent fix for 'lxc config edit' because I've not tested that functionality myself yet and the structure of the usage block in that file might benefit from a larger refactoring for legibility.
 
Signed-off-by: Matt Saunders <matt@tidzo.com>