### PR TITLE
LXD should also look in its environment for a proxy

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -99,6 +99,7 @@ func (d *Daemon) httpGetSync(url string) (*lxd.Response, error) {
 	tr := &http.Transport{
 		TLSClientConfig: d.tlsconfig,
 		Dial:            shared.RFC3493Dialer,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	myhttp := http.Client{
 		Transport: tr,
@@ -139,6 +140,7 @@ func (d *Daemon) httpGetFile(url string) (*http.Response, error) {
 	tr := &http.Transport{
 		TLSClientConfig: d.tlsconfig,
 		Dial:            shared.RFC3493Dialer,
+		Proxy:           http.ProxyFromEnvironment,
 	}
 	myhttp := http.Client{
 		Transport: tr,


### PR DESCRIPTION
In case people are running their LXDs behind a proxy, LXD should also look
in its environment for this information.

Closes #1264

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>