### PR TITLE
don't require a client cert for untrusted reqs

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -195,7 +195,7 @@ func GetTLSConfig(certf string, keyf string) (*tls.Config, error) {
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
-		ClientAuth:         tls.RequireAnyClientCert,
+		ClientAuth:         tls.RequestClientCert,
 		Certificates:       []tls.Certificate{cert},
 		MinVersion:         tls.VersionTLS12,
 		MaxVersion:         tls.VersionTLS12,

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -55,6 +55,9 @@ test_basic_usage() {
   # gen untrusted cert
   gen_third_cert
 
+  # don't allow requests without a cert to get trusted data
+  curl -k -s -X GET "https://${LXD_ADDR}/1.0/containers/foo" | grep 403
+
   # Test unprivileged container publish
   lxc publish bar --alias=foo-image prop1=val1
   lxc image show foo-image | grep val1


### PR DESCRIPTION
Since we have the concept of "trusted" and "untrusted" requests, and we
don't verify the client cert for untrusted requests, we may as well not
require one.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>