### PR TITLE
Close the control socket on exit

### DIFF
--- a/client.go
+++ b/client.go
@@ -1238,8 +1238,9 @@ func (c *Client) Exec(name string, cmd []string, env map[string]string,
 	}
 
 	if controlHandler != nil {
+		var control *websocket.Conn
 		if wsControl, ok := md.FDs["control"]; ok {
-			control, err := c.websocket(resp.Operation, wsControl)
+			control, err = c.websocket(resp.Operation, wsControl)
 			if err != nil {
 				return -1, err
 			}
@@ -1252,6 +1253,10 @@ func (c *Client) Exec(name string, cmd []string, env map[string]string,
 		}
 		shared.WebsocketSendStream(conn, stdin)
 		<-shared.WebsocketRecvStream(stdout, conn)
+
+		if control != nil {
+			control.Close()
+		}
 	} else {
 		conns := make([]*websocket.Conn, 3)
 		dones := make([]chan bool, 3)


### PR DESCRIPTION
This avoids keeping the control socket open indefinitely when Exec is
used within a long running software.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>