### PR TITLE
close exec's control connection on cmd finish

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -196,8 +196,12 @@ func (s *execWs) Do(id string) shared.OperationResult {
 		tty.Close()
 	}
 
-	if s.interactive && s.conns[-1] == nil {
-		controlExit <- true
+	if s.conns[-1] == nil {
+		if s.interactive {
+			controlExit <- true
+		}
+	} else {
+		s.conns[-1].Close()
 	}
 
 	wgEOF.Wait()


### PR DESCRIPTION
We should do this in the server as well.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>