### PR TITLE
Add events interface

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -177,6 +177,7 @@ var commands = map[string]command{
 	"init":     &initCmd{},
 	"launch":   &launchCmd{},
 	"list":     &listCmd{},
+	"monitor":  &monitorCmd{},
 	"move":     &moveCmd{},
 	"pause":    &actionCmd{shared.Freeze, false, false, "pause"},
 	"profile":  &profileCmd{},

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/chai2010/gettext-go/gettext"
+	"gopkg.in/yaml.v2"
+
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared/gnuflag"
+)
+
+type monitorCmd struct{}
+
+func (c *monitorCmd) showByDefault() bool {
+	return false
+}
+
+func (c *monitorCmd) usage() string {
+	return gettext.Gettext(
+		`Monitor activity on the LXD server.
+
+lxc monitor [remote:] [--type=TYPE...]
+
+Connects to the monitoring interface of the specified LXD server.
+
+By default will listen to all message types.
+Specific types to listen to can be specified with --type.
+
+Example:
+lxc monitor --type=logging`)
+}
+
+type typeList []string
+
+func (f *typeList) String() string {
+	return fmt.Sprint(*f)
+}
+
+func (f *typeList) Set(value string) error {
+	if value == "" {
+		return fmt.Errorf("Invalid type: %s", value)
+	}
+
+	if f == nil {
+		*f = make(typeList, 1)
+	} else {
+		*f = append(*f, value)
+	}
+	return nil
+}
+
+var typeArgs typeList
+
+func (c *monitorCmd) flags() {
+	gnuflag.Var(&typeArgs, "type", gettext.Gettext("Event type to listen for"))
+}
+
+func (c *monitorCmd) run(config *lxd.Config, args []string) error {
+	var remote string
+
+	if len(args) > 1 {
+		return errArgs
+	}
+
+	if len(args) == 0 {
+		remote, _ = config.ParseRemoteAndContainer("")
+	} else {
+		remote, _ = config.ParseRemoteAndContainer(args[0])
+	}
+
+	d, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	handler := func(message interface{}) {
+		render, err := yaml.Marshal(&message)
+		if err != nil {
+			return
+		}
+
+		fmt.Printf("%s\n\n", render)
+	}
+
+	return d.Monitor(typeArgs, handler)
+}

--- a/lxd/api10.go
+++ b/lxd/api10.go
@@ -23,6 +23,7 @@ var api10 = []Command{
 	containerExecCmd,
 	aliasCmd,
 	aliasesCmd,
+	eventsCmd,
 	imageCmd,
 	imagesCmd,
 	imagesExportCmd,

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/satori/go.uuid"
+
+	"github.com/lxc/lxd/shared"
+)
+
+var eventsLock sync.Mutex
+var eventListeners map[string]*eventListener = make(map[string]*eventListener)
+
+type eventListener struct {
+	connection   *websocket.Conn
+	messageTypes []string
+	active       chan bool
+	id           string
+}
+
+type eventsServe struct {
+	req *http.Request
+}
+
+func (r *eventsServe) Render(w http.ResponseWriter) error {
+	return eventsSocket(r.req, w)
+}
+
+func eventsSocket(r *http.Request, w http.ResponseWriter) error {
+	listener := eventListener{}
+
+	typeStr := r.FormValue("type")
+	if typeStr == "" {
+		typeStr = "logging,operations"
+	}
+
+	c, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+	if err != nil {
+		return err
+	}
+
+	listener.active = make(chan bool, 1)
+	listener.connection = c
+	listener.id = uuid.NewV4().String()
+	listener.messageTypes = strings.Split(typeStr, ",")
+
+	eventsLock.Lock()
+	eventListeners[listener.id] = &listener
+	eventsLock.Unlock()
+
+	shared.Debugf("New events listener: %s", listener.id)
+
+	<-listener.active
+
+	return nil
+}
+
+func eventsGet(d *Daemon, r *http.Request) Response {
+	return &eventsServe{r}
+}
+
+var eventsCmd = Command{name: "events", get: eventsGet}
+
+func eventSend(eventType string, eventMessage interface{}) error {
+	event := shared.Jmap{}
+	event["type"] = eventType
+	event["timestamp"] = time.Now()
+	event["metadata"] = eventMessage
+
+	body, err := json.Marshal(event)
+	if err != nil {
+		return err
+	}
+
+	eventsLock.Lock()
+	for id, listener := range eventListeners {
+		err = listener.connection.WriteMessage(websocket.TextMessage, body)
+		if err != nil {
+			listener.connection.Close()
+			listener.active <- false
+			delete(eventListeners, id)
+			shared.Debugf("Disconnected events listener: %s", id)
+		}
+	}
+	eventsLock.Unlock()
+
+	return nil
+}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -849,7 +849,7 @@ func doImageGet(d *Daemon, fingerprint string, public bool) (shared.ImageInfo, R
 }
 
 func imageValidSecret(fingerprint string, secret string) bool {
-	lock.Lock()
+	operationLock.Lock()
 	for _, op := range operations {
 		if op.Resources == nil {
 			continue
@@ -891,11 +891,11 @@ func imageValidSecret(fingerprint string, secret string) bool {
 		}
 
 		if opSecret == secret {
-			lock.Unlock()
+			operationLock.Unlock()
 			return true
 		}
 	}
-	lock.Unlock()
+	operationLock.Unlock()
 
 	return false
 }

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2015-11-03 15:21-0500\n"
+        "POT-Creation-Date: 2015-11-10 13:39-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -125,7 +125,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: client.go:1672
+#: client.go:1713
 msgid   "Cannot change profile name"
 msgstr  ""
 
@@ -251,9 +251,13 @@ msgstr  ""
 msgid   "Ephemeral container"
 msgstr  ""
 
-#: client.go:616 client.go:626 client.go:873 client.go:1915
+#: client.go:616 client.go:626 client.go:873 client.go:1956
 #, c-format
 msgid   "Error adding alias %s"
+msgstr  ""
+
+#: lxc/monitor.go:56
+msgid   "Event type to listen for"
 msgstr  ""
 
 #: lxc/exec.go:27
@@ -533,6 +537,20 @@ msgstr  ""
 
 #: lxc/help.go:87
 msgid   "Missing summary."
+msgstr  ""
+
+#: lxc/monitor.go:20
+msgid   "Monitor activity on the LXD server.\n"
+        "\n"
+        "lxc monitor [remote:] [--type=TYPE...]\n"
+        "\n"
+        "Connects to the monitoring interface of the specified LXD server.\n"
+        "\n"
+        "By default will listen to all message types.\n"
+        "Specific types to listen to can be specified with --type.\n"
+        "\n"
+        "Example:\n"
+        "lxc monitor --type=logging"
 msgstr  ""
 
 #: lxc/file.go:156
@@ -831,7 +849,7 @@ msgstr  ""
 msgid   "bad number of things scanned from image, container or snapshot"
 msgstr  ""
 
-#: client.go:1703
+#: client.go:1744
 #, c-format
 msgid   "bad profile url %s"
 msgstr  ""
@@ -840,7 +858,7 @@ msgstr  ""
 msgid   "bad result type from action"
 msgstr  ""
 
-#: client.go:1707
+#: client.go:1748
 msgid   "bad version in profile url"
 msgstr  ""
 
@@ -862,7 +880,7 @@ msgstr  ""
 msgid   "cannot resolve unix socket address: %v"
 msgstr  ""
 
-#: client.go:1756 client.go:1813
+#: client.go:1797 client.go:1854
 msgid   "device already exists"
 msgstr  ""
 
@@ -898,7 +916,7 @@ msgstr  ""
 msgid   "failed group lookup: %s"
 msgstr  ""
 
-#: client.go:1305 client.go:1877
+#: client.go:1346 client.go:1918
 #, c-format
 msgid   "got bad op status %s"
 msgstr  ""
@@ -912,7 +930,7 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: client.go:1476
+#: client.go:1517
 #, c-format
 msgid   "invalid wait url %s"
 msgstr  ""
@@ -925,7 +943,7 @@ msgstr  ""
 msgid   "no response!"
 msgstr  ""
 
-#: client.go:1749 client.go:1806
+#: client.go:1790 client.go:1847
 #, c-format
 msgid   "no value found in %q"
 msgstr  ""
@@ -938,7 +956,7 @@ msgstr  ""
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:217 lxc/main.go:221
+#: lxc/main.go:218 lxc/main.go:222
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -977,7 +995,7 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:193
+#: lxc/main.go:194
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -670,7 +670,7 @@ This URL isn't a real REST API endpoint, instead doing a GET query on it
 will upgrade the connection to a websocket on which notifications will
 be sent.
 
-### GET
+### GET (?type=operation,logging)
  * Description: websocket upgrade
  * Authentication: trusted
  * Operation: sync
@@ -680,22 +680,20 @@ Supported arguments are:
  * type: comma separated list of notifications to subscribe to (defaults to all)
 
 The notification types are:
- * operations
+ * operation
  * logging
 
 This never returns. Each notification is sent as a separate JSON dict:
 
     {
         'timestamp': "2015-06-09T19:07:24.379615253-06:00",                # Current timestamp
-        'type': "operations",                                              # Notification type
-        'resource': "/1.0/operations/<uuid>",                              # Resource URL
+        'type': "operation",                                               # Notification type
         'metadata': {}                                                     # Extra resource or type specific metadata
     }
 
     {
         'timestamp': "2015-06-09T19:07:24.379615253-06:00",
         'type': "logging",
-        'resource': "/1.0",
         'metadata' {'message': "Service started"}
     }
 


### PR DESCRIPTION
This adds the events interface and eventSend function that can be hooked
wherever we want to send events back to the client.

Also adds a basic "lxc monitor" command (hidden) to show messages as
they arrive.

Note that some operation events aren't currently handled as the
operation subsystem doesn't provide a single codepath for operation
completion and cancelation, making it hard to send an event for those.

Also, this doesn't hook in our logging system yet.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>