### PR TITLE
drop extra change_profile call in nesting case

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -41,7 +41,6 @@ const NESTING_AA_PROFILE = `
   # So allow all mounts until that is straightened out:
   mount,
   mount options=bind /var/lib/lxd/shmounts/** -> /var/lib/lxd/**,
-  change_profile -> lxc-container-default,
   # lxc-container-default-with-nesting also inherited these
   # from start-container, and seems to need them.
   ptrace,


### PR DESCRIPTION
This doesn't have any effect, since we do a change_profile later, so let's
drop it.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>