### PR TITLE
Replace goproxy by minimal http proxy

### DIFF
--- a/lxd-bridge/lxd-bridge-proxy/main.go
+++ b/lxd-bridge/lxd-bridge-proxy/main.go
@@ -2,16 +2,24 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
-
-	"github.com/elazarl/goproxy"
+	"net/http/httputil"
 )
+
+func NewProxy() *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		if req.Method == "CONNECT" {
+			fmt.Printf("CONNECT: %s\n", req.Host)
+		}
+	}
+	return &httputil.ReverseProxy{Director: director}
+}
 
 func main() {
 	addr := flag.String("addr", "[fe80::1%lxdbr0]:3128", "proxy listen address")
 	flag.Parse()
 
-	proxy := goproxy.NewProxyHttpServer()
-	log.Fatal(http.ListenAndServe(*addr, proxy))
+	log.Fatal(http.ListenAndServe(*addr, NewProxy()))
 }


### PR DESCRIPTION
This gets us rid of goproxy and all its dependencies.

The result is equivalent for HTTP proxying, we do loose support for
proxying of other protocols but since lxd-bridg-proxy has never been
turned on for anyone, that's fine for now.

We'll set it as an HTTP proxy by default and if there's strong demand,
add HTTPs proxying then (CONNECT support).

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>