### PR TITLE
Various image fixes

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -112,7 +112,7 @@ func untarImage(imagefname string, destpath string) error {
 }
 
 func compressFile(path string, compress string) (string, error) {
-	cmd := exec.Command(compress, path, "-c")
+	cmd := exec.Command(compress, path, "-c", "-n")
 
 	outfile, err := os.Create(path + ".compressed")
 	if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -187,16 +187,6 @@ func imgPostContInfo(d *Daemon, r *http.Request, req imagePostReq,
 		info.Public = false
 	}
 
-	snap := ""
-	if ctype == "snapshot" {
-		fields := strings.SplitN(name, "/", 2)
-		if len(fields) != 2 {
-			return info, fmt.Errorf("Not a snapshot")
-		}
-		name = fields[0]
-		snap = fields[1]
-	}
-
 	c, err := containerLXDLoad(d, name)
 	if err != nil {
 		return info, err
@@ -208,7 +198,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req imagePostReq,
 		return info, err
 	}
 
-	if err := c.ExportToTar(snap, tarfile); err != nil {
+	if err := c.ExportToTar(tarfile); err != nil {
 		tarfile.Close()
 		return info, fmt.Errorf("imgPostContInfo: exportToTar failed: %s", err)
 	}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -641,7 +641,8 @@ func setupLXD() error {
 		if shared.StringInSlice(storageMode, []string{"loop", "device"}) {
 			output, err := exec.Command(
 				"zpool",
-				"create", storagePool, storageDevice).CombinedOutput()
+				"create", storagePool, storageDevice,
+				"-m", "none").CombinedOutput()
 			if err != nil {
 				return fmt.Errorf("Failed to create the ZFS pool: %s", output)
 			}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -128,6 +128,8 @@ type storage interface {
 		snapshotContainer container, sourceContainer container) error
 	ContainerSnapshotDelete(snapshotContainer container) error
 	ContainerSnapshotRename(snapshotContainer container, newName string) error
+	ContainerSnapshotStart(container container) error
+	ContainerSnapshotStop(container container) error
 
 	ImageCreate(fingerprint string) error
 	ImageDelete(fingerprint string) error
@@ -410,6 +412,16 @@ func (lw *storageLogWrapper) ContainerSnapshotRename(
 			"snapshotContainer": snapshotContainer.Name(),
 			"newName":           newName})
 	return lw.w.ContainerSnapshotRename(snapshotContainer, newName)
+}
+
+func (lw *storageLogWrapper) ContainerSnapshotStart(container container) error {
+	lw.log.Debug("ContainerStart", log.Ctx{"container": container.Name()})
+	return lw.w.ContainerSnapshotStart(container)
+}
+
+func (lw *storageLogWrapper) ContainerSnapshotStop(container container) error {
+	lw.log.Debug("ContainerStop", log.Ctx{"container": container.Name()})
+	return lw.w.ContainerSnapshotStop(container)
 }
 
 func (lw *storageLogWrapper) ImageCreate(fingerprint string) error {

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -220,6 +220,14 @@ func (s *storageDir) ContainerSnapshotRename(
 	return nil
 }
 
+func (s *storageDir) ContainerSnapshotStart(container container) error {
+	return nil
+}
+
+func (s *storageDir) ContainerSnapshotStop(container container) error {
+	return nil
+}
+
 func (s *storageDir) ImageCreate(fingerprint string) error {
 	return nil
 }

--- a/lxd/storage_test.go
+++ b/lxd/storage_test.go
@@ -86,6 +86,14 @@ func (s *storageMock) ContainerSnapshotRename(
 	return nil
 }
 
+func (s *storageMock) ContainerSnapshotStart(container container) error {
+	return nil
+}
+
+func (s *storageMock) ContainerSnapshotStop(container container) error {
+	return nil
+}
+
 func (s *storageMock) ImageCreate(fingerprint string) error {
 	return nil
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -172,7 +172,9 @@ cleanup() {
     # shellcheck disable=SC2086
     printf "To poke around, use:\n LXD_DIR=%s LXD_CONF=%s sudo -E %s/bin/lxc COMMAND\n" "${LXD_DIR}" "${LXD_CONF}" ${GOPATH:-}
     echo "Tests Completed (${TEST_RESULT}): hit enter to continue"
-    read
+
+    # shellcheck disable=SC2034
+    read nothing
   fi
 
   echo "==> Cleaning up"

--- a/test/suites/lvm.sh
+++ b/test/suites/lvm.sh
@@ -33,7 +33,9 @@ cleanup_vg() {
     # shellcheck disable=SC2086
     printf "To poke around, use:\n LXD_DIR=%s LXD_CONF=%s sudo -E %s/bin/lxc COMMAND\n" "${LXD5_DIR}" "${LXD_CONF}" ${GOPATH:-}
     echo "Pausing to inspect LVM state. Hit Enter to continue cleanup."
-    read
+
+    # shellcheck disable=SC2034
+    read nothing
   fi
 
   if [ -d "${LXD5_DIR}"/containers/testcontainer ]; then
@@ -234,8 +236,11 @@ test_lvm_withpool() {
     lvs "${VGNAME}/test--container-superchill" || die "superchill should exist"
     lvs "${VGNAME}/test--container-chillbro" && die "chillbro should not exist"
 
-    lxc publish test-container || die "Couldn't publish test-container"
-    lxc publish test-container/unchillbro || die "Couldn't publish snapshot"
+    lxc publish test-container --alias image || die "Couldn't publish test-container"
+    lxc image delete image
+
+    lxc publish test-container/unchillbro --alias image || die "Couldn't publish snapshot"
+    lxc image delete image
 
     # TODO busybox ignores SIGPWR, breaking restart:
     # check that 'shutdown' also unmounts:


### PR DESCRIPTION
This makes our compression be reproducible and then fixes publication of a snapshot.

In the past our code was utterly broken and would always publish the container rather than the requested snapshot, once that was fixed, lvm, btrfs and zfs all failed for different reasons:
 - lvm: snapshot is read-only
 - btrfs: snapshot is read-only
 - zfs: snapshot isn't mountable and is read-only

So I had to extend the storage API to add the ContainerSnapshotStart and ContainerSnapshotStop functions which are now called when calling StorageStart and StorageStop on a snapshot.

In those functions, I had to do different tricks depending on the way things are stored in the different supported filesystems:
 - dir: nothing
 - btrfs: move existing mount to a ".ro" and make a temporary read-write snapshot in the original path
 - lvm: create a temporary writable LV and mount it at the expected location
 - zfs: create a temporary filesystem and mount it at the expected location

The LVM testsuite was also assuming that you could publish an identical container twice (a container and its unmodified snapshot) and will get different image IDs. That's not the case so I had to add some image delete calls in there too.

All in all, looks like things are now working as expected for all backends.