### PR TITLE
drop security restrictions from "migratable" profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,27 +238,20 @@ And it has a --destroy argument to clean up the bits as well:
 
 #### How can I live migrate a container using LXD?
 
-**NOTE**: in order to have a migratable container, you need to disable almost
-all of the security that LXD provides. We are working on fixing this, but it
-requires several kernel changes that take time. You should not use migratable
-containers for untrusted workloads right now.
-
-Live migration requires a tool called [CRIU](http://criu.org), which is
-available via:
+Live migration requires a tool installed on both hosts called
+[CRIU](http://criu.org), which is available in Ubuntu via:
 
     sudo apt-get install criu
 
-In order to create a migratable container, LXD provides a built in profile
-called "migratable". First, launch your container with the following,
+Then, launch your container with the following,
 
-    lxc launch -p default -p migratable ubuntu $somename
-
-Ensure you have criu installed on both hosts (`sudo apt-get install criu` for
-Ubuntu), and do:
-
+    lxc launch ubuntu $somename
+    sleep 5s # let the container get to an interesting state
     lxc move host1:$somename host2:$somename
 
-And with luck you'll have migrated the container :)
+And with luck you'll have migrated the container :). Migration is still in
+experimental stages and may not work for all workloads. Please report bugs on
+lxc-devel, and we can escalate to CRIU lists as necessary.
 
 #### Can I bind mount my home directory in a container?
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -621,6 +621,12 @@ func (c *containerLXD) init() error {
 	if err := setConfigItem(c, "lxc.tty", "0"); err != nil {
 		return err
 	}
+	if err := setConfigItem(c, "lxc.cgroup.devices.deny", "c 5:1 rwm"); err != nil {
+		return err
+	}
+	if err := setConfigItem(c, "lxc.console", "none"); err != nil {
+		return err
+	}
 	if err := setupDevLxdMount(c); err != nil {
 		return err
 	}

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -180,12 +180,7 @@ func createDb(db *sql.DB) (err error) {
 		}
 	}
 
-	err = dbProfileCreateDefault(db)
-	if err != nil {
-		return err
-	}
-
-	return dbProfileCreateMigratable(db)
+	return dbProfileCreateDefault(db)
 }
 
 func dbGetSchema(db *sql.DB) (v int) {

--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -109,28 +109,6 @@ func dbProfileCreateDefault(db *sql.DB) error {
 	return nil
 }
 
-func dbProfileCreateMigratable(db *sql.DB) error {
-	id, err := dbProfileID(db, "migratable")
-	if err != nil {
-		return err
-	}
-
-	if id != -1 {
-		// migratable profile already exists
-		return nil
-	}
-
-	config := map[string]string{
-		"security.privileged": "true",
-		"raw.lxc": `lxc.console = none
-lxc.cgroup.devices.deny = c 5:1 rwm
-lxc.seccomp =`,
-	}
-
-	_, err = dbProfileCreate(db, "migratable", config, shared.Devices{})
-	return err
-}
-
 // Get the profile configuration map from the DB
 func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 	var key, value string

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -11,15 +11,15 @@ import (
 const DB_FIXTURES string = `
     INSERT INTO containers (name, architecture, type) VALUES ('thename', 1, 1);
     INSERT INTO profiles (name) VALUES ('theprofile');
-    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 3);
+    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 2);
     INSERT INTO containers_config (container_id, key, value) VALUES (1, 'thekey', 'thevalue');
     INSERT INTO containers_devices (container_id, name, type) VALUES (1, 'somename', 1);
     INSERT INTO containers_devices_config (key, value, container_device_id) VALUES ('configkey', 'configvalue', 1);
     INSERT INTO images (fingerprint, filename, size, architecture, creation_date, expiry_date, upload_date) VALUES ('fingerprint', 'filename', 1024, 0,  1431547174,  1431547175,  1431547176);
     INSERT INTO images_aliases (name, image_id, description) VALUES ('somealias', 1, 'some description');
     INSERT INTO images_properties (image_id, type, key, value) VALUES (1, 0, 'thekey', 'some value');
-    INSERT INTO profiles_config (profile_id, key, value) VALUES (3, 'thekey', 'thevalue');
-    INSERT INTO profiles_devices (profile_id, name, type) VALUES (3, 'devicename', 1);
+    INSERT INTO profiles_config (profile_id, key, value) VALUES (2, 'thekey', 'thevalue');
+    INSERT INTO profiles_devices (profile_id, name, type) VALUES (2, 'devicename', 1);
     INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (2, 'devicekey', 'devicevalue');
     `
 
@@ -117,7 +117,7 @@ func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
 	}
 
 	// Make sure there are 0 container_profiles entries left.
-	statements = `SELECT count(*) FROM containers_profiles WHERE profile_id = 3;`
+	statements = `SELECT count(*) FROM containers_profiles WHERE profile_id = 2;`
 	err = db.QueryRow(statements).Scan(&count)
 
 	if count != 0 {
@@ -125,7 +125,7 @@ func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
 	}
 
 	// Make sure there are 0 profiles_devices entries left.
-	statements = `SELECT count(*) FROM profiles_devices WHERE profile_id == 3;`
+	statements = `SELECT count(*) FROM profiles_devices WHERE profile_id == 2;`
 	err = db.QueryRow(statements).Scan(&count)
 
 	if count != 0 {
@@ -133,7 +133,7 @@ func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
 	}
 
 	// Make sure there are 0 profiles_config entries left.
-	statements = `SELECT count(*) FROM profiles_config WHERE profile_id == 3;`
+	statements = `SELECT count(*) FROM profiles_config WHERE profile_id == 2;`
 	err = db.QueryRow(statements).Scan(&count)
 
 	if count != 0 {
@@ -141,7 +141,7 @@ func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
 	}
 
 	// Make sure there are 0 profiles_devices_config entries left.
-	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 3;`
+	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 2;`
 	err = db.QueryRow(statements).Scan(&count)
 
 	if count != 0 {
@@ -531,7 +531,7 @@ func Test_dbProfileConfig(t *testing.T) {
 	db = createTestDb(t)
 	defer db.Close()
 
-	_, err = db.Exec("INSERT INTO profiles_config (profile_id, key, value) VALUES (3, 'something', 'something else');")
+	_, err = db.Exec("INSERT INTO profiles_config (profile_id, key, value) VALUES (2, 'something', 'something else');")
 
 	result, err = dbProfileConfig(db, "theprofile")
 	if err != nil {

--- a/lxd/profiles_test.go
+++ b/lxd/profiles_test.go
@@ -18,9 +18,9 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 	statements := `
     INSERT INTO containers (name, architecture, type) VALUES ('thename', 1, 1);
     INSERT INTO profiles (name) VALUES ('theprofile');
-    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 3);
-    INSERT INTO profiles_devices (name, profile_id) VALUES ('somename', 3);
-    INSERT INTO profiles_config (key, value, profile_id) VALUES ('thekey', 'thevalue', 3);
+    INSERT INTO containers_profiles (container_id, profile_id) VALUES (1, 2);
+    INSERT INTO profiles_devices (name, profile_id) VALUES ('somename', 2);
+    INSERT INTO profiles_config (key, value, profile_id) VALUES ('thekey', 'thevalue', 2);
     INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (1, 'something', 'boring');`
 
 	_, err = db.Exec(statements)


### PR DESCRIPTION
As of kernel 4.4/criu 1.8, users will be able to checkpoint/restore
containers which are in user namespaces and using seccomp filters (as well
as STRICT mode). Since (at least) these versions will be in 16.04, let's
drop this restriction.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>