### PR TITLE
Use atexit instead of __del__ for cleanup

### DIFF
--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Let's stick to core python3 modules
 import argparse
+import atexit
 import gettext
 import hashlib
 import http.client
@@ -98,8 +99,9 @@ class LXD(object):
 
         # Create our workdir
         self.workdir = tempfile.mkdtemp()
+        print("workdir is " + self.workdir)
 
-    def __del__(self):
+    def cleanup(self):
         if self.workdir:
             shutil.rmtree(self.workdir)
 
@@ -268,7 +270,7 @@ class Busybox(object):
         # Create our workdir
         self.workdir = tempfile.mkdtemp()
 
-    def __del__(self):
+    def cleanup(self):
         if self.workdir:
             shutil.rmtree(self.workdir)
 
@@ -398,7 +400,7 @@ class Ubuntu(Image):
         # Get ready to work with this server
         self.gpg_update()
 
-    def __del__(self):
+    def cleanup(self):
         if self.workdir:
             shutil.rmtree(self.workdir)
 
@@ -514,6 +516,7 @@ if __name__ == "__main__":
         print(_("LXD isn't running."))
         sys.exit(1)
     lxd = LXD(lxd_socket)
+    atexit.register(lxd.cleanup)
 
     def setup_alias(aliases, fingerprint):
         existing = lxd.aliases_list()
@@ -526,6 +529,7 @@ if __name__ == "__main__":
 
     def import_busybox(parser, args):
         busybox = Busybox()
+        atexit.register(busybox.cleanup)
 
         if args.split:
             meta_path, rootfs_path = busybox.create_tarball(split=True)
@@ -576,6 +580,7 @@ if __name__ == "__main__":
             image = ubuntu.image_lookup(args.release, args.architecture,
                                         args.version)
 
+        atexit.register(ubuntu.cleanup)
         sync = False
         if args.sync:
             sync = "ubuntu:%s:%s:%s" % (args.stream, args.release,


### PR DESCRIPTION
Fixes errors caused by shutil not being defined when `__del__` is called.

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>

specifically, when called with --help, it would display the following traceback:

```
  ~/go/src/github.com/lxc/lxd/scripts/lxd-images --help
usage: lxd-images [-h] [--quiet] {import,sync} ...

LXD: image store helper

positional arguments:
  {import,sync}
    import       Import images
    sync         Sync images

optional arguments:
  -h, --help     show this help message and exit
  --quiet        Silence all non-error output

Examples:
 To import the latest Ubuntu Cloud image with an alias:
    /home/ubuntu/go/src/github.com/lxc/lxd/scripts/lxd-images import ubuntu --alias ubuntu

 To import a basic busybox image:
    /home/ubuntu/go/src/github.com/lxc/lxd/scripts/lxd-images import busybox --alias busybox

 Some images can be kept in sync for you, use --sync for that:
    /home/ubuntu/go/src/github.com/lxc/lxd/scripts/lxd-images import ubuntu --alias ubuntu --sync

 Then make sure the following command is executed regularly (e.g. crontab):
    /home/ubuntu/go/src/github.com/lxc/lxd/scripts/lxd-images sync
Exception ignored in: <bound method LXD.__del__ of <__main__.LXD object at 0x7fcffd1cbcf8>>
Traceback (most recent call last):
  File "/home/ubuntu/go/src/github.com/lxc/lxd/scripts/lxd-images", line 104, in __del__
AttributeError: 'NoneType' object has no attribute 'rmtree'
```