### PR TITLE
fix alternate storage backends snapshotting

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -361,7 +361,8 @@ func (s *storageBtrfs) ContainerSnapshotRename(
 }
 
 func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	return fmt.Errorf("btrfs empty snapshot create not implemented")
+	dpath := snapshotContainer.Path("")
+	return s.subvolCreate(dpath)
 }
 
 func (s *storageBtrfs) ImageCreate(fingerprint string) error {

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -565,7 +565,7 @@ func (s *storageLvm) ContainerSnapshotStop(container container) error {
 }
 
 func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	return fmt.Errorf("lvm empty snapshot create not implemented")
+	return s.ContainerCreate(snapshotContainer)
 }
 
 func (s *storageLvm) ImageCreate(fingerprint string) error {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -478,7 +478,7 @@ func (s *storageZfs) ContainerSnapshotStop(container container) error {
 }
 
 func (s *storageZfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	return fmt.Errorf("zfs empty snapshot create not implemented")
+	return fmt.Errorf("can't transfer snapshots to zfs from non-zfs backend")
 }
 
 func (s *storageZfs) ImageCreate(fingerprint string) error {


### PR DESCRIPTION
except for zfs, which can't create empty snapshots. In that case, render a
more accurate error message. N.b. that this means people can't copy
containers with zfs snapshots right now, because the zfs-specific fs
transfer mechanism hasn't landed yet.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>