### PR TITLE
setupSharedMounts: always create shmounts

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -351,15 +351,15 @@ func (d *Daemon) SetupStorageDriver() error {
 
 func setupSharedMounts() error {
 	path := shared.VarPath("shmounts")
-	if shared.IsOnSharedMount(path) {
-		// / may already be ms-shared, or shmounts may have
-		// been mounted by a previous lxd run
-		return nil
-	}
 	if !shared.PathExists(path) {
 		if err := os.Mkdir(path, 0755); err != nil {
 			return err
 		}
+	}
+	if shared.IsOnSharedMount(path) {
+		// / may already be ms-shared, or shmounts may have
+		// been mounted by a previous lxd run
+		return nil
 	}
 	if err := syscall.Mount(path, path, "none", syscall.MS_BIND, ""); err != nil {
 		return err


### PR DESCRIPTION
so check whether it is on a shared mount ptah after we created it

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>