### PR TITLE
fix jenkins build link

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ To easily see what LXD is about, you can [try it online](https://linuxcontainers
 ## CI status
 
  * Travis: [![Build Status](https://travis-ci.org/lxc/lxd.svg?branch=master)](https://travis-ci.org/lxc/lxd)
- * Jenkins: [![Build Status](https://jenkins.linuxcontainers.org/job/lxd-github-commit/badge/icon)](https://jenkins.linuxcontainers.org/job/lxd-trigger-github/)
+ * Jenkins: [![Build Status](https://jenkins.linuxcontainers.org/job/lxd-github-commit/badge/icon)](https://jenkins.linuxcontainers.org/job/lxd-github-commit/)
 
 ## Getting started with LXD
 


### PR DESCRIPTION
The current one gives a 404.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>