### PR TITLE
Implement the rest of limits.memory.*

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -374,9 +374,9 @@ func (c *containerLXC) initLXC() error {
 
 		// Configure the memory limits
 		if memory != "" {
-			var valueInt int
+			var valueInt int64
 			if strings.HasSuffix(memory, "%") {
-				percent, err := strconv.Atoi(strings.TrimSuffix(memory, "%"))
+				percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
 				if err != nil {
 					return err
 				}
@@ -386,7 +386,7 @@ func (c *containerLXC) initLXC() error {
 					return err
 				}
 
-				valueInt = int((memoryTotal / 100) * percent)
+				valueInt = int64((memoryTotal / 100) * percent)
 			} else {
 				valueInt, err = deviceParseBytes(memory)
 				if err != nil {
@@ -1496,7 +1496,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 				if memory == "" {
 					memory = "-1"
 				} else if strings.HasSuffix(memory, "%") {
-					percent, err := strconv.Atoi(strings.TrimSuffix(memory, "%"))
+					percent, err := strconv.ParseInt(strings.TrimSuffix(memory, "%"), 10, 64)
 					if err != nil {
 						return err
 					}
@@ -1506,7 +1506,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 						return err
 					}
 
-					memory = fmt.Sprintf("%d", int((memoryTotal/100)*percent))
+					memory = fmt.Sprintf("%d", int64((memoryTotal/100)*percent))
 				} else {
 					valueInt, err := deviceParseBytes(memory)
 					if err != nil {

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -34,7 +34,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 18
+const DB_CURRENT_VERSION int = 19
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -378,6 +378,12 @@ func ValidContainerConfigKey(k string) bool {
 		return true
 	case "limits.memory":
 		return true
+	case "limits.memory.enforce":
+		return true
+	case "limits.memory.swap":
+		return true
+	case "limits.memory.swap.priority":
+		return true
 	case "security.privileged":
 		return true
 	case "security.nesting":

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -510,7 +510,7 @@ func deviceParseCPU(cpuAllowance string, cpuPriority string) (string, string, st
 	return fmt.Sprintf("%d", cpuShares), cpuCfsQuota, cpuCfsPeriod, nil
 }
 
-func deviceParseBytes(input string) (int, error) {
+func deviceParseBytes(input string) (int64, error) {
 	if len(input) < 3 {
 		return -1, fmt.Errorf("Invalid value: %s", input)
 	}
@@ -520,7 +520,7 @@ func deviceParseBytes(input string) (int, error) {
 
 	// Extract the value
 	value := input[0 : len(input)-2]
-	valueInt, err := strconv.Atoi(value)
+	valueInt, err := strconv.ParseInt(value, 10, 64)
 	if err != nil {
 		return -1, fmt.Errorf("Invalid integer: %s", input)
 	}
@@ -530,7 +530,7 @@ func deviceParseBytes(input string) (int, error) {
 	}
 
 	// Figure out the multiplicator
-	multiplicator := 0
+	multiplicator := int64(0)
 	switch suffix {
 	case "kB":
 		multiplicator = 1024
@@ -551,7 +551,7 @@ func deviceParseBytes(input string) (int, error) {
 	return valueInt * multiplicator, nil
 }
 
-func deviceTotalMemory() (int, error) {
+func deviceTotalMemory() (int64, error) {
 	// Open /proc/meminfo
 	f, err := os.Open("/proc/meminfo")
 	if err != nil {

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -62,7 +62,10 @@ environment.\*                  | string        | -                 | key/value 
 limits.cpu                      | string        | - (all)           | Number or range of CPUs to expose to the container
 limits.cpu.allowance            | string        | 100%              | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
 limits.cpu.priority             | integer       | 10 (maximum)      | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit)
-limits.memory                   | string        | - (all)           | Size in bytes of the memory allocation for the container (supported suffixes: k, K, m, M, g or G)
+limits.memory                   | string        | - (all)           | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
+limits.memory.enforce           | string        | hard              | Whether to allow the container to go past its limit if host resources are available
+limits.memory.swap              | boolean       | true              | Whether to allow some of the container's memory to be swapped out to disk
+limits.memory.swap.priority     | integer       | 10 (maximum)      | The higher this is set, the least likely the container is to be swapped to disk
 raw.apparmor                    | blob          | -                 | Apparmor profile entries to be appended to the generated profile
 raw.lxc                         | blob          | -                 | Raw LXC configuration to be appended to the generated one
 security.nesting                | boolean       | false             | Support running lxd (nested) inside the container

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -63,7 +63,7 @@ limits.cpu                      | string        | - (all)           | Number or 
 limits.cpu.allowance            | string        | 100%              | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
 limits.cpu.priority             | integer       | 10 (maximum)      | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit)
 limits.memory                   | string        | - (all)           | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
-limits.memory.enforce           | string        | hard              | Whether to allow the container to go past its limit if host resources are available
+limits.memory.enforce           | string        | hard              | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
 limits.memory.swap              | boolean       | true              | Whether to allow some of the container's memory to be swapped out to disk
 limits.memory.swap.priority     | integer       | 10 (maximum)      | The higher this is set, the least likely the container is to be swapped to disk
 raw.apparmor                    | blob          | -                 | Apparmor profile entries to be appended to the generated profile


### PR DESCRIPTION
 - Implement basic converter for various units to bytes and bits
 - Have existing memory limit code call said converter code
 - Update the DB to move everything to the supported syntax
 - Adds support for percentage based memory allocation
 - Implement limits.memory.enforce (soft or hard, defaults hard)
 - Implement limits.memory.swap (true or false, defaults true)
 - Implement limits.memory.swap.priority (1 to 10, defaults 10)

Note that on some older kernel (3.13 at least), swap restrictions,
specifically, the swappiness configuration only works in some cases and
fails with EINVAL in others. It's advised that those users upgrade to a
newer kernel (3.19 has been confirmed to work properly) or don't use the
swap restrictions (default configuration doesn't hit the issue).

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>