### PR TITLE
log: get rid of shared.Ctx

### DIFF
--- a/shared/log.go
+++ b/shared/log.go
@@ -5,8 +5,6 @@ import (
 	"runtime"
 )
 
-type Ctx map[string]interface{}
-
 type Logger interface {
 	Debug(msg string, ctx ...interface{})
 	Info(msg string, ctx ...interface{})

--- a/shared/logging/log.go
+++ b/shared/logging/log.go
@@ -78,7 +78,7 @@ func GetLogger(syslog string, logfile string, verbose bool, debug bool, customHa
 func AddContext(logger shared.Logger, ctx log.Ctx) shared.Logger {
 	log15logger, ok := logger.(log.Logger)
 	if !ok {
-		logger.Error("couldn't downcast logger to add context", shared.Ctx{"logger": log15logger, "ctx": ctx})
+		logger.Error("couldn't downcast logger to add context", log.Ctx{"logger": log15logger, "ctx": ctx})
 		return logger
 	}
 


### PR DESCRIPTION
We can't use it anyway without some special casing in logContextMap (see panic
below), and all of the code in lxd/ still uses log.Ctx. I think it's a good
idea only to have one "entry point" for this, so let's not declare a second
false one.

Creating nonlive EROR[12-15|09:38:45] TYCHO: got zfs snapshot LOG15_ERROR= LOG15_ERROR="Normalized odd number of arguments by adding nil"
panic: interface conversion: interface is shared.Ctx, not string

goroutine 53 [running]:
main.logContextMap(0xc8200f1740, 0x4, 0x4, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/events.go:27 +0x13e
main.eventsHandler.Log(0xc82021ed00, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/events.go:41 +0x89
main.(*eventsHandler).Log(0x11ef6e8, 0xc82021ed00, 0x0, 0x0)
  <autogenerated>:88 +0xa3
gopkg.in/inconshreveable/log15%2ev2.MultiHandler.func1(0xc82021ed00, 0x0, 0x0)
  /home/tycho/packages/go/src/gopkg.in/inconshreveable/log15.v2/handler.go:218 +0xa0
gopkg.in/inconshreveable/log15%2ev2.funcHandler.Log(0xc820011c20, 0xc82021ed00, 0x0, 0x0)
  /home/tycho/packages/go/src/gopkg.in/inconshreveable/log15.v2/handler.go:32 +0x32
gopkg.in/inconshreveable/log15%2ev2.(*swapHandler).Log(0xc82002e0b0, 0xc82021ed00, 0x0, 0x0)
  /home/tycho/packages/go/src/gopkg.in/inconshreveable/log15.v2/handler_other.go:17 +0x64
gopkg.in/inconshreveable/log15%2ev2.(*logger).write(0xc820011b40, 0xc41a50, 0x17, 0x1, 0xc82022bea0, 0x1, 0x1)
  /home/tycho/packages/go/src/gopkg.in/inconshreveable/log15.v2/logger.go:111 +0x1e8
gopkg.in/inconshreveable/log15%2ev2.(*logger).Error(0xc820011b40, 0xc41a50, 0x17, 0xc82022bea0, 0x1, 0x1)
  /home/tycho/packages/go/src/gopkg.in/inconshreveable/log15.v2/logger.go:141 +0x5c
main.(*storageZfs).zfsListSubvolumes(0xc8201f83c0, 0xc8201f8f00, 0x47, 0x0, 0x0, 0x0, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/storage_zfs.go:900 +0x893
main.(*storageZfs).zfsClone(0xc8201f83c0, 0xc8201f8f00, 0x47, 0xbb8f50, 0x8, 0xc8200ec080, 0x12, 0xc82021ec01, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/storage_zfs.go:623 +0xa23
main.(*storageZfs).ContainerCreateFromImage(0xc8201f83c0, 0x7f4a5522eb98, 0xc8202ac3c0, 0xc82020a340, 0x40, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/storage_zfs.go:136 +0x54b
main.(*storageLogWrapper).ContainerCreateFromImage(0xc82020c8c0, 0x7f4a5522eb98, 0xc8202ac3c0, 0xc82020a340, 0x40, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/storage.go:380 +0x3a3
main.containerCreateFromImage(0xc82007c9a0, 0x0, 0x2, 0xc82020a340, 0x40, 0xc8201f6900, 0x0, 0x0, 0x0, 0xc8202649f0, ...)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/container.go:170 +0x2b1
main.createFromImage.func1(0xc82039dd90, 0x0, 0x0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/containers_post.go:101 +0x29d
main.(*operation).Run.func1(0xc82039dd90, 0xc8201f49c0)
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/operations.go:110 +0x3a
created by main.(*operation).Run
  /home/tycho/packages/go/src/github.com/lxc/lxd/lxd/operations.go:135 +0x127

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>