### PR TITLE
tests: add a shebang to backend scripts

### DIFF
--- a/test/backends/btrfs.sh
+++ b/test/backends/btrfs.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 btrfs_setup() {
   local LXD_DIR
   LXD_DIR=$1

--- a/test/backends/dir.sh
+++ b/test/backends/dir.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # Nothing need be done for the dir backed, but we still need some functions.
 # This file can also serve as a skel file for what needs to be done to
 # implement a new backend.

--- a/test/backends/zfs.sh
+++ b/test/backends/zfs.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 zfs_setup() {
   local LXD_DIR
   LXD_DIR=$1


### PR DESCRIPTION
This avoids:

==> TEST: doing static analysis of commits

In test/backends/btrfs.sh line 1:
btrfs_setup() {
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

In test/backends/dir.sh line 1:
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

In test/backends/zfs.sh line 1:
zfs_setup() {
^-- SC2148: Tips depend on target shell and yours is unknown. Add a shebang.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>