### PR TITLE
zfs: use uuid instead of timestamp for zfs temp snapshot

### DIFF
--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1233,7 +1233,7 @@ func (s *storageZfs) MigrationSource(container container) ([]MigrationStorageSou
 	/* We can't send running fses, so let's snapshot the fs and send
 	 * the snapshot.
 	 */
-	snapshotName := fmt.Sprintf("migration-send-%s", time.Now().Format(time.RFC3339))
+	snapshotName := fmt.Sprintf("migration-send-%s", uuid.NewRandom().String())
 	if err := s.zfsSnapshotCreate(fmt.Sprintf("containers/%s", container.Name()), snapshotName); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If two people try and migrate a snapshot in the same second (or indeed, if
one snapshot doesn't finish deleting before the next migration back starts
as in our test suite) we can get collisions. Let's use a uuid instead.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>