### PR TITLE
exec: lock fds map for exclusive writes

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -41,6 +41,7 @@ type execWs struct {
 	rootGid          int
 	options          lxc.AttachOptions
 	conns            map[int]*websocket.Conn
+	connsLock        sync.Mutex
 	allConnected     chan bool
 	controlConnected chan bool
 	interactive      bool
@@ -73,7 +74,9 @@ func (s *execWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) 
 				return err
 			}
 
+			s.connsLock.Lock()
 			s.conns[fd] = conn
+			s.connsLock.Unlock()
 
 			if fd == -1 {
 				s.controlConnected <- true


### PR DESCRIPTION
This avoids:

fatal error: concurrent map writes

goroutine 1337 [running]:
runtime.throw(0x876c710, 0x15)
  /lxd/build/tmp.FYCkSnkCEv/gimme/versions/go/src/runtime/panic.go:530 +0x7f fp=0x5082e608 sp=0x5082e5fc
runtime.mapassign1(0x856bac0, 0x506feb40, 0x5082e690, 0x5082e694)
  /lxd/build/tmp.FYCkSnkCEv/gimme/versions/go/src/runtime/hashmap.go:445 +0x8b fp=0x5082e668 sp=0x5082e608
main.(*execWs).Connect(0x50670af0, 0x50670bd0, 0x5071cc40, 0x71502130, 0x5066a100, 0x0, 0x0)
  /lxd/build/tmp.1h89I19sQ8/go/src/github.com/lxc/lxd/lxd/container_exec.go:76 +0x1e7 fp=0x5082e71c sp=0x5082e668
main.(*execWs).Connect-fm(0x50670bd0, 0x5071cc40, 0x71502130, 0x5066a100, 0x0, 0x0)
  /lxd/build/tmp.1h89I19sQ8/go/src/github.com/lxc/lxd/lxd/container_exec.go:321 +0x4c fp=0x5082e73c sp=0x5082e71c
main.(*operation).Connect.func1(0x5071cc40, 0x71502130, 0x5066a100, 0x50670bd0, 0x5059e6c0)
  /lxd/build/tmp.1h89I19sQ8/go/src/github.com/lxc/lxd/lxd/operations.go:222 +0x52 fp=0x5082e7c8 sp=0x5082e73c
runtime.goexit()
  /lxd/build/tmp.FYCkSnkCEv/gimme/versions/go/src/runtime/asm_386.s:1583 +0x1 fp=0x5082e7cc sp=0x5082e7c8
created by main.(*operation).Connect
  /lxd/build/tmp.1h89I19sQ8/go/src/github.com/lxc/lxd/lxd/operations.go:237 +0x130

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>