### PR TITLE
Don't call Finger() for every new client

### DIFF
--- a/client.go
+++ b/client.go
@@ -253,10 +253,6 @@ func NewClient(config *Config, remote string) (*Client, error) {
 		return nil, fmt.Errorf(i18n.G("unknown remote name: %q"), remote)
 	}
 
-	if err := c.Finger(); err != nil {
-		return nil, err
-	}
-
 	return &c, nil
 }
 
@@ -970,7 +966,13 @@ func (c *Client) ListAliases() ([]shared.ImageAlias, error) {
 
 func (c *Client) UserAuthServerCert(name string, acceptCert bool) error {
 	if !c.scertDigestSet {
-		return fmt.Errorf(i18n.G("No certificate on this connection"))
+		if err := c.Finger(); err != nil {
+			return err
+		}
+
+		if !c.scertDigestSet {
+			return fmt.Errorf(i18n.G("No certificate on this connection"))
+		}
 	}
 
 	if c.scert != nil {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -775,12 +775,12 @@ func (c *containerLXC) startCommon() (string, error) {
 		return "", err
 	}
 
-	err = os.MkdirAll(shared.VarPath("devices", c.Name()), 0700)
+	err = os.MkdirAll(shared.VarPath("devices", c.Name()), 0711)
 	if err != nil {
 		return "", err
 	}
 
-	err = os.MkdirAll(shared.VarPath("shmounts", c.Name()), 0700)
+	err = os.MkdirAll(shared.VarPath("shmounts", c.Name()), 0711)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
We already call Finger() on remote add where it makes the most sense and
we then handle errors properly everywhere else, so there's no reason to
call finger in newClient.

Dropping it reduces the number of REST queries by half in most cases,
reducing CPU load and improving performance very significantly on high
latency (transatlantic in my case) links.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>