### PR TITLE
lvm: Fix ImageCreate() call in ContainerCreateFromImage()

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -256,7 +256,7 @@ func (s *storageLvm) ContainerCreateFromImage(
 		"images", fmt.Sprintf("%s.lv", imageFingerprint))
 
 	if !shared.PathExists(imageLVFilename) {
-		if err := s.ImageCreate(imageLVFilename); err != nil {
+		if err := s.ImageCreate(imageFingerprint); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
ImageCreate() accepts the image fingerprint, not .lv symlink.

This bit me when I was creating a container after changing the storage backend from other to lvm.

```
# lxc config show
config: {}
# lxd-images import busybox --alias busybox
Image imported as: 30e7e15f81023247468be0a3d703e74e52d6fbf83b60917005f518714f08d432
Setup alias: busybox
# lxc config set storage.lvm_vg_name lxd
# lxc init busybox c1
Creating c1 error.
error: Error Creating LVM LV for new image: Error making filesystem on image LV: exit status 1
# lxc config show
config:
  storage.lvm_thinpool_name: LXDPool
  storage.lvm_vg_name: lxd
# lvs lxd
  LV                                                                  VG   Attr      LSize  Pool    Origin Data%  Move Log Copy%  Convert
  30e7e15f81023247468be0a3d703e74e52d6fbf83b60917005f518714f08d432.lv lxd  Vwi-a-tz- 10.00g LXDPool          0.00                        
  LXDPool                                                             lxd  twi-a-tz- 98.00g                  0.00                        
```

`lxd --debug` output:

```
INFO[12-27|08:29:54] handling                                 url=/1.0/operations/bdfea15e-7d38-4b21-9a5e-8a7c3c0128de/wait ip=@ method=GET
DBUG[12-27|08:29:54] ContainerCreateFromImage                 driver=storage/lvm imageFingerprint=30e7e15f81023247468be0a3d703e74e52d6fbf83b60917005f518714f08d432 name=c1 isPrivileged=false
EROR[12-27|08:30:00] mkfs.ext4                                driver=storage/lvm output="mke2fs 1.42.9 (4-Feb-2014)\nCould not stat /dev/lxd//var/lib/lxd/images/30e7e15f81023247468be0a3d703e74e52d6fbf83b60917005f518714f08d432.lv --- No such file or directory\n\nThe device apparently does not exist; did you specify it correctly?\n"
EROR[12-27|08:30:00] LVMCreateThinLV                          driver=storage/lvm err="Error making filesystem on image LV: exit status 1"
DBUG[12-27|08:30:00] containerDeleteSnapshots                 container=c1
DBUG[12-27|08:30:00] ContainerDelete                          driver=storage/lvm container=c1
DBUG[12-27|08:30:06] Could not remove LV                      driver=storage/lvm lvname=c1 output="  One or more specified logical volume(s) not found.\n"
DBUG[12-27|08:30:06] Failure for task operation: bdfea15e-7d38-4b21-9a5e-8a7c3c0128de: Error Creating LVM LV for new image: Error making filesystem on image LV: exit status 1 
```