### PR TITLE
lvm: only pass -kn to lvcreate for lvm > 2.02.99

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -254,7 +254,7 @@ func (s *storageLvm) lvmVersionIsAtLeast(versionString string) (bool, error) {
 
 	if lvmMaj < inMaj || lvmMin < inMin || lvmInc < inInc {
 		return false, nil
-	}else{
+	} else {
 		return true, nil
 	}
 
@@ -921,7 +921,7 @@ func (s *storageLvm) createSnapshotLV(lvname string, origlvname string, readonly
 			"-kn",
 			"-n", lvname,
 			"-s", fmt.Sprintf("/dev/%s/%s", s.vgName, origlvname))
-	}else{
+	} else {
 		output, err = s.tryExec(
 			"lvcreate",
 			"-n", lvname,


### PR DESCRIPTION
-kn, aka '--setactivationskip n', is required after LVM version 2.02.99, which sets
the activationskip flag to true by default for thin LVs.

However, it is not supported prior to that version so we need to send it
conditionally.

Fixes #1470 

Signed-off-by: Michael McCracken <mike.mccracken@canonical.com>