### PR TITLE
Added choosable formatting filesystem for LVs

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -161,6 +161,11 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err != nil {
 				return InternalError(err)
 			}
+		} else if key == "storage.lvm_fstype" {
+			err := storageLVMSetFsTypeConfig(d, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
 		} else if key == "storage.zfs_pool_name" {
 			err := storageZFSSetPoolNameConfig(d, value.(string))
 			if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1081,6 +1081,8 @@ func (d *Daemon) ConfigKeyIsValid(key string) bool {
 		return true
 	case "storage.lvm_thinpool_name":
 		return true
+	case "storage.lvm_fstype":
+		return true
 	case "storage.zfs_pool_name":
 		return true
 	case "images.remote_cache_expiry":

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -161,6 +161,15 @@ func storageLVMSetVolumeGroupNameConfig(d *Daemon, vgname string) error {
 	return nil
 }
 
+func storageLVMSetFsTypeConfig(d *Daemon, fstype string) error {
+	err := d.ConfigValueSet("storage.lvm_fstype", fstype)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func containerNameToLVName(containerName string) string {
 	lvName := strings.Replace(containerName, "-", "--", -1)
 	return strings.Replace(lvName, shared.SnapshotDelimiter, "-", -1)
@@ -334,7 +343,25 @@ func (s *storageLvm) ContainerCreateFromImage(
 		return err
 	}
 
-	err = s.tryMount(lvpath, destPath, "ext4", 0, "discard")
+	var fstype string
+	fstype, err = s.d.ConfigValueGet("storage.lvm_fstype")
+	if err != nil {
+		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	// Generate a new xfs's UUID
+	if fstype == "xfs" {
+		output, err := exec.Command(
+			"xfs_admin",
+			"-U", "generate",
+			lvpath).CombinedOutput()
+		if err != nil {
+			s.ContainerDelete(container)
+			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+		}
+	}
+
+	err = s.tryMount(lvpath, destPath, fstype, 0, "discard")
 	if err != nil {
 		s.ContainerDelete(container)
 		return fmt.Errorf("Error mounting snapshot LV: %v", err)
@@ -428,7 +455,12 @@ func (s *storageLvm) ContainerCopy(container container, sourceContainer containe
 func (s *storageLvm) ContainerStart(container container) error {
 	lvName := containerNameToLVName(container.Name())
 	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvName)
-	err := s.tryMount(lvpath, container.Path(), "ext4", 0, "discard")
+	fstype, err := s.d.ConfigValueGet("storage.lvm_fstype")
+	if err != nil {
+		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	err = s.tryMount(lvpath, container.Path(), fstype, 0, "discard")
 	if err != nil {
 		return fmt.Errorf(
 			"Error mounting snapshot LV path='%s': %v",
@@ -709,7 +741,25 @@ func (s *storageLvm) ContainerSnapshotStart(container container) error {
 		}
 	}
 
-	err = s.tryMount(lvpath, container.Path(), "ext4", 0, "discard")
+	var fstype string
+	fstype, err = s.d.ConfigValueGet("storage.lvm_fstype")
+	if err != nil {
+		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	// Generate a new xfs's UUID
+	if fstype == "xfs" {
+		output, err := exec.Command(
+			"xfs_admin",
+			"-U", "generate",
+			lvpath).CombinedOutput()
+		if err != nil {
+			s.ContainerDelete(container)
+			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+		}
+	}
+
+	err = s.tryMount(lvpath, container.Path(), fstype, 0, "discard")
 	if err != nil {
 		return fmt.Errorf(
 			"Error mounting snapshot LV path='%s': %v",
@@ -763,7 +813,25 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 		}
 	}()
 
-	err = s.tryMount(lvpath, tempLVMountPoint, "ext4", 0, "discard")
+	var fstype string
+	fstype, err = s.d.ConfigValueGet("storage.lvm_fstype")
+	if err != nil {
+		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	// Generate a new xfs's UUID
+	if fstype == "xfs" {
+		output, err := exec.Command(
+			"xfs_admin",
+			"-U", "generate",
+			lvpath).CombinedOutput()
+		if err != nil {
+			// s.ContainerDelete(container)
+			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+		}
+	}
+
+	err = s.tryMount(lvpath, tempLVMountPoint, fstype, 0, "discard")
 	if err != nil {
 		shared.Logf("Error mounting image LV for untarring: %v", err)
 		return fmt.Errorf("Error mounting image LV: %v", err)
@@ -880,10 +948,20 @@ func (s *storageLvm) createThinLV(lvname string) (string, error) {
 
 	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvname)
 
-	output, err = s.tryExec(
-		"mkfs.ext4",
-		"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0",
-		lvpath)
+	fstype, err := s.d.ConfigValueGet("storage.lvm_fstype")
+
+	switch fstype {
+	case "xfs":
+		output, err = s.tryExec(
+			"mkfs.xfs",
+			lvpath)
+	default:
+		// default = ext4
+		output, err = s.tryExec(
+			"mkfs.ext4",
+			"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0",
+			lvpath)
+	}
 
 	if err != nil {
 		s.log.Error("mkfs.ext4", log.Ctx{"output": string(output)})

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -361,6 +361,10 @@ func (s *storageLvm) ContainerCreateFromImage(
 		return fmt.Errorf("Error checking server config, err=%v", err)
 	}
 
+	if fstype == "" {
+		fstype = "ext4"
+	}
+
 	// Generate a new xfs's UUID
 	if fstype == "xfs" {
 		err := xfsGenerateNewUUID(lvpath)
@@ -467,6 +471,10 @@ func (s *storageLvm) ContainerStart(container container) error {
 	fstype, err := s.d.ConfigValueGet("storage.lvm_fstype")
 	if err != nil {
 		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	if fstype == "" {
+		fstype = "ext4"
 	}
 
 	err = s.tryMount(lvpath, container.Path(), fstype, 0, "discard")
@@ -756,6 +764,10 @@ func (s *storageLvm) ContainerSnapshotStart(container container) error {
 		return fmt.Errorf("Error checking server config, err=%v", err)
 	}
 
+	if fstype == "" {
+		fstype = "ext4"
+	}
+
 	// Generate a new xfs's UUID
 	if fstype == "xfs" {
 		err := xfsGenerateNewUUID(lvpath)
@@ -823,6 +835,10 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 	fstype, err = s.d.ConfigValueGet("storage.lvm_fstype")
 	if err != nil {
 		return fmt.Errorf("Error checking server config, err=%v", err)
+	}
+
+	if fstype == "" {
+		fstype = "ext4"
 	}
 
 	err = s.tryMount(lvpath, tempLVMountPoint, fstype, 0, "discard")

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -357,7 +357,7 @@ func (s *storageLvm) ContainerCreateFromImage(
 			lvpath).CombinedOutput()
 		if err != nil {
 			s.ContainerDelete(container)
-			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+			return fmt.Errorf("Error generating new UUID: %v\noutput:'%s'", err, string(output))
 		}
 	}
 
@@ -755,7 +755,7 @@ func (s *storageLvm) ContainerSnapshotStart(container container) error {
 			lvpath).CombinedOutput()
 		if err != nil {
 			s.ContainerDelete(container)
-			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+			return fmt.Errorf("Error generating new UUID: %v\noutput:'%s'", err, string(output))
 		}
 	}
 
@@ -827,7 +827,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 			lvpath).CombinedOutput()
 		if err != nil {
 			// s.ContainerDelete(container)
-			return fmt.Errorf("Error mounting snapshot LV: %v\noutput:'%s'", err, string(output))
+			return fmt.Errorf("Error generating new UUID: %v\noutput:'%s'", err, string(output))
 		}
 	}
 

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -23,7 +23,7 @@ core.https\_address             | string        | -                         | Ad
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 storage.lvm\_vg\_name           | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.
-storage.lvm\_fstype             | string        | -                         | Format LV with filesystem, for now it's value can be only ext4 (default) or xfs.
+storage.lvm\_fstype             | string        | ext4                      | Format LV with filesystem, for now it's value can be only ext4 (default) or xfs.
 storage.zfs\_pool\_name         | string        | -                         | ZFS pool name
 images.compression\_algorithm   | string        | gzip                      | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -23,6 +23,7 @@ core.https\_address             | string        | -                         | Ad
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 storage.lvm\_vg\_name           | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.
+storage.lvm\_fstype             | string        | -                         | Format LV with filesystem, for now it's value can be only ext4 (default) or xfs.
 storage.zfs\_pool\_name         | string        | -                         | ZFS pool name
 images.compression\_algorithm   | string        | gzip                      | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
 images.remote\_cache\_expiry    | integer       | 10                        | Number of days after which an unused cached remote image will be flushed


### PR DESCRIPTION
LXD has hardcoded ext4 as the filesystem to be used when LVM storage backend is choosed, I don't like very much ext* filesystems and prefer xfs over them so I've done a little patch to be able to use it with LXD.

To be able to choose preferred filesystem a key was added to the configuration parameter of LXD: storage.lvm_fstype, for now it's value can be only ext4 (default, so I don't break anything) and xfs, but it's trivial to add other filesystems.

For now the filesystem has to be choosen at LXD installation time, in the future I think it will be better to let the users to choose filesystem at container creation time so it'll be possible to have different filesystem for different container and so migrating a container from one host to another will be possible even if they have different default filesystem.