### PR TITLE
lxd-images: print newline when reporting an error

### DIFF
--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -28,7 +28,7 @@ quiet = False
 
 class FriendlyParser(argparse.ArgumentParser):
     def error(self, message):
-        sys.stderr.write('error: %s\n' % message)
+        sys.stderr.write('\nerror: %s\n' % message)
         self.print_help()
         sys.exit(2)
 


### PR DESCRIPTION
In the case of an error, if we're in the middle of a progress report, we
might overwrite one of the \rs. Instead, let's just print a \n to clear the
error.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>