### PR TITLE
Add a new linux.kernel_modules option

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -59,6 +59,8 @@ func containerValidConfigKey(k string) bool {
 		return true
 	case "limits.memory.swap.priority":
 		return true
+	case "linux.kernel_modules":
+		return true
 	case "security.privileged":
 		return true
 	case "security.nesting":

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -780,6 +780,18 @@ func (c *containerLXC) startCommon() (string, error) {
 		return "", fmt.Errorf("The container is already running")
 	}
 
+	// Load any required kernel modules
+	kernelModules := c.expandedConfig["linux.kernel_modules"]
+	if kernelModules != "" {
+		for _, module := range strings.Split(kernelModules, ",") {
+			module = strings.TrimPrefix(module, " ")
+			out, err := exec.Command("modprobe", module).CombinedOutput()
+			if err != nil {
+				return "", fmt.Errorf("Failed to load kernel module '%s': %s", module, out)
+			}
+		}
+	}
+
 	/* Deal with idmap changes */
 	idmap := c.IdmapSet()
 

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -68,6 +68,7 @@ limits.memory                   | string        | - (all)           | Percentage
 limits.memory.enforce           | string        | hard              | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
 limits.memory.swap              | boolean       | true              | Whether to allow some of the container's memory to be swapped out to disk
 limits.memory.swap.priority     | integer       | 10 (maximum)      | The higher this is set, the least likely the container is to be swapped to disk
+linux.kernel\_modules           | string        | -                 | Comma separated list of kernel modules to load before starting the container
 raw.apparmor                    | blob          | -                 | Apparmor profile entries to be appended to the generated profile
 raw.lxc                         | blob          | -                 | Raw LXC configuration to be appended to the generated one
 security.nesting                | boolean       | false             | Support running lxd (nested) inside the container


### PR DESCRIPTION
Make it possible to load kernel modules before starting a container.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>