### PR TITLE
s/OK/OperationCreated/g

### DIFF
--- a/lxd/response.go
+++ b/lxd/response.go
@@ -150,8 +150,8 @@ func (r *operationResponse) Render(w http.ResponseWriter) error {
 
 	body := resp{
 		Type:       lxd.Async,
-		Status:     shared.OK.String(),
-		StatusCode: shared.OK,
+		Status:     shared.OperationCreated.String(),
+		StatusCode: shared.OperationCreated,
 		Operation:  url,
 		Metadata:   md}
 

--- a/shared/status.go
+++ b/shared/status.go
@@ -3,18 +3,18 @@ package shared
 type StatusCode int
 
 const (
-	OK         StatusCode = 100
-	Started    StatusCode = 101
-	Stopped    StatusCode = 102
-	Running    StatusCode = 103
-	Cancelling StatusCode = 104
-	Pending    StatusCode = 105
-	Starting   StatusCode = 106
-	Stopping   StatusCode = 107
-	Aborting   StatusCode = 108
-	Freezing   StatusCode = 109
-	Frozen     StatusCode = 110
-	Thawed     StatusCode = 111
+	OperationCreated StatusCode = 100
+	Started          StatusCode = 101
+	Stopped          StatusCode = 102
+	Running          StatusCode = 103
+	Cancelling       StatusCode = 104
+	Pending          StatusCode = 105
+	Starting         StatusCode = 106
+	Stopping         StatusCode = 107
+	Aborting         StatusCode = 108
+	Freezing         StatusCode = 109
+	Frozen           StatusCode = 110
+	Thawed           StatusCode = 111
 
 	Success StatusCode = 200
 
@@ -24,21 +24,21 @@ const (
 
 func (o StatusCode) String() string {
 	return map[StatusCode]string{
-		OK:         "OK",
-		Started:    "Started",
-		Stopped:    "Stopped",
-		Running:    "Running",
-		Cancelling: "Cancelling",
-		Pending:    "Pending",
-		Success:    "Success",
-		Failure:    "Failure",
-		Cancelled:  "Cancelled",
-		Starting:   "Starting",
-		Stopping:   "Stopping",
-		Aborting:   "Aborting",
-		Freezing:   "Freezing",
-		Frozen:     "Frozen",
-		Thawed:     "Thawed",
+		OperationCreated: "Operation created",
+		Started:          "Started",
+		Stopped:          "Stopped",
+		Running:          "Running",
+		Cancelling:       "Cancelling",
+		Pending:          "Pending",
+		Success:          "Success",
+		Failure:          "Failure",
+		Cancelled:        "Cancelled",
+		Starting:         "Starting",
+		Stopping:         "Stopping",
+		Aborting:         "Aborting",
+		Freezing:         "Freezing",
+		Frozen:           "Frozen",
+		Thawed:           "Thawed",
 	}[o]
 }
 

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -119,7 +119,7 @@ The codes are always 3 digits, with the following ranges:
 
 Code  | Meaning
 :---  | :------
-100   | OK
+100   | Operation created
 101   | Started
 102   | Stopped
 103   | Running


### PR DESCRIPTION
After some discussion at the sprint, Paul points out that OK here is
confusing, when what we really mean is that the operation has been created
and you should check that for further results.

Reported by: Paul Hummer
Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>