### PR TITLE
cleanup temporary directories if we fail to find the image.

### DIFF
--- a/scripts/lxd-images
+++ b/scripts/lxd-images
@@ -568,6 +568,7 @@ if __name__ == "__main__":
                                                 args.architecture,
                                                 args.version)
                 except:
+                    ubuntu.cleanup()
                     continue
 
                 args.stream = stream


### PR DESCRIPTION
We use atexit.register(ubuntu.cleanup), however if we're doing auto searching and the version isn't part of 'releases', then we'll "leak" the first Ubuntu object without calling cleanup.
Now, the code will still register cleanup for the last one we try, but if both fail the lookup, then the 'image' object isn't going to be initialized anyway, so things will just fall over later. This way we at least don't leave garbage on disk.
