### PR TITLE
Print message on sucessfull copy of image

### DIFF
--- a/client.go
+++ b/client.go
@@ -593,6 +593,10 @@ func (c *Client) CopyImage(image string, dest *Client, copy_aliases bool, aliase
 		if ok {
 			progressHandler(opMd["download_progress"].(string))
 		}
+
+		if shared.StatusCode(md["status_code"].(float64)).IsFinal() {
+			fmt.Printf("Image copied successfully!\n")
+		}
 	}
 
 	if progressHandler != nil {


### PR DESCRIPTION
Example:
[root@lxc-dev ~]# lxc image copy images:centos/6/i386 local: --alias c6
Image copied succesfully!
[root@lxc-dev ~]#

Fixes #1530

Signed-off-by: Nehal J Wani <nehaljw.kkd1@gmail.com>