### PR TITLE
Better deal with broken LXC

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ ZFS has many different ways to procure a zpool, which is what you need to feed
 LXD. For example, if you have an extra block device laying around, you can
 just:
 
-    sudo zpool create lxd /dev/sdc6
+    sudo zpool create lxd /dev/sdc6 -m none
 
 However, if you want to test things out on a laptop or don't have an extra disk
 laying around, ZFS has its own loopback driver and can be used directly on a
@@ -182,7 +182,7 @@ laying around, ZFS has its own loopback driver and can be used directly on a
 
 then,
 
-    sudo zpool create lxd /var/lib/lxd.img
+    sudo zpool create lxd /var/lib/lxd.img -m none
 
 Finally, whichever method you used to create your zpool, you need to tell LXD
 to use it:

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3749,7 +3749,8 @@ func (c *containerLXC) IsPrivileged() bool {
 }
 
 func (c *containerLXC) IsRunning() bool {
-	return c.State() != "STOPPED"
+	state := c.State()
+	return state != "BROKEN" && state != "STOPPED"
 }
 
 func (c *containerLXC) IsSnapshot() bool {
@@ -3844,7 +3845,7 @@ func (c *containerLXC) State() string {
 	// Load the go-lxc struct
 	err := c.initLXC()
 	if err != nil {
-		return ""
+		return "BROKEN"
 	}
 
 	return c.c.State().String()

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -724,8 +724,8 @@ func (d *Daemon) Init() error {
 		shared.Log.Warn("Couldn't find the CGroup memory controller, memory limits will be ignored.")
 	}
 
-	cgNetPrioController = shared.PathExists("/sys/fs/cgroup/net_cls/")
-	if !cgMemoryController {
+	cgNetPrioController = shared.PathExists("/sys/fs/cgroup/net_prio/")
+	if !cgNetPrioController {
 		shared.Log.Warn("Couldn't find the CGroup network class controller, network limits will be ignored.")
 	}
 

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -401,12 +401,12 @@ func deviceEventListener(d *Daemon) {
 				continue
 			}
 
-			if e[0] == "cpu" {
+			if e[0] == "cpu" && cgCpusetController {
 				shared.Debugf("Scheduler: %s: %s is now %s: re-balancing", e[0], e[1], e[2])
 				deviceTaskBalance(d)
 			}
 
-			if e[0] == "net" && e[2] == "add" {
+			if e[0] == "net" && e[2] == "add" && cgNetPrioController {
 				shared.Debugf("Scheduler: %s: %s has been added: updating network priorities", e[0], e[1])
 				deviceNetworkPriority(d, e[1])
 			}
@@ -415,8 +415,11 @@ func deviceEventListener(d *Daemon) {
 				shared.Log.Error("Scheduler: received an invalid rebalance event")
 				continue
 			}
-			shared.Debugf("Scheduler: %s %s %s: re-balancing", e[0], e[1], e[2])
-			deviceTaskBalance(d)
+
+			if cgCpusetController {
+				shared.Debugf("Scheduler: %s %s %s: re-balancing", e[0], e[1], e[2])
+				deviceTaskBalance(d)
+			}
 		}
 	}
 }


### PR DESCRIPTION
If LXC fails to parse the config, we should make it clearer by setting a
BROKEN container status which downstreams can react to.

This specifically should allow removing containers with broken LXC config.

Reported-by: Justin Thomas
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>