### PR TITLE
only set io limits when they are nonzero

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -580,24 +580,32 @@ func (c *containerLXC) initLXC() error {
 		}
 
 		for block, limit := range diskLimits {
-			err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_bps_device", fmt.Sprintf("%s %d", block, limit.readBps))
-			if err != nil {
-				return err
+			if limit.readBps > 0 {
+				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_bps_device", fmt.Sprintf("%s %d", block, limit.readBps))
+				if err != nil {
+					return err
+				}
 			}
 
-			err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_iops_device", fmt.Sprintf("%s %d", block, limit.readIops))
-			if err != nil {
-				return err
+			if limit.readIops > 0 {
+				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_iops_device", fmt.Sprintf("%s %d", block, limit.readIops))
+				if err != nil {
+					return err
+				}
 			}
 
-			err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_bps_device", fmt.Sprintf("%s %d", block, limit.writeBps))
-			if err != nil {
-				return err
+			if limit.writeBps > 0 {
+				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_bps_device", fmt.Sprintf("%s %d", block, limit.writeBps))
+				if err != nil {
+					return err
+				}
 			}
 
-			err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_iops_device", fmt.Sprintf("%s %d", block, limit.writeIops))
-			if err != nil {
-				return err
+			if limit.writeIops > 0 {
+				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_iops_device", fmt.Sprintf("%s %d", block, limit.writeIops))
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3516,7 +3516,7 @@ func (c *containerLXC) getDiskLimits() (map[string]deviceBlockLimit, error) {
 				return nil, fmt.Errorf("Invalid major:minor: %s", block)
 			}
 
-			if !shared.PathExists(fmt.Sprintf("/sys/class/block/%s/partition", dev)) {
+			if shared.PathExists(fmt.Sprintf("/sys/class/block/%s/partition", dev)) {
 				fields[1] = "0"
 			}
 

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -782,7 +782,8 @@ func deviceGetParentBlock(path string) ([]string, error) {
 		expDev = absDev
 	}
 
-	// Deal with per-filesystem oddities
+	// Deal with per-filesystem oddities. We don't care about failures here
+	// because any non-special filesystem => directory backend.
 	fs, _ := filesystemDetect(expPath)
 
 	// ZFS can be backed by multiple block devices
@@ -844,7 +845,8 @@ func deviceGetParentBlocks(path string) ([]string, error) {
 		return nil, fmt.Errorf("Couldn't find a match /proc/self/mountinfo entry")
 	}
 
-	// Deal with per-filesystem oddities
+	// Deal with per-filesystem oddities. We don't care about failures here
+	// because any non-special filesystem => directory backend.
 	fs, _ := filesystemDetect(expPath)
 
 	if fs == "zfs" {


### PR DESCRIPTION
My kernel doesn't like setting zero limits:

            lxc 20160126090053.350 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1535 - call to cgmanager_set_value_sync failed: invalid request
            lxc 20160126090053.350 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1538 - Error setting cgroup blkio:lxc/unpriv limit type blkio.throttle.read_bps_device
            lxc 20160126090053.350 ERROR    lxc_start - start.c:lxc_spawn:1090 - failed to setup the cgroup limits for 'unpriv'
            lxc 20160126090053.383 ERROR    lxc_start - start.c:__lxc_start:1272 - failed to spawn 'unpriv'
            lxc 20160126090438.835 ERROR    lxc_monitor - monitor.c:lxc_monitor_open:209 - connect : backing off 10
            lxc 20160126090438.864 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1535 - call to cgmanager_set_value_sync failed: invalid request
            lxc 20160126090438.864 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1538 - Error setting cgroup blkio:lxc/unpriv limit type blkio.throttle.read_bps_device
            lxc 20160126090438.864 ERROR    lxc_start - start.c:lxc_spawn:1090 - failed to setup the cgroup limits for 'unpriv'
            lxc 20160126090438.891 ERROR    lxc_start - start.c:__lxc_start:1272 - failed to spawn 'unpriv'
            lxc 20160126090813.053 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1535 - call to cgmanager_set_value_sync failed: invalid request
            lxc 20160126090813.053 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1538 - Error setting cgroup blkio:lxc/unpriv limit type blkio.throttle.read_iops_device
            lxc 20160126090813.053 ERROR    lxc_start - start.c:lxc_spawn:1090 - failed to setup the cgroup limits for 'unpriv'
            lxc 20160126090813.079 ERROR    lxc_start - start.c:__lxc_start:1272 - failed to spawn 'unpriv'
            lxc 20160126090908.619 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1535 - call to cgmanager_set_value_sync failed: invalid request
            lxc 20160126090908.619 ERROR    lxc_cgmanager - cgmanager.c:cgm_setup_limits:1538 - Error setting cgroup blkio:lxc/unpriv limit type blkio.throttle.write_bps_device
            lxc 20160126090908.619 ERROR    lxc_start - start.c:lxc_spawn:1090 - failed to setup the cgroup limits for 'unpriv'
            lxc 20160126090908.643 ERROR    lxc_start - start.c:__lxc_start:1272 - failed to spawn 'unpriv'

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>