### PR TITLE
Regex for image list filters

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 	"syscall"
 	"time"
-	"regexp"
 
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/crypto/ssh/terminal"
@@ -638,7 +638,7 @@ func imageShouldShow(filters []string, state *shared.ImageInfo) bool {
 					//try to test filter value as a regexp
 					regexpValue := value
 					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
-							regexpValue = "^" + regexpValue + "$"
+						regexpValue = "^" + regexpValue + "$"
 					}
 					r, err := regexp.Compile(regexpValue)
 					//if not regexp compatible use original value
@@ -647,7 +647,7 @@ func imageShouldShow(filters []string, state *shared.ImageInfo) bool {
 							found = true
 							break
 						}
-					}	else if r.MatchString(configValue) == true {
+					} else if r.MatchString(configValue) == true {
 						found = true
 						break
 					}

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -635,7 +635,13 @@ func imageShouldShow(filters []string, state *shared.ImageInfo) bool {
 
 			for configKey, configValue := range state.Properties {
 				if dotPrefixMatch(key, configKey) {
-					r, err := regexp.Compile(value)
+					//try to test filter value as a regexp
+					regexpValue := value
+					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
+							regexpValue = "^" + regexpValue + "$"
+					}
+					r, err := regexp.Compile(regexpValue)
+					//if not regexp compatible use original value
 					if err != nil {
 						if value == configValue {
 							found = true

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 	"time"
+	"regexp"
 
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/crypto/ssh/terminal"
@@ -634,7 +635,13 @@ func imageShouldShow(filters []string, state *shared.ImageInfo) bool {
 
 			for configKey, configValue := range state.Properties {
 				if dotPrefixMatch(key, configKey) {
-					if value == configValue {
+					r, err := regexp.Compile(value)
+					if err != nil {
+						if value == configValue {
+							found = true
+							break
+						}
+					}	else if r.MatchString(configValue) == true {
 						found = true
 						break
 					}

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 	"regexp"
-	
+
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/lxc/lxd"
@@ -114,7 +114,13 @@ func shouldShow(filters []string, state *shared.ContainerState) bool {
 			found := false
 			for configKey, configValue := range state.Config {
 				if dotPrefixMatch(key, configKey) {
-					r, err := regexp.Compile(value)
+					//try to test filter value as a regexp
+					regexpValue := value
+					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
+							regexpValue = "^" + regexpValue + "$"
+					}
+					r, err := regexp.Compile(regexpValue)
+					//if not regexp compatible use original value
 					if err != nil {
 						if value == configValue {
 							found = true

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -3,9 +3,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
-	"regexp"
 
 	"github.com/olekukonko/tablewriter"
 
@@ -117,7 +117,7 @@ func shouldShow(filters []string, state *shared.ContainerState) bool {
 					//try to test filter value as a regexp
 					regexpValue := value
 					if !(strings.Contains(value, "^") || strings.Contains(value, "$")) {
-							regexpValue = "^" + regexpValue + "$"
+						regexpValue = "^" + regexpValue + "$"
 					}
 					r, err := regexp.Compile(regexpValue)
 					//if not regexp compatible use original value
@@ -129,7 +129,7 @@ func shouldShow(filters []string, state *shared.ContainerState) bool {
 							// the property was found but didn't match
 							return false
 						}
-					}	else if r.MatchString(configValue) == true {
+					} else if r.MatchString(configValue) == true {
 						found = true
 						break
 					}

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -5,7 +5,8 @@ import (
 	"os"
 	"sort"
 	"strings"
-
+	"regexp"
+	
 	"github.com/olekukonko/tablewriter"
 
 	"github.com/lxc/lxd"
@@ -113,12 +114,18 @@ func shouldShow(filters []string, state *shared.ContainerState) bool {
 			found := false
 			for configKey, configValue := range state.Config {
 				if dotPrefixMatch(key, configKey) {
-					if value == configValue {
+					r, err := regexp.Compile(value)
+					if err != nil {
+						if value == configValue {
+							found = true
+							break
+						} else {
+							// the property was found but didn't match
+							return false
+						}
+					}	else if r.MatchString(configValue) == true {
 						found = true
 						break
-					} else {
-						// the property was found but didn't match
-						return false
 					}
 				}
 			}


### PR DESCRIPTION
Proposal : regex on lxc image filter. Example with images.linuxcontainers.org : 
- before : 
lxc image list images: description=Ubuntu => no results
- after : 
lxc image list images: description=Ubuntu 
OR
lxc image list images: description='Ubu.*'
==> all ubuntus images 

Used a regex test and falling back to old test to ensure it won't fail. 

Let me know if it sounds good for you. 


Signed-off-by: Joel Seguillon <joel.seguillon@gmail.com>