### PR TITLE
fix profile tests and cli user experience examples of limits.memory to include byte suffix

### DIFF
--- a/specs/command-line-user-experience.md
+++ b/specs/command-line-user-experience.md
@@ -111,7 +111,7 @@ Command                                                                         
 lxc config show                                                                 | Show the local server's configuration
 lxc config show dakara:                                                         | Show "dakara"'s server' configuration
 lxc config set core.trust\_password new-trust-password                          | Set the local server's trust password to "new-trust-password"
-lxc config set c1 limits.memory 2G                                              | Set a memory limit of 2GB for container "c1"
+lxc config set c1 limits.memory 2GB                                             | Set a memory limit of 2GB for container "c1"
 lxc config show c1                                                              | Show the configuration of the "c1" container, starting by the list of profiles it’s based on, then the container specific settings and finally the resulting overall configuration.
 lxc config trust add new-client-cert.crt                                        | Add new-client-cert.pem to the default remote's trust store (typically local LXD)
 lxc config trust add dakara: new-client-cert.crt                                | Add new-client-cert.pem to the "dakara"'s trust store
@@ -472,7 +472,7 @@ local container still references it.
 Command                                                                  | Result
 :------                                                                  | :-----
 lxc profile create micro                                                 | Create a new "micro" profile.
-lxc profile set micro limits.memory 256M                                 | Restrict memory usage to 256MB
+lxc profile set micro limits.memory 256MB                                | Restrict memory usage to 256MB
 lxc profile set micro limits.cpu 1                                      | Restrict CPU usage to a single core
 lxc profile copy micro dakara:                                           | Copy the resulting profile over to "dakara"
 lxc profile show micro                                                   | Show all the options associated with the "micro" profile and all the containers using it

--- a/test/extras/stresstest.sh
+++ b/test/extras/stresstest.sh
@@ -162,7 +162,7 @@ configthread() {
     echo "configthread: I am $$"
     for i in `seq 1 20`; do
         lxc profile create p$i
-        lxc profile set p$i limits.memory 100M
+        lxc profile set p$i limits.memory 100MB
         lxc profile delete p$i
     done
     exit 0


### PR DESCRIPTION
This pull request fixes configthread() in stresstest.sh and command-line-user-experience.md examples of limits.memory to include byte suffix.

Signed-off-by: Janne Savikko <janne.savikko@aalto.fi>