### PR TITLE
Re-enable /dev/console

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -386,17 +386,6 @@ func (c *containerLXC) initLXC() error {
 		return err
 	}
 
-	// FIXME: Should go away once CRIU supports checkpoint/restore of /dev/console
-	err = lxcSetConfigItem(cc, "lxc.console", "none")
-	if err != nil {
-		return err
-	}
-
-	err = lxcSetConfigItem(cc, "lxc.cgroup.devices.deny", "c 5:1 rwm")
-	if err != nil {
-		return err
-	}
-
 	// Setup the hostname
 	err = lxcSetConfigItem(cc, "lxc.utsname", c.Name())
 	if err != nil {


### PR DESCRIPTION
This re-enables a pts device backing /dev/console and allows container
writes to it.

That change will break CRIU until it knows how to deal with
/dev/console, but lakc of /dev/console is breaking enough workloads that
it's the best option for now.

Closes #1463

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>