### PR TITLE
Disregard block devices in /dev subdirectories

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3509,8 +3509,13 @@ func (c *containerLXC) getDiskLimits() (map[string]deviceBlockLimit, error) {
 
 		for _, block := range blocks {
 			dev := strings.TrimPrefix(block, "/dev/")
+
+			if strings.Contains(dev, "/") {
+				continue
+			}
+
 			if !shared.PathExists(fmt.Sprintf("/sys/class/block/%s/dev", dev)) {
-				return nil, fmt.Errorf("Disk is missing /sys/class/block entry")
+				return nil, fmt.Errorf("Disk %s is missing /sys/class/block entry", dev)
 			}
 
 			block, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/block/%s/dev", dev))


### PR DESCRIPTION
... instead of failing the action entirely.

My root disk is mounted on /dev/mapper/root, note the unexpected
subdirectory.  Without the continue clause, 'lxc init' fails with the
"Disk is missing /sys/class/block entry" error since there is no
/sys/class/block/mapper/root.  Also 'lxc list' fails silently (displays
a table with a header but no containers).

Since a device node with the same major:minor is also at /dev/dm-0, it's
valid to simply ignore the identical node at /dev/mapper/root

Signed-off by: Erik Mackdanz <stasibear@gentoo.org>