### PR TITLE
Make blkio limits more robust

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -563,37 +563,51 @@ func (c *containerLXC) initLXC() error {
 			}
 		}
 
-		diskLimits, err := c.getDiskLimits()
-		if err != nil {
-			return err
+		hasDiskLimits := false
+		for _, m := range c.expandedDevices {
+			if m["type"] != "disk" {
+				continue
+			}
+
+			if m["limits.read"] != "" || m["limits.write"] != "" || m["limits.max"] != "" {
+				hasDiskLimits = true
+				break
+			}
 		}
 
-		for block, limit := range diskLimits {
-			if limit.readBps > 0 {
-				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_bps_device", fmt.Sprintf("%s %d", block, limit.readBps))
-				if err != nil {
-					return err
-				}
+		if hasDiskLimits {
+			diskLimits, err := c.getDiskLimits()
+			if err != nil {
+				return err
 			}
 
-			if limit.readIops > 0 {
-				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_iops_device", fmt.Sprintf("%s %d", block, limit.readIops))
-				if err != nil {
-					return err
+			for block, limit := range diskLimits {
+				if limit.readBps > 0 {
+					err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_bps_device", fmt.Sprintf("%s %d", block, limit.readBps))
+					if err != nil {
+						return err
+					}
 				}
-			}
 
-			if limit.writeBps > 0 {
-				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_bps_device", fmt.Sprintf("%s %d", block, limit.writeBps))
-				if err != nil {
-					return err
+				if limit.readIops > 0 {
+					err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.read_iops_device", fmt.Sprintf("%s %d", block, limit.readIops))
+					if err != nil {
+						return err
+					}
 				}
-			}
 
-			if limit.writeIops > 0 {
-				err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_iops_device", fmt.Sprintf("%s %d", block, limit.writeIops))
-				if err != nil {
-					return err
+				if limit.writeBps > 0 {
+					err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_bps_device", fmt.Sprintf("%s %d", block, limit.writeBps))
+					if err != nil {
+						return err
+					}
+				}
+
+				if limit.writeIops > 0 {
+					err = lxcSetConfigItem(cc, "lxc.cgroup.blkio.throttle.write_iops_device", fmt.Sprintf("%s %d", block, limit.writeIops))
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -3479,6 +3493,33 @@ func (c *containerLXC) removeDiskDevices() error {
 func (c *containerLXC) getDiskLimits() (map[string]deviceBlockLimit, error) {
 	result := map[string]deviceBlockLimit{}
 
+	// Build a list of all valid block devices
+	validBlocks := []string{}
+
+	dents, err := ioutil.ReadDir("/sys/class/block/")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range dents {
+		fPath := filepath.Join("/sys/class/block/", f.Name())
+		if shared.PathExists(fmt.Sprintf("%s/partition", fPath)) {
+			continue
+		}
+
+		if !shared.PathExists(fmt.Sprintf("%s/dev", fPath)) {
+			continue
+		}
+
+		block, err := ioutil.ReadFile(fmt.Sprintf("%s/dev", fPath))
+		if err != nil {
+			return nil, err
+		}
+
+		validBlocks = append(validBlocks, strings.TrimSuffix(string(block), "\n"))
+	}
+
+	// Process all the limits
 	blockLimits := map[string][]deviceBlockLimit{}
 	for _, m := range c.expandedDevices {
 		if m["type"] != "disk" {
@@ -3491,48 +3532,49 @@ func (c *containerLXC) getDiskLimits() (map[string]deviceBlockLimit, error) {
 			m["limits.write"] = m["limits.max"]
 		}
 
+		// Parse the user input
+		readBps, readIops, writeBps, writeIops, err := deviceParseDiskLimit(m["limits.read"], m["limits.write"])
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the source path
 		source := m["source"]
 		if m["path"] == "" {
 			source = c.RootfsPath()
 		}
 
+		// Get the backing block devices (major:minor)
 		blocks, err := deviceGetParentBlocks(source)
 		if err != nil {
-			return nil, err
-		}
-
-		readBps, readIops, writeBps, writeIops, err := deviceParseDiskLimit(m["limits.read"], m["limits.write"])
-		if err != nil {
-			return nil, err
-		}
-		device := deviceBlockLimit{readBps: readBps, readIops: readIops, writeBps: writeBps, writeIops: writeIops}
-
-		for _, block := range blocks {
-			dev := strings.TrimPrefix(block, "/dev/")
-
-			if strings.Contains(dev, "/") {
+			if readBps == 0 && readIops == 0 && writeBps == 0 && writeIops == 0 {
+				// If the device doesn't exist, there is no limit to clear so ignore the failure
 				continue
-			}
-
-			if !shared.PathExists(fmt.Sprintf("/sys/class/block/%s/dev", dev)) {
-				return nil, fmt.Errorf("Disk %s is missing /sys/class/block entry", dev)
-			}
-
-			block, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/block/%s/dev", dev))
-			if err != nil {
+			} else {
 				return nil, err
 			}
+		}
 
-			fields := strings.SplitN(strings.TrimSuffix(string(block), "\n"), ":", 2)
-			if len(fields) != 2 {
-				return nil, fmt.Errorf("Invalid major:minor: %s", block)
-			}
+		device := deviceBlockLimit{readBps: readBps, readIops: readIops, writeBps: writeBps, writeIops: writeIops}
+		for _, block := range blocks {
+			blockStr := ""
 
-			if shared.PathExists(fmt.Sprintf("/sys/class/block/%s/partition", dev)) {
+			if shared.StringInSlice(block, validBlocks) {
+				// Straightforward entry (full block device)
+				blockStr = block
+			} else {
+				// Attempt to deal with a partition (guess its parent)
+				fields := strings.SplitN(block, ":", 2)
 				fields[1] = "0"
+				if shared.StringInSlice(fmt.Sprintf("%s:%s", fields[0], fields[1]), validBlocks) {
+					blockStr = fmt.Sprintf("%s:%s", fields[0], fields[1])
+				}
 			}
 
-			blockStr := fmt.Sprintf("%s:%s", fields[0], fields[1])
+			if blockStr == "" {
+				return nil, fmt.Errorf("Block device doesn't support quotas: %s", block)
+			}
+
 			if blockLimits[blockStr] == nil {
 				blockLimits[blockStr] = []deviceBlockLimit{}
 			}
@@ -3540,6 +3582,7 @@ func (c *containerLXC) getDiskLimits() (map[string]deviceBlockLimit, error) {
 		}
 	}
 
+	// Average duplicate limits
 	for block, limits := range blockLimits {
 		var readBpsCount, readBpsTotal, readIopsCount, readIopsTotal, writeBpsCount, writeBpsTotal, writeIopsCount, writeIopsTotal int64
 


### PR DESCRIPTION
Lets not completely fail startup/update on things the user cannot do
anything about. It's almost impossible to know what devices we can set
block limits on, so if we can't, just move on.

Closes #1568

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>