### PR TITLE
add eth0 "name" to the default profile

### DIFF
--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -98,6 +98,7 @@ func dbProfileCreateDefault(db *sql.DB) error {
 	// TODO: We should the scan for bridges and use the best available as default.
 	devices := shared.Devices{
 		"eth0": shared.Device{
+			"name":    "eth0",
 			"type":    "nic",
 			"nictype": "bridged",
 			"parent":  "lxcbr0"}}


### PR DESCRIPTION
I'm not sure if we want to try and do this retroactively or not.

Closes #1491

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>