### PR TITLE
DB fixups

### DIFF
--- a/lxd/db.go
+++ b/lxd/db.go
@@ -34,7 +34,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 22
+const DB_CURRENT_VERSION int = 23
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db_devices.go
+++ b/lxd/db_devices.go
@@ -79,6 +79,11 @@ func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices shared.Devices) error
 		id := int(id64)
 
 		for ck, cv := range v {
+			// The type is stored as int in the parent entry
+			if ck == "type" {
+				continue
+			}
+
 			_, err = stmt2.Exec(id, ck, cv)
 			if err != nil {
 				return err

--- a/specs/database.md
+++ b/specs/database.md
@@ -136,7 +136,7 @@ Column          | Type          | Default       | Constraint        | Descriptio
 id              | INTEGER       | SERIAL        | NOT NULL          | SERIAL
 container\_id   | INTEGER       | -             | NOT NULL          | containers.id FK
 name            | VARCHAR(255)  | -             | NOT NULL          | Container name
-type            | INTEGER       | 0             | NOT NULL          | Container type (see configuration.md)
+type            | INTEGER       | 0             | NOT NULL          | Device type (see configuration.md)
 
 Index: UNIQUE ON id AND container\_id + name
 
@@ -250,7 +250,7 @@ Column          | Type          | Default       | Constraint        | Descriptio
 id              | INTEGER       | SERIAL        | NOT NULL          | SERIAL
 profile\_id     | INTEGER       | -             | NOT NULL          | profiles.id FK
 name            | VARCHAR(255)  | -             | NOT NULL          | Container name
-type            | INTEGER       | 0             | NOT NULL          | Container type (see configuration.md)
+type            | INTEGER       | 0             | NOT NULL          | Device type (see configuration.md)
 
 Index: UNIQUE ON id AND profile\_id + name
 


### PR DESCRIPTION
This fixes a broken DB migration path when upgrading from pre-0.27 to
current LXD.

It also clarifies the DB spec a bit and remove duplicated data from the DB.

Closes #1598

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>