### PR TITLE
list: Query containers by batch of 10

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -49,6 +49,7 @@ func (a ByName) Less(i, j int) bool {
 
 type listCmd struct {
 	chosenColumnRunes string
+	fast              bool
 }
 
 func (c *listCmd) showByDefault() bool {
@@ -59,7 +60,7 @@ func (c *listCmd) usage() string {
 	return i18n.G(
 		`Lists the available resources.
 
-lxc list [resource] [filters] -c [columns]
+lxc list [resource] [filters] [-c columns] [--fast]
 
 The filters are:
 * A single keyword like "web" which will list any container with "web" in its name.
@@ -70,17 +71,24 @@ The filters are:
 * "s.privileged=1" will do the same
 
 The columns are:
+* 4 - IPv4 address
+* 6 - IPv6 address
+* a - architecture
+* c - creation date
 * n - name
+* p - pid of container init process
+* P - profiles
 * s - state
-* 4 - IP4
-* 6 - IP6
-* e - ephemeral
-* S - snapshots
-* p - pid of container init process`)
+* t - type (persistent or ephemeral)
+
+Default column layout: ns46tS
+Fast column layout: nsacPt`)
 }
 
 func (c *listCmd) flags() {
-	gnuflag.StringVar(&c.chosenColumnRunes, "c", "ns46eS", i18n.G("Columns"))
+	gnuflag.StringVar(&c.chosenColumnRunes, "c", "ns46tS", i18n.G("Columns"))
+	gnuflag.StringVar(&c.chosenColumnRunes, "columns", "ns46tS", i18n.G("Columns"))
+	gnuflag.BoolVar(&c.fast, "fast", false, i18n.G("Fast mode (same as --columns=nsacPt"))
 }
 
 // This seems a little excessive.
@@ -321,13 +329,20 @@ func (c *listCmd) run(config *lxd.Config, args []string) error {
 	}
 
 	columns_map := map[rune]Column{
-		'n': Column{i18n.G("NAME"), c.nameColumnData, false, false},
-		's': Column{i18n.G("STATE"), c.statusColumnData, false, false},
 		'4': Column{i18n.G("IPV4"), c.IP4ColumnData, true, false},
 		'6': Column{i18n.G("IPV6"), c.IP6ColumnData, true, false},
-		'e': Column{i18n.G("EPHEMERAL"), c.isEphemeralColumnData, false, false},
-		'S': Column{i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
+		'a': Column{i18n.G("ARCHITECTURE"), c.ArchitectureColumnData, false, false},
+		'c': Column{i18n.G("CREATED AT"), c.CreatedColumnData, false, false},
+		'n': Column{i18n.G("NAME"), c.nameColumnData, false, false},
 		'p': Column{i18n.G("PID"), c.PIDColumnData, true, false},
+		'P': Column{i18n.G("PROFILES"), c.ProfilesColumnData, false, false},
+		'S': Column{i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
+		's': Column{i18n.G("STATE"), c.statusColumnData, false, false},
+		't': Column{i18n.G("TYPE"), c.typeColumnData, false, false},
+	}
+
+	if c.fast {
+		c.chosenColumnRunes = "nsacPt"
 	}
 
 	columns := []Column{}
@@ -390,11 +405,11 @@ func (c *listCmd) IP6ColumnData(cInfo shared.ContainerInfo, cState *shared.Conta
 	}
 }
 
-func (c *listCmd) isEphemeralColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
+func (c *listCmd) typeColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
 	if cInfo.Ephemeral {
-		return i18n.G("YES")
+		return i18n.G("EPHEMERAL")
 	} else {
-		return i18n.G("NO")
+		return i18n.G("PERSISTENT")
 	}
 }
 
@@ -408,4 +423,22 @@ func (c *listCmd) PIDColumnData(cInfo shared.ContainerInfo, cState *shared.Conta
 	} else {
 		return ""
 	}
+}
+
+func (c *listCmd) ArchitectureColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
+	return cInfo.Architecture
+}
+
+func (c *listCmd) ProfilesColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
+	return strings.Join(cInfo.Profiles, "\n")
+}
+
+func (c *listCmd) CreatedColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
+	layout := "2006/01/02 15:04 UTC"
+
+	if cInfo.CreationDate.UTC().Unix() != 0 {
+		return cInfo.CreationDate.UTC().Format(layout)
+	}
+
+	return ""
 }

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -158,20 +158,20 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 		headers = append(headers, column.Name)
 	}
 
-	cStates := map[string]*shared.ContainerState{}
-	cStatesLock := sync.Mutex{}
-	cStatesQueue := make(chan string, 1)
-	cStatesWg := sync.WaitGroup{}
-
-	cSnapshots := map[string][]shared.SnapshotInfo{}
-	cSnapshotsLock := sync.Mutex{}
-	cSnapshotsQueue := make(chan string, 1)
-	cSnapshotsWg := sync.WaitGroup{}
-
 	threads := 10
 	if len(cinfos) < threads {
 		threads = len(cinfos)
 	}
+
+	cStates := map[string]*shared.ContainerState{}
+	cStatesLock := sync.Mutex{}
+	cStatesQueue := make(chan string, threads)
+	cStatesWg := sync.WaitGroup{}
+
+	cSnapshots := map[string][]shared.SnapshotInfo{}
+	cSnapshotsLock := sync.Mutex{}
+	cSnapshotsQueue := make(chan string, threads)
+	cSnapshotsWg := sync.WaitGroup{}
 
 	for i := 0; i < threads; i++ {
 		cStatesWg.Add(1)

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -406,7 +406,7 @@ func deviceEventListener(d *Daemon) {
 				deviceTaskBalance(d)
 			}
 
-			if e[0] == "net" && e[2] == "add" && cgNetPrioController {
+			if e[0] == "net" && e[2] == "add" && cgNetPrioController && shared.PathExists(fmt.Sprintf("/sys/class/net/%s", e[1])) {
 				shared.Debugf("Scheduler: %s: %s has been added: updating network priorities", e[0], e[1])
 				deviceNetworkPriority(d, e[1])
 			}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-02-23 00:41-0500\n"
+        "POT-Creation-Date: 2016-02-23 19:02-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -86,6 +86,10 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
+#: lxc/list.go:334
+msgid   "ARCHITECTURE"
+msgstr  ""
+
 #: lxc/remote.go:50
 msgid   "Accept certificate"
 msgstr  ""
@@ -114,6 +118,10 @@ msgstr  ""
 
 #: lxc/config.go:265
 msgid   "COMMON NAME"
+msgstr  ""
+
+#: lxc/list.go:335
+msgid   "CREATED AT"
 msgstr  ""
 
 #: lxc/config.go:112
@@ -146,7 +154,7 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: lxc/list.go:82
+#: lxc/list.go:89 lxc/list.go:90
 msgid   "Columns"
 msgstr  ""
 
@@ -248,7 +256,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/list.go:250
+#: lxc/list.go:410
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -295,6 +303,10 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
+#: lxc/list.go:91
+msgid   "Fast mode (same as --columns=nsacPt"
+msgstr  ""
+
 #: lxc/image.go:290
 #, c-format
 msgid   "Fingerprint: %s"
@@ -326,11 +338,11 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/list.go:248
+#: lxc/list.go:332
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:249
+#: lxc/list.go:333
 msgid   "IPV6"
 msgstr  ""
 
@@ -413,10 +425,10 @@ msgid   "List information on containers.\n"
         "lxc info [<remote>:]container [--show-log]"
 msgstr  ""
 
-#: lxc/list.go:58
+#: lxc/list.go:60
 msgid   "Lists the available resources.\n"
         "\n"
-        "lxc list [resource] [filters] -c [columns]\n"
+        "lxc list [resource] [filters] [-c columns] [--fast]\n"
         "\n"
         "The filters are:\n"
         "* A single keyword like \"web\" which will list any container with \"web\" in its name.\n"
@@ -427,13 +439,18 @@ msgid   "Lists the available resources.\n"
         "* \"s.privileged=1\" will do the same\n"
         "\n"
         "The columns are:\n"
+        "* 4 - IPv4 address\n"
+        "* 6 - IPv6 address\n"
+        "* a - architecture\n"
+        "* c - creation date\n"
         "* n - name\n"
+        "* p - pid of container init process\n"
+        "* P - profiles\n"
         "* s - state\n"
-        "* 4 - IP4\n"
-        "* 6 - IP6\n"
-        "* e - ephemeral\n"
-        "* S - snapshots\n"
-        "* p - pid of container init process"
+        "* t - type (persistent or ephemeral)\n"
+        "\n"
+        "Default column layout: ns46tS\n"
+        "Fast column layout: nsacPt"
 msgstr  ""
 
 #: lxc/info.go:159
@@ -627,11 +644,11 @@ msgid   "Move containers within or in between lxd instances.\n"
         "    Rename a local container.\n"
 msgstr  ""
 
-#: lxc/list.go:246 lxc/remote.go:296
+#: lxc/list.go:336 lxc/remote.go:296
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/list.go:319 lxc/remote.go:282
+#: lxc/remote.go:282
 msgid   "NO"
 msgstr  ""
 
@@ -669,8 +686,16 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:252
+#: lxc/list.go:412
+msgid   "PERSISTENT"
+msgstr  ""
+
+#: lxc/list.go:337
 msgid   "PID"
+msgstr  ""
+
+#: lxc/list.go:338
+msgid   "PROFILES"
 msgstr  ""
 
 #: lxc/image.go:555 lxc/remote.go:298
@@ -796,11 +821,11 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:251
+#: lxc/list.go:339
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/list.go:247
+#: lxc/list.go:340
 msgid   "STATE"
 msgstr  ""
 
@@ -870,6 +895,10 @@ msgstr  ""
 
 #: lxc/delete.go:106 lxc/publish.go:111
 msgid   "Stopping container failed!"
+msgstr  ""
+
+#: lxc/list.go:341
+msgid   "TYPE"
 msgstr  ""
 
 #: lxc/delete.go:92
@@ -943,7 +972,7 @@ msgstr  ""
 msgid   "Whether to show the expanded configuration"
 msgstr  ""
 
-#: lxc/list.go:317 lxc/remote.go:284
+#: lxc/remote.go:284
 msgid   "YES"
 msgstr  ""
 


### PR DESCRIPTION
This improves performance about as much as we can realistically do it,
less than 100ms per container when retrieving all network information,
cgroup and disk usage.

To get any faster, simply not requesting the information by using -c is
the way to go.

Closes #671

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>