### PR TITLE
Refactor the GenCert function so it can be reused.

### DIFF
--- a/shared/cert_test.go
+++ b/shared/cert_test.go
@@ -1,0 +1,39 @@
+package shared
+
+import (
+	"encoding/pem"
+	"testing"
+)
+
+func TestGenerateMemCert(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping cert generation in short mode")
+	}
+	cert, key, err := GenerateMemCert()
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	if cert == nil {
+		t.Error("GenerateMemCert returned a nil cert")
+		return
+	}
+	if key == nil {
+		t.Error("GenerateMemCert returned a nil key")
+		return
+	}
+	block, rest := pem.Decode(cert)
+	if len(rest) != 0 {
+		t.Errorf("GenerateMemCert returned a cert with trailing content: %q", string(rest))
+	}
+	if block.Type != "CERTIFICATE" {
+		t.Errorf("GenerateMemCert returned a cert with Type %q not \"CERTIFICATE\"", block.Type)
+	}
+	block, rest = pem.Decode(key)
+	if len(rest) != 0 {
+		t.Errorf("GenerateMemCert returned a key with trailing content: %q", string(rest))
+	}
+	if block.Type != "RSA PRIVATE KEY" {
+		t.Errorf("GenerateMemCert returned a cert with Type %q not \"RSA PRIVATE KEY\"", block.Type)
+	}
+}

--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -91,7 +91,7 @@ func TestReadLastNLines(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	fmt.Println(lines)
+	// fmt.Println(lines)
 
 	split = strings.Split(lines, "\n")
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Juju was working around the fact that GenCert always wrote directly to disk. Instead split the
function into 2 functions. One that just generates the certificate bytes, and another one
that will write that content into files.
Add a test for the helper function. It is unfortunately a bit slow (2s), but it can be skipped with 'go test -short'.
Also, suppress printing all the lines that were read by ReadLastNLines, as it makes it
hard to see what the actual test suite is doing.

Signed-off-by: John Arbash Meinel <john@arbash-meinel.com>