### PR TITLE
tests: get rid of commented out code

### DIFF
--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -91,7 +91,6 @@ func TestReadLastNLines(t *testing.T) {
 		t.Error(err)
 		return
 	}
-	// fmt.Println(lines)
 
 	split = strings.Split(lines, "\n")
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Rather than go through another reivew cycle, here's my only comment for
PR #1641.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>