### PR TITLE
shared: export limit parsing function

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -618,7 +618,7 @@ func containerConfigureInternal(c container) error {
 			continue
 		}
 
-		size, err := deviceParseBytes(m["size"])
+		size, err := shared.ParseByteSizeString(m["size"])
 		if err != nil {
 			return err
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3904,7 +3904,7 @@ func (c *containerLXC) setNetworkLimits(name string, m shared.Device) error {
 	// Parse the values
 	var ingressInt int64
 	if m["limits.ingress"] != "" {
-		ingressInt, err = deviceParseBits(m["limits.ingress"])
+		ingressInt, err = shared.ParseBitSizeString(m["limits.ingress"])
 		if err != nil {
 			return err
 		}
@@ -3912,7 +3912,7 @@ func (c *containerLXC) setNetworkLimits(name string, m shared.Device) error {
 
 	var egressInt int64
 	if m["limits.egress"] != "" {
-		egressInt, err = deviceParseBits(m["limits.egress"])
+		egressInt, err = shared.ParseBitSizeString(m["limits.egress"])
 		if err != nil {
 			return err
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -470,7 +470,7 @@ func (c *containerLXC) initLXC() error {
 
 				valueInt = int64((memoryTotal / 100) * percent)
 			} else {
-				valueInt, err = deviceParseBytes(memory)
+				valueInt, err = shared.ParseByteSizeString(memory)
 				if err != nil {
 					return err
 				}
@@ -1883,7 +1883,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 		}
 
 		if m["size"] != oldRootfsSize {
-			size, err := deviceParseBytes(m["size"])
+			size, err := shared.ParseByteSizeString(m["size"])
 			if err != nil {
 				undoChanges()
 				return err
@@ -1986,7 +1986,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 
 					memory = fmt.Sprintf("%d", int64((memoryTotal/100)*percent))
 				} else {
-					valueInt, err := deviceParseBytes(memory)
+					valueInt, err := shared.ParseByteSizeString(memory)
 					if err != nil {
 						undoChanges()
 						return err

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -84,7 +84,7 @@ func dbUpdateFromV18(db *sql.DB) error {
 		value += "B"
 
 		// Deal with completely broken values
-		_, err = deviceParseBytes(value)
+		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
 			shared.Debugf("Invalid container memory limit, id=%d value=%s, removing.", id, value)
 			_, err = db.Exec("DELETE FROM containers_config WHERE id=?;", id)
@@ -121,7 +121,7 @@ func dbUpdateFromV18(db *sql.DB) error {
 		value += "B"
 
 		// Deal with completely broken values
-		_, err = deviceParseBytes(value)
+		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
 			shared.Debugf("Invalid profile memory limit, id=%d value=%s, removing.", id, value)
 			_, err = db.Exec("DELETE FROM profiles_config WHERE id=?;", id)

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -611,51 +611,6 @@ func deviceParseCPU(cpuAllowance string, cpuPriority string) (string, string, st
 	return fmt.Sprintf("%d", cpuShares), cpuCfsQuota, cpuCfsPeriod, nil
 }
 
-func deviceParseBits(input string) (int64, error) {
-	if input == "" {
-		return 0, nil
-	}
-
-	if len(input) < 5 {
-		return -1, fmt.Errorf("Invalid value: %s", input)
-	}
-
-	// Extract the suffix
-	suffix := input[len(input)-4:]
-
-	// Extract the value
-	value := input[0 : len(input)-4]
-	valueInt, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return -1, fmt.Errorf("Invalid integer: %s", input)
-	}
-
-	if valueInt < 0 {
-		return -1, fmt.Errorf("Invalid value: %d", valueInt)
-	}
-
-	// Figure out the multiplicator
-	multiplicator := int64(0)
-	switch suffix {
-	case "kbit":
-		multiplicator = 1000
-	case "Mbit":
-		multiplicator = 1000 * 1000
-	case "Gbit":
-		multiplicator = 1000 * 1000 * 1000
-	case "Tbit":
-		multiplicator = 1000 * 1000 * 1000 * 1000
-	case "Pbit":
-		multiplicator = 1000 * 1000 * 1000 * 1000 * 1000
-	case "Ebit":
-		multiplicator = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
-	default:
-		return -1, fmt.Errorf("Unsupported suffix: %s", suffix)
-	}
-
-	return valueInt * multiplicator, nil
-}
-
 func deviceTotalMemory() (int64, error) {
 	// Open /proc/meminfo
 	f, err := os.Open("/proc/meminfo")
@@ -678,8 +633,8 @@ func deviceTotalMemory() (int64, error) {
 		fields := strings.Split(line, " ")
 		value := fields[len(fields)-2] + fields[len(fields)-1]
 
-		// Feed the result to shared.ParseByteSizeString to get an int value
-		valueBytes, err := shared.ParseByteSizeString(value)
+		// Feed the result to shared.ParseSizeString to get an int value
+		valueBytes, err := shared.ParseSizeString(value)
 		if err != nil {
 			return -1, err
 		}
@@ -847,7 +802,7 @@ func deviceParseDiskLimit(readSpeed string, writeSpeed string) (int64, int64, in
 				return -1, -1, err
 			}
 		} else {
-			bps, err = shared.ParseByteSizeString(value)
+			bps, err = shared.ParseSizeString(value)
 			if err != nil {
 				return -1, -1, err
 			}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -656,51 +656,6 @@ func deviceParseBits(input string) (int64, error) {
 	return valueInt * multiplicator, nil
 }
 
-func deviceParseBytes(input string) (int64, error) {
-	if input == "" {
-		return 0, nil
-	}
-
-	if len(input) < 3 {
-		return -1, fmt.Errorf("Invalid value: %s", input)
-	}
-
-	// Extract the suffix
-	suffix := input[len(input)-2:]
-
-	// Extract the value
-	value := input[0 : len(input)-2]
-	valueInt, err := strconv.ParseInt(value, 10, 64)
-	if err != nil {
-		return -1, fmt.Errorf("Invalid integer: %s", input)
-	}
-
-	if valueInt < 0 {
-		return -1, fmt.Errorf("Invalid value: %d", valueInt)
-	}
-
-	// Figure out the multiplicator
-	multiplicator := int64(0)
-	switch suffix {
-	case "kB":
-		multiplicator = 1024
-	case "MB":
-		multiplicator = 1024 * 1024
-	case "GB":
-		multiplicator = 1024 * 1024 * 1024
-	case "TB":
-		multiplicator = 1024 * 1024 * 1024 * 1024
-	case "PB":
-		multiplicator = 1024 * 1024 * 1024 * 1024 * 1024
-	case "EB":
-		multiplicator = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
-	default:
-		return -1, fmt.Errorf("Unsupported suffix: %s", suffix)
-	}
-
-	return valueInt * multiplicator, nil
-}
-
 func deviceTotalMemory() (int64, error) {
 	// Open /proc/meminfo
 	f, err := os.Open("/proc/meminfo")
@@ -723,8 +678,8 @@ func deviceTotalMemory() (int64, error) {
 		fields := strings.Split(line, " ")
 		value := fields[len(fields)-2] + fields[len(fields)-1]
 
-		// Feed the result to deviceParseBytes to get an int value
-		valueBytes, err := deviceParseBytes(value)
+		// Feed the result to shared.ParseByteSizeString to get an int value
+		valueBytes, err := shared.ParseByteSizeString(value)
 		if err != nil {
 			return -1, err
 		}
@@ -892,7 +847,7 @@ func deviceParseDiskLimit(readSpeed string, writeSpeed string) (int64, int64, in
 				return -1, -1, err
 			}
 		} else {
-			bps, err = deviceParseBytes(value)
+			bps, err = shared.ParseByteSizeString(value)
 			if err != nil {
 				return -1, -1, err
 			}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -633,8 +633,8 @@ func deviceTotalMemory() (int64, error) {
 		fields := strings.Split(line, " ")
 		value := fields[len(fields)-2] + fields[len(fields)-1]
 
-		// Feed the result to shared.ParseSizeString to get an int value
-		valueBytes, err := shared.ParseSizeString(value)
+		// Feed the result to shared.ParseByteSizeString to get an int value
+		valueBytes, err := shared.ParseByteSizeString(value)
 		if err != nil {
 			return -1, err
 		}
@@ -802,7 +802,7 @@ func deviceParseDiskLimit(readSpeed string, writeSpeed string) (int64, int64, in
 				return -1, -1, err
 			}
 		} else {
-			bps, err = shared.ParseSizeString(value)
+			bps, err = shared.ParseByteSizeString(value)
 			if err != nil {
 				return -1, -1, err
 			}

--- a/shared/util.go
+++ b/shared/util.go
@@ -609,3 +609,50 @@ func ParseByteSizeString(input string) (int64, error) {
 
 	return valueInt * multiplicator, nil
 }
+
+// Parse a size string in bits (e.g. 200kbit or 5Gbit) into the number of bits
+// it represents. Supports suffixes up to Ebit. "" == 0.
+func ParseBitSizeString(input string) (int64, error) {
+	if input == "" {
+		return 0, nil
+	}
+
+	if len(input) < 5 {
+		return -1, fmt.Errorf("Invalid value: %s", input)
+	}
+
+	// Extract the suffix
+	suffix := input[len(input)-4:]
+
+	// Extract the value
+	value := input[0 : len(input)-4]
+	valueInt, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("Invalid integer: %s", input)
+	}
+
+	if valueInt < 0 {
+		return -1, fmt.Errorf("Invalid value: %d", valueInt)
+	}
+
+	// Figure out the multiplicator
+	multiplicator := int64(0)
+	switch suffix {
+	case "kbit":
+		multiplicator = 1000
+	case "Mbit":
+		multiplicator = 1000 * 1000
+	case "Gbit":
+		multiplicator = 1000 * 1000 * 1000
+	case "Tbit":
+		multiplicator = 1000 * 1000 * 1000 * 1000
+	case "Pbit":
+		multiplicator = 1000 * 1000 * 1000 * 1000 * 1000
+	case "Ebit":
+		multiplicator = 1000 * 1000 * 1000 * 1000 * 1000 * 1000
+	default:
+		return -1, fmt.Errorf("Unsupported suffix: %s", suffix)
+	}
+
+	return valueInt * multiplicator, nil
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -562,3 +562,50 @@ func ParseMetadata(metadata interface{}) (map[string]interface{}, error) {
 
 	return newMetadata, nil
 }
+
+// Parse a size string in bytes (e.g. 200kB or 5GB) into the number of bytes it
+// represents. Supports suffixes up to EB. "" == 0.
+func ParseByteSizeString(input string) (int64, error) {
+	if input == "" {
+		return 0, nil
+	}
+
+	if len(input) < 3 {
+		return -1, fmt.Errorf("Invalid value: %s", input)
+	}
+
+	// Extract the suffix
+	suffix := input[len(input)-2:]
+
+	// Extract the value
+	value := input[0 : len(input)-2]
+	valueInt, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return -1, fmt.Errorf("Invalid integer: %s", input)
+	}
+
+	if valueInt < 0 {
+		return -1, fmt.Errorf("Invalid value: %d", valueInt)
+	}
+
+	// Figure out the multiplicator
+	multiplicator := int64(0)
+	switch suffix {
+	case "kB":
+		multiplicator = 1024
+	case "MB":
+		multiplicator = 1024 * 1024
+	case "GB":
+		multiplicator = 1024 * 1024 * 1024
+	case "TB":
+		multiplicator = 1024 * 1024 * 1024 * 1024
+	case "PB":
+		multiplicator = 1024 * 1024 * 1024 * 1024 * 1024
+	case "EB":
+		multiplicator = 1024 * 1024 * 1024 * 1024 * 1024 * 1024
+	default:
+		return -1, fmt.Errorf("Unsupported suffix: %s", suffix)
+	}
+
+	return valueInt * multiplicator, nil
+}


### PR DESCRIPTION
For other golang clients who want to figure out the memory from a LXD limit
in string format from the config, this is useful.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>