### PR TITLE
Revert "exec: don't s/\\n/\\r\\n/g when interactive"

### DIFF
--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -59,8 +59,6 @@ void configure_pty(int fd) {
 
 	term_settings.c_cflag |= HUPCL;
 
-	term_settings.c_oflag &= ~ONLCR;
-
 	if (tcsetattr(fd, TCSANOW, &term_settings) < 0) {
 		fprintf(stderr, "Failed to set settings: %s\n", strerror(errno));
 		return;


### PR DESCRIPTION
This reverts commit 17d3dcf7404f9e6f5bc2702193cb8cac1153ed9e.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>