### PR TITLE
Implement initial simplestreams support

### DIFF
--- a/config.go
+++ b/config.go
@@ -40,17 +40,36 @@ type Config struct {
 
 // RemoteConfig holds details for communication with a remote daemon.
 type RemoteConfig struct {
-	Addr   string `yaml:"addr"`
-	Public bool   `yaml:"public"`
+	Addr     string `yaml:"addr"`
+	Public   bool   `yaml:"public"`
+	Protocol string `yaml:"protocol,omitempty"`
+	Static   bool   `yaml:"-"`
 }
 
 var LocalRemote = RemoteConfig{
 	Addr:   "unix://",
+	Static: true,
 	Public: false}
-var defaultRemote = map[string]RemoteConfig{"local": LocalRemote}
+
+var UbuntuRemote = RemoteConfig{
+	Addr:     "https://cloud-images.ubuntu.com/releases",
+	Static:   true,
+	Public:   true,
+	Protocol: "simplestreams"}
+
+var UbuntuDailyRemote = RemoteConfig{
+	Addr:     "https://cloud-images.ubuntu.com/daily",
+	Static:   true,
+	Public:   true,
+	Protocol: "simplestreams"}
+
+var StaticRemotes = map[string]RemoteConfig{
+	"local":        LocalRemote,
+	"ubuntu":       UbuntuRemote,
+	"ubuntu-daily": UbuntuDailyRemote}
 
 var DefaultConfig = Config{
-	Remotes:       defaultRemote,
+	Remotes:       StaticRemotes,
 	DefaultRemote: "local",
 	Aliases:       map[string]string{},
 }
@@ -79,11 +98,19 @@ func LoadConfig(path string) (*Config, error) {
 	}
 	c.ConfigDir = filepath.Dir(path)
 
+	for k, v := range StaticRemotes {
+		c.Remotes[k] = v
+	}
+
 	return &c, nil
 }
 
 // SaveConfig writes the provided configuration to the config file.
 func SaveConfig(c *Config, fname string) error {
+	for k, _ := range StaticRemotes {
+		delete(c.Remotes, k)
+	}
+
 	// Ignore errors on these two calls. Create will report any problems.
 	os.Remove(fname + ".new")
 	os.Mkdir(filepath.Dir(fname), 0700)

--- a/config.go
+++ b/config.go
@@ -51,6 +51,10 @@ var LocalRemote = RemoteConfig{
 	Static: true,
 	Public: false}
 
+var ImagesRemote = RemoteConfig{
+	Addr:   "https://images.linuxcontainers.org",
+	Public: true}
+
 var UbuntuRemote = RemoteConfig{
 	Addr:     "https://cloud-images.ubuntu.com/releases",
 	Static:   true,
@@ -68,8 +72,14 @@ var StaticRemotes = map[string]RemoteConfig{
 	"ubuntu":       UbuntuRemote,
 	"ubuntu-daily": UbuntuDailyRemote}
 
+var DefaultRemotes = map[string]RemoteConfig{
+	"images":       ImagesRemote,
+	"local":        LocalRemote,
+	"ubuntu":       UbuntuRemote,
+	"ubuntu-daily": UbuntuDailyRemote}
+
 var DefaultConfig = Config{
-	Remotes:       StaticRemotes,
+	Remotes:       DefaultRemotes,
 	DefaultRemote: "local",
 	Aliases:       map[string]string{},
 }

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -240,13 +240,12 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		if err != nil {
 			return err
 		}
-		image := c.dereferenceAlias(d, inName)
 
 		progressHandler := func(progress string) {
 			fmt.Printf(i18n.G("Copying the image: %s")+"\r", progress)
 		}
 
-		err = d.CopyImage(image, dest, c.copyAliases, c.addAliases, c.publicImage, progressHandler)
+		err = d.CopyImage(inName, dest, c.copyAliases, c.addAliases, c.publicImage, progressHandler)
 		if err == nil {
 			fmt.Println(i18n.G("Image copied successfully!"))
 		}
@@ -450,7 +449,8 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		if len(args) > 2 {
 			target = args[2]
 		}
-		_, outfile, err := d.ExportImage(image, target)
+
+		outfile, err := d.ExportImage(image, target)
 		if err != nil {
 			return err
 		}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -24,6 +24,7 @@ type containerImageSource struct {
 	Fingerprint string `json:"fingerprint"`
 	Server      string `json:"server"`
 	Secret      string `json:"secret"`
+	Protocol    string `json:"protocol"`
 
 	/*
 	 * for "migration" and "copy" types, as an optimization users can
@@ -80,7 +81,7 @@ func createFromImage(d *Daemon, req *containerPostReq) Response {
 
 	run := func(op *operation) error {
 		if req.Source.Server != "" {
-			err := d.ImageDownload(op, req.Source.Server, req.Source.Certificate, req.Source.Secret, hash, true, false)
+			hash, err = d.ImageDownload(op, req.Source.Server, req.Source.Protocol, req.Source.Certificate, req.Source.Secret, hash, true)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -758,17 +758,9 @@ func (d *Daemon) Init() error {
 	/* Get the list of supported architectures */
 	var architectures = []int{}
 
-	uname := syscall.Utsname{}
-	if err := syscall.Uname(&uname); err != nil {
+	architectureName, err := shared.ArchitectureGetLocal()
+	if err != nil {
 		return err
-	}
-
-	architectureName := ""
-	for _, c := range uname.Machine {
-		if c == 0 {
-			break
-		}
-		architectureName += string(byte(c))
 	}
 
 	architecture, err := shared.ArchitectureId(architectureName)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -292,8 +292,7 @@ func imgPostRemoteInfo(d *Daemon, req imagePostReq, op *operation) error {
 		return fmt.Errorf("must specify one of alias or fingerprint for init from image")
 	}
 
-	err = d.ImageDownload(op, req.Source["server"], req.Source["certificate"], req.Source["secret"], hash, false, false)
-
+	hash, err = d.ImageDownload(op, req.Source["server"], req.Source["protocol"], req.Source["certificate"], req.Source["secret"], hash, false)
 	if err != nil {
 		return err
 	}
@@ -377,8 +376,7 @@ func imgPostURLInfo(d *Daemon, req imagePostReq, op *operation) error {
 	}
 
 	// Import the image
-	err = d.ImageDownload(op, url, "", "", hash, false, true)
-
+	hash, err = d.ImageDownload(op, url, "direct", "", "", hash, false)
 	if err != nil {
 		return err
 	}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-02-25 16:37-0500\n"
+        "POT-Creation-Date: 2016-02-25 23:25-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/config.go:36
+#: lxc/config.go:37
 msgid   "### This is a yaml representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -65,7 +65,7 @@ msgid   "### This is a yaml representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/image.go:534
+#: lxc/image.go:535
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -78,11 +78,11 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:553 lxc/image.go:575
+#: lxc/image.go:555 lxc/image.go:579
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:557
+#: lxc/image.go:559
 msgid   "ARCH"
 msgstr  ""
 
@@ -116,7 +116,7 @@ msgstr  ""
 msgid   "Available commands:"
 msgstr  ""
 
-#: lxc/config.go:265
+#: lxc/config.go:268
 msgid   "COMMON NAME"
 msgstr  ""
 
@@ -124,12 +124,12 @@ msgstr  ""
 msgid   "CREATED AT"
 msgstr  ""
 
-#: lxc/config.go:112
+#: lxc/config.go:113
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/config.go:125 lxc/config.go:158 lxc/config.go:180
+#: lxc/config.go:126 lxc/config.go:159 lxc/config.go:181
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
@@ -162,7 +162,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:491 lxc/config.go:556 lxc/image.go:631 lxc/profile.go:187
+#: lxc/config.go:492 lxc/config.go:557 lxc/image.go:633 lxc/profile.go:187
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -234,7 +234,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:556 lxc/image.go:577
+#: lxc/image.go:558 lxc/image.go:581
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -246,12 +246,12 @@ msgid   "Delete containers or container snapshots.\n"
         "Destroy containers or snapshots with any attached data (configuration, snapshots, ...)."
 msgstr  ""
 
-#: lxc/config.go:604
+#: lxc/config.go:605
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config.go:632
+#: lxc/config.go:633
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -260,7 +260,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/config.go:267
+#: lxc/config.go:270
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -301,7 +301,7 @@ msgstr  ""
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/config.go:264 lxc/image.go:554 lxc/image.go:576
+#: lxc/config.go:267 lxc/image.go:556 lxc/image.go:580
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -320,7 +320,7 @@ msgid   "Fingers the LXD instance to check if it is up and working.\n"
         "lxc finger <remote>"
 msgstr  ""
 
-#: lxc/main.go:156
+#: lxc/main.go:146
 msgid   "For example: 'lxd-images import ubuntu --alias ubuntu'."
 msgstr  ""
 
@@ -336,7 +336,7 @@ msgstr  ""
 msgid   "Force using the local unix socket."
 msgstr  ""
 
-#: lxc/main.go:148
+#: lxc/main.go:138
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -348,11 +348,11 @@ msgstr  ""
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config.go:266
+#: lxc/config.go:269
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/main.go:155
+#: lxc/main.go:145
 msgid   "If this is your first run, you will need to import images using the 'lxd-images' script."
 msgstr  ""
 
@@ -499,7 +499,7 @@ msgid   "Manage configuration profiles.\n"
         "    using the specified profile."
 msgstr  ""
 
-#: lxc/config.go:57
+#: lxc/config.go:58
 msgid   "Manage configuration.\n"
         "\n"
         "lxc config device add <[remote:]container> <name> <type> [key=value]...     Add a device to a container.\n"
@@ -646,11 +646,11 @@ msgid   "Move containers within or in between lxd instances.\n"
         "    Rename a local container.\n"
 msgstr  ""
 
-#: lxc/list.go:336 lxc/remote.go:296
+#: lxc/list.go:336 lxc/remote.go:312
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/remote.go:282
+#: lxc/remote.go:287 lxc/remote.go:292
 msgid   "NO"
 msgstr  ""
 
@@ -663,11 +663,11 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/config.go:278
+#: lxc/config.go:279
 msgid   "No certificate provided to add"
 msgstr  ""
 
-#: lxc/config.go:301
+#: lxc/config.go:302
 msgid   "No fingerprint specified."
 msgstr  ""
 
@@ -675,11 +675,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
-#: lxc/help.go:63 lxc/main.go:132
+#: lxc/help.go:63 lxc/main.go:122
 msgid   "Options:"
 msgstr  ""
 
-#: lxc/image.go:459
+#: lxc/image.go:460
 #, c-format
 msgid   "Output is in %s"
 msgstr  ""
@@ -700,7 +700,11 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/image.go:555 lxc/remote.go:298
+#: lxc/remote.go:314
+msgid   "PROTOCOL"
+msgstr  ""
+
+#: lxc/image.go:557 lxc/remote.go:315
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -731,7 +735,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:492 lxc/config.go:557 lxc/image.go:632
+#: lxc/config.go:493 lxc/config.go:558 lxc/image.go:634
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -819,7 +823,7 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: lxc/image.go:558
+#: lxc/image.go:560
 msgid   "SIZE"
 msgstr  ""
 
@@ -829,6 +833,10 @@ msgstr  ""
 
 #: lxc/list.go:340
 msgid   "STATE"
+msgstr  ""
+
+#: lxc/remote.go:316
+msgid   "STATIC"
 msgstr  ""
 
 #: lxc/remote.go:164
@@ -936,11 +944,11 @@ msgstr  ""
 msgid   "Type: persistent"
 msgstr  ""
 
-#: lxc/image.go:559
+#: lxc/image.go:561
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/remote.go:297
+#: lxc/remote.go:313
 msgid   "URL"
 msgstr  ""
 
@@ -949,7 +957,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/main.go:132
+#: lxc/main.go:122
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
@@ -970,11 +978,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/config.go:32
+#: lxc/config.go:33
 msgid   "Whether to show the expanded configuration"
 msgstr  ""
 
-#: lxc/remote.go:284
+#: lxc/remote.go:289 lxc/remote.go:294
 msgid   "YES"
 msgstr  ""
 
@@ -994,11 +1002,11 @@ msgstr  ""
 msgid   "can't copy to the same container name"
 msgstr  ""
 
-#: lxc/remote.go:272
+#: lxc/remote.go:277
 msgid   "can't remove the default remote"
 msgstr  ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:303
 msgid   "default"
 msgstr  ""
 
@@ -1006,12 +1014,12 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/main.go:25 lxc/main.go:167
+#: lxc/main.go:25 lxc/main.go:157
 #, c-format
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/help.go:40 lxc/main.go:127
+#: lxc/help.go:40 lxc/main.go:117
 #, c-format
 msgid   "error: unknown command: %s"
 msgstr  ""
@@ -1020,7 +1028,7 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: lxc/image.go:291 lxc/image.go:537
+#: lxc/image.go:291 lxc/image.go:538
 msgid   "no"
 msgstr  ""
 
@@ -1032,17 +1040,17 @@ msgstr  ""
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:274 lxc/main.go:278
+#: lxc/main.go:264 lxc/main.go:268
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:338
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:268 lxc/remote.go:312 lxc/remote.go:342 lxc/remote.go:353
+#: lxc/remote.go:269 lxc/remote.go:330 lxc/remote.go:365 lxc/remote.go:381
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
@@ -1050,6 +1058,11 @@ msgstr  ""
 #: lxc/remote.go:252
 #, c-format
 msgid   "remote %s exists as <%s>"
+msgstr  ""
+
+#: lxc/remote.go:273 lxc/remote.go:334 lxc/remote.go:369
+#, c-format
+msgid   "remote %s is static and cannot be modified"
 msgstr  ""
 
 #: lxc/info.go:139
@@ -1069,11 +1082,11 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:207
+#: lxc/main.go:197
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/delete.go:45 lxc/image.go:294 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:294 lxc/image.go:542
 msgid   "yes"
 msgstr  ""
 

--- a/shared/architectures.go
+++ b/shared/architectures.go
@@ -59,6 +59,8 @@ var architectureSupportedPersonalities = map[int][]int{
 	ARCH_64BIT_S390_BIG_ENDIAN:       []int{},
 }
 
+const ArchitectureDefault = "x86_64"
+
 func ArchitectureName(arch int) (string, error) {
 	arch_name, exists := architectureNames[arch]
 	if exists {

--- a/shared/architectures.go
+++ b/shared/architectures.go
@@ -27,6 +27,16 @@ var architectureNames = map[int]string{
 	ARCH_64BIT_S390_BIG_ENDIAN:       "s390x",
 }
 
+var architectureAliases = map[int][]string{
+	ARCH_32BIT_INTEL_X86:             []string{"i386"},
+	ARCH_64BIT_INTEL_X86:             []string{"amd64"},
+	ARCH_32BIT_ARMV7_LITTLE_ENDIAN:   []string{"armel", "armhf"},
+	ARCH_64BIT_ARMV8_LITTLE_ENDIAN:   []string{"arm64"},
+	ARCH_32BIT_POWERPC_BIG_ENDIAN:    []string{"powerpc"},
+	ARCH_64BIT_POWERPC_BIG_ENDIAN:    []string{"powerpc64"},
+	ARCH_64BIT_POWERPC_LITTLE_ENDIAN: []string{"ppc64el"},
+}
+
 var architecturePersonalities = map[int]string{
 	ARCH_32BIT_INTEL_X86:             "linux32",
 	ARCH_64BIT_INTEL_X86:             "linux64",
@@ -62,6 +72,14 @@ func ArchitectureId(arch string) (int, error) {
 	for arch_id, arch_name := range architectureNames {
 		if arch_name == arch {
 			return arch_id, nil
+		}
+	}
+
+	for arch_id, arch_aliases := range architectureAliases {
+		for _, arch_name := range arch_aliases {
+			if arch_name == arch {
+				return arch_id, nil
+			}
 		}
 	}
 

--- a/shared/architectures_linux.go
+++ b/shared/architectures_linux.go
@@ -1,0 +1,24 @@
+// +build linux
+
+package shared
+
+import (
+	"syscall"
+)
+
+func ArchitectureGetLocal() (string, error) {
+	uname := syscall.Utsname{}
+	if err := syscall.Uname(&uname); err != nil {
+		return ArchitectureDefault, err
+	}
+
+	architectureName := ""
+	for _, c := range uname.Machine {
+		if c == 0 {
+			break
+		}
+		architectureName += string(byte(c))
+	}
+
+	return architectureName, nil
+}

--- a/shared/architectures_others.go
+++ b/shared/architectures_others.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package shared
+
+func ArchitectureGetLocal() (string, error) {
+	return ArchitectureDefault, nil
+}

--- a/shared/simplestreams.go
+++ b/shared/simplestreams.go
@@ -1,0 +1,595 @@
+package shared
+
+import (
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"syscall"
+	"time"
+)
+
+type ssSortImage []ImageInfo
+
+func (a ssSortImage) Len() int {
+	return len(a)
+}
+
+func (a ssSortImage) Swap(i, j int) {
+	a[i], a[j] = a[j], a[i]
+}
+
+func (a ssSortImage) Less(i, j int) bool {
+	if a[i].Properties["os"] == a[j].Properties["os"] {
+		if a[i].Properties["release"] == a[j].Properties["release"] {
+			if a[i].CreationDate.UTC().Unix() == 0 {
+				return true
+			}
+
+			if a[j].CreationDate.UTC().Unix() == 0 {
+				return false
+			}
+
+			return a[i].CreationDate.UTC().Unix() > a[j].CreationDate.UTC().Unix()
+		}
+
+		if a[i].Properties["release"] == "" {
+			return false
+		}
+
+		if a[j].Properties["release"] == "" {
+			return true
+		}
+
+		return a[i].Properties["release"] < a[j].Properties["release"]
+	}
+
+	if a[i].Properties["os"] == "" {
+		return false
+	}
+
+	if a[j].Properties["os"] == "" {
+		return true
+	}
+
+	return a[i].Properties["os"] < a[j].Properties["os"]
+}
+
+var ssDefaultOS = map[string]string{
+	"https://cloud-images.ubuntu.com": "ubuntu",
+}
+
+type SimpleStreamsManifest struct {
+	Updated  string                                  `json:"updated"`
+	DataType string                                  `json:"datatype"`
+	Format   string                                  `json:"format"`
+	License  string                                  `json:"license"`
+	Products map[string]SimpleStreamsManifestProduct `json:"products"`
+}
+
+func (s *SimpleStreamsManifest) ToLXD() ([]ImageInfo, map[string][][]string) {
+	downloads := map[string][][]string{}
+
+	images := []ImageInfo{}
+	nameLayout := "20060102"
+	eolLayout := "2006-01-02"
+
+	for _, product := range s.Products {
+		// Skip unsupported architectures
+		architecture, err := ArchitectureId(product.Architecture)
+		if err != nil {
+			continue
+		}
+
+		architectureName, err := ArchitectureName(architecture)
+		if err != nil {
+			continue
+		}
+
+		for name, version := range product.Versions {
+			// Short of anything better, use the name as date
+			creationDate, err := time.Parse(nameLayout, name)
+			if err != nil {
+				continue
+			}
+
+			size := int64(0)
+			filename := ""
+			fingerprint := ""
+
+			metaPath := ""
+			metaHash := ""
+			rootfsPath := ""
+			rootfsHash := ""
+
+			found := 0
+			for _, item := range version.Items {
+				// Skip the files we don't care about
+				if !StringInSlice(item.FileType, []string{"root.tar.xz", "lxd.tar.xz"}) {
+					continue
+				}
+				found += 1
+
+				size += item.Size
+				if item.LXDHashSha256 != "" {
+					fingerprint = item.LXDHashSha256
+				}
+
+				if item.FileType == "lxd.tar.xz" {
+					fields := strings.Split(item.Path, "/")
+					filename = fields[len(fields)-1]
+					metaPath = item.Path
+					metaHash = item.HashSha256
+				}
+
+				if item.FileType == "root.tar.xz" {
+					rootfsPath = item.Path
+					rootfsHash = item.HashSha256
+				}
+			}
+
+			if found != 2 || size == 0 || filename == "" || fingerprint == "" {
+				// Invalid image
+				continue
+			}
+
+			// Generate the actual image entry
+			image := ImageInfo{}
+			image.Architecture = architectureName
+			image.Public = true
+			image.Size = size
+			image.CreationDate = creationDate
+			image.UploadDate = creationDate
+			image.Filename = filename
+			image.Fingerprint = fingerprint
+			image.Properties = map[string]string{
+				"os":           product.OperatingSystem,
+				"release":      product.Release,
+				"architecture": product.Architecture,
+				"label":        version.Label,
+				"serial":       name,
+				"description":  fmt.Sprintf("%s %s %s (%s) (%s)", product.OperatingSystem, product.ReleaseTitle, product.Architecture, version.Label, name),
+			}
+
+			// Attempt to parse the EOL
+			if product.SupportedEOL != "" {
+				eolDate, err := time.Parse(eolLayout, product.SupportedEOL)
+				if err == nil {
+					image.ExpiryDate = eolDate
+				}
+			}
+
+			downloads[fingerprint] = [][]string{[]string{metaPath, metaHash}, []string{rootfsPath, rootfsHash}}
+			images = append(images, image)
+		}
+	}
+
+	return images, downloads
+}
+
+type SimpleStreamsManifestProduct struct {
+	Architecture    string                                         `json:"arch"`
+	OperatingSystem string                                         `json:"os"`
+	Release         string                                         `json:"release"`
+	ReleaseCodename string                                         `json:"release_codename"`
+	ReleaseTitle    string                                         `json:"release_title"`
+	Supported       bool                                           `json:"supported"`
+	SupportedEOL    string                                         `json:"support_eol"`
+	Version         string                                         `json:"version"`
+	Versions        map[string]SimpleStreamsManifestProductVersion `json:"versions"`
+}
+
+type SimpleStreamsManifestProductVersion struct {
+	PublicName string                                             `json:"pubname"`
+	Label      string                                             `json:"label"`
+	Items      map[string]SimpleStreamsManifestProductVersionItem `json:"items"`
+}
+
+type SimpleStreamsManifestProductVersionItem struct {
+	Path          string `json:"path"`
+	FileType      string `json:"ftype"`
+	HashMd5       string `json:"md5"`
+	HashSha256    string `json:"sha256"`
+	LXDHashSha256 string `json:"combined_sha256"`
+	Size          int64  `json:"size"`
+}
+
+type SimpleStreamsIndex struct {
+	Format  string                              `json:"format"`
+	Index   map[string]SimpleStreamsIndexStream `json:"index"`
+	Updated string                              `json:"updated"`
+}
+
+type SimpleStreamsIndexStream struct {
+	Updated  string   `json:"updated"`
+	DataType string   `json:"datatype"`
+	Path     string   `json:"path"`
+	Products []string `json:"products"`
+}
+
+func SimpleStreamsClient(url string) (*SimpleStreams, error) {
+	// Setup a http client
+	tlsConfig, err := GetTLSConfig("", "", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig: tlsConfig,
+		Dial:            RFC3493Dialer,
+		Proxy:           http.ProxyFromEnvironment,
+	}
+
+	myHttp := http.Client{
+		Transport: tr,
+	}
+
+	return &SimpleStreams{
+		http:           &myHttp,
+		url:            url,
+		cachedManifest: map[string]*SimpleStreamsManifest{}}, nil
+}
+
+type SimpleStreams struct {
+	http *http.Client
+	url  string
+
+	cachedIndex    *SimpleStreamsIndex
+	cachedManifest map[string]*SimpleStreamsManifest
+	cachedImages   []ImageInfo
+	cachedAliases  map[string]*ImageAliasesEntry
+}
+
+func (s *SimpleStreams) parseIndex() (*SimpleStreamsIndex, error) {
+	if s.cachedIndex != nil {
+		return s.cachedIndex, nil
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/streams/v1/index.json", s.url), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+
+	r, err := s.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the idnex
+	ssIndex := SimpleStreamsIndex{}
+	err = json.Unmarshal(body, &ssIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cachedIndex = &ssIndex
+
+	return &ssIndex, nil
+}
+
+func (s *SimpleStreams) parseManifest(path string) (*SimpleStreamsManifest, error) {
+	if s.cachedManifest[path] != nil {
+		return s.cachedManifest[path], nil
+	}
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/%s", s.url, path), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", UserAgent)
+
+	r, err := s.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Body.Close()
+
+	body, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse the idnex
+	ssManifest := SimpleStreamsManifest{}
+	err = json.Unmarshal(body, &ssManifest)
+	if err != nil {
+		return nil, err
+	}
+
+	s.cachedManifest[path] = &ssManifest
+
+	return &ssManifest, nil
+}
+
+func (s *SimpleStreams) applyAliases(images []ImageInfo) ([]ImageInfo, map[string]*ImageAliasesEntry, error) {
+	aliases := map[string]*ImageAliasesEntry{}
+
+	sort.Sort(ssSortImage(images))
+
+	defaultOS := ""
+	for k, v := range ssDefaultOS {
+		if strings.HasPrefix(s.url, k) {
+			defaultOS = v
+			break
+		}
+	}
+
+	addAlias := func(name string, fingerprint string) *ImageAlias {
+		if defaultOS != "" {
+			name = strings.TrimPrefix(name, fmt.Sprintf("%s/", defaultOS))
+		}
+
+		if aliases[name] != nil {
+			return nil
+		}
+
+		alias := ImageAliasesEntry{}
+		alias.Name = name
+		alias.Target = fingerprint
+		aliases[name] = &alias
+
+		return &ImageAlias{Name: name}
+	}
+
+	uname := syscall.Utsname{}
+	if err := syscall.Uname(&uname); err != nil {
+		return nil, nil, err
+	}
+
+	architectureName := ""
+	for _, c := range uname.Machine {
+		if c == 0 {
+			break
+		}
+		architectureName += string(byte(c))
+	}
+
+	newImages := []ImageInfo{}
+	for _, image := range images {
+		// Short
+		if image.Architecture == architectureName {
+			alias := addAlias(fmt.Sprintf("%s/%s", image.Properties["os"], image.Properties["release"]), image.Fingerprint)
+			if alias != nil {
+				image.Aliases = append(image.Aliases, *alias)
+			}
+
+			alias = addAlias(fmt.Sprintf("%s/%s/%s", image.Properties["os"], image.Properties["release"], image.Properties["serial"]), image.Fingerprint)
+			if alias != nil {
+				image.Aliases = append(image.Aliases, *alias)
+			}
+		}
+
+		// Medium
+		alias := addAlias(fmt.Sprintf("%s/%s/%s", image.Properties["os"], image.Properties["release"], image.Properties["architecture"]), image.Fingerprint)
+		if alias != nil {
+			image.Aliases = append(image.Aliases, *alias)
+		}
+
+		// Medium
+		alias = addAlias(fmt.Sprintf("%s/%s/%s/%s", image.Properties["os"], image.Properties["release"], image.Properties["architecture"], image.Properties["serial"]), image.Fingerprint)
+		if alias != nil {
+			image.Aliases = append(image.Aliases, *alias)
+		}
+
+		newImages = append(newImages, image)
+	}
+
+	return newImages, aliases, nil
+}
+
+func (s *SimpleStreams) getImages() ([]ImageInfo, map[string]*ImageAliasesEntry, error) {
+	if s.cachedImages != nil && s.cachedAliases != nil {
+		return s.cachedImages, s.cachedAliases, nil
+	}
+
+	images := []ImageInfo{}
+
+	// Load the main index
+	ssIndex, err := s.parseIndex()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Iterate through the various image manifests
+	for _, entry := range ssIndex.Index {
+		// We only care about images
+		if entry.DataType != "image-downloads" {
+			continue
+		}
+
+		// No point downloading an empty image list
+		if len(entry.Products) == 0 {
+			continue
+		}
+
+		manifest, err := s.parseManifest(entry.Path)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		manifestImages, _ := manifest.ToLXD()
+
+		for _, image := range manifestImages {
+			images = append(images, image)
+		}
+	}
+
+	// Setup the aliases
+	images, aliases, err := s.applyAliases(images)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	s.cachedImages = images
+	s.cachedAliases = aliases
+
+	return images, aliases, nil
+}
+
+func (s *SimpleStreams) getPaths(fingerprint string) ([][]string, error) {
+	// Load the main index
+	ssIndex, err := s.parseIndex()
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate through the various image manifests
+	for _, entry := range ssIndex.Index {
+		// We only care about images
+		if entry.DataType != "image-downloads" {
+			continue
+		}
+
+		// No point downloading an empty image list
+		if len(entry.Products) == 0 {
+			continue
+		}
+
+		manifest, err := s.parseManifest(entry.Path)
+		if err != nil {
+			return nil, err
+		}
+
+		manifestImages, downloads := manifest.ToLXD()
+
+		for _, image := range manifestImages {
+			if strings.HasPrefix(image.Fingerprint, fingerprint) {
+				urls := [][]string{}
+				for _, path := range downloads[image.Fingerprint] {
+					urls = append(urls, []string{path[0], path[1]})
+				}
+				return urls, nil
+			}
+		}
+	}
+
+	return nil, fmt.Errorf("Couldn't find the requested image")
+}
+
+func (s *SimpleStreams) ListAliases() (ImageAliases, error) {
+	_, aliasesMap, err := s.getImages()
+	if err != nil {
+		return nil, err
+	}
+
+	aliases := ImageAliases{}
+
+	for _, alias := range aliasesMap {
+		aliases = append(aliases, *alias)
+	}
+
+	return aliases, nil
+}
+
+func (s *SimpleStreams) ListImages() ([]ImageInfo, error) {
+	images, _, err := s.getImages()
+	return images, err
+}
+
+func (s *SimpleStreams) GetAlias(name string) string {
+	_, aliasesMap, err := s.getImages()
+	if err != nil {
+		return ""
+	}
+
+	alias, ok := aliasesMap[name]
+	if !ok {
+		return ""
+	}
+
+	return alias.Target
+}
+
+func (s *SimpleStreams) GetImageInfo(fingerprint string) (*ImageInfo, error) {
+	images, _, err := s.getImages()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, image := range images {
+		if strings.HasPrefix(image.Fingerprint, fingerprint) {
+			return &image, nil
+		}
+	}
+
+	return nil, fmt.Errorf("The requested image couldn't be found.")
+}
+
+func (s *SimpleStreams) downloadFile(path string, hash string, target string) error {
+	if !IsDir(target) {
+		return fmt.Errorf("Split images can only be written to a directory.")
+	}
+
+	download := func(url string, hash string, target string) error {
+		out, err := os.Create(target)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		resp, err := s.http.Get(url)
+		if err != nil {
+		}
+		defer resp.Body.Close()
+
+		sha256 := sha256.New()
+		_, err = io.Copy(io.MultiWriter(out, sha256), resp.Body)
+		if err != nil {
+			return err
+		}
+
+		if fmt.Sprintf("%x", sha256.Sum(nil)) != hash {
+			os.Remove(target)
+			return fmt.Errorf("Hash mismatch")
+		}
+
+		return nil
+	}
+
+	fields := strings.Split(path, "/")
+	targetFile := filepath.Join(target, fields[len(fields)-1])
+
+	// Try http first
+	if strings.HasPrefix(s.url, "https://") {
+		err := download(fmt.Sprintf("http://%s/%s", strings.TrimPrefix(s.url, "https://"), path), hash, targetFile)
+		if err == nil {
+			return nil
+		}
+	}
+
+	err := download(fmt.Sprintf("%s/%s", s.url, path), hash, targetFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *SimpleStreams) ExportImage(image string, target string) (string, error) {
+	paths, err := s.getPaths(image)
+	if err != nil {
+		return "", err
+	}
+
+	for _, path := range paths {
+		err := s.downloadFile(path[0], path[1], target)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	return target, nil
+}

--- a/shared/simplestreams.go
+++ b/shared/simplestreams.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -344,18 +343,7 @@ func (s *SimpleStreams) applyAliases(images []ImageInfo) ([]ImageInfo, map[strin
 		return &ImageAlias{Name: name}
 	}
 
-	uname := syscall.Utsname{}
-	if err := syscall.Uname(&uname); err != nil {
-		return nil, nil, err
-	}
-
-	architectureName := ""
-	for _, c := range uname.Machine {
-		if c == 0 {
-			break
-		}
-		architectureName += string(byte(c))
-	}
+	architectureName, _ := ArchitectureGetLocal()
 
 	newImages := []ImageInfo{}
 	for _, image := range images {

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -410,6 +410,7 @@ Input (using a public remote image):
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "mode": "pull",                                          # One of "local" (default) or "pull"
                    "server": "https://10.0.2.3:8443",                       # Remote server (pull mode only)
+                   "protocol": "lxd",                                       # Protocol (one of lxd or simplestreams, defaults to lxd)
                    "certificate": "PEM certificate",                        # Optional PEM certificate. If not mentioned, system CA is used.
                    "alias": "ubuntu/devel"},                                # Name of the alias
     }
@@ -1044,6 +1045,7 @@ In the source image case, the following dict must be used:
             "type": "image",
             "mode": "pull",                     # Only pull is supported for now
             "server": "https://10.0.2.3:8443",  # Remote server (pull mode only)
+            "protocol": "lxd",                  # Protocol (one of lxd or simplestreams, defaults to lxd)
             "secret": "my-secret-string",       # Secret (pull mode only, private images only)
             "certificate": "PEM certificate",   # Optional PEM certificate. If not mentioned, system CA is used.
             "fingerprint": "SHA256",            # Fingerprint of the image (must be set if alias isn't)


### PR DESCRIPTION
With this, we get the two simplestreams remote and can interact with the remote image store, copy from it, export from it and start containers from it.

The next step will involve implementing sync support into the LXD daemon so that those images can be kept in sync in the background.