### PR TITLE
Improve stateful stop

### DIFF
--- a/client.go
+++ b/client.go
@@ -1441,13 +1441,6 @@ func (c *Client) Action(name string, action shared.ContainerAction, timeout int,
 		"timeout": timeout,
 		"force":   force}
 
-	if action == "start" {
-		current, err := c.ContainerState(name)
-		if err == nil && current.StatusCode == shared.Frozen {
-			body["action"] = "unfreeze"
-		}
-	}
-
 	if shared.StringInSlice(string(action), []string{"start", "stop"}) {
 		body["stateful"] = stateful
 	}

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -220,6 +220,16 @@ func dbContainerConfigRemove(db *sql.DB, id int, name string) error {
 	return err
 }
 
+func dbContainerSetStateful(db *sql.DB, id int, stateful bool) error {
+	statefulInt := 0
+	if stateful {
+		statefulInt = 1
+	}
+
+	_, err := dbExec(db, "UPDATE containers SET stateful=? WHERE id=?", statefulInt, id)
+	return err
+}
+
 func dbContainerProfilesInsert(tx *sql.Tx, id int, profiles []string) error {
 	applyOrder := 1
 	str := `INSERT INTO containers_profiles (container_id, profile_id, apply_order) VALUES

--- a/shared/container.go
+++ b/shared/container.go
@@ -70,6 +70,7 @@ type ContainerInfo struct {
 	ExpandedDevices Devices           `json:"expanded_devices"`
 	Name            string            `json:"name"`
 	Profiles        []string          `json:"profiles"`
+	Stateful        bool              `json:"stateful"`
 	Status          string            `json:"status"`
 	StatusCode      StatusCode        `json:"status_code"`
 }

--- a/specs/rest-api.md
+++ b/specs/rest-api.md
@@ -508,6 +508,7 @@ Output:
         "profiles": [
             "default"
         ],
+        "stateful": false,      # If true, indicates that the container has some stored state that can be restored on startup
         "status": "Running",
         "status_code": 103
     }


### PR DESCRIPTION
This exports the fact that the container contains stored state through
the same "stateful" property already used by snapshots.
    
With this information, the client can now only restore a stateful
startup when state is in fact stored.
    
Which in turn means the daemon can return an error when requested to
restore state for a container which has none.
    
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>