### PR TITLE
Don't stop at an unsatisfactory sub?id entry

### DIFF
--- a/shared/idmapset_linux.go
+++ b/shared/idmapset_linux.go
@@ -322,6 +322,9 @@ func getFromMap(fname string, username string) (int, int, error) {
 			}
 			min = int(bigmin)
 			idrange = int(bigIdrange)
+			if idrange < minIDRange {
+				continue
+			}
 			return min, idrange, nil
 		}
 	}
@@ -373,14 +376,6 @@ func DefaultIdmapSet() (*IdmapSet, error) {
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	if urange < minIDRange {
-		return nil, fmt.Errorf("uidrange less than %d", minIDRange)
-	}
-
-	if grange < minIDRange {
-		return nil, fmt.Errorf("gidrange less than %d", minIDRange)
 	}
 
 	m := new(IdmapSet)


### PR DESCRIPTION
We parse /etc/sub?id and stop when we find an entry for the user.  If
that isn't big enough, we later refuse to start unpriv containers.  But
sub?id may have later entries which are big enough - so just always
make sure to only return entries which will suffice.

Closes #1687

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>