### PR TITLE
client: better error on `lxc stop remote:`

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -59,6 +59,10 @@ func (c *actionCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 
+		if name == "" {
+			return fmt.Errorf(i18n.G("Must supply container name for: ")+"\"%s\"", nameArg)
+		}
+
 		if c.action == shared.Start || c.action == shared.Stop {
 			current, err := d.ContainerInfo(name)
 			if err != nil {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-03-01 00:43-0500\n"
+        "POT-Creation-Date: 2016-03-02 14:02-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -650,6 +650,10 @@ msgid   "Move containers within or in between lxd instances.\n"
         "    Rename a local container.\n"
 msgstr  ""
 
+#: lxc/action.go:63
+msgid   "Must supply container name for: "
+msgstr  ""
+
 #: lxc/list.go:336 lxc/remote.go:312
 msgid   "NAME"
 msgstr  ""
@@ -944,7 +948,7 @@ msgstr  ""
 msgid   "Transfering image: %d%%"
 msgstr  ""
 
-#: lxc/action.go:89 lxc/launch.go:130
+#: lxc/action.go:93 lxc/launch.go:130
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -1007,7 +1011,7 @@ msgstr  ""
 msgid   "bad number of things scanned from image, container or snapshot"
 msgstr  ""
 
-#: lxc/action.go:85
+#: lxc/action.go:89
 msgid   "bad result type from action"
 msgstr  ""
 


### PR DESCRIPTION
$ lxc stop images:
error: Must supply container name for: "images:"

Closes #1689

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>