### PR TITLE
client: add default config in NewClientFromInfo

### DIFF
--- a/client.go
+++ b/client.go
@@ -311,6 +311,10 @@ func NewClientFromInfo(info ConnectInfo) (*Client, error) {
 	c := &Client{
 		// Config: *config,
 		Http: http.Client{},
+		Config: Config{
+			Remotes: DefaultRemotes,
+			Aliases: map[string]string{},
+		},
 	}
 	c.Name = info.Name
 	var err error


### PR DESCRIPTION
Now that the API is designed to use these default "ubuntu" remotes, let's
make sure they're available in all instances of the client.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>