### PR TITLE
Workaround kernel overmounting protection

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -324,7 +324,7 @@ func (c *containerLXC) initLXC() error {
 	}
 
 	for _, mnt := range []string{"/proc/sys/fs/binfmt_misc", "/sys/firmware/efi/efivars", "/sys/fs/fuse/connections", "/sys/fs/pstore", "/sys/kernel/debug", "/sys/kernel/security"} {
-		err = lxcSetConfigItem(cc, "lxc.mount.entry", fmt.Sprintf("%s %s none bind,optional", mnt, strings.TrimPrefix(mnt, "/")))
+		err = lxcSetConfigItem(cc, "lxc.mount.entry", fmt.Sprintf("%s %s none rbind,optional", mnt, strings.TrimPrefix(mnt, "/")))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The kernel prevents us from bind-mounting filesystems which have entries
hidden by overmounting.

This currently prevents startup of some containers when
/sys/kernel/debug/tracing, an auto-mounted path has been accessed on the
host.

Fix this by simply recursively bind-mounting things into the container.

Reported by: cmars & stokachu
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>