### PR TITLE
migration: attempt to be slightly smart about moving filesystems

### DIFF
--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -418,15 +418,15 @@ func Test_dbImageGet_finds_image_for_fingerprint(t *testing.T) {
 		t.Fatal("Filename should be set.")
 	}
 
-	if result.CreationDate != time.Unix(1431547174, 0).UTC() {
+	if result.CreationDate.UTC() != time.Unix(1431547174, 0).UTC() {
 		t.Fatal(fmt.Sprintf("%s != %s", result.CreationDate, time.Unix(1431547174, 0)))
 	}
 
-	if result.ExpiryDate != time.Unix(1431547175, 0).UTC() { // It was short lived
+	if result.ExpiryDate.UTC() != time.Unix(1431547175, 0).UTC() { // It was short lived
 		t.Fatal(fmt.Sprintf("%s != %s", result.ExpiryDate, time.Unix(1431547175, 0)))
 	}
 
-	if result.UploadDate != time.Unix(1431547176, 0).UTC() {
+	if result.UploadDate.UTC() != time.Unix(1431547176, 0).UTC() {
 		t.Fatal(fmt.Sprintf("%s != %s", result.UploadDate, time.Unix(1431547176, 0)))
 	}
 }

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -266,10 +266,10 @@ func (s *storageDir) MigrationType() MigrationFSType {
 	return MigrationFSType_RSYNC
 }
 
-func (s *storageDir) MigrationSource(container container) ([]MigrationStorageSource, error) {
+func (s *storageDir) MigrationSource(container container) (MigrationStorageSourceDriver, error) {
 	return rsyncMigrationSource(container)
 }
 
-func (s *storageDir) MigrationSink(container container, snapshots []container, conn *websocket.Conn) error {
-	return rsyncMigrationSink(container, snapshots, conn)
+func (s *storageDir) MigrationSink(live bool, container container, snapshots []container, conn *websocket.Conn) error {
+	return rsyncMigrationSink(live, container, snapshots, conn)
 }

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1056,10 +1056,10 @@ func (s *storageLvm) MigrationType() MigrationFSType {
 	return MigrationFSType_RSYNC
 }
 
-func (s *storageLvm) MigrationSource(container container) ([]MigrationStorageSource, error) {
+func (s *storageLvm) MigrationSource(container container) (MigrationStorageSourceDriver, error) {
 	return rsyncMigrationSource(container)
 }
 
-func (s *storageLvm) MigrationSink(container container, snapshots []container, conn *websocket.Conn) error {
-	return rsyncMigrationSink(container, snapshots, conn)
+func (s *storageLvm) MigrationSink(live bool, container container, snapshots []container, conn *websocket.Conn) error {
+	return rsyncMigrationSink(live, container, snapshots, conn)
 }

--- a/lxd/storage_test.go
+++ b/lxd/storage_test.go
@@ -131,9 +131,9 @@ func (s *storageMock) MigrationType() MigrationFSType {
 	return MigrationFSType_RSYNC
 }
 
-func (s *storageMock) MigrationSource(container container) ([]MigrationStorageSource, error) {
+func (s *storageMock) MigrationSource(container container) (MigrationStorageSourceDriver, error) {
 	return nil, fmt.Errorf("not implemented")
 }
-func (s *storageMock) MigrationSink(container container, snapshots []container, conn *websocket.Conn) error {
+func (s *storageMock) MigrationSink(live bool, container container, snapshots []container, conn *websocket.Conn) error {
 	return nil
 }

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1157,66 +1157,38 @@ func storageZFSSetPoolNameConfig(d *Daemon, poolname string) error {
 	return nil
 }
 
-type zfsMigrationSource struct {
-	lxdName            string
-	deleteAfterSending bool
-	zfsName            string
-	zfsParent          string
-
-	zfs *storageZfs
+type zfsMigrationSourceDriver struct {
+	container        container
+	snapshots        []container
+	zfsSnapshotNames []string
+	zfs              *storageZfs
+	runningSnapName  string
+	stoppedSnapName  string
 }
 
-func (s zfsMigrationSource) Name() string {
-	return s.lxdName
+func (s *zfsMigrationSourceDriver) Snapshots() []container {
+	return s.snapshots
 }
 
-func (s zfsMigrationSource) IsSnapshot() bool {
-	return !s.deleteAfterSending
-}
-
-func (s zfsMigrationSource) Send(conn *websocket.Conn) error {
-	args := []string{"send", fmt.Sprintf("%s/%s", s.zfs.zfsPool, s.zfsName)}
-	if s.zfsParent != "" {
-		args = append(args, "-i", fmt.Sprintf("%s/%s", s.zfs.zfsPool, s.zfsParent))
+func (s *zfsMigrationSourceDriver) send(conn *websocket.Conn, zfsName string, zfsParent string) error {
+	args := []string{"send", fmt.Sprintf("%s/containers/%s@%s", s.zfs.zfsPool, s.container.Name(), zfsName)}
+	if zfsParent != "" {
+		args = append(args, "-i", fmt.Sprintf("%s/containers/%s@%s", s.zfs.zfsPool, s.container.Name(), zfsParent))
 	}
 
 	cmd := exec.Command("zfs", args...)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		/* If this is not a lxd snapshot, that means it is the root container.
-		 * The way we zfs send a root container is by taking a temporary zfs
-		 * snapshot and sending that, then deleting that snapshot. Here's where
-		 * we delete it.
-		 *
-		 * Note that we can't use a defer here, because zfsDestroy
-		 * takes some time, and defer doesn't block the current
-		 * goroutine. Due to our retry mechanism for network failures
-		 * (and because zfsDestroy takes a while), we might retry
-		 * moving (and thus creating a temporary snapshot) before the
-		 * last one is deleted, resulting in either a snapshot name
-		 * collision if it was fast enough, or an extra snapshot with
-		 * an odd name on the destination side. Instead, we don't use
-		 * defer so we always block until the snapshot is dead.
-		 */
-		if s.deleteAfterSending {
-			s.zfs.zfsDestroy(s.zfsName)
-		}
 		return err
 	}
 
 	stderr, err := cmd.StderrPipe()
 	if err != nil {
-		if s.deleteAfterSending {
-			s.zfs.zfsDestroy(s.zfsName)
-		}
 		return err
 	}
 
 	if err := cmd.Start(); err != nil {
-		if s.deleteAfterSending {
-			s.zfs.zfsDestroy(s.zfsName)
-		}
 		return err
 	}
 
@@ -1231,39 +1203,97 @@ func (s zfsMigrationSource) Send(conn *websocket.Conn) error {
 	if err != nil {
 		shared.Log.Error("problem with zfs send", "output", string(output))
 	}
-	if s.deleteAfterSending {
-		s.zfs.zfsDestroy(s.zfsName)
-	}
+
 	return err
+}
+
+func (s *zfsMigrationSourceDriver) SendWhileRunning(conn *websocket.Conn) error {
+	if s.container.IsSnapshot() {
+		fields := strings.SplitN(s.container.Name(), shared.SnapshotDelimiter, 2)
+		snapshotName := fmt.Sprintf("containers/%s@snapshot-%s", fields[0], fields[1])
+		return s.send(conn, snapshotName, "")
+	}
+
+	lastSnap := ""
+
+	for i, snap := range s.zfsSnapshotNames {
+
+		prev := ""
+		if i > 0 {
+			prev = s.zfsSnapshotNames[i-1]
+		}
+
+		lastSnap = snap
+
+		if err := s.send(conn, snap, prev); err != nil {
+			return err
+		}
+	}
+
+	s.runningSnapName = fmt.Sprintf("migration-send-%s", uuid.NewRandom().String())
+	if err := s.zfs.zfsSnapshotCreate(fmt.Sprintf("containers/%s", s.container.Name()), s.runningSnapName); err != nil {
+		return err
+	}
+
+	if err := s.send(conn, s.runningSnapName, lastSnap); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *zfsMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn) error {
+	s.stoppedSnapName = fmt.Sprintf("migration-send-%s", uuid.NewRandom().String())
+	if err := s.zfs.zfsSnapshotCreate(fmt.Sprintf("containers/%s", s.container.Name()), s.stoppedSnapName); err != nil {
+		return err
+	}
+
+	if err := s.send(conn, s.stoppedSnapName, s.runningSnapName); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *zfsMigrationSourceDriver) Cleanup() {
+	if s.stoppedSnapName != "" {
+		s.zfs.zfsSnapshotDestroy(fmt.Sprintf("containers/%s", s.container.Name()), s.stoppedSnapName)
+	}
+
+	if s.runningSnapName != "" {
+		s.zfs.zfsSnapshotDestroy(fmt.Sprintf("containers/%s", s.container.Name()), s.runningSnapName)
+	}
 }
 
 func (s *storageZfs) MigrationType() MigrationFSType {
 	return MigrationFSType_ZFS
 }
 
-func (s *storageZfs) MigrationSource(container container) ([]MigrationStorageSource, error) {
-	sources := []MigrationStorageSource{}
-
+func (s *storageZfs) MigrationSource(ct container) (MigrationStorageSourceDriver, error) {
 	/* If the container is a snapshot, let's just send that; we don't need
 	 * to send anything else, because that's all the user asked for.
 	 */
-	if container.IsSnapshot() {
-		fields := strings.SplitN(container.Name(), shared.SnapshotDelimiter, 2)
-		snapshotName := fmt.Sprintf("containers/%s@snapshot-%s", fields[0], fields[1])
-		sources = append(sources, zfsMigrationSource{container.Name(), false, snapshotName, "", s})
-		return sources, nil
+	if ct.IsSnapshot() {
+		return &zfsMigrationSourceDriver{container: ct}, nil
+	}
+
+	driver := zfsMigrationSourceDriver{
+		container:        ct,
+		snapshots:        []container{},
+		zfsSnapshotNames: []string{},
+		zfs:              s,
 	}
 
 	/* List all the snapshots in order of reverse creation. The idea here
 	 * is that we send the oldest to newest snapshot, hopefully saving on
 	 * xfer costs. Then, after all that, we send the container itself.
 	 */
-	snapshots, err := s.zfsListSnapshots(fmt.Sprintf("containers/%s", container.Name()))
+	snapshots, err := s.zfsListSnapshots(fmt.Sprintf("containers/%s", ct.Name()))
 	if err != nil {
 		return nil, err
 	}
 
-	for i, snap := range snapshots {
+	for _, snap := range snapshots {
 		/* In the case of e.g. multiple copies running at the same
 		 * time, we will have potentially multiple migration-send
 		 * snapshots. (Or in the case of the test suite, sometimes one
@@ -1273,41 +1303,22 @@ func (s *storageZfs) MigrationSource(container container) ([]MigrationStorageSou
 			continue
 		}
 
-		prev := ""
-		if i > 0 {
-			prev = snapshots[i-1]
+		lxdName := fmt.Sprintf("%s%s%s", ct.Name(), shared.SnapshotDelimiter, snap[len("snapshot-"):])
+		zfsName := fmt.Sprintf("containers/%s@%s", ct.Name(), snap)
+
+		snapshot, err := containerLoadByName(s.d, lxdName)
+		if err != nil {
+			return nil, err
 		}
 
-		lxdName := fmt.Sprintf("%s%s%s", container.Name(), shared.SnapshotDelimiter, snap[len("snapshot-"):])
-		zfsName := fmt.Sprintf("containers/%s@%s", container.Name(), snap)
-		parentName := ""
-		if prev != "" {
-			parentName = fmt.Sprintf("containers/%s@%s", container.Name(), prev)
-		}
-
-		sources = append(sources, zfsMigrationSource{lxdName, false, zfsName, parentName, s})
+		driver.snapshots = append(driver.snapshots, snapshot)
+		driver.zfsSnapshotNames = append(driver.zfsSnapshotNames, zfsName)
 	}
 
-	/* We can't send running fses, so let's snapshot the fs and send
-	 * the snapshot.
-	 */
-	snapshotName := fmt.Sprintf("migration-send-%s", uuid.NewRandom().String())
-	if err := s.zfsSnapshotCreate(fmt.Sprintf("containers/%s", container.Name()), snapshotName); err != nil {
-		return nil, err
-	}
-
-	zfsName := fmt.Sprintf("containers/%s@%s", container.Name(), snapshotName)
-	zfsParent := ""
-	if len(sources) > 0 {
-		zfsParent = sources[len(sources)-1].(zfsMigrationSource).zfsName
-	}
-
-	sources = append(sources, zfsMigrationSource{container.Name(), true, zfsName, zfsParent, s})
-
-	return sources, nil
+	return &driver, nil
 }
 
-func (s *storageZfs) MigrationSink(container container, snapshots []container, conn *websocket.Conn) error {
+func (s *storageZfs) MigrationSink(live bool, container container, snapshots []container, conn *websocket.Conn) error {
 	zfsRecv := func(zfsName string) error {
 		zfsFsName := fmt.Sprintf("%s/%s", s.zfsPool, zfsName)
 		args := []string{"receive", "-F", "-u", zfsFsName}
@@ -1384,9 +1395,33 @@ func (s *storageZfs) MigrationSink(container container, snapshots []container, c
 		}
 	}
 
+	defer func() {
+		/* clean up our migration-send snapshots that we got from recv. */
+		snapshots, err := s.zfsListSnapshots(fmt.Sprintf("containers/%s", container.Name()))
+		if err != nil {
+			shared.Log.Error("failed listing snapshots post migration", "err", err)
+			return
+		}
+
+		for _, snap := range snapshots {
+			if !strings.HasPrefix(snap, "migration-send") {
+				continue
+			}
+
+			s.zfsSnapshotDestroy(fmt.Sprintf("containers/%s", container.Name()), snap)
+		}
+	}()
+
 	/* finally, do the real container */
 	if err := zfsRecv(zfsName); err != nil {
 		return err
+	}
+
+	if live {
+		/* and again for the post-running snapshot if this was a live migration */
+		if err := zfsRecv(zfsName); err != nil {
+			return err
+		}
 	}
 
 	/* Sometimes, zfs recv mounts this anyway, even if we pass -u


### PR DESCRIPTION
This breaks up live migrations into two parts: first we send a snapshot of
the filesystem while the container is running (and all of its snapshots),
then we do the checkpoint and do a final incremental send. The goal here is
to minimize the amount of downtime for the container.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>