### PR TITLE
Allow reducing the LVM LV size and update tests

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -952,11 +952,16 @@ func (s *storageLvm) createThinLV(lvname string) (string, error) {
 		}
 	}
 
+	lvSize := os.Getenv("LXD_LVM_LVSIZE")
+	if lvSize == "" {
+		lvSize = storageLvmDefaultThinLVSize
+	}
+
 	output, err := s.tryExec(
 		"lvcreate",
 		"--thin",
 		"-n", lvname,
-		"--virtualsize", storageLvmDefaultThinLVSize,
+		"--virtualsize", lvSize,
 		fmt.Sprintf("%s/%s", s.vgName, poolname))
 
 	if err != nil {

--- a/test/backends/lvm.sh
+++ b/test/backends/lvm.sh
@@ -10,7 +10,7 @@ lvm_setup() {
     echo "Couldn't find the lvm binary"; false
   fi
 
-  truncate -s 100G "${TEST_DIR}/$(basename "${LXD_DIR}").lvm"
+  truncate -s 4G "${TEST_DIR}/$(basename "${LXD_DIR}").lvm"
   pvloopdev=$(losetup --show -f "${TEST_DIR}/$(basename "${LXD_DIR}").lvm")
   if [ ! -e "${pvloopdev}" ]; then
     echo "failed to setup loop"
@@ -28,6 +28,7 @@ lvm_configure() {
 
   echo "==> Configuring lvm backend in ${LXD_DIR}"
 
+  export LXD_LVM_LVSIZE="10Mib"
   lxc config set storage.lvm_vg_name "lxdtest-$(basename "${LXD_DIR}")"
 }
 


### PR DESCRIPTION
We spend more than 50% of the LVM test time in mkfs.ext4, despite using
test images only a few kB large, so lets make the LV size configurable
through environment and set it to something really small for the
testsuite.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>