### PR TITLE
profiles: don't mask error message when not found

### DIFF
--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -37,7 +37,7 @@ func dbProfileGet(db *sql.DB, profile string) (int64, *shared.ProfileConfig, err
 	arg2 := []interface{}{&id, &description}
 	err := dbQueryRowScan(db, q, arg1, arg2)
 	if err != nil {
-		return -1, nil, fmt.Errorf("here: %s", err)
+		return -1, nil, err
 	}
 
 	config, err := dbProfileConfig(db, profile)


### PR DESCRIPTION
If we mask this error with the useless "here" prefix, the rest of the error
handling code doesn't figure out that it's a sql.NoRows error, and thus
doesn't propagate the 404 correctly, so we end up with:

$ lxc profile edit host1:invalid
error: here: sql: no rows in result set

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>