### PR TITLE
mounting: only block devices hold filesystems

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -758,7 +758,7 @@ func (c *containerLXC) initLXC() error {
 			// Various option checks
 			isOptional := m["optional"] == "1" || m["optional"] == "true"
 			isReadOnly := m["readonly"] == "1" || m["readonly"] == "true"
-			isFile := !shared.IsDir(srcPath) && !deviceIsDevice(srcPath)
+			isFile := !shared.IsDir(srcPath) && !deviceIsBlockdev(srcPath)
 
 			// Deal with a rootfs
 			if tgtPath == "" {
@@ -3611,7 +3611,7 @@ func (c *containerLXC) createDiskDevice(name string, m shared.Device) (string, e
 	// Check if read-only
 	isOptional := m["optional"] == "1" || m["optional"] == "true"
 	isReadOnly := m["readonly"] == "1" || m["readonly"] == "true"
-	isFile := !shared.IsDir(srcPath) && !deviceIsDevice(srcPath)
+	isFile := !shared.IsDir(srcPath) && !deviceIsBlockdev(srcPath)
 
 	// Check if the source exists
 	if !shared.PathExists(srcPath) {

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -431,17 +431,12 @@ func deviceTaskSchedulerTrigger(srcType string, srcName string, srcStatus string
 	}()
 }
 
-func deviceIsDevice(path string) bool {
+func deviceIsBlockdev(path string) bool {
 	// Get a stat struct from the provided path
 	stat := syscall.Stat_t{}
 	err := syscall.Stat(path, &stat)
 	if err != nil {
 		return false
-	}
-
-	// Check if it's a character device
-	if stat.Mode&syscall.S_IFMT == syscall.S_IFCHR {
-		return true
 	}
 
 	// Check if it's a block device
@@ -532,7 +527,7 @@ func deviceMountDisk(srcPath string, dstPath string, readonly bool) error {
 
 	// Detect the filesystem
 	fstype := "none"
-	if deviceIsDevice(srcPath) {
+	if deviceIsBlockdev(srcPath) {
 		fstype, err = shared.BlockFsDetect(srcPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
If we lxc config device add x1 disk type=disk source=/dev/null, lxd
should not try to detect the filesystem (and fail when it can't).

The function as it stands woudl've made sense, but every caller of
it really wants to know whether it's a block device, so rename the
fn and have it return false for chardevs.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>