### PR TITLE
daemon: support proxy configuration options

### DIFF
--- a/client.go
+++ b/client.go
@@ -314,7 +314,7 @@ func NewClientFromInfo(info ConnectInfo) (*Client, error) {
 	}
 
 	if info.RemoteConfig.Protocol == "simplestreams" {
-		ss, err := shared.SimpleStreamsClient(c.Remote.Addr)
+		ss, err := shared.SimpleStreamsClient(c.Remote.Addr, http.ProxyFromEnvironment)
 		if err != nil {
 			return nil, err
 		}

--- a/client.go
+++ b/client.go
@@ -273,7 +273,7 @@ func connectViaHttp(c *Client, remote *RemoteConfig, clientCert, clientKey, serv
 	tr := &http.Transport{
 		TLSClientConfig: tlsconfig,
 		Dial:            shared.RFC3493Dialer,
-		Proxy:           http.ProxyFromEnvironment,
+		Proxy:           shared.ProxyFromEnvironment,
 	}
 
 	c.websocketDialer.NetDial = shared.RFC3493Dialer
@@ -314,7 +314,7 @@ func NewClientFromInfo(info ConnectInfo) (*Client, error) {
 	}
 
 	if info.RemoteConfig.Protocol == "simplestreams" {
-		ss, err := shared.SimpleStreamsClient(c.Remote.Addr, http.ProxyFromEnvironment)
+		ss, err := shared.SimpleStreamsClient(c.Remote.Addr, shared.ProxyFromEnvironment)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -239,6 +239,13 @@ func api10Put(d *Daemon, r *http.Request) Response {
 			if err != nil {
 				return InternalError(err)
 			}
+		} else if key == "core.proxy_https" || key == "core.proxy_http" || key == "core.proxy_ignore_hosts" {
+			err = d.ConfigValueSet(key, value.(string))
+			if err != nil {
+				return InternalError(err)
+			}
+
+			d.updateProxy()
 		} else {
 			err := d.ConfigValueSet(key, value.(string))
 			if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -847,6 +847,7 @@ func (d *Daemon) Init() error {
 		return err
 	}
 
+	/* set the initial proxy function based on config values in the DB */
 	d.updateProxy()
 
 	/* Auto-update images */

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -27,14 +27,9 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 
 	fp := alias
 
-	proxy, err := d.proxyFunc()
-	if err != nil {
-		return "", err
-	}
-
 	// Expand aliases
 	if protocol == "simplestreams" {
-		ss, err = shared.SimpleStreamsClient(server, proxy)
+		ss, err = shared.SimpleStreamsClient(server, d.proxy)
 		if err != nil {
 			return "", err
 		}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -27,9 +27,14 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 
 	fp := alias
 
+	proxy, err := d.proxyFunc()
+	if err != nil {
+		return "", err
+	}
+
 	// Expand aliases
 	if protocol == "simplestreams" {
-		ss, err = shared.SimpleStreamsClient(server)
+		ss, err = shared.SimpleStreamsClient(server, proxy)
 		if err != nil {
 			return "", err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -325,10 +325,15 @@ func imgPostURLInfo(d *Daemon, req imagePostReq, op *operation) error {
 		return err
 	}
 
+	proxy, err := d.proxyFunc()
+	if err != nil {
+		return err
+	}
+
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
 		Dial:            shared.RFC3493Dialer,
-		Proxy:           http.ProxyFromEnvironment,
+		Proxy:           proxy,
 	}
 
 	myhttp := http.Client{

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -325,15 +325,10 @@ func imgPostURLInfo(d *Daemon, req imagePostReq, op *operation) error {
 		return err
 	}
 
-	proxy, err := d.proxyFunc()
-	if err != nil {
-		return err
-	}
-
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
 		Dial:            shared.RFC3493Dialer,
-		Proxy:           proxy,
+		Proxy:           d.proxy,
 	}
 
 	myhttp := http.Client{

--- a/shared/network.go
+++ b/shared/network.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net"
-	"net/http"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -32,35 +31,6 @@ func RFC3493Dialer(network, address string) (net.Conn, error) {
 		return c, err
 	}
 	return nil, fmt.Errorf("Unable to connect to: " + address)
-}
-
-func GetRemoteCertificate(address string) (*x509.Certificate, error) {
-	// Setup a permissive TLS config
-	tlsConfig, err := GetTLSConfig("", "", nil)
-	if err != nil {
-		return nil, err
-	}
-
-	tlsConfig.InsecureSkipVerify = true
-	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-		Dial:            RFC3493Dialer,
-		Proxy:           http.ProxyFromEnvironment,
-	}
-
-	// Connect
-	client := &http.Client{Transport: tr}
-	resp, err := client.Get(address)
-	if err != nil {
-		return nil, err
-	}
-
-	// Retrieve the certificate
-	if resp.TLS == nil || len(resp.TLS.PeerCertificates) == 0 {
-		return nil, fmt.Errorf("Unable to read remote TLS certificate")
-	}
-
-	return resp.TLS.PeerCertificates[0], nil
 }
 
 func initTLSConfig() *tls.Config {

--- a/shared/proxy.go
+++ b/shared/proxy.go
@@ -1,0 +1,162 @@
+package shared
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+)
+
+var (
+	httpProxyEnv = &envOnce{
+		names: []string{"HTTP_PROXY", "http_proxy"},
+	}
+	httpsProxyEnv = &envOnce{
+		names: []string{"HTTPS_PROXY", "https_proxy"},
+	}
+	noProxyEnv = &envOnce{
+		names: []string{"NO_PROXY", "no_proxy"},
+	}
+)
+
+type envOnce struct {
+	names []string
+	once  sync.Once
+	val   string
+}
+
+func (e *envOnce) Get() string {
+	e.once.Do(e.init)
+	return e.val
+}
+
+func (e *envOnce) init() {
+	for _, n := range e.names {
+		e.val = os.Getenv(n)
+		if e.val != "" {
+			return
+		}
+	}
+}
+
+// This is basically the same as golang's ProxyFromEnvironment, except it
+// doesn't fall back to http_proxy when https_proxy isn't around, which is
+// incorrect behavior. It still respects HTTP_PROXY, HTTPS_PROXY, and NO_PROXY.
+func ProxyFromEnvironment(req *http.Request) (*url.URL, error) {
+	return ProxyFromConfig("", "", "")(req)
+}
+
+func ProxyFromConfig(httpsProxy string, httpProxy string, noProxy string) func(req *http.Request) (*url.URL, error) {
+	return func(req *http.Request) (*url.URL, error) {
+		var proxy, port string
+		var err error
+
+		switch req.URL.Scheme {
+		case "https":
+			proxy = httpsProxy
+			if proxy == "" {
+				proxy = httpsProxyEnv.Get()
+			}
+			port = ":443"
+		case "http":
+			proxy = httpProxy
+			if proxy == "" {
+				proxy = httpProxyEnv.Get()
+			}
+			port = ":80"
+		default:
+			return nil, fmt.Errorf("unknown scheme %s", req.URL.Scheme)
+		}
+
+		if proxy == "" {
+			return nil, nil
+		}
+
+		addr := req.URL.Host
+		if !hasPort(addr) {
+			addr = addr + port
+		}
+
+		use, err := useProxy(addr, noProxy)
+		if err != nil {
+			return nil, err
+		}
+		if !use {
+			return nil, nil
+		}
+
+		proxyURL, err := url.Parse(proxy)
+		if err != nil || !strings.HasPrefix(proxyURL.Scheme, "http") {
+			// proxy was bogus. Try prepending "http://" to it and
+			// see if that parses correctly. If not, we fall
+			// through and complain about the original one.
+			if proxyURL, err := url.Parse("http://" + proxy); err == nil {
+				return proxyURL, nil
+			}
+		}
+		if err != nil {
+			return nil, fmt.Errorf("invalid proxy address %q: %v", proxy, err)
+		}
+		return proxyURL, nil
+	}
+}
+
+func hasPort(s string) bool {
+	return strings.LastIndex(s, ":") > strings.LastIndex(s, "]")
+}
+
+func useProxy(addr string, noProxy string) (bool, error) {
+	if noProxy == "" {
+		noProxy = noProxyEnv.Get()
+	}
+
+	if len(addr) == 0 {
+		return true, nil
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false, nil
+	}
+	if host == "localhost" {
+		return false, nil
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		if ip.IsLoopback() {
+			return false, nil
+		}
+	}
+
+	if noProxy == "*" {
+		return false, nil
+	}
+
+	addr = strings.ToLower(strings.TrimSpace(addr))
+	if hasPort(addr) {
+		addr = addr[:strings.LastIndex(addr, ":")]
+	}
+
+	for _, p := range strings.Split(noProxy, ",") {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if len(p) == 0 {
+			continue
+		}
+		if hasPort(p) {
+			p = p[:strings.LastIndex(p, ":")]
+		}
+		if addr == p {
+			return false, nil
+		}
+		if p[0] == '.' && (strings.HasSuffix(addr, p) || addr == p[1:]) {
+			// noProxy ".foo.com" matches "bar.foo.com" or "foo.com"
+			return false, nil
+		}
+		if p[0] != '.' && strings.HasSuffix(addr, p) && addr[len(addr)-len(p)-1] == '.' {
+			// noProxy "foo.com" matches "bar.foo.com"
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/shared/simplestreams.go
+++ b/shared/simplestreams.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"sort"
@@ -215,7 +216,7 @@ type SimpleStreamsIndexStream struct {
 	Products []string `json:"products"`
 }
 
-func SimpleStreamsClient(url string) (*SimpleStreams, error) {
+func SimpleStreamsClient(url string, proxy func(*http.Request) (*url.URL, error)) (*SimpleStreams, error) {
 	// Setup a http client
 	tlsConfig, err := GetTLSConfig("", "", nil)
 	if err != nil {
@@ -225,7 +226,7 @@ func SimpleStreamsClient(url string) (*SimpleStreams, error) {
 	tr := &http.Transport{
 		TLSClientConfig: tlsConfig,
 		Dial:            RFC3493Dialer,
-		Proxy:           http.ProxyFromEnvironment,
+		Proxy:           proxy,
 	}
 
 	myHttp := http.Client{

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -24,8 +24,8 @@ core.https\_allowed\_origin     | string        | -                         | Ac
 core.https\_allowed\_methods    | string        | -                         | Access-Control-Allow-Methods http header value
 core.https\_allowed\_headers    | string        | -                         | Access-Control-Allow-Headers http header value
 core.proxy\_https               | string        | -                         | https proxy to use, if any (falls back to HTTPS_PROXY environment variable)
-core.proxy\_http                | string        | -                         | http proxy to use, if any (falls back to HTTP_PROXY)
-core.proxy\_ignore\_hosts       | string        | -                         | hosts which don't need the proxy for use (similar format to NO_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO_PROXY)
+core.proxy\_http                | string        | -                         | http proxy to use, if any (falls back to HTTP_PROXY environment variable)
+core.proxy\_ignore\_hosts       | string        | -                         | hosts which don't need the proxy for use (similar format to NO_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO_PROXY environment varialbe)
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 storage.lvm\_vg\_name           | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.

--- a/specs/configuration.md
+++ b/specs/configuration.md
@@ -23,6 +23,9 @@ core.https\_address             | string        | -                         | Ad
 core.https\_allowed\_origin     | string        | -                         | Access-Control-Allow-Origin http header value
 core.https\_allowed\_methods    | string        | -                         | Access-Control-Allow-Methods http header value
 core.https\_allowed\_headers    | string        | -                         | Access-Control-Allow-Headers http header value
+core.proxy\_https               | string        | -                         | https proxy to use, if any (falls back to HTTPS_PROXY environment variable)
+core.proxy\_http                | string        | -                         | http proxy to use, if any (falls back to HTTP_PROXY)
+core.proxy\_ignore\_hosts       | string        | -                         | hosts which don't need the proxy for use (similar format to NO_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO_PROXY)
 core.trust\_password            | string        | -                         | Password to be provided by clients to setup a trust
 storage.lvm\_vg\_name           | string        | -                         | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string        | "LXDPool"                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.


### PR DESCRIPTION
juju will want to set proxy information on the daemon to tell it where to
ask for images. This commit adds configuration varaibles for common proxy
information, so that juju can use the LXD API as opposed to hacking the
init script to start LXD with HTTP_PROXY env enabled.

Note that this commit will no longer use HTTP_PROXY, but requires users to
use the configuration instead.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>