### PR TITLE
Fix error message when snapshot with duplicate name

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -594,6 +594,9 @@ func containerCreateInternal(d *Daemon, args containerArgs) (container, error) {
 
 	path := containerPath(args.Name, args.Ctype == cTypeSnapshot)
 	if shared.PathExists(path) {
+		if shared.IsSnapshot(args.Name) {
+			return nil, fmt.Errorf("Snapshot '%s' already exists", args.Name)
+		}
 		return nil, fmt.Errorf("The container already exists")
 	}
 


### PR DESCRIPTION
This pull requests fixes inaccurate error message of snapshotting with existing snapshot name (issue #1725) by using message format "Snapshot '<container>/<snapshot>' already exists".

Signed-off-by: Janne Savikko <janne.savikko@aalto.fi>