### PR TITLE
Handle unresponsive container monitors

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -230,7 +230,7 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 		}
 
 		for _, column := range columns {
-			if column.NeedsState && cInfo.StatusCode != shared.Stopped {
+			if column.NeedsState && cIsActive(cInfo) {
 				_, ok := cStates[cInfo.Name]
 				if ok {
 					continue
@@ -367,8 +367,19 @@ func (c *listCmd) statusColumnData(cInfo shared.ContainerInfo, cState *shared.Co
 	return strings.ToUpper(cInfo.Status)
 }
 
+func cIsActive(cInfo shared.ContainerInfo) bool {
+	switch cInfo.StatusCode {
+	case shared.Stopped:
+		return false
+	case shared.Error:
+		return false
+	default:
+		return true
+	}
+}
+
 func (c *listCmd) IP4ColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cInfo.StatusCode != shared.Stopped {
+	if cIsActive(cInfo) {
 		ipv4s := []string{}
 		for netName, net := range cState.Network {
 			if net.Type == "loopback" {
@@ -392,7 +403,7 @@ func (c *listCmd) IP4ColumnData(cInfo shared.ContainerInfo, cState *shared.Conta
 }
 
 func (c *listCmd) IP6ColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cInfo.StatusCode != shared.Stopped {
+	if cIsActive(cInfo) {
 		ipv6s := []string{}
 		for netName, net := range cState.Network {
 			if net.Type == "loopback" {
@@ -428,7 +439,7 @@ func (c *listCmd) numberSnapshotsColumnData(cInfo shared.ContainerInfo, cState *
 }
 
 func (c *listCmd) PIDColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cInfo.StatusCode != shared.Stopped {
+	if cIsActive(cInfo) {
 		return fmt.Sprintf("%d", cState.Pid)
 	}
 

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -230,7 +230,7 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 		}
 
 		for _, column := range columns {
-			if column.NeedsState && cIsActive(cInfo) {
+			if column.NeedsState && cInfo.IsActive() {
 				_, ok := cStates[cInfo.Name]
 				if ok {
 					continue
@@ -367,19 +367,8 @@ func (c *listCmd) statusColumnData(cInfo shared.ContainerInfo, cState *shared.Co
 	return strings.ToUpper(cInfo.Status)
 }
 
-func cIsActive(cInfo shared.ContainerInfo) bool {
-	switch cInfo.StatusCode {
-	case shared.Stopped:
-		return false
-	case shared.Error:
-		return false
-	default:
-		return true
-	}
-}
-
 func (c *listCmd) IP4ColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cIsActive(cInfo) {
+	if cInfo.IsActive() {
 		ipv4s := []string{}
 		for netName, net := range cState.Network {
 			if net.Type == "loopback" {
@@ -403,7 +392,7 @@ func (c *listCmd) IP4ColumnData(cInfo shared.ContainerInfo, cState *shared.Conta
 }
 
 func (c *listCmd) IP6ColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cIsActive(cInfo) {
+	if cInfo.IsActive() {
 		ipv6s := []string{}
 		for netName, net := range cState.Network {
 			if net.Type == "loopback" {
@@ -439,7 +428,7 @@ func (c *listCmd) numberSnapshotsColumnData(cInfo shared.ContainerInfo, cState *
 }
 
 func (c *listCmd) PIDColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
-	if cIsActive(cInfo) {
+	if cInfo.IsActive() {
 		return fmt.Sprintf("%d", cState.Pid)
 	}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1556,7 +1556,6 @@ func (c *containerLXC) RenderState() (*shared.ContainerState, error) {
 		return nil, err
 	}
 
-	// FIXME: RenderState shouldn't directly access the go-lxc struct
 	cState, err := c.getLxcState()
 	if err != nil {
 		return nil, err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1486,7 +1486,7 @@ var LxcMonitorStateError = fmt.Errorf("Monitor is hung")
 
 // Get lxc container state, with 1 second timeout
 // If we don't get a reply, assume the lxc monitor is hung
-func (c *containerLXC) GetLxcState() (lxc.State, error) {
+func (c *containerLXC) getLxcState() (lxc.State, error) {
 	monitor := make(chan lxc.State, 1)
 
 	go func(c *lxc.Container) {
@@ -1526,7 +1526,7 @@ func (c *containerLXC) Render() (interface{}, error) {
 		}, nil
 	} else {
 		// FIXME: Render shouldn't directly access the go-lxc struct
-		cState, err := c.GetLxcState()
+		cState, err := c.getLxcState()
 		if err != nil {
 			return nil, err
 		}
@@ -1557,7 +1557,7 @@ func (c *containerLXC) RenderState() (*shared.ContainerState, error) {
 	}
 
 	// FIXME: RenderState shouldn't directly access the go-lxc struct
-	cState, err := c.GetLxcState()
+	cState, err := c.getLxcState()
 	if err != nil {
 		return nil, err
 	}
@@ -4273,7 +4273,7 @@ func (c *containerLXC) State() string {
 	}
 
 	cString := "Error"
-	state, err := c.GetLxcState()
+	state, err := c.getLxcState()
 	if err == nil {
 		cString = state.String()
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4272,12 +4272,11 @@ func (c *containerLXC) State() string {
 		return "BROKEN"
 	}
 
-	cString := "Error"
 	state, err := c.getLxcState()
-	if err == nil {
-		cString = state.String()
+	if err != nil {
+		return shared.Error.String()
 	}
-	return cString
+	return state.String()
 }
 
 // Various container paths

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -70,8 +70,8 @@ func doContainerGet(d *Daemon, cname string) (*shared.ContainerInfo, Response) {
 	if err == LxcMonitorStateError {
 		return &shared.ContainerInfo{
 			Name:       cname,
-			Status:     "Error",
-			StatusCode: 112,
+			Status:     shared.Error.String(),
+			StatusCode: shared.Error,
 		}, nil
 	} else if err != nil {
 		return nil, SmartError(err)

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -67,7 +67,13 @@ func doContainerGet(d *Daemon, cname string) (*shared.ContainerInfo, Response) {
 	}
 
 	cts, err := c.Render()
-	if err != nil {
+	if err == LxcMonitorStateError {
+		return &shared.ContainerInfo{
+			Name:       cname,
+			Status:     "Error",
+			StatusCode: 112,
+		}, nil
+	} else if err != nil {
 		return nil, SmartError(err)
 	}
 

--- a/shared/container.go
+++ b/shared/container.go
@@ -82,6 +82,17 @@ type ContainerInfo struct {
 	StatusCode      StatusCode        `json:"status_code"`
 }
 
+func (c ContainerInfo) IsActive() bool {
+	switch c.StatusCode {
+	case Stopped:
+		return false
+	case Error:
+		return false
+	default:
+		return true
+	}
+}
+
 /*
  * BriefContainerState contains a subset of the fields in
  * ContainerState, namely those which a user may update

--- a/shared/status.go
+++ b/shared/status.go
@@ -15,6 +15,7 @@ const (
 	Freezing         StatusCode = 109
 	Frozen           StatusCode = 110
 	Thawed           StatusCode = 111
+	Error            StatusCode = 112
 
 	Success StatusCode = 200
 
@@ -39,6 +40,7 @@ func (o StatusCode) String() string {
 		Freezing:         "Freezing",
 		Frozen:           "Frozen",
 		Thawed:           "Thawed",
+		Error:            "Error",
 	}[o]
 }
 
@@ -61,5 +63,6 @@ func FromLXCState(state int) StatusCode {
 		6: Freezing,
 		7: Frozen,
 		8: Thawed,
+		9: Error,
 	}[state]
 }


### PR DESCRIPTION
If a container monitor is unresponsive, we may wait forever for
responses over the lxc command socket.

An easy way to reproduce this is to choose a container monitor
process (look for a process like:
	[lxc monitor] /var/lib/lxc/containers containername
) and suspend it with 'kill -STOP'.

So put a one-second timeout around calls to the go-lxc State()
function.  This leads to lxc list feedback like:

0 ✓ serge@sl ~ $ lxc list
+------+-------+------+------+------------+-----------+
| NAME | STATE | IPV4 | IPV6 |    TYPE    | SNAPSHOTS |
+------+-------+------+------+------------+-----------+
| x1   | ERROR |      |      | PERSISTENT | 0         |
+------+-------+------+------+------------+-----------+
0 ✓ serge@sl ~ $ lxc info x1
error: Monitor is hung
1 ✗ serge@sl ~ $ lxc stop x1
error: Monitor is hung

If there were thousands of containers with hung monitors the 1s
each would add up, but this is supposed to be a mitigation for a
rare case.  If we end up with a lot of hung monitors we should
figure out why and prevent it.

Closes #1752

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>