### PR TITLE
Fix devlxd failing to detect container

### DIFF
--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -338,6 +338,10 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 			return nil, err
 		}
 
+		if !c.IsRunning() {
+			continue
+		}
+
 		initpid := c.InitPID()
 		pidNs, err := os.Readlink(fmt.Sprintf("/proc/%d/ns/pid", initpid))
 		if err != nil {


### PR DESCRIPTION
When some containers are stopped and devlxd is accessed through an
interactive LXD exec shell, the code fails to find what container the
request came from.

To fix that, just make sure we skip stopped containers.

This may be the source of #1751

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>