### PR TITLE
docker profile: add the apparmor enabled overmount

### DIFF
--- a/lxd/db.go
+++ b/lxd/db.go
@@ -34,7 +34,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 28
+const DB_CURRENT_VERSION int = 29
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -134,7 +134,12 @@ func dbProfileCreateDocker(db *sql.DB) error {
 		"path": "/dev/fuse",
 		"type": "unix-char",
 	}
-	devices := map[string]shared.Device{"fuse": fusedev}
+	aadisable := map[string]string{
+		"path":   "/sys/module/apparmor/parameters/enabled",
+		"type":   "disk",
+		"source": "/dev/null",
+	}
+	devices := map[string]shared.Device{"fuse": fusedev, "aadisable": aadisable}
 
 	_, err = dbProfileCreate(db, "docker", "Profile supporting docker in containers", config, devices)
 	return err

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -22,7 +22,7 @@ const DB_FIXTURES string = `
     INSERT INTO images_properties (image_id, type, key, value) VALUES (1, 0, 'thekey', 'some value');
     INSERT INTO profiles_config (profile_id, key, value) VALUES (3, 'thekey', 'thevalue');
     INSERT INTO profiles_devices (profile_id, name, type) VALUES (3, 'devicename', 1);
-    INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (3, 'devicekey', 'devicevalue');
+    INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (4, 'devicekey', 'devicevalue');
     `
 
 //  This Helper will initialize a test in-memory DB.
@@ -147,7 +147,7 @@ func Test_deleting_a_profile_cascades_on_related_tables(t *testing.T) {
 	}
 
 	// Make sure there are 0 profiles_devices_config entries left.
-	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 3;`
+	statements = `SELECT count(*) FROM profiles_devices_config WHERE profile_device_id == 4;`
 	err = db.QueryRow(statements).Scan(&count)
 
 	if count != 0 {


### PR DESCRIPTION
Until we have stackable apparmor profiles, docker needs to be told that
apparmor is not enabled, so that it won't try (and fail) to load new
profiles.

Do this by mounting /dev/null over /sys/module/apparmor/parameters/enabled

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>