### PR TITLE
Make it possible to have templates only apply for non-existing files

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2626,6 +2626,10 @@ func (c *containerLXC) TemplateApply(trigger string) error {
 		// Open the file to template, create if needed
 		fullpath := filepath.Join(c.RootfsPath(), strings.TrimLeft(templatePath, "/"))
 		if shared.PathExists(fullpath) {
+			if template.CreateOnly {
+				continue
+			}
+
 			// Open the existing file
 			w, err = os.Create(fullpath)
 			if err != nil {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -144,9 +144,10 @@ func compressFile(path string, compress string) (string, error) {
 }
 
 type templateEntry struct {
-	When       []string
-	Template   string
-	Properties map[string]string
+	When       []string          `yaml:"when"`
+	CreateOnly bool              `yaml:"create_only"`
+	Template   string            `yaml:"template"`
+	Properties map[string]string `yaml:"properties"`
 }
 
 type imagePostReq struct {

--- a/specs/image-handling.md
+++ b/specs/image-handling.md
@@ -77,6 +77,11 @@ LXD, at the moment, this contains:
         when:
           - start
         template: hostname.tpl
+      /etc/network/interfaces:
+        when:
+          - create
+        template: interfaces.tpl
+        create_only: true
 
 The architecture and creation\_date fields are mandatory, the properties
 are just a set of default properties for the image. The os, release,
@@ -95,6 +100,8 @@ The templates will always receive the following context:
  - config: key/value map of the container's configuration (map[string]string)
  - devices: key/value map of the devices assigned to this container (map[string]map[string]string)
  - properties: key/value map of the template properties specified in metadata.yaml (map[string]string)
+
+The "create\_only" key can be set to have LXD only only create missing files but not overwrite an existing file.
 
 As a general rule, you should never template a file which is owned by a
 package or is otherwise expected to be overwritten by normal operation


### PR DESCRIPTION
We unfortunately can't use the suggested "overwrite" keyword because
we'd need it to default to true when unset and the yaml parser doesn't
let us do that.

So instead we call it "create_only" and have it default to false
(default for bool types) which gives us an equivalent behavior.

Closes #1757

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>