### PR TITLE
Block sys_rawio in LXD too

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -284,7 +284,7 @@ func (c *containerLXC) initLXC() error {
 	}
 
 	// Base config
-	err = lxcSetConfigItem(cc, "lxc.cap.drop", "mac_admin mac_override sys_time sys_module")
+	err = lxcSetConfigItem(cc, "lxc.cap.drop", "mac_admin mac_override sys_time sys_module sys_rawio")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
After we just made that change in LXC, lets replicate it in the LXD
default config too.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>