### PR TITLE
Document 'auto_update' parameter for 'POST /1.0/images'

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1080,7 +1080,8 @@ In the source image case, the following dict must be used:
 
     {
         "filename": filename,                   # Used for export (optional)
-        "public": true,                         # Whether the image can be downloaded by untrusted users (defaults to false
+        "public": true,                         # Whether the image can be downloaded by untrusted users (defaults to false)
+        "auto_update": true,                    # Whether the image should be auto-updated (optional; defaults to false)
         "properties": {                         # Image properties (optional, applied on top of source properties)
             "os": "Ubuntu"
         },


### PR DESCRIPTION
Signed-off-by: Jeff Shantz <jeff@csd.uwo.ca>

I just added the `auto_update` parameter to the API documentation for `POST /1.0/images`.  I'm implementing an API client in Ruby and didn't realize it was allowed until I inspected the output of `lxc image copy ... --debug --verbose`.