### PR TITLE
stateful stop: remove snapshot from db on failure too

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1101,16 +1101,36 @@ func (c *containerLXC) Start(stateful bool) error {
 			return fmt.Errorf("Container has no existing state to restore.")
 		}
 
-		err := c.c.Restore(lxc.RestoreOptions{
-			Directory: c.StatePath(),
-			Verbose:   true,
-		})
-
-		err2 := os.RemoveAll(c.StatePath())
-		if err2 != nil {
-			return err2
+		if !c.IsPrivileged() {
+			if err := c.IdmapSet().ShiftRootfs(c.StatePath()); err != nil {
+				return err
+			}
 		}
 
+		out, err := exec.Command(
+			c.daemon.execPath,
+			"forkmigrate",
+			c.name,
+			c.daemon.lxcpath,
+			configPath,
+			c.StatePath()).CombinedOutput()
+		if string(out) != "" {
+			for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+				shared.Debugf("forkmigrate: %s", line)
+			}
+		}
+		CollectCRIULogFile(c, c.StatePath(), "snapshot", "restore")
+
+		if err != nil {
+			return err
+		}
+
+		os.RemoveAll(c.StatePath())
+		c.stateful = false
+		return dbContainerSetStateful(c.daemon.db, c.id, false)
+	} else if c.stateful {
+		/* stateless start required when we have state, let's delete it */
+		err := os.RemoveAll(c.StatePath())
 		if err != nil {
 			return err
 		}
@@ -1120,8 +1140,6 @@ func (c *containerLXC) Start(stateful bool) error {
 		if err != nil {
 			return err
 		}
-
-		return nil
 	}
 
 	// Start the LXC container


### PR DESCRIPTION
We deleted the snapshot contents on failure, but not the db state. Let's do
that too.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>