### PR TITLE
Bits needed by lxd-bridge init scripts

### DIFF
--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -69,9 +69,11 @@ lxc profile apply <container> <profiles>
              lxc profile apply bar,default # Apply default second now
 
 Devices:
-lxc profile device list <profile>              List devices in the given profile.
-lxc profile device show <profile>              Show full device details in the given profile.
-lxc profile device remove <profile> <name>     Remove a device from a profile.
+lxc profile device list <profile>                                   List devices in the given profile.
+lxc profile device show <profile>                                   Show full device details in the given profile.
+lxc profile device remove <profile> <name>                          Remove a device from a profile.
+lxc profile device set <[remote:]container> <name> <key> <value>    Set a device property.
+lxc profile device unset <[remote:]container> <name> <key>          Unset a device property.
 lxc profile device add <profile name> <device name> <device type> [key=value]...
     Add a profile device, such as a disk or a nic, to the containers
     using the specified profile.`)
@@ -276,6 +278,10 @@ func (c *profileCmd) doProfileDevice(config *lxd.Config, args []string) error {
 		return cfg.deviceList(config, "profile", args)
 	case "show":
 		return cfg.deviceShow(config, "profile", args)
+	case "set":
+		return cfg.deviceSet(config, "profile", args)
+	case "unset":
+		return cfg.deviceUnset(config, "profile", args)
 	default:
 		return errArgs
 	}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -8,9 +9,25 @@ import (
 )
 
 var apiInternal = []Command{
+	internalReadyCmd,
 	internalShutdownCmd,
 	internalContainerOnStartCmd,
 	internalContainerOnStopCmd,
+}
+
+func internalReady(d *Daemon, r *http.Request) Response {
+	if !d.SetupMode {
+		return InternalError(fmt.Errorf("The server isn't currently in setup mode"))
+	}
+
+	err := d.Ready()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	d.SetupMode = false
+
+	return EmptySyncResponse
 }
 
 func internalShutdown(d *Daemon, r *http.Request) Response {
@@ -63,5 +80,6 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 }
 
 var internalShutdownCmd = Command{name: "shutdown", put: internalShutdown}
+var internalReadyCmd = Command{name: "ready", put: internalReady}
 var internalContainerOnStartCmd = Command{name: "containers/{id}/onstart", get: internalContainerOnStart}
 var internalContainerOnStopCmd = Command{name: "containers/{id}/onstop", get: internalContainerOnStop}

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -30,6 +30,12 @@ func internalReady(d *Daemon, r *http.Request) Response {
 	return EmptySyncResponse
 }
 
+func internalWaitReady(d *Daemon, r *http.Request) Response {
+	<-d.readyChan
+
+	return EmptySyncResponse
+}
+
 func internalShutdown(d *Daemon, r *http.Request) Response {
 	d.shutdownChan <- true
 
@@ -80,6 +86,6 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 }
 
 var internalShutdownCmd = Command{name: "shutdown", put: internalShutdown}
-var internalReadyCmd = Command{name: "ready", put: internalReady}
+var internalReadyCmd = Command{name: "ready", put: internalReady, get: internalWaitReady}
 var internalContainerOnStartCmd = Command{name: "containers/{id}/onstart", get: internalContainerOnStart}
 var internalContainerOnStopCmd = Command{name: "containers/{id}/onstop", get: internalContainerOnStop}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3308,6 +3308,11 @@ func (c *containerLXC) createUnixDevice(name string, m shared.Device) (string, e
 		return "", fmt.Errorf("Failed to chown device %s: %s", devPath, err)
 	}
 
+	// Needed as mknod respects the umask
+	if err := os.Chmod(devPath, mode); err != nil {
+		return "", fmt.Errorf("Failed to chmod device %s: %s", devPath, err)
+	}
+
 	if c.idmapset != nil {
 		if err := c.idmapset.ShiftFile(devPath); err != nil {
 			// uidshift failing is weird, but not a big problem.  Log and proceed

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -528,8 +528,6 @@ func (d *Daemon) UpdateHTTPsPort(oldAddress string, newAddress string) error {
 func startDaemon(group string) (*Daemon, error) {
 	d := &Daemon{
 		group:                 group,
-		imagesDownloading:     map[string]chan bool{},
-		imagesDownloadingLock: sync.RWMutex{},
 	}
 
 	if err := d.Init(); err != nil {
@@ -551,6 +549,9 @@ func haveMacAdmin() bool {
 }
 
 func (d *Daemon) Init() error {
+	/* Initialize some variables */
+	d.imagesDownloading = map[string]chan bool{}
+
 	d.shutdownChan = make(chan bool)
 
 	/* Set the executable path */

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -90,7 +90,7 @@ type Daemon struct {
 
 	configValues map[string]string
 
-	IsMock bool
+	MockMode bool
 
 	imagesDownloading     map[string]chan bool
 	imagesDownloadingLock sync.RWMutex
@@ -528,7 +528,6 @@ func (d *Daemon) UpdateHTTPsPort(oldAddress string, newAddress string) error {
 func startDaemon(group string) (*Daemon, error) {
 	d := &Daemon{
 		group:                 group,
-		IsMock:                false,
 		imagesDownloading:     map[string]chan bool{},
 		imagesDownloadingLock: sync.RWMutex{},
 	}
@@ -575,11 +574,11 @@ func (d *Daemon) Init() error {
 		}
 	}
 
-	if !d.IsMock {
-		shared.Log.Info("LXD is starting",
+	if d.MockMode {
+		shared.Log.Info("Mock LXD is starting",
 			log.Ctx{"path": shared.VarPath("")})
 	} else {
-		shared.Log.Info("Mock LXD is starting",
+		shared.Log.Info("LXD is starting",
 			log.Ctx{"path": shared.VarPath("")})
 	}
 
@@ -744,7 +743,7 @@ func (d *Daemon) Init() error {
 	}
 
 	/* Setup the storage driver */
-	if !d.IsMock {
+	if !d.MockMode {
 		err = d.SetupStorageDriver()
 		if err != nil {
 			return fmt.Errorf("Failed to setup storage: %s", err)
@@ -824,7 +823,7 @@ func (d *Daemon) Init() error {
 		return err
 	}
 
-	if !d.IsMock {
+	if !d.MockMode {
 		/* Start the scheduler */
 		go deviceEventListener(d)
 
@@ -992,7 +991,7 @@ func (d *Daemon) Init() error {
 	})
 
 	// Restore containers
-	if !d.IsMock {
+	if !d.MockMode {
 		/* Restart containers */
 		go containersRestart(d)
 
@@ -1072,7 +1071,7 @@ func (d *Daemon) Stop() error {
 	shared.Log.Debug("Stopping /dev/lxd handler")
 	d.devlxd.Close()
 
-	if d.IsMock || forceStop {
+	if d.MockMode || forceStop {
 		return nil
 	}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -76,6 +76,7 @@ type Daemon struct {
 	lxcpath             string
 	mux                 *mux.Router
 	tomb                tomb.Tomb
+	readyChan           chan bool
 	pruneChan           chan bool
 	shutdownChan        chan bool
 	resetAutoUpdateChan chan bool
@@ -540,6 +541,7 @@ func (d *Daemon) Init() error {
 	/* Initialize some variables */
 	d.imagesDownloading = map[string]chan bool{}
 
+	d.readyChan = make(chan bool)
 	d.shutdownChan = make(chan bool)
 
 	/* Set the executable path */
@@ -999,6 +1001,8 @@ func (d *Daemon) Ready() error {
 
 	/* Re-balance in case things changed while LXD was down */
 	deviceTaskBalance(d)
+
+	close(d.readyChan)
 
 	return nil
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -524,19 +524,6 @@ func (d *Daemon) UpdateHTTPsPort(oldAddress string, newAddress string) error {
 	return nil
 }
 
-// StartDaemon starts the shared daemon with the provided configuration.
-func startDaemon(group string) (*Daemon, error) {
-	d := &Daemon{
-		group:                 group,
-	}
-
-	if err := d.Init(); err != nil {
-		return nil, err
-	}
-
-	return d, nil
-}
-
 func haveMacAdmin() bool {
 	c, err := capability.NewPid(0)
 	if err != nil {

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -37,7 +37,7 @@ func createTestDb(t *testing.T) (db *sql.DB) {
 	}
 
 	var err error
-	d := &Daemon{IsMock: true}
+	d := &Daemon{MockMode: true}
 	err = initializeDbObject(d, ":memory:")
 	db = d.db
 
@@ -195,7 +195,7 @@ func Test_initializing_db_is_indempotent(t *testing.T) {
 	var err error
 
 	// This calls "createDb" once already.
-	d := &Daemon{IsMock: true}
+	d := &Daemon{MockMode: true}
 	err = initializeDbObject(d, ":memory:")
 	db = d.db
 
@@ -230,7 +230,7 @@ func Test_running_dbUpdateFromV6_adds_on_delete_cascade(t *testing.T) {
 	var err error
 	var count int
 
-	d := &Daemon{IsMock: true}
+	d := &Daemon{MockMode: true}
 	err = initializeDbObject(d, ":memory:")
 	defer d.db.Close()
 
@@ -372,7 +372,7 @@ INSERT INTO containers_config (container_id, key, value) VALUES (1, 'thekey', 't
 
 	// The "foreign key" on containers_config now points to nothing.
 	// Let's run the schema upgrades.
-	d := &Daemon{IsMock: true}
+	d := &Daemon{MockMode: true}
 	d.db = db
 	err = dbUpdate(d, 1)
 

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -334,7 +334,7 @@ INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
 }
 
 func dbUpdateFromV11(d *Daemon) error {
-	if d.IsMock {
+	if d.MockMode {
 		// No need to move snapshots no mock runs,
 		// dbUpdateFromV12 will then set the db version to 13
 		return nil
@@ -412,7 +412,7 @@ INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
 }
 
 func dbUpdateFromV10(d *Daemon) error {
-	if d.IsMock {
+	if d.MockMode {
 		// No need to move lxc to containers in mock runs,
 		// dbUpdateFromV12 will then set the db version to 13
 		return nil

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -120,7 +120,8 @@ func TestHttpRequest(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	d, err := startDaemon("")
+	d := &Daemon{}
+	err := d.Init()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -196,26 +196,29 @@ func run() error {
 		// "forkputfile", "forkgetfile", "forkmount" and "forkumount" are handled specially in nsexec.go
 		// "forkgetnet" is partially handled in nsexec.go (setns)
 		switch os.Args[1] {
+		// Main commands
 		case "activateifneeded":
-			return activateIfNeeded()
+			return cmdActivateIfNeeded()
 		case "daemon":
-			return daemon()
+			return cmdDaemon()
+		case "callhook":
+			return cmdCallHook(os.Args[1:])
+		case "init":
+			return cmdInit()
+		case "ready":
+			return cmdReady()
+		case "shutdown":
+			return cmdShutdown()
+		case "waitready":
+			return cmdWaitReady()
+
+		// Internal commands
 		case "forkgetnet":
 			return printnet()
 		case "forkmigrate":
 			return MigrateContainer(os.Args[1:])
 		case "forkstart":
 			return startContainer(os.Args[1:])
-		case "callhook":
-			return callHook(os.Args[1:])
-		case "init":
-			return setupLXD()
-		case "ready":
-			return cmdReady()
-		case "shutdown":
-			return cleanShutdown()
-		case "waitready":
-			return waitReady()
 		}
 	}
 
@@ -225,10 +228,10 @@ func run() error {
 		return fmt.Errorf("Unknown arguments")
 	}
 
-	return daemon()
+	return cmdDaemon()
 }
 
-func callHook(args []string) error {
+func cmdCallHook(args []string) error {
 	if len(args) < 4 {
 		return fmt.Errorf("Invalid arguments")
 	}
@@ -297,7 +300,7 @@ func callHook(args []string) error {
 	return nil
 }
 
-func daemon() error {
+func cmdDaemon() error {
 	if *argCPUProfile != "" {
 		f, err := os.Create(*argCPUProfile)
 		if err != nil {
@@ -410,7 +413,7 @@ func cmdReady() error {
 	return nil
 }
 
-func cleanShutdown() error {
+func cmdShutdown() error {
 	var timeout int
 
 	if *argTimeout == -1 {
@@ -449,7 +452,7 @@ func cleanShutdown() error {
 	return nil
 }
 
-func activateIfNeeded() error {
+func cmdActivateIfNeeded() error {
 	// Don't start a full daemon, we just need DB access
 	d := &Daemon{
 		imagesDownloading:     map[string]chan bool{},
@@ -505,7 +508,7 @@ func activateIfNeeded() error {
 	return nil
 }
 
-func waitReady() error {
+func cmdWaitReady() error {
 	var timeout int
 
 	if *argTimeout == -1 {
@@ -538,7 +541,7 @@ func waitReady() error {
 	return nil
 }
 
-func setupLXD() error {
+func cmdInit() error {
 	var storageBackend string // dir or zfs
 	var storageMode string    // existing, loop or device
 	var storageLoopSize int   // Size in GB

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -325,8 +325,8 @@ func daemon() error {
 		}()
 	}
 
-	d, err := startDaemon(*argGroup)
-
+	d := &Daemon{group: *argGroup}
+	err := d.Init()
 	if err != nil {
 		if d != nil && d.db != nil {
 			d.db.Close()

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -520,7 +520,25 @@ func cmdWaitReady() error {
 	finger := make(chan error, 1)
 	go func() {
 		for {
-			_, err := lxd.NewClient(&lxd.DefaultConfig, "local")
+			c, err := lxd.NewClient(&lxd.DefaultConfig, "local")
+			if err != nil {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			req, err := http.NewRequest("GET", c.BaseURL+"/internal/ready", nil)
+			if err != nil {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			raw, err := c.Http.Do(req)
+			if err != nil {
+				time.Sleep(500 * time.Millisecond)
+				continue
+			}
+
+			_, err = lxd.HoistResponse(raw, lxd.Sync)
 			if err != nil {
 				time.Sleep(500 * time.Millisecond)
 				continue

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -422,7 +422,6 @@ func cleanShutdown() error {
 func activateIfNeeded() error {
 	// Don't start a full daemon, we just need DB access
 	d := &Daemon{
-		IsMock:                false,
 		imagesDownloading:     map[string]chan bool{},
 		imagesDownloadingLock: sync.RWMutex{},
 	}

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -12,7 +12,7 @@ import (
 
 func mockStartDaemon() (*Daemon, error) {
 	d := &Daemon{
-		IsMock:                true,
+		MockMode:              true,
 		imagesDownloading:     map[string]chan bool{},
 		imagesDownloadingLock: sync.RWMutex{},
 	}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -196,7 +196,7 @@ func newStorage(d *Daemon, sType storageType) (storage, error) {
 }
 
 func newStorageWithConfig(d *Daemon, sType storageType, config map[string]interface{}) (storage, error) {
-	if d.IsMock {
+	if d.MockMode {
 		return d.Storage, nil
 	}
 
@@ -236,7 +236,7 @@ func storageForFilename(d *Daemon, filename string) (storage, error) {
 	config := make(map[string]interface{})
 	storageType := storageTypeDir
 
-	if d.IsMock {
+	if d.MockMode {
 		return newStorageWithConfig(d, storageTypeMock, config)
 	}
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-03-16 15:52-0400\n"
+        "POT-Creation-Date: 2016-03-22 21:56-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -74,7 +74,7 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name"
 msgstr  ""
 
-#: lxc/profile.go:223
+#: lxc/profile.go:225
 msgid   "(none)"
 msgstr  ""
 
@@ -121,7 +121,7 @@ msgstr  ""
 msgid   "Available commands:"
 msgstr  ""
 
-#: lxc/config.go:269
+#: lxc/config.go:271
 msgid   "COMMON NAME"
 msgstr  ""
 
@@ -129,17 +129,17 @@ msgstr  ""
 msgid   "CREATED AT"
 msgstr  ""
 
-#: lxc/config.go:113
+#: lxc/config.go:115
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/config.go:126 lxc/config.go:159 lxc/config.go:181
+#: lxc/config.go:128 lxc/config.go:161 lxc/config.go:183
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
 
-#: lxc/profile.go:334
+#: lxc/profile.go:340
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
@@ -167,7 +167,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:493 lxc/config.go:558 lxc/image.go:669 lxc/profile.go:187
+#: lxc/config.go:499 lxc/config.go:564 lxc/image.go:669 lxc/profile.go:189
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -251,12 +251,12 @@ msgid   "Delete containers or container snapshots.\n"
         "Destroy containers or snapshots with any attached data (configuration, snapshots, ...)."
 msgstr  ""
 
-#: lxc/config.go:610
+#: lxc/config.go:616
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config.go:640
+#: lxc/config.go:759
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -265,7 +265,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/config.go:271
+#: lxc/config.go:273
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -306,7 +306,7 @@ msgstr  ""
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/config.go:268 lxc/image.go:591 lxc/image.go:616
+#: lxc/config.go:270 lxc/image.go:591 lxc/image.go:616
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -349,7 +349,7 @@ msgstr  ""
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config.go:270
+#: lxc/config.go:272
 msgid   "ISSUE DATE"
 msgstr  ""
 
@@ -502,9 +502,11 @@ msgid   "Manage configuration profiles.\n"
         "             lxc profile apply bar,default # Apply default second now\n"
         "\n"
         "Devices:\n"
-        "lxc profile device list <profile>              List devices in the given profile.\n"
-        "lxc profile device show <profile>              Show full device details in the given profile.\n"
-        "lxc profile device remove <profile> <name>     Remove a device from a profile.\n"
+        "lxc profile device list <profile>                                   List devices in the given profile.\n"
+        "lxc profile device show <profile>                                   Show full device details in the given profile.\n"
+        "lxc profile device remove <profile> <name>                          Remove a device from a profile.\n"
+        "lxc profile device set <[remote:]container> <name> <key> <value>    Set a device property.\n"
+        "lxc profile device unset <[remote:]container> <name> <key>          Unset a device property.\n"
         "lxc profile device add <profile name> <device name> <device type> [key=value]...\n"
         "    Add a profile device, such as a disk or a nic, to the containers\n"
         "    using the specified profile."
@@ -514,6 +516,8 @@ msgstr  ""
 msgid   "Manage configuration.\n"
         "\n"
         "lxc config device add <[remote:]container> <name> <type> [key=value]...     Add a device to a container.\n"
+        "lxc config device set <[remote:]container> <name> <key> <value>             Set a device property.\n"
+        "lxc config device unset <[remote:]container> <name> <key>                   Unset a device property.\n"
         "lxc config device list [remote:]<container>                                 List devices for container.\n"
         "lxc config device show [remote:]<container>                                 Show full device details for container.\n"
         "lxc config device remove [remote:]<container> <name>                        Remove device from container.\n"
@@ -682,11 +686,11 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/config.go:280
+#: lxc/config.go:282
 msgid   "No certificate provided to add"
 msgstr  ""
 
-#: lxc/config.go:303
+#: lxc/config.go:305
 msgid   "No fingerprint specified."
 msgstr  ""
 
@@ -754,11 +758,11 @@ msgid   "Presents details on how to use LXD.\n"
         "lxd help [--all]"
 msgstr  ""
 
-#: lxc/profile.go:188
+#: lxc/profile.go:190
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:494 lxc/config.go:559 lxc/image.go:670
+#: lxc/config.go:500 lxc/config.go:565 lxc/image.go:670
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -785,17 +789,17 @@ msgstr  ""
 msgid   "Processes: %d"
 msgstr  ""
 
-#: lxc/profile.go:225
+#: lxc/profile.go:227
 #, c-format
 msgid   "Profile %s applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:139
+#: lxc/profile.go:141
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:209
+#: lxc/profile.go:211
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
@@ -952,6 +956,10 @@ msgstr  ""
 
 #: lxc/publish.go:89
 msgid   "The container is currently running. Use --force to have it stopped and restarted."
+msgstr  ""
+
+#: lxc/config.go:645 lxc/config.go:663 lxc/config.go:701 lxc/config.go:719
+msgid   "The device doesn't exist"
 msgstr  ""
 
 #: lxc/publish.go:62


### PR DESCRIPTION
We need a way to update the default profile at startup time before any container gets spawned but after the daemon is responsive over REST.

This is achieved through a new setup mode which lets us do just that.

While doing that, also improve waitready to wait until the daemon is actually ready rather than just until it answers.

And then because having to rewrite device entries every time you want to change a property is a bit annoying, implement device set/unset too.