### PR TITLE
Allow the bridge to be brought down even if disabled

### DIFF
--- a/lxd-bridge/lxd-bridge
+++ b/lxd-bridge/lxd-bridge
@@ -157,8 +157,6 @@ start() {
 }
 
 stop() {
-    [ "x${USE_LXD_BRIDGE}" = "xtrue" ] || { exit 0; }
-
     [ -f "${varrun}/network_up" ] || [ "${1}" = "force" ] || { echo "lxd-bridge isn't running"; exit 1; }
 
     if [ -d /sys/class/net/${LXD_BRIDGE} ]; then


### PR DESCRIPTION
Otherwise we can't stop it after changing the settings.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>