### PR TITLE
Some more lxd-bridge fixes

### DIFF
--- a/lxd-bridge/lxd-bridge
+++ b/lxd-bridge/lxd-bridge
@@ -1,8 +1,7 @@
-#!/bin/sh -
-
-distrosysconfdir="/etc/default/"
-varrun="/run/lxd/"
-varlib="/var/lib/lxd/lxd-bridge/"
+#!/bin/sh
+config="/etc/default/lxd-bridge"
+varrun="/run/lxd-bridge/"
+varlib="/var/lib/lxd-bridge/"
 
 # lxdbr0 defaults to only setting up the standard IPv6 link-local network
 # to enable routable IPv4 and/or IPv6, please edit /etc/default/lxd
@@ -28,7 +27,7 @@ LXD_IPV6_NETWORK=""
 LXD_IPV6_NAT="false"
 LXD_IPV6_PROXY="true"
 
-[ ! -f "${distrosysconfdir}/lxd-bridge" ] || . "${distrosysconfdir}/lxd-bridge"
+[ ! -f "${config}" ] || . "${config}"
 
 use_iptables_lock="-w"
 iptables -w -L -n > /dev/null 2>&1 || use_iptables_lock=""
@@ -63,7 +62,7 @@ start() {
     [ ! -f "${varrun}/network_up" ] || { echo "lxd-bridge is already running"; exit 1; }
 
     if [ -d /sys/class/net/${LXD_BRIDGE} ]; then
-        stop force || true
+        stop force 2>/dev/null || true
     fi
 
     FAILED=1
@@ -82,6 +81,9 @@ start() {
     # set up the lxd network
     [ ! -d "/sys/class/net/${LXD_BRIDGE}" ] && ip link add dev "${LXD_BRIDGE}" type bridge
 
+    echo 0 > "/proc/sys/net/ipv6/conf/${LXD_BRIDGE}/autoconf" || true
+    echo 0 > "/proc/sys/net/ipv6/conf/${LXD_BRIDGE}/accept_dad" || true
+
     # if we are run from systemd on a system with selinux enabled,
     # the mkdir will create /run/lxd as init_var_run_t which dnsmasq
     # can't write its pid into, so we restorecon it (to var_run_t)
@@ -89,6 +91,13 @@ start() {
         mkdir -p "${varrun}"
         if which restorecon >/dev/null 2>&1; then
             restorecon "${varrun}"
+        fi
+    fi
+
+    if [ ! -d "${varlib}" ]; then
+        mkdir -p "${varlib}"
+        if which restorecon >/dev/null 2>&1; then
+            restorecon "${varlib}"
         fi
     fi
 
@@ -105,9 +114,15 @@ start() {
 
     LXD_IPV6_ARG=""
     if [ -n "${LXD_IPV6_ADDR}" ] && [ -n "${LXD_IPV6_MASK}" ] && [ -n "${LXD_IPV6_NETWORK}" ]; then
-        echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
-        echo 0 > "/proc/sys/net/ipv6/conf/${LXD_BRIDGE}/autoconf"
-        echo 0 > "/proc/sys/net/ipv6/conf/${LXD_BRIDGE}/accept_dad" || true
+        # IPv6 sysctls don't respect the "all" path...
+        for interface in /proc/sys/net/ipv6/conf/*; do
+            echo 2 > ${interface}/accept_ra
+        done
+
+        for interface in /proc/sys/net/ipv6/conf/*; do
+            echo 1 > ${interface}/forwarding
+        done
+
         ip -6 addr add dev "${LXD_BRIDGE}" "${LXD_IPV6_ADDR}/${LXD_IPV6_MASK}"
         if [ "${LXD_IPV6_NAT}" = "true" ]; then
             ip6tables "${use_iptables_lock}" -t nat -A POSTROUTING -s "${LXD_IPV6_NETWORK}" ! -d "${LXD_IPV6_NETWORK}" -j MASQUERADE
@@ -143,11 +158,11 @@ start() {
 
     if [ -n "${LXD_IPV4_ADDR}" ] || [ -n "${LXD_IPV6_ADDR}" ]; then
         # shellcheck disable=SC2086
-        dnsmasq ${LXD_CONFILE_ARG} ${LXD_DOMAIN_ARG} -u "${DNSMASQ_USER}" --strict-order --bind-interfaces --pid-file="${varrun}/dnsmasq.pid" --dhcp-no-override --except-interface=lo --interface="${LXD_BRIDGE}" --dhcp-leasefile="${varlib}/misc/dnsmasq.${LXD_BRIDGE}.leases" --dhcp-authoritative ${LXD_IPV4_ARG} ${LXD_IPV6_ARG} || cleanup
+        dnsmasq ${LXD_CONFILE_ARG} ${LXD_DOMAIN_ARG} -u "${DNSMASQ_USER}" --strict-order --bind-interfaces --pid-file="${varrun}/dnsmasq.pid" --dhcp-no-override --except-interface=lo --interface="${LXD_BRIDGE}" --dhcp-leasefile="${varlib}/dnsmasq.${LXD_BRIDGE}.leases" --dhcp-authoritative ${LXD_IPV4_ARG} ${LXD_IPV6_ARG} || cleanup
     fi
 
     if [ "${LXD_IPV6_PROXY}" = "true" ]; then
-        lxd-bridge-proxy -addr="[fe80::1%${LXD_BRIDGE}]:3128" &
+        PATH=${PATH}:$(dirname ${0}) lxd-bridge-proxy --addr="[fe80::1%${LXD_BRIDGE}]:3128" &
         PID=$!
         echo "${PID}" > "${varrun}/proxy.pid"
     fi


### PR DESCRIPTION
 - Use /run/lxd-bridge and /var/lib/lxd-bridge
 - Set the right path for lxd-bridge-proxy
 - Correctly pass the address to lxd-bridge-proxy
 - Properly configure IPv6 forwarding
 - Disable IPv6 duplicate address detection and auto-configuration even
   if not setting a global IPv6 address

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>