### PR TITLE
exec: wait until the window size is set

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -131,6 +131,7 @@ func (s *execWs) Do(op *operation) error {
 
 	if s.interactive {
 		wgEOF.Add(1)
+		windowSizeSet := make(chan bool, 1)
 		go func() {
 			select {
 			case <-s.controlConnected:
@@ -178,6 +179,7 @@ func (s *execWs) Do(op *operation) error {
 					}
 
 					err = shared.SetSize(int(ptys[0].Fd()), winchWidth, winchHeight)
+					windowSizeSet <- true
 					if err != nil {
 						shared.Debugf("Failed to set window size to: %dx%d", winchWidth, winchHeight)
 						continue
@@ -190,6 +192,9 @@ func (s *execWs) Do(op *operation) error {
 				}
 			}
 		}()
+
+		<-windowSizeSet
+
 		go func() {
 			readDone, writeDone := shared.WebsocketMirror(s.conns[0], ptys[0], ptys[0])
 			<-readDone


### PR DESCRIPTION
While debugging something else, I noticed that the term size for exec is racy:
if the command happens to run before the goroutine in the client sends the
actual size of the terminal, we just get the default size for the pty.

Let's wait until the window size is set at least once before we do exec. It may
be worth documenting that this needs to happen somewhere, but I'm not sure
where :)

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>