### PR TITLE
exec: remove dead code path

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -183,11 +183,6 @@ func (s *execWs) Do(op *operation) error {
 						continue
 					}
 				}
-
-				if err != nil {
-					shared.Debugf("Got error writing to writer %s", err)
-					break
-				}
 			}
 		}()
 		go func() {


### PR DESCRIPTION
This error message looks to be copy pasted from somewhere incorrectly.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>