### PR TITLE
Improve bash completions

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -40,8 +40,8 @@ _have lxc && {
         "exec")
           _lxd_names
           ;;
-        "exec")
-          COMPREPLY=( $(compgen -W "pull push" -- $cur) )
+        "file")
+          COMPREPLY=( $(compgen -W "pull push edit" -- $cur) )
           ;;
         "help")
           COMPREPLY=( $(compgen -W "$lxc_cmds" -- $cur) )
@@ -91,5 +91,5 @@ _have lxc && {
     return 0
   }
 
-  complete -F _lxd_complete lxc
+  complete -o default -F _lxd_complete lxc
 }


### PR DESCRIPTION
* Fix `lxc file` completion.
* Fallback to default bash file/path completion if we do not provide
  any. Useful with `lxc file push` and `lxc file pull`, maybe with
  others.

Signed-off-by: Yura Pakhuchiy <pakhuchiy@gmail.com>