### PR TITLE
Tests: Don't translate lxc output for parsing it.

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -1,6 +1,9 @@
 #!/bin/sh -eu
 [ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
 
+# Don't translate lxc output for parsing in it in tests.
+export "LC_ALL=C"
+
 if [ -n "${LXD_DEBUG:-}" ]; then
   set -x
   DEBUG="--debug"


### PR DESCRIPTION
tests_basic_usage for example parses the output of `lxc` so we need LC_ALL to be english/C.

Signed-off-by: Rene Jochum <rene@jochums.at>