### PR TITLE
Use fork for command execution

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -162,7 +162,6 @@ func (c *execCmd) run(config *lxd.Config, args []string) error {
 		termios.Restore(cfd, oldttystate)
 	}
 
-	/* we get the result of waitpid() here so we need to transform it */
-	os.Exit(ret >> 8)
+	os.Exit(ret)
 	return fmt.Errorf(i18n.G("unreachable return reached"))
 }

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -346,6 +346,9 @@ type container interface {
 	FilePull(srcpath string, dstpath string) error
 	FilePush(srcpath string, dstpath string, uid int, gid int, mode os.FileMode) error
 
+	// Command execution
+	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error)
+
 	// Status
 	Render() (interface{}, error)
 	RenderState() (*shared.ContainerState, error)
@@ -383,7 +386,6 @@ type container interface {
 	LogPath() string
 
 	// FIXME: Those should be internal functions
-	LXContainerGet() *lxc.Container
 	StorageStart() error
 	StorageStop() error
 	Storage() storage

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -298,7 +298,8 @@ func execContainer(args []string) (int, error) {
 
 	section := ""
 	for _, arg := range args[5:len(args)] {
-		if arg == "--" {
+		// The "cmd" section must come last as it may contain a --
+		if arg == "--" && section != "cmd" {
 			section = ""
 			continue
 		}

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"sort"
 	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -198,8 +199,6 @@ func containerDeleteSnapshots(d *Daemon, cname string) error {
  * This is called by lxd when called as "lxd forkstart <container>"
  * 'forkstart' is used instead of just 'start' in the hopes that people
  * do not accidentally type 'lxd start' instead of 'lxc start'
- *
- * We expect to read the lxcconfig over fd 3.
  */
 func startContainer(args []string) error {
 	if len(args) != 4 {
@@ -245,4 +244,89 @@ func startContainer(args []string) error {
 	shared.FileMove(configPath, shared.LogPath(name, "lxc.conf"))
 
 	return c.Start()
+}
+
+/*
+ * This is called by lxd when called as "lxd forkexec <container>"
+ */
+func execContainer(args []string) (int, error) {
+	if len(args) < 6 {
+		return -1, fmt.Errorf("Bad arguments: %q", args)
+	}
+
+	name := args[1]
+	lxcpath := args[2]
+	configPath := args[3]
+
+	c, err := lxc.NewContainer(name, lxcpath)
+	if err != nil {
+		return -1, fmt.Errorf("Error initializing container for start: %q", err)
+	}
+
+	err = c.LoadConfigFile(configPath)
+	if err != nil {
+		return -1, fmt.Errorf("Error opening startup config file: %q", err)
+	}
+
+	syscall.Dup3(int(os.Stdin.Fd()), 200, 0)
+	syscall.Dup3(int(os.Stdout.Fd()), 201, 0)
+	syscall.Dup3(int(os.Stderr.Fd()), 202, 0)
+
+	syscall.Close(int(os.Stdin.Fd()))
+	syscall.Close(int(os.Stdout.Fd()))
+	syscall.Close(int(os.Stderr.Fd()))
+
+	opts := lxc.DefaultAttachOptions
+	opts.ClearEnv = true
+	opts.StdinFd = 200
+	opts.StdoutFd = 201
+	opts.StderrFd = 202
+
+	logPath := shared.LogPath(name, "forkexec.log")
+	if shared.PathExists(logPath) {
+		os.Remove(logPath)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	if err == nil {
+		syscall.Dup3(int(logFile.Fd()), 1, 0)
+		syscall.Dup3(int(logFile.Fd()), 2, 0)
+	}
+
+	env := []string{}
+	cmd := []string{}
+
+	section := ""
+	for _, arg := range args[5:len(args)] {
+		if arg == "--" {
+			section = ""
+			continue
+		}
+
+		if section == "" {
+			section = arg
+			continue
+		}
+
+		if section == "env" {
+			fields := strings.SplitN(arg, "=", 2)
+			if len(fields) == 2 && fields[0] == "HOME" {
+				opts.Cwd = fields[1]
+			}
+			env = append(env, arg)
+		} else if section == "cmd" {
+			cmd = append(cmd, arg)
+		} else {
+			return -1, fmt.Errorf("Invalid exec section: %s", section)
+		}
+	}
+
+	opts.Env = env
+
+	status, err := c.RunCommandStatus(cmd, opts)
+	if err != nil {
+		return -1, fmt.Errorf("Failed running command: %q", err)
+	}
+
+	return status >> 8, nil
 }

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -138,6 +138,8 @@ func run() error {
 		fmt.Printf("        How long to wait before failing\n")
 
 		fmt.Printf("\n\nInternal commands (don't call these directly):\n")
+		fmt.Printf("    forkexec\n")
+		fmt.Printf("        Execute a command in a container\n")
 		fmt.Printf("    forkgetnet\n")
 		fmt.Printf("        Get container network information\n")
 		fmt.Printf("    forkgetfile\n")
@@ -219,6 +221,12 @@ func run() error {
 			return MigrateContainer(os.Args[1:])
 		case "forkstart":
 			return startContainer(os.Args[1:])
+		case "forkexec":
+			ret, err := execContainer(os.Args[1:])
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			}
+			os.Exit(ret)
 		}
 	}
 


### PR DESCRIPTION
This introduces a new "forkexec" sub-command which is used for all exec
calls. The thought is that the random lockups we were seeing before this
were caused by a race between go-lxc calling liblxc which called fork()
and some of the other goroutines.

Closes #1803

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>