### PR TITLE
Stop the storage code after we're done remapping

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -963,6 +963,11 @@ func (c *containerLXC) startCommon() (string, error) {
 				return "", err
 			}
 		}
+
+		err = c.StorageStop()
+		if err != nil {
+			return "", err
+		}
 	}
 
 	err = c.ConfigKeySet("volatile.last_state.idmap", jsonIdmap)


### PR DESCRIPTION
Without this we forget to unmount the partition on LVM which then
prevents the container from starting.

Closes #1839

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>