### PR TITLE
rebalance: don't use the cpu map from /proc/self/status

### DIFF
--- a/lxd/cgroup.go
+++ b/lxd/cgroup.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+)
+
+func getInitCgroupPath(controller string) string {
+	f, err := os.Open("/proc/1/cgroup")
+	if err != nil {
+		return "/"
+	}
+	defer f.Close()
+
+	scan := bufio.NewScanner(f)
+	for scan.Scan() {
+		line := scan.Text()
+
+		fields := strings.Split(line, ":")
+		if len(fields) != 3 {
+			return "/"
+		}
+
+		if fields[2] != controller {
+			continue
+		}
+
+		initPath := string(fields[3])
+
+		// ignore trailing /init.scope if it is there
+		dir, file := path.Split(initPath)
+		if file == "init.scope" {
+			return dir
+		} else {
+			return initPath
+		}
+	}
+
+	return "/"
+}
+
+func cGroupGet(controller, cgroup, file string) (string, error) {
+	initPath := getInitCgroupPath(controller)
+	path := path.Join("/sys/fs/cgroup", controller, initPath, cgroup, file)
+
+	contents, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return strings.Trim(string(contents), "\n"), nil
+}
+
+func cGroupSet(controller, cgroup, file string, value string) error {
+	initPath := getInitCgroupPath(controller)
+	path := path.Join("/sys/fs/cgroup", controller, initPath, cgroup, file)
+
+	return ioutil.WriteFile(path, []byte(value), 0755)
+}


### PR DESCRIPTION
it shows offline cpus.  So as discussed on irc,

17:51 < stgraber> hallyn: so I think we should 1) get rid of
	deviceGetCurrentCPUs 2) change deviceTaskBalance to read
	/sys/fs/cgroup/cpuset/cpuset.effective_cpus 3) replicate it to
	/lxc/cpuset.effective_cpus (not sure if we need that but I seem to remember
	cpuset being weird) 4) use that list instead of deviceGetCurrentCPUs when
	nothing is listed in limits.cpu

Add two simple helpers in lxd/cgroup.go to get/set cgroup files.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>