### PR TITLE
exec: create config file before referencing it

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2987,7 +2987,13 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	args := []string{c.daemon.execPath, "forkexec", c.name, c.daemon.lxcpath, filepath.Join(c.LogPath(), "lxc.conf")}
+	configPath := filepath.Join(c.LogPath(), "lxc.conf")
+	err := c.c.SaveConfigFile(configPath)
+	if err != nil {
+		return -1, err
+	}
+
+	args := []string{c.daemon.execPath, "forkexec", c.name, c.daemon.lxcpath, configPath}
 
 	args = append(args, "--")
 	args = append(args, "env")
@@ -3004,7 +3010,7 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 
-	err := cmd.Run()
+	err = cmd.Run()
 	if err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if ok {


### PR DESCRIPTION
This config file is created when starting a container, but not migrating it
or resuming it or probably some other cases. Instead, let's just always
create it so that we don't have to worry about it existing.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>