### PR TITLE
lxd: do run if we fail to mount shmounts

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1116,7 +1116,7 @@ func (c *containerLXC) Start(stateful bool) error {
 	}
 
 	if err := setupSharedMounts(); err != nil {
-		return fmt.Errorf("Daemon failed to setup shared mounts base: %s", err)
+		return fmt.Errorf("Daemon failed to setup shared mounts base: %s.\nDoes security.nesting need to be turned on?", err)
 	}
 
 	// Run the shared start code

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1115,8 +1115,8 @@ func (c *containerLXC) Start(stateful bool) error {
 		wgStopping.Wait()
 	}
 
-	if !c.daemon.SharedMounts {
-		return fmt.Errorf("Daemon failed to setup shared mounts")
+	if err := setupSharedMounts(); err != nil {
+		return fmt.Errorf("Daemon failed to setup shared mounts base: %s", err)
 	}
 
 	// Run the shared start code

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1115,6 +1115,10 @@ func (c *containerLXC) Start(stateful bool) error {
 		wgStopping.Wait()
 	}
 
+	if !c.daemon.SharedMounts {
+		return fmt.Errorf("Daemon failed to setup shared mounts")
+	}
+
 	// Run the shared start code
 	configPath, err := c.startCommon()
 	if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -81,6 +81,8 @@ type Daemon struct {
 	shutdownChan        chan bool
 	resetAutoUpdateChan chan bool
 	execPath            string
+	// did we manage to setup shared mounts?
+	SharedMounts bool
 
 	Storage storage
 
@@ -761,7 +763,10 @@ func (d *Daemon) Init() error {
 	}
 
 	if err := setupSharedMounts(); err != nil {
-		return err
+		d.SharedMounts = false
+		shared.Log.Error("Error setting up shared mounts base", log.Ctx{"err": err})
+	} else {
+		d.SharedMounts = true
 	}
 
 	if !d.MockMode {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -404,7 +404,6 @@ var sharedMounted bool
 var sharedMountsLock sync.Mutex
 
 func setupSharedMounts() error {
-
 	if sharedMounted {
 		return nil
 	}


### PR DESCRIPTION
If a container is setup without security.nesting = true, and someone
runs lxd in that container, we want lxd to run but fail (with clear
error) when starting a container.  Otherwise 'lxc list' and
dpkg-reconfigure lxd will hang forever, with errors going only to
syslog.

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>