### PR TITLE
write the container's config file on start to the log path directly

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1084,19 +1084,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	}
 
 	// Generate the LXC config
-	f, err := ioutil.TempFile("", "lxd_lxc_startconfig_")
-	if err != nil {
-		return "", err
-	}
-
-	configPath := f.Name()
-	if err = f.Chmod(0600); err != nil {
-		f.Close()
-		os.Remove(configPath)
-		return "", err
-	}
-	f.Close()
-
+	configPath := filepath.Join(c.LogPath(), "lxc.conf")
 	err = c.c.SaveConfigFile(configPath)
 	if err != nil {
 		os.Remove(configPath)

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -240,9 +240,6 @@ func startContainer(args []string) error {
 		syscall.Dup3(int(logFile.Fd()), 2, 0)
 	}
 
-	// Move the config so we can inspect it on failure
-	shared.FileMove(configPath, shared.LogPath(name, "lxc.conf"))
-
 	return c.Start()
 }
 


### PR DESCRIPTION
Now that we're dending on this file to exist in all cases when execing,
let's always write it.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>