### PR TITLE
command line: fix example in `lxc launch`

### DIFF
--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -30,7 +30,7 @@ Not specifying -p will result in the default profile.
 Specifying "-p" with no argument will result in no profile.
 
 Example:
-lxc launch ubuntu u1`)
+lxc launch ubuntu:16.04 u1`)
 }
 
 func (c *launchCmd) flags() {

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-04-24 15:14-0400\n"
+        "POT-Creation-Date: 2016-04-25 14:47-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:374
+#: lxc/list.go:378
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -145,7 +145,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/list.go:375
+#: lxc/list.go:379
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -281,7 +281,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/list.go:458
+#: lxc/list.go:462
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -365,11 +365,11 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/list.go:372
+#: lxc/list.go:376
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:373
+#: lxc/list.go:377
 msgid   "IPV6"
 msgstr  ""
 
@@ -454,7 +454,7 @@ msgid   "Launch a container from a particular image.\n"
         "Specifying \"-p\" with no argument will result in no profile.\n"
         "\n"
         "Example:\n"
-        "lxc launch ubuntu u1"
+        "lxc launch ubuntu:16.04 u1"
 msgstr  ""
 
 #: lxc/info.go:25
@@ -712,7 +712,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:376 lxc/remote.go:363
+#: lxc/list.go:380 lxc/remote.go:363
 msgid   "NAME"
 msgstr  ""
 
@@ -758,15 +758,15 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:460
+#: lxc/list.go:464
 msgid   "PERSISTENT"
 msgstr  ""
 
-#: lxc/list.go:377
+#: lxc/list.go:381
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:378
+#: lxc/list.go:382
 msgid   "PROFILES"
 msgstr  ""
 
@@ -919,11 +919,11 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:379
+#: lxc/list.go:383
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/list.go:380
+#: lxc/list.go:384
 msgid   "STATE"
 msgstr  ""
 
@@ -1019,7 +1019,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/list.go:381
+#: lxc/list.go:385
 msgid   "TYPE"
 msgstr  ""
 


### PR DESCRIPTION
Let's give a CLI example that actually launches a container successfully.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>