### PR TITLE
cpuset: fall back to cpuset.cpus on older kernels

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -184,8 +184,12 @@ func deviceTaskBalance(d *Daemon) {
 	// Get effective cpus list - those are all guaranteed to be online
 	effectiveCpus, err := cGroupGet("cpuset", "/", "cpuset.effective_cpus")
 	if err != nil {
-		shared.Log.Error("Error reading host's cpuset.effective_cpus")
-		return
+		// Older kernel - use cpuset.cpus
+		effectiveCpus, err = cGroupGet("cpuset", "/", "cpuset.cpus")
+		if err != nil {
+			shared.Log.Error("Error reading host's cpuset.cpus")
+			return
+		}
 	}
 	err = cGroupSet("cpuset", "/lxc", "cpuset.cpus", effectiveCpus)
 	if err != nil && shared.PathExists("/sys/fs/cgroup/cpuset/lxc") {
@@ -193,7 +197,7 @@ func deviceTaskBalance(d *Daemon) {
 	}
 	cpus, err := parseCpuset(effectiveCpus)
 	if err != nil {
-		shared.Log.Error("Error parsing host's cpuset.effective_cpus", log.Ctx{"cpuset": effectiveCpus, "err": err})
+		shared.Log.Error("Error parsing host's cpu set", log.Ctx{"cpuset": effectiveCpus, "err": err})
 		return
 	}
 


### PR DESCRIPTION
cpuset.effective_cpus is better because it does not include cpus which
we cannot use.  But it is not available on older kernels.  In that
case fall back to using cpuset.cpus and hoping for the best.

Closes #1929

Signed-off-by: Serge Hallyn <serge.hallyn@ubuntu.com>