### PR TITLE
Fix daemonConfig handling of storage

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -344,27 +344,27 @@ func (d *Daemon) createCmd(version string, c Command) {
 	})
 }
 
-func (d *Daemon) SetupStorageDriver(driver string) error {
+func (d *Daemon) SetupStorageDriver() error {
 	var err error
 
 	lvmVgName := daemonConfig["storage.lvm_vg_name"].Get()
 	zfsPoolName := daemonConfig["storage.zfs_pool_name"].Get()
 
-	if driver == "lvm" || lvmVgName != "" {
+	if lvmVgName != "" {
 		d.Storage, err = newStorage(d, storageTypeLvm)
 		if err != nil {
 			shared.Logf("Could not initialize storage type LVM: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
-	} else if driver == "zfs" || zfsPoolName != "" {
+	} else if zfsPoolName != "" {
 		d.Storage, err = newStorage(d, storageTypeZfs)
 		if err != nil {
 			shared.Logf("Could not initialize storage type ZFS: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
-	} else if driver == "btrfs" || d.BackingFs == "btrfs" {
+	} else if d.BackingFs == "btrfs" {
 		d.Storage, err = newStorage(d, storageTypeBtrfs)
 		if err != nil {
 			shared.Logf("Could not initialize storage type btrfs: %s - falling back to dir", err)
@@ -743,7 +743,7 @@ func (d *Daemon) Init() error {
 
 	/* Setup the storage driver */
 	if !d.MockMode {
-		err = d.SetupStorageDriver("")
+		err = d.SetupStorageDriver()
 		if err != nil {
 			return fmt.Errorf("Failed to setup storage: %s", err)
 		}

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -253,23 +253,20 @@ func daemonConfigSetPassword(d *Daemon, key string, value string) (string, error
 }
 
 func daemonConfigSetStorage(d *Daemon, key string, value string) (string, error) {
-	driver := ""
+	// The storage driver looks at daemonConfig so just set it temporarily
+	daemonConfigLock.Lock()
+	oldValue := daemonConfig[key].Get()
+	daemonConfig[key].currentValue = value
+	daemonConfigLock.Unlock()
 
-	// Guess the driver name from the key
-	switch key {
-	case "storage.lvm_vg_name":
-		driver = "lvm"
-	case "storage.zfs_pool_name":
-		driver = "zfs"
-	}
-
-	// Should never actually hit this
-	if driver == "" {
-		return "", fmt.Errorf("Invalid storage key: %s", key)
-	}
+	defer func() {
+		daemonConfigLock.Lock()
+		daemonConfig[key].currentValue = oldValue
+		daemonConfigLock.Unlock()
+	}()
 
 	// Update the current storage driver
-	err := d.SetupStorageDriver(driver)
+	err := d.SetupStorageDriver()
 	if err != nil {
 		return "", err
 	}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -819,8 +819,14 @@ func (s *storageLvm) createDefaultThinPool() (string, error) {
 func (s *storageLvm) createThinLV(lvname string) (string, error) {
 	var err error
 
+	vgname := daemonConfig["storage.lvm_vg_name"].Get()
 	poolname := daemonConfig["storage.lvm_thinpool_name"].Get()
-	if poolname == "" {
+	exists, err := storageLVMThinpoolExists(vgname, poolname)
+	if err != nil {
+		return "", err
+	}
+
+	if !exists {
 		poolname, err = s.createDefaultThinPool()
 		if err != nil {
 			return "", fmt.Errorf("Error creating LVM thin pool: %v", err)


### PR DESCRIPTION
Storage functions unfortunately have the habit of reading the daemon
configuration, so we need to at least temporarily set daemonConfig to
the right value...

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>