### PR TITLE
don't remove config file on forkmigrate

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -712,8 +712,6 @@ func MigrateContainer(args []string) error {
 	configPath := args[3]
 	imagesDir := args[4]
 
-	defer os.Remove(configPath)
-
 	c, err := lxc.NewContainer(name, lxcpath)
 	if err != nil {
 		return err


### PR DESCRIPTION
068313ad07d8971cd148a345463310227fcdad39 moved the config file to a
non-temp file, so let's not delete it.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>