### PR TITLE
don't alias rsync error condition

### DIFF
--- a/lxd/rsync.go
+++ b/lxd/rsync.go
@@ -141,7 +141,8 @@ func RsyncSend(path string, conn *websocket.Conn) error {
 		shared.Debugf("problem reading rsync stderr %s", err)
 	}
 
-	if err := cmd.Wait(); err != nil {
+	err = cmd.Wait()
+	if err != nil {
 		shared.Debugf("problem with rsync send of %s: %s: %s", path, err, string(output))
 	}
 


### PR DESCRIPTION
When rsyncing something, let's not mask err, so we can fail properly if the
rsync fails.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>