### PR TITLE
state: fix state dir

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4494,5 +4494,13 @@ func (c *containerLXC) TemplatesPath() string {
 }
 
 func (c *containerLXC) StatePath() string {
-	return filepath.Join(c.RootfsPath(), "state")
+	/* FIXME: backwards compatibility: we used to use Join(RootfsPath(),
+	 * "state"), which was bad. Let's just check to see if that directory
+	 * exists.
+	 */
+	oldStatePath := filepath.Join(c.RootfsPath(), "state")
+	if shared.IsDir(oldStatePath) {
+		return oldStatePath
+	}
+	return filepath.Join(c.Path(), "state")
 }


### PR DESCRIPTION
We were using /containers/$container/rootfs/state as the directory to save
CRIU state in; instead, let's just use /containers/$container/state.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>