### PR TITLE
client: Init() supports passing in devices

### DIFF
--- a/client.go
+++ b/client.go
@@ -1197,7 +1197,7 @@ func (c *Client) GetAlias(alias string) string {
 
 // Init creates a container from either a fingerprint or an alias; you must
 // provide at least one.
-func (c *Client) Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, ephem bool) (*Response, error) {
+func (c *Client) Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, devices shared.Devices, ephem bool) (*Response, error) {
 	if c.Remote.Public {
 		return nil, fmt.Errorf("This function isn't supported by public remotes.")
 	}
@@ -1297,6 +1297,10 @@ func (c *Client) Init(name string, imgremote string, image string, profiles *[]s
 
 	if config != nil {
 		body["config"] = config
+	}
+
+	if devices != nil {
+		body["devices"] = devices
 	}
 
 	if ephem {

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -356,10 +356,10 @@ Input (container based on a local image with the "ubuntu/devel" alias):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
@@ -374,10 +374,10 @@ Input (container based on a local image identified by its fingerprint):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
@@ -392,10 +392,10 @@ Input (container based on most recent match based on image properties):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
@@ -414,10 +414,10 @@ Input (container without a pre-populated rootfs, useful when attaching to an exi
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "none"},                                         # Can be: "image", "migration", "copy" or "none"
@@ -431,10 +431,10 @@ Input (using a public remote image):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
@@ -454,10 +454,10 @@ Input (using a private remote image after having obtained a secret for that imag
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
-        "devices": {                                                        # any devices the container should have
+        "devices": {                                                        # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
@@ -476,10 +476,10 @@ Input (using a remote container, sent over the migration websocket):
         "profiles": ["default"],                                                        # List of profiles
         "ephemeral": true,                                                              # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                                  # Config override.
-        "devices": {                                                                    # any devices the container should have
+        "devices": {                                                                    # optional list of devices the container should have
             "rootfs": {
-                "path": "/",
-                "type": "disk"
+                "path": "/dev/kvm",
+                "type": "unix-char"
             },
         },
         "source": {"type": "migration",                                                 # Can be: "image", "migration", "copy" or "none"

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -356,6 +356,12 @@ Input (container based on a local image with the "ubuntu/devel" alias):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "alias": "ubuntu/devel"},                                # Name of the alias
     }
@@ -368,6 +374,12 @@ Input (container based on a local image identified by its fingerprint):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "fingerprint": "SHA-256"},                               # Fingerprint
     }
@@ -380,6 +392,12 @@ Input (container based on most recent match based on image properties):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "properties": {                                          # Properties
                         "os": "ubuntu",
@@ -396,6 +414,12 @@ Input (container without a pre-populated rootfs, useful when attaching to an exi
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "none"},                                         # Can be: "image", "migration", "copy" or "none"
     }
 
@@ -407,6 +431,12 @@ Input (using a public remote image):
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "mode": "pull",                                          # One of "local" (default) or "pull"
                    "server": "https://10.0.2.3:8443",                       # Remote server (pull mode only)
@@ -424,6 +454,12 @@ Input (using a private remote image after having obtained a secret for that imag
         "profiles": ["default"],                                            # List of profiles
         "ephemeral": true,                                                  # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                      # Config override.
+        "devices": {                                                        # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "mode": "pull",                                          # One of "local" (default) or "pull"
                    "server": "https://10.0.2.3:8443",                       # Remote server (pull mode only)
@@ -440,6 +476,12 @@ Input (using a remote container, sent over the migration websocket):
         "profiles": ["default"],                                                        # List of profiles
         "ephemeral": true,                                                              # Whether to destroy the container on shutdown
         "config": {"limits.cpu": "2"},                                                  # Config override.
+        "devices": {                                                                    # any devices the container should have
+            "rootfs": {
+                "path": "/",
+                "type": "disk"
+            },
+        },
         "source": {"type": "migration",                                                 # Can be: "image", "migration", "copy" or "none"
                    "mode": "pull",                                                      # Only "pull" is supported for now
                    "operation": "https://10.0.2.3:8443/1.0/operations/<UUID>",          # Full URL to the remote operation (pull mode only)

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -180,9 +180,9 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 	iremote, image = c.guessImage(config, d, remote, iremote, image)
 
 	if !initRequestedEmptyProfiles && len(profiles) == 0 {
-		resp, err = d.Init(name, iremote, image, nil, configMap, c.ephem)
+		resp, err = d.Init(name, iremote, image, nil, configMap, nil, c.ephem)
 	} else {
-		resp, err = d.Init(name, iremote, image, &profiles, configMap, c.ephem)
+		resp, err = d.Init(name, iremote, image, &profiles, configMap, nil, c.ephem)
 	}
 	if err != nil {
 		return err

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -78,9 +78,9 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 	iremote, image = c.init.guessImage(config, d, remote, iremote, image)
 
 	if !initRequestedEmptyProfiles && len(profiles) == 0 {
-		resp, err = d.Init(name, iremote, image, nil, configMap, c.init.ephem)
+		resp, err = d.Init(name, iremote, image, nil, configMap, nil, c.init.ephem)
 	} else {
-		resp, err = d.Init(name, iremote, image, &profiles, configMap, c.init.ephem)
+		resp, err = d.Init(name, iremote, image, &profiles, configMap, nil, c.init.ephem)
 	}
 
 	if err != nil {

--- a/test/lxd-benchmark/main.go
+++ b/test/lxd-benchmark/main.go
@@ -165,7 +165,7 @@ func spawnContainers(c *lxd.Client, count int, image string, privileged bool) er
 		config["user.lxd-benchmark"] = "true"
 
 		// Create
-		resp, err := c.Init(name, "local", fingerprint, nil, config, false)
+		resp, err := c.Init(name, "local", fingerprint, nil, config, nil, false)
 		if err != nil {
 			logf(fmt.Sprintf("Failed to spawn container '%s': %s", name, err))
 			return


### PR DESCRIPTION
containers_post.go has an implementation which respects the devices
parameter. Let's document it and also pass it in.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>