### PR TITLE
images: don't fail deleting when the storage delete fails

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -911,12 +911,12 @@ func doDeleteImage(d *Daemon, fingerprint string) error {
 	// look at the path
 	s, err := storageForImage(d, imgInfo)
 	if err != nil {
-		return err
-	}
-
-	// Remove the image from storage backend
-	if err = s.ImageDelete(imgInfo.Fingerprint); err != nil {
-		return err
+		shared.Log.Error("error detecting image storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
+	} else {
+		// Remove the image from storage backend
+		if err = s.ImageDelete(imgInfo.Fingerprint); err != nil {
+			shared.Log.Error("error deleting the image from storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
+		}
 	}
 
 	// Remove main image file


### PR DESCRIPTION
e.g. if someone deletes the zpool manually, they then can't delete an
image, because we can't detect the filesystem type for the path, because it
doesn't exist any more. Let's not fail so hard when we can't detect the
filesystem.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>