### PR TITLE
add more checks for the criu binary

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -507,6 +507,10 @@ func containerCreateAsSnapshot(d *Daemon, args containerArgs, sourceContainer co
 			return nil, fmt.Errorf("Container not running, cannot do stateful snapshot")
 		}
 
+		if err := findCriu("snapshot"); err != nil {
+			return nil, err
+		}
+
 		stateDir := sourceContainer.StatePath()
 		err := os.MkdirAll(stateDir, 0700)
 		if err != nil {


### PR DESCRIPTION
In particular, stateful stop/snapshot didn't have a check.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>