### PR TITLE
rework (live) migration tests

### DIFF
--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -64,8 +64,12 @@ test_migration() {
     return
   fi
 
-  lxc_remote launch testimage migratee
+  lxc_remote launch testimage l1:migratee
 
-  lxc_remote move l1:migratee l2:migratee
-  lxc_remote stop l2:migratee --force
+  # let the container do some interesting things
+  sleep 1s
+
+  lxc_remote stop --stateful l1:migratee
+  lxc_remote start l1:migratee
+  lxc_remote stop --force l1:migratee
 }


### PR DESCRIPTION
In particular, same-host-different-lxd migration doesn't work right now
because of some cgroup path issues. CRIU will need to learn how to rewrite
mount paths to support this use case, but it's not a super high priority
right now.

Instead, let's use stateful snapshot/restore which will work, so that we
can at least test the CRIU machenery.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>