### PR TITLE
better bash completion

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -4,7 +4,7 @@ _have lxc && {
     _lxd_names()
     {
       COMPREPLY=( $( compgen -W \
-        "$( lxc list --fast | tail -n +4 | awk '{print $2}' | egrep -v '^(\||^$)' )" "$cur" )
+        "$( lxc list --fast | tail -n +4 | awk '{print $2}' | egrep -v '^(\||^$)' ) $1" "$cur" )
       )
     }
 
@@ -15,84 +15,183 @@ _have lxc && {
       )
     }
 
-    local cur prev
+    _lxd_remotes()
+    {
+      COMPREPLY=( $( compgen -W \
+        "$( lxc remote list | tail -n +4 | awk '{print $2}' | egrep -v '^(\||^$)' )" "$cur" )
+      )
+    }
+
+    _lxd_profiles()
+    {
+      COMPREPLY=( $( compgen -W "$( lxc profile list )" "$cur" ) )
+    }
 
     COMPREPLY=()
-    cur=${COMP_WORDS[COMP_CWORD]}
-    prev=${COMP_WORDS[COMP_CWORD-1]}
+    # ignore special --foo args
+    if [[ ${COMP_WORDS[COMP_CWORD]} == -* ]]; then
+      return 0
+    fi
+
     lxc_cmds="config copy delete exec file help image info init launch \
       list move profile publish remote restart restore snapshot start stop \
       version"
 
+    global_keys="core.https_address core.https_allowd_origin \
+      core.https_allowed_methods core.https_allowed_headers core.proxy_https \
+      core.proxy_http core.proxy_ignore_host core.trust_password \
+      storage.lvm_vg_name storage.lvm_thinpool_name storage.lvm_fstype \
+      storage.lvm_volume_size storage.zfs_pool_name
+      storage.zfs_remove_snapshots images.compression_algorithm \
+      images.remot_cache_expiry images.auto_update_interval \
+      images.auto_update_cached"
+
+    container_keys="boot.autostart boot.autostart.delay boot.autostart.priority \
+      limits.cpu limits.cpu.allowance limits.cpu.priority limits.disk.priority \
+      limits.memory limits.memory.enforce limits.memory.swap \
+      limits.memory.swap.priority limits.network.priority limits.processes \
+      linux.kernel_modules raw.apparmor raw.lxc security.nesting \
+      security.privileged volatile.apply_template volatile.base_image \
+      volatile.last_state.idmap volatile.last_state.power user.network_mode \
+      user.meta-data user.user-data user.vendor-data"
+
     if [ $COMP_CWORD -eq 1 ]; then
-      COMPREPLY=( $(compgen -W "$lxc_cmds" -- $cur) )
-    elif [ $COMP_CWORD -eq 2 ]; then
-      case "$prev" in
-        "config")
-          COMPREPLY=( $(compgen -W "device edit get set show trust" -- $cur) )
-          ;;
-        "copy")
-          _lxd_names
-          ;;
-        "delete")
-          _lxd_names
-          ;;
-        "exec")
-          _lxd_names
-          ;;
-        "file")
-          COMPREPLY=( $(compgen -W "pull push edit" -- $cur) )
-          ;;
-        "help")
-          COMPREPLY=( $(compgen -W "$lxc_cmds" -- $cur) )
-          ;;
-        "image")
-          COMPREPLY=( $(compgen -W "import copy delete edit export info list show alias" -- $cur) )
-          ;;
-        "info")
-          _lxd_names
-          ;;
-        "init")
-          _lxd_images
-          ;;
-        "launch")
-          _lxd_images
-          ;;
-        "move")
-          _lxd_names
-          ;;
-        "profile")
-          COMPREPLY=( $(compgen -W \
-            "list show create edit copy get set delete apply device" -- $cur) )
-          ;;
-        "publish")
-          _lxd_names
-          ;;
-        "remote")
-          COMPREPLY=( $(compgen -W \
-            "add remove list rename set-url set-default get-default" -- $cur) )
-          ;;
-        "restart")
-          _lxd_names
-          ;;
-        "restore")
-          _lxd_names
-          ;;
-        "snapshot")
-          _lxd_names
-          ;;
-        "start")
-          # should check if containers are stopped
-          _lxd_names
-          ;;
-        "stop")
-          # should check if containers are started
-          _lxd_names
-          ;;
-        *)
-          ;;
-      esac
+      COMPREPLY=( $(compgen -W "$lxc_cmds" -- ${COMP_WORDS[COMP_CWORD]}) )
+      return 0
     fi
+
+    local no_dashargs
+    cur=${COMP_WORDS[COMP_CWORD]}
+
+    no_dashargs=(${COMP_WORDS[@]//-*})
+    pos=$((COMP_CWORD - (${#COMP_WORDS[@]} - ${#no_dashargs[@]})))
+    if [ -z "$cur" ]; then
+      pos=$(($pos + 1))
+    fi
+
+    case ${no_dashargs[1]} in
+      "config")
+        case $pos in
+          2)
+            COMPREPLY=( $(compgen -W "device edit get set show trust" -- $cur) )
+            ;;
+          3)
+            case ${no_dashargs[2]} in
+              "trust")
+                COMPREPLY=( $(compgen -W "list add remove" -- $cur) )
+                ;;
+              "device")
+                COMPREPLY=( $(compgen -W "add get set unset list show remove" -- $cur) )
+                ;;
+              "show"|"edit")
+                _lxd_names
+                ;;
+              "get"|"set"|"unset")
+                _lxd_names "$global_keys"
+                ;;
+            esac
+            ;;
+          4)
+            case ${no_dashargs[2]} in
+              "trust")
+                _lxd_remotes
+                ;;
+              "device")
+                _lxd_names
+                ;;
+              "get"|"set"|"unset")
+                COMPREPLY=( $(compgen -W "$container_keys" -- $cur) )
+                ;;
+            esac
+            ;;
+        esac
+        ;;
+      "copy")
+        if [ $pos -lt 4 ]; then
+          _lxd_names
+        fi
+        ;;
+      "delete")
+        _lxd_names
+        ;;
+      "exec")
+        _lxd_names
+        ;;
+      "file")
+        COMPREPLY=( $(compgen -W "pull push edit" -- $cur) )
+        ;;
+      "help")
+        COMPREPLY=( $(compgen -W "$lxc_cmds" -- $cur) )
+        ;;
+      "image")
+        COMPREPLY=( $(compgen -W "import copy delete edit export info list show alias" -- $cur) )
+        ;;
+      "info")
+        _lxd_names
+        ;;
+      "init")
+        _lxd_images
+        ;;
+      "launch")
+        _lxd_images
+        ;;
+      "move")
+        _lxd_names
+        ;;
+      "profile")
+        case $pos in
+          2)
+            COMPREPLY=( $(compgen -W "list copy delete apply device edit get set show" -- $cur) )
+            ;;
+          3)
+            case ${no_dashargs[2]} in
+              "device")
+                COMPREPLY=( $(compgen -W "add get set unset list show remove" -- $cur) )
+                ;;
+              *)
+                _lxd_profiles
+                ;;
+            esac
+            ;;
+          4)
+            case ${no_dashargs[2]} in
+              "device")
+                _lxd_profiles
+                ;;
+              *)
+                COMPREPLY=( $(compgen -W "$container_keys" -- $cur) )
+                ;;
+            esac
+            ;;
+        esac
+        ;;
+      "publish")
+        _lxd_names
+        ;;
+      "remote")
+        COMPREPLY=( $(compgen -W \
+          "add remove list rename set-url set-default get-default" -- $cur) )
+        ;;
+      "restart")
+        _lxd_names
+        ;;
+      "restore")
+        _lxd_names
+        ;;
+      "snapshot")
+        _lxd_names
+        ;;
+      "start")
+        # should check if containers are stopped
+        _lxd_names
+        ;;
+      "stop")
+        # should check if containers are started
+        _lxd_names
+        ;;
+      *)
+        ;;
+    esac
 
     return 0
   }


### PR DESCRIPTION
* add completion of global and container config keys
* ignore --arguments when completing
* add completion of remote and profile names where it makes sense (but
  still always prefer completing local container names in commands like
  `lxc start`)
* do a better job of completing subcommands like `lxc config trust` and
  `lxc config device`

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>