### PR TITLE
add some seccomp knobs

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -64,29 +64,33 @@ currently supported:
 
 The currently supported keys are:
 
-Key                         | Type      | Default       | Live update   | Description
-:--                         | :---      | :------       | :----------   | :----------
-boot.autostart              | boolean   | false         | n/a           | Always start the container when LXD starts
-boot.autostart.delay        | integer   | 0             | n/a           | Number of seconds to wait after the container started before starting the next one
-boot.autostart.priority     | integer   | 0             | n/a           | What order to start the containers in (starting with highest)
-boot.host_shutdown_timeout  | integer   | 30            | yes           | Seconds to wait for container to shutdown before it is force stopped
-environment.\*              | string    | -             | yes (exec)    | key/value environment variables to export to the container and set on exec
-limits.cpu                  | string    | - (all)       | yes           | Number or range of CPUs to expose to the container
-limits.cpu.allowance        | string    | 100%          | yes           | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
-limits.cpu.priority         | integer   | 10 (maximum)  | yes           | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit)
-limits.disk.priority        | integer   | 5 (medium)    | yes           | When under load, how much priority to give to the container's I/O requests
-limits.memory               | string    | - (all)       | yes           | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
-limits.memory.enforce       | string    | hard          | yes           | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
-limits.memory.swap          | boolean   | true          | yes           | Whether to allow some of the container's memory to be swapped out to disk
-limits.memory.swap.priority | integer   | 10 (maximum)  | yes           | The higher this is set, the least likely the container is to be swapped to disk
-limits.network.priority     | integer   | 0 (minimum)   | yes           | When under load, how much priority to give to the container's network requests
-limits.processes            | integer   | - (max)       | yes           | Maximum number of processes that can run in the container
-linux.kernel\_modules       | string    | -             | yes           | Comma separated list of kernel modules to load before starting the container
-raw.apparmor                | blob      | -             | yes           | Apparmor profile entries to be appended to the generated profile
-raw.lxc                     | blob      | -             | no            | Raw LXC configuration to be appended to the generated one
-security.nesting            | boolean   | false         | yes           | Support running lxd (nested) inside the container
-security.privileged         | boolean   | false         | no            | Runs the container in privileged mode
-user.\*                     | string    | -             | n/a           | Free form user key/value storage (can be used in search)
+Key                                  | Type      | Default       | Live update   | Description
+:--                                  | :---      | :------       | :----------   | :----------
+boot.autostart                       | boolean   | false         | n/a           | Always start the container when LXD starts
+boot.autostart.delay                 | integer   | 0             | n/a           | Number of seconds to wait after the container started before starting the next one
+boot.autostart.priority              | integer   | 0             | n/a           | What order to start the containers in (starting with highest)
+boot.host_shutdown_timeout           | integer   | 30            | yes           | Seconds to wait for container to shutdown before it is force stopped
+environment.\*                       | string    | -             | yes (exec)    | key/value environment variables to export to the container and set on exec
+limits.cpu                           | string    | - (all)       | yes           | Number or range of CPUs to expose to the container
+limits.cpu.allowance                 | string    | 100%          | yes           | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
+limits.cpu.priority                  | integer   | 10 (maximum)  | yes           | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit)
+limits.disk.priority                 | integer   | 5 (medium)    | yes           | When under load, how much priority to give to the container's I/O requests
+limits.memory                        | string    | - (all)       | yes           | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
+limits.memory.enforce                | string    | hard          | yes           | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
+limits.memory.swap                   | boolean   | true          | yes           | Whether to allow some of the container's memory to be swapped out to disk
+limits.memory.swap.priority          | integer   | 10 (maximum)  | yes           | The higher this is set, the least likely the container is to be swapped to disk
+limits.network.priority              | integer   | 0 (minimum)   | yes           | When under load, how much priority to give to the container's network requests
+limits.processes                     | integer   | - (max)       | yes           | Maximum number of processes that can run in the container
+linux.kernel\_modules                | string    | -             | yes           | Comma separated list of kernel modules to load before starting the container
+raw.apparmor                         | blob      | -             | yes           | Apparmor profile entries to be appended to the generated profile
+raw.lxc                              | blob      | -             | no            | Raw LXC configuration to be appended to the generated one
+security.nesting                     | boolean   | false         | yes           | Support running lxd (nested) inside the container
+security.privileged                  | boolean   | false         | no            | Runs the container in privileged mode
+security.syscalls.blacklist\_default | boolean   | true          | no            | Enables the default syscall blacklist
+security.syscalls.blacklist\_compat  | boolean   | false         | no            | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
+security.syscalls.blacklist          | string    | -             | no            | A '\n' separated list of syscalls to blacklist
+seucrity.syscalls.whitelist          | string    | -             | no            | A '\n' separated list of syscalls to whitelist (mutually exclusive with security.syscalls.blacklist\*)
+user.\*                              | string    | -             | n/a           | Free form user key/value storage (can be used in search)
 
 The following volatile keys are currently internally used by LXD:
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -45,9 +45,11 @@ var api10 = []Command{
 
 func api10Get(d *Daemon, r *http.Request) Response {
 	body := shared.Jmap{
-		"api_extensions": []string{},
-		"api_status":     "stable",
-		"api_version":    shared.APIVersion,
+		"api_extensions": []string{
+			"syscall_filtering",
+		},
+		"api_status":  "stable",
+		"api_version": shared.APIVersion,
 	}
 
 	if d.isTrustedClient(r) {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -466,10 +466,12 @@ func (c *containerLXC) initLXC() error {
 		}
 	}
 
-	// Setup Seccomp
-	err = lxcSetConfigItem(cc, "lxc.seccomp", SeccompProfilePath(c))
-	if err != nil {
-		return err
+	// Setup Seccomp if necessary
+	if ContainerNeedsSeccomp(c) {
+		err = lxcSetConfigItem(cc, "lxc.seccomp", SeccompProfilePath(c))
+		if err != nil {
+			return err
+		}
 	}
 
 	// Setup idmap

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -151,7 +151,7 @@ func containerLXCCreate(d *Daemon, args containerArgs) (container, error) {
 	}
 
 	// Validate expanded config
-	err = containerValidConfig(c.expandedConfig, false, true)
+	err = containerValidConfig(d, c.expandedConfig, false, true)
 	if err != nil {
 		c.Delete()
 		return nil, err
@@ -1974,7 +1974,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 	}
 
 	// Validate the new config
-	err := containerValidConfig(args.Config, false, false)
+	err := containerValidConfig(c.daemon, args.Config, false, false)
 	if err != nil {
 		return err
 	}
@@ -2124,7 +2124,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 	removeDevices, addDevices, updateDevices := oldExpandedDevices.Update(c.expandedDevices)
 
 	// Do some validation of the config diff
-	err = containerValidConfig(c.expandedConfig, false, true)
+	err = containerValidConfig(c.daemon, c.expandedConfig, false, true)
 	if err != nil {
 		undoChanges()
 		return err

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -66,7 +66,7 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("No name provided"))
 	}
 
-	err := containerValidConfig(req.Config, true, false)
+	err := containerValidConfig(d, req.Config, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}
@@ -135,7 +135,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 	}
 
 	// Sanity checks
-	err := containerValidConfig(req.Config, true, false)
+	err := containerValidConfig(d, req.Config, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/seccomp.go
+++ b/lxd/seccomp.go
@@ -8,16 +8,55 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-const DEFAULT_SECCOMP_POLICY = `
+const SECCOMP_HEADER = `
 2
-blacklist
+`
+
+const DEFAULT_SECCOMP_POLICY = `
 reject_force_umount  # comment this to allow umount -f;  not recommended
 [all]
-kexec_load errno 1
-open_by_handle_at errno 1
-init_module errno 1
-finit_module errno 1
-delete_module errno 1
+kexec_load errno 38
+open_by_handle_at errno 38
+init_module errno 38
+finit_module errno 38
+delete_module errno 38
+`
+const COMPAT_BLOCKING_POLICY = `
+[x86_64]
+compat_sys_rt_sigaction errno 38
+stub_x32_rt_sigreturn errno 38
+compat_sys_ioctl errno 38
+compat_sys_readv errno 38
+compat_sys_writev errno 38
+compat_sys_recvfrom errno 38
+compat_sys_sendmsg errno 38
+compat_sys_recvmsg errno 38
+stub_x32_execve errno 38
+compat_sys_ptrace errno 38
+compat_sys_rt_sigpending errno 38
+compat_sys_rt_sigtimedwait errno 38
+compat_sys_rt_sigqueueinfo errno 38
+compat_sys_sigaltstack errno 38
+compat_sys_timer_create errno 38
+compat_sys_mq_notify errno 38
+compat_sys_kexec_load errno 38
+compat_sys_waitid errno 38
+compat_sys_set_robust_list errno 38
+compat_sys_get_robust_list errno 38
+compat_sys_vmsplice errno 38
+compat_sys_move_pages errno 38
+compat_sys_preadv64 errno 38
+compat_sys_pwritev64 errno 38
+compat_sys_rt_tgsigqueueinfo errno 38
+compat_sys_recvmmsg errno 38
+compat_sys_sendmmsg errno 38
+compat_sys_process_vm_readv errno 38
+compat_sys_process_vm_writev errno 38
+compat_sys_setsockopt errno 38
+compat_sys_getsockopt errno 38
+compat_sys_io_setup errno 38
+compat_sys_io_submit errno 38
+stub_x32_execveat errno 38
 `
 
 var seccompPath = shared.VarPath("security", "seccomp")
@@ -26,9 +65,68 @@ func SeccompProfilePath(c container) string {
 	return path.Join(seccompPath, c.Name())
 }
 
+func ContainerNeedsSeccomp(c container) bool {
+	config := c.ExpandedConfig()
+
+	keys := []string{
+		"raw.seccomp",
+		"security.syscalls.whitelist",
+		"security.syscalls.blacklist",
+	}
+
+	for _, k := range keys {
+		_, hasKey := config[k]
+		if hasKey {
+			return true
+		}
+	}
+
+	compat := config["security.syscalls.blacklist_compat"]
+	if shared.IsTrue(compat) {
+		return true
+	}
+
+	/* this are enabled by default, so if the keys aren't present, that
+	 * means "true"
+	 */
+	default_, ok := config["security.syscalls.blacklist_default"]
+	if !ok || shared.IsTrue(default_) {
+		return true
+	}
+
+	return false
+}
+
 func getSeccompProfileContent(c container) string {
-	/* for now there are no seccomp knobs. */
-	return DEFAULT_SECCOMP_POLICY
+	config := c.ExpandedConfig()
+
+	raw := config["raw.seccomp"]
+	if raw != "" {
+		return raw
+	}
+
+	policy := SECCOMP_HEADER
+
+	whitelist := config["security.syscalls.whitelist"]
+	if whitelist != "" {
+		policy += "whitelist\n[all]\n"
+		policy += whitelist
+		return policy
+	}
+
+	policy += "blacklist\n"
+
+	default_, ok := config["security.syscalls.blacklist_default"]
+	if !ok || shared.IsTrue(default_) {
+		policy += DEFAULT_SECCOMP_POLICY
+	}
+
+	compat := config["security.syscalls.blacklist_compat"]
+	if shared.IsTrue(compat) {
+		policy += COMPAT_BLOCKING_POLICY
+	}
+
+	return policy
 }
 
 func SeccompCreateProfile(c container) error {
@@ -38,6 +136,10 @@ func SeccompCreateProfile(c container) error {
 	 * the mtime on the file for any compiler purpose, so let's just write
 	 * out the profile.
 	 */
+	if !ContainerNeedsSeccomp(c) {
+		return nil
+	}
+
 	profile := getSeccompProfileContent(c)
 	if err := os.MkdirAll(seccompPath, 0700); err != nil {
 		return err

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -250,6 +250,16 @@ test_basic_usage() {
   lxc delete lxd-apparmor-test
   [ ! -f "${LXD_DIR}/security/apparmor/profiles/lxd-lxd-apparmor-test" ]
 
+  lxc launch testimage lxd-seccomp-test
+  init=$(lxc info lxd-seccomp-test | grep Pid | cut -f2 -d" ")
+  [ "$(grep Seccomp "/proc/${init}/status" | cut -f2)" -eq "2" ]
+  lxc stop --force lxd-seccomp-test
+  lxc config set lxd-seccomp-test security.syscalls.blacklist_default false
+  lxc start lxd-seccomp-test
+  init=$(lxc info lxd-seccomp-test | grep Pid | cut -f2 -d" ")
+  [ "$(grep Seccomp "/proc/${init}/status" | cut -f2)" -eq "0" ]
+  lxc stop --force lxd-seccomp-test
+
   # make sure that privileged containers are not world-readable
   lxc profile create unconfined
   lxc profile set unconfined security.privileged true


### PR DESCRIPTION
In particular,

* make the default seccomp config optional
* add a knob to block x32 syscalls on amd64 (enabled by default)
* add a way for users to inject their own seccomp stuff

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>