### PR TITLE
use default buffer size for WebsocketUpgrader

### DIFF
--- a/shared/operation.go
+++ b/shared/operation.go
@@ -8,9 +8,7 @@ import (
 )
 
 var WebsocketUpgrader = websocket.Upgrader{
-	ReadBufferSize:  1024,
-	WriteBufferSize: 1024,
-	CheckOrigin:     func(r *http.Request) bool { return true },
+	CheckOrigin: func(r *http.Request) bool { return true },
 }
 
 type Operation struct {


### PR DESCRIPTION
Let's use the default for this now so we do less copying. In my tests this
doesn't make a huge difference, but it does shave 2 seconds off of a 50
second or so transfer on average. Presumably bumping this higher when we
know we're going to be dumping a lot of data is a good idea, but that's for
a later set when I've done more experiments.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>