### PR TITLE
Add config key for container force shutdown timeout

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -47,8 +47,8 @@ _have lxc && {
       images.auto_update_cached"
 
     container_keys="boot.autostart boot.autostart.delay boot.autostart.priority \
-      limits.cpu limits.cpu.allowance limits.cpu.priority limits.disk.priority \
-      limits.memory limits.memory.enforce limits.memory.swap \
+      boot.force_shutdown_timeout limits.cpu limits.cpu.allowance limits.cpu.priority \
+      limits.disk.priority limits.memory limits.memory.enforce limits.memory.swap \
       limits.memory.swap.priority limits.network.priority limits.processes \
       linux.kernel_modules raw.apparmor raw.lxc security.nesting \
       security.privileged volatile.apply_template volatile.base_image \

--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -47,7 +47,7 @@ _have lxc && {
       images.auto_update_cached"
 
     container_keys="boot.autostart boot.autostart.delay boot.autostart.priority \
-      boot.force_shutdown_timeout limits.cpu limits.cpu.allowance limits.cpu.priority \
+      boot.host_shutdown_timeout limits.cpu limits.cpu.allowance limits.cpu.priority \
       limits.disk.priority limits.memory limits.memory.enforce limits.memory.swap \
       limits.memory.swap.priority limits.network.priority limits.processes \
       linux.kernel_modules raw.apparmor raw.lxc security.nesting \

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -69,6 +69,7 @@ Key                         | Type      | Default       | Live update   | Descri
 boot.autostart              | boolean   | false         | n/a           | Always start the container when LXD starts
 boot.autostart.delay        | integer   | 0             | n/a           | Number of seconds to wait after the container started before starting the next one
 boot.autostart.priority     | integer   | 0             | n/a           | What order to start the containers in (starting with highest)
+boot.force_shutdown_timeout | integer   | 30            | yes           | Seconds to wait for container to shutdown before it is force stopped
 environment.\*              | string    | -             | yes (exec)    | key/value environment variables to export to the container and set on exec
 limits.cpu                  | string    | - (all)       | yes           | Number or range of CPUs to expose to the container
 limits.cpu.allowance        | string    | 100%          | yes           | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -69,7 +69,7 @@ Key                         | Type      | Default       | Live update   | Descri
 boot.autostart              | boolean   | false         | n/a           | Always start the container when LXD starts
 boot.autostart.delay        | integer   | 0             | n/a           | Number of seconds to wait after the container started before starting the next one
 boot.autostart.priority     | integer   | 0             | n/a           | What order to start the containers in (starting with highest)
-boot.force_shutdown_timeout | integer   | 30            | yes           | Seconds to wait for container to shutdown before it is force stopped
+boot.host_shutdown_timeout  | integer   | 30            | yes           | Seconds to wait for container to shutdown before it is force stopped
 environment.\*              | string    | -             | yes (exec)    | key/value environment variables to export to the container and set on exec
 limits.cpu                  | string    | - (all)       | yes           | Number or range of CPUs to expose to the container
 limits.cpu.allowance        | string    | 100%          | yes           | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -83,7 +83,7 @@ func containerValidConfigKey(key string, value string) error {
 		return isInt64(key, value)
 	case "boot.autostart.priority":
 		return isInt64(key, value)
-	case "boot.force_shutdown_timeout":
+	case "boot.host_shutdown_timeout":
 		return isInt64(key, value)
 	case "limits.cpu":
 		return nil

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -83,6 +83,8 @@ func containerValidConfigKey(key string, value string) error {
 		return isInt64(key, value)
 	case "boot.autostart.priority":
 		return isInt64(key, value)
+	case "boot.force_shutdown_timeout":
+		return isInt64(key, value)
 	case "limits.cpu":
 		return nil
 	case "limits.cpu.allowance":

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -152,10 +152,19 @@ func containersShutdown(d *Daemon) error {
 			return err
 		}
 
+		var timeoutSeconds int
+
+		value, ok := c.ExpandedConfig()["boot.force_shutdown_timeout"]
+		if ok {
+			timeoutSeconds, _ = strconv.Atoi(value)
+		} else {
+			timeoutSeconds = 30
+		}
+
 		if c.IsRunning() {
 			wg.Add(1)
 			go func() {
-				c.Shutdown(time.Second * 30)
+				c.Shutdown(time.Second * time.Duration(timeoutSeconds))
 				c.Stop(false)
 				wg.Done()
 			}()

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -154,7 +154,7 @@ func containersShutdown(d *Daemon) error {
 
 		var timeoutSeconds int
 
-		value, ok := c.ExpandedConfig()["boot.force_shutdown_timeout"]
+		value, ok := c.ExpandedConfig()["boot.host_shutdown_timeout"]
 		if ok {
 			timeoutSeconds, _ = strconv.Atoi(value)
 		} else {

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -258,6 +258,13 @@ test_basic_usage() {
   lxc delete foo2
   lxc profile delete unconfined
 
+  # Test boot.force_shutdown_timeout config setting
+  lxc init testimage configtest --config boot.force_shutdown_timeout=45
+  [ "$(lxc config get configtest boot.force_shutdown_timeout)" -eq 45 ]
+  lxc config set configtest boot.force_shutdown_timeout 15
+  [ "$(lxc config get configtest boot.force_shutdown_timeout)" -eq 15 ]
+  lxc delete configtest
+
   # Ephemeral
   lxc launch testimage foo -e
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -258,11 +258,11 @@ test_basic_usage() {
   lxc delete foo2
   lxc profile delete unconfined
 
-  # Test boot.force_shutdown_timeout config setting
-  lxc init testimage configtest --config boot.force_shutdown_timeout=45
-  [ "$(lxc config get configtest boot.force_shutdown_timeout)" -eq 45 ]
-  lxc config set configtest boot.force_shutdown_timeout 15
-  [ "$(lxc config get configtest boot.force_shutdown_timeout)" -eq 15 ]
+  # Test boot.host_shutdown_timeout config setting
+  lxc init testimage configtest --config boot.host_shutdown_timeout=45
+  [ "$(lxc config get configtest boot.host_shutdown_timeout)" -eq 45 ]
+  lxc config set configtest boot.host_shutdown_timeout 15
+  [ "$(lxc config get configtest boot.host_shutdown_timeout)" -eq 15 ]
   lxc delete configtest
 
   # Ephemeral


### PR DESCRIPTION
Currently, if a container takes more than 30 seconds to shutdown it is stopped anyway. The 30 second timeout is hardcoded and this change makes the timeout configurable.

This `boot.force_shutdown_timeout` container config key sets how long to wait (in seconds) for a container to shutdown before it is force stopped.

I used config key `boot.force_shutdown_timeout` as its pretty meaningful, and shouldn't get confused with unrelated `lxd shutdown --timeout` option. If there are any other suggestions for the config key name, or if it should be in a different namespace than "boot", please let me know.

Closes https://github.com/lxc/lxd/issues/2027

Signed-off-by: Rene Fragoso <ctrlrsf@gmail.com>