### PR TITLE
Make sure lxc file edit doesn't change target file's permissions

### DIFF
--- a/client.go
+++ b/client.go
@@ -1664,6 +1664,29 @@ func (c *Client) PushFile(container string, p string, gid int, uid int, mode os.
 	return err
 }
 
+func (c *Client) PushFileEdit(container string, p string, buf io.ReadSeeker) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	query := url.Values{"path": []string{p}}
+	uri := c.url(shared.APIVersion, "containers", container, "files") + "?" + query.Encode()
+
+	req, err := http.NewRequest("POST", uri, buf)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("User-Agent", shared.UserAgent)
+
+	raw, err := c.Http.Do(req)
+	if err != nil {
+		return err
+	}
+
+	_, err = HoistResponse(raw, Sync)
+	return err
+}
+
 func (c *Client) PullFile(container string, p string) (int, int, int, io.ReadCloser, error) {
 	if c.Remote.Public {
 		return 0, 0, 0, nil, fmt.Errorf("This function isn't supported by public remotes.")

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -218,6 +218,14 @@ test_basic_usage() {
   lxc exec foo /bin/cat /root/in1 | grep abc
   lxc exec foo -- /bin/rm -f root/in1
 
+  # test lxc file edit doesn't change target file's owner and permissions
+  echo "content" | lxc file push - foo/tmp/edit_test
+  lxc exec foo -- chown 55.55 /tmp/edit_test
+  lxc exec foo -- chmod 555 /tmp/edit_test
+  echo "new content" | lxc file edit foo/tmp/edit_test
+  [ "$(lxc exec foo -- cat /tmp/edit_test)" = "new content" ]
+  [ "$(lxc exec foo -- stat -c \"%u %g %a\" /tmp/edit_test)" = "55 55 555" ]
+
   # make sure stdin is chowned to our container root uid (Issue #590)
   [ -t 0 ] && [ -t 1 ] && lxc exec foo -- chown 1000:1000 /proc/self/fd/0
 


### PR DESCRIPTION
This change prevents `lxc file edit` from changing the target file's permissions when a container's file is edited. To fix this, a new PushFileEdit() method was added that does not send any permission information to lxd server. When no permission information is passed on, permissions for the target file are not changed.

Reason for adding PushFileEdit instead of reusing existing PushFile() method is that there was no way of specifying -1 for its mode argument(os.FileMode type, which is uint32). The zero value of os.FileMode is actually a valid mode, so couldn't use that to indicate "no mode" either.

Closes https://github.com/lxc/lxd/issues/2047