### PR TITLE
Allow lxc image delete to delete multiple images

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -119,7 +119,7 @@ lxc image copy [remote:]<image> <remote>: [--alias=ALIAS].. [--copy-aliases] [--
     The auto-update flag instructs the server to keep this image up to
     date. It requires the source to be an alias and for it to be public.
 
-lxc image delete [remote:]<image> [<image>...]
+lxc image delete [remote:]<image> [remote:][<image>...]
     Delete one or more images from the LXD image store.
 
 lxc image export [remote:]<image>
@@ -278,29 +278,23 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		return err
 
 	case "delete":
-		/* delete [<remote>:]<image> [<image>...] */
+		/* delete [<remote>:]<image> [<remote>:][<image>...] */
 		if len(args) < 2 {
 			return errArgs
 		}
 
-		remote, inName := config.ParseRemoteAndContainer(args[1])
-		if inName == "" {
-			inName = "default"
-		}
+		for _, arg := range args[1:] {
+			remote, inName := config.ParseRemoteAndContainer(arg)
+			if inName == "" {
+				inName = "default"
+			}
 
-		imageNames := []string{inName}
+			d, err := lxd.NewClient(config, remote)
+			if err != nil {
+				return err
+			}
 
-		if len(args) > 2 {
-			imageNames = append(imageNames, args[2:]...)
-		}
-
-		d, err := lxd.NewClient(config, remote)
-		if err != nil {
-			return err
-		}
-
-		for _, imageName := range imageNames {
-			image := c.dereferenceAlias(d, imageName)
+			image := c.dereferenceAlias(d, inName)
 			err = d.DeleteImage(image)
 			if err != nil {
 				return err

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -291,9 +291,7 @@ func (c *imageCmd) run(config *lxd.Config, args []string) error {
 		imageNames := []string{inName}
 
 		if len(args) > 2 {
-			for _, extraImage := range args[2:] {
-				imageNames = append(imageNames, extraImage)
-			}
+			imageNames = append(imageNames, args[2:]...)
 		}
 
 		d, err := lxd.NewClient(config, remote)

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-05-23 07:23-0600\n"
+        "POT-Creation-Date: 2016-06-01 10:08-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgid   "### This is a yaml representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/image.go:597
+#: lxc/image.go:611
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -90,11 +90,11 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:618 lxc/image.go:660
+#: lxc/image.go:632 lxc/image.go:674
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:622
+#: lxc/image.go:636
 msgid   "ARCH"
 msgstr  ""
 
@@ -111,7 +111,7 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:350
+#: lxc/image.go:364
 msgid   "Aliases:"
 msgstr  ""
 
@@ -119,12 +119,12 @@ msgstr  ""
 msgid   "An environment variable of the form HOME=/home/foo"
 msgstr  ""
 
-#: lxc/image.go:333 lxc/info.go:90
+#: lxc/image.go:347 lxc/info.go:90
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/image.go:354
+#: lxc/image.go:368
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -187,7 +187,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:527 lxc/config.go:592 lxc/image.go:714 lxc/profile.go:217
+#: lxc/config.go:527 lxc/config.go:592 lxc/image.go:728 lxc/profile.go:217
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -245,7 +245,7 @@ msgid   "Create a read-only snapshot of a container.\n"
         "lxc snapshot u1 snap0"
 msgstr  ""
 
-#: lxc/image.go:338 lxc/info.go:92
+#: lxc/image.go:352 lxc/info.go:92
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -259,7 +259,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:621 lxc/image.go:662
+#: lxc/image.go:635 lxc/image.go:676
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -317,16 +317,16 @@ msgid   "Execute the specified command in a container.\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/image.go:342
+#: lxc/image.go:356
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:344
+#: lxc/image.go:358
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/config.go:269 lxc/image.go:619 lxc/image.go:661
+#: lxc/config.go:269 lxc/image.go:633 lxc/image.go:675
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -334,7 +334,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt"
 msgstr  ""
 
-#: lxc/image.go:331
+#: lxc/image.go:345
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -393,7 +393,7 @@ msgstr  ""
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/image.go:422
+#: lxc/image.go:436
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
@@ -638,8 +638,8 @@ msgid   "Manipulate container images.\n"
         "    The auto-update flag instructs the server to keep this image up to\n"
         "    date. It requires the source to be an alias and for it to be public.\n"
         "\n"
-        "lxc image delete [remote:]<image>\n"
-        "    Delete an image from the LXD image store.\n"
+        "lxc image delete [remote:]<image> [<image>...]\n"
+        "    Delete one or more images from the LXD image store.\n"
         "\n"
         "lxc image export [remote:]<image>\n"
         "    Export an image from the LXD image store into a distributable tarball.\n"
@@ -743,7 +743,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:414
+#: lxc/image.go:428
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
@@ -751,7 +751,7 @@ msgstr  ""
 msgid   "Options:"
 msgstr  ""
 
-#: lxc/image.go:518
+#: lxc/image.go:532
 #, c-format
 msgid   "Output is in %s"
 msgstr  ""
@@ -776,7 +776,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:620 lxc/remote.go:366
+#: lxc/image.go:634 lxc/remote.go:366
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -815,7 +815,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:528 lxc/config.go:593 lxc/image.go:715
+#: lxc/config.go:528 lxc/config.go:593 lxc/image.go:729
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -876,7 +876,7 @@ msgstr  ""
 msgid   "Profiles: %s"
 msgstr  ""
 
-#: lxc/image.go:346
+#: lxc/image.go:360
 msgid   "Properties:"
 msgstr  ""
 
@@ -884,7 +884,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:334
+#: lxc/image.go:348
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -917,7 +917,7 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: lxc/image.go:623
+#: lxc/image.go:637
 msgid   "SIZE"
 msgstr  ""
 
@@ -978,7 +978,7 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/image.go:332
+#: lxc/image.go:346
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
@@ -987,7 +987,7 @@ msgstr  ""
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/image.go:356
+#: lxc/image.go:370
 msgid   "Source:"
 msgstr  ""
 
@@ -1050,7 +1050,7 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: lxc/image.go:335
+#: lxc/image.go:349
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -1058,7 +1058,7 @@ msgstr  ""
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
 
-#: lxc/image.go:405
+#: lxc/image.go:419
 #, c-format
 msgid   "Transferring image: %d%%"
 msgstr  ""
@@ -1076,7 +1076,7 @@ msgstr  ""
 msgid   "Type: persistent"
 msgstr  ""
 
-#: lxc/image.go:624
+#: lxc/image.go:638
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -1088,7 +1088,7 @@ msgstr  ""
 msgid   "Unable to read remote TLS certificate"
 msgstr  ""
 
-#: lxc/image.go:340
+#: lxc/image.go:354
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -1150,11 +1150,11 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:326
+#: lxc/image.go:340
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/image.go:328
+#: lxc/image.go:342
 msgid   "enabled"
 msgstr  ""
 
@@ -1172,7 +1172,7 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: lxc/image.go:321 lxc/image.go:600
+#: lxc/image.go:335 lxc/image.go:614
 msgid   "no"
 msgstr  ""
 
@@ -1230,7 +1230,7 @@ msgstr  ""
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/delete.go:45 lxc/image.go:323 lxc/image.go:604
+#: lxc/delete.go:45 lxc/image.go:337 lxc/image.go:618
 msgid   "yes"
 msgstr  ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-06-01 10:08-0400\n"
+        "POT-Creation-Date: 2016-06-02 08:59-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -77,7 +77,7 @@ msgid   "### This is a yaml representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/image.go:611
+#: lxc/image.go:603
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -90,11 +90,11 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:632 lxc/image.go:674
+#: lxc/image.go:624 lxc/image.go:666
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:636
+#: lxc/image.go:628
 msgid   "ARCH"
 msgstr  ""
 
@@ -111,7 +111,7 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:364
+#: lxc/image.go:356
 msgid   "Aliases:"
 msgstr  ""
 
@@ -119,12 +119,12 @@ msgstr  ""
 msgid   "An environment variable of the form HOME=/home/foo"
 msgstr  ""
 
-#: lxc/image.go:347 lxc/info.go:90
+#: lxc/image.go:339 lxc/info.go:90
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/image.go:368
+#: lxc/image.go:360
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
@@ -187,7 +187,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:527 lxc/config.go:592 lxc/image.go:728 lxc/profile.go:217
+#: lxc/config.go:527 lxc/config.go:592 lxc/image.go:720 lxc/profile.go:217
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -245,7 +245,7 @@ msgid   "Create a read-only snapshot of a container.\n"
         "lxc snapshot u1 snap0"
 msgstr  ""
 
-#: lxc/image.go:352 lxc/info.go:92
+#: lxc/image.go:344 lxc/info.go:92
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -259,7 +259,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:635 lxc/image.go:676
+#: lxc/image.go:627 lxc/image.go:668
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -317,16 +317,16 @@ msgid   "Execute the specified command in a container.\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
 
-#: lxc/image.go:356
+#: lxc/image.go:348
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:358
+#: lxc/image.go:350
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/config.go:269 lxc/image.go:633 lxc/image.go:675
+#: lxc/config.go:269 lxc/image.go:625 lxc/image.go:667
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -334,7 +334,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt"
 msgstr  ""
 
-#: lxc/image.go:345
+#: lxc/image.go:337
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -393,7 +393,7 @@ msgstr  ""
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/image.go:436
+#: lxc/image.go:428
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
@@ -638,7 +638,7 @@ msgid   "Manipulate container images.\n"
         "    The auto-update flag instructs the server to keep this image up to\n"
         "    date. It requires the source to be an alias and for it to be public.\n"
         "\n"
-        "lxc image delete [remote:]<image> [<image>...]\n"
+        "lxc image delete [remote:]<image> [remote:][<image>...]\n"
         "    Delete one or more images from the LXD image store.\n"
         "\n"
         "lxc image export [remote:]<image>\n"
@@ -743,7 +743,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:428
+#: lxc/image.go:420
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
@@ -751,7 +751,7 @@ msgstr  ""
 msgid   "Options:"
 msgstr  ""
 
-#: lxc/image.go:532
+#: lxc/image.go:524
 #, c-format
 msgid   "Output is in %s"
 msgstr  ""
@@ -776,7 +776,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:634 lxc/remote.go:366
+#: lxc/image.go:626 lxc/remote.go:366
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -815,7 +815,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:528 lxc/config.go:593 lxc/image.go:729
+#: lxc/config.go:528 lxc/config.go:593 lxc/image.go:721
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -876,7 +876,7 @@ msgstr  ""
 msgid   "Profiles: %s"
 msgstr  ""
 
-#: lxc/image.go:360
+#: lxc/image.go:352
 msgid   "Properties:"
 msgstr  ""
 
@@ -884,7 +884,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:348
+#: lxc/image.go:340
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -917,7 +917,7 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
-#: lxc/image.go:637
+#: lxc/image.go:629
 msgid   "SIZE"
 msgstr  ""
 
@@ -978,7 +978,7 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/image.go:346
+#: lxc/image.go:338
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
@@ -987,7 +987,7 @@ msgstr  ""
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/image.go:370
+#: lxc/image.go:362
 msgid   "Source:"
 msgstr  ""
 
@@ -1050,7 +1050,7 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it."
 msgstr  ""
 
-#: lxc/image.go:349
+#: lxc/image.go:341
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -1058,7 +1058,7 @@ msgstr  ""
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
 
-#: lxc/image.go:419
+#: lxc/image.go:411
 #, c-format
 msgid   "Transferring image: %d%%"
 msgstr  ""
@@ -1076,7 +1076,7 @@ msgstr  ""
 msgid   "Type: persistent"
 msgstr  ""
 
-#: lxc/image.go:638
+#: lxc/image.go:630
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -1088,7 +1088,7 @@ msgstr  ""
 msgid   "Unable to read remote TLS certificate"
 msgstr  ""
 
-#: lxc/image.go:354
+#: lxc/image.go:346
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -1150,11 +1150,11 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:340
+#: lxc/image.go:332
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/image.go:342
+#: lxc/image.go:334
 msgid   "enabled"
 msgstr  ""
 
@@ -1172,7 +1172,7 @@ msgstr  ""
 msgid   "got bad version"
 msgstr  ""
 
-#: lxc/image.go:335 lxc/image.go:614
+#: lxc/image.go:327 lxc/image.go:606
 msgid   "no"
 msgstr  ""
 
@@ -1230,7 +1230,7 @@ msgstr  ""
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/delete.go:45 lxc/image.go:337 lxc/image.go:618
+#: lxc/delete.go:45 lxc/image.go:329 lxc/image.go:610
 msgid   "yes"
 msgstr  ""
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -265,6 +265,25 @@ test_basic_usage() {
   [ "$(lxc config get configtest boot.host_shutdown_timeout)" -eq 15 ]
   lxc delete configtest
 
+  # Test deleting multiple images
+  # Start 3 containers to create 3 different images
+  lxc launch testimage c1
+  lxc launch testimage c2
+  lxc launch testimage c3
+  lxc exec c1 -- touch /tmp/c1
+  lxc exec c2 -- touch /tmp/c2
+  lxc exec c3 -- touch /tmp/c3
+  lxc publish --force c1 --alias=image1
+  lxc publish --force c2 --alias=image2
+  lxc publish --force c3 --alias=image3
+  # Delete multiple images with lxc delete and confirm they're deleted
+  lxc image delete image1 image2 image3
+  ! lxc image list | grep -q image1
+  ! lxc image list | grep -q image2
+  ! lxc image list | grep -q image3
+  # Cleanup the containers
+  lxc delete --force c1 c2 c3
+
   # Ephemeral
   lxc launch testimage foo -e
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -277,7 +277,7 @@ test_basic_usage() {
   lxc publish --force c2 --alias=image2
   lxc publish --force c3 --alias=image3
   # Delete multiple images with lxc delete and confirm they're deleted
-  lxc image delete image1 image2 image3
+  lxc image delete local:image1 local:image2 local:image3
   ! lxc image list | grep -q image1
   ! lxc image list | grep -q image2
   ! lxc image list | grep -q image3


### PR DESCRIPTION
This change allows lxc image delete subcommand to take multiple arguments. Each image name specified will be deleted.

Currently we try to delete the images in sequence, but will exit with an error if deleting any image returns an error.

Change is backwards compatible since `lxc image delete [remote:]<image>` still works as before.

Closes https://github.com/lxc/lxd/issues/2054

New subcommand help output:
```
lxc image delete [remote:]<image> [<image>...]
    Delete one or more images from the LXD image store.
```

Sample usage / confirmation:
```
vagrant@vagrant:~/go/src/github.com/lxc/lxd/test$ lxc image list
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
| ALIAS | FINGERPRINT  | PUBLIC |             DESCRIPTION             |  ARCH  |  SIZE  |         UPLOAD DATE         |
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
|       | 9655ac187f88 | no     | Alpine 3.2 (amd64) (20160529_17:50) | x86_64 | 2.61MB | Jun 1, 2016 at 2:37am (UTC) |
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
|       | 38fc26a0bed4 | no     | Alpine 3.3 (amd64) (20160530_17:50) | x86_64 | 2.61MB | Jun 1, 2016 at 1:26pm (UTC) |
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
|       | a8bbd15d9ab7 | no     | Alpine 3.3 (i386) (20160529_17:50)  | i686   | 2.45MB | Jun 1, 2016 at 1:58pm (UTC) |
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
|       | 2b6ac543470c | no     | Alpine 3.3 (i386) (20160530_17:50)  | i686   | 2.45MB | Jun 1, 2016 at 1:26pm (UTC) |
+-------+--------------+--------+-------------------------------------+--------+--------+-----------------------------+
vagrant@vagrant:~/go/src/github.com/lxc/lxd/test$ lxc image delete local:9655ac187f88

vagrant@vagrant:~/go/src/github.com/lxc/lxd/test$ lxc image delete 38fc26a0bed4 a8bbd15d9ab7 2b6ac543470c

vagrant@vagrant:~/go/src/github.com/lxc/lxd/test$ lxc image list
+-------+-------------+--------+-------------+------+------+-------------+
| ALIAS | FINGERPRINT | PUBLIC | DESCRIPTION | ARCH | SIZE | UPLOAD DATE |
+-------+-------------+--------+-------------+------+------+-------------+
```