### PR TITLE
use crypto/rand instead of math/rand for testing

### DIFF
--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"math/rand"
+	"crypto/rand"
 	"os"
 	"strings"
 	"testing"


### PR DESCRIPTION
We don't really need good crypto data here, but the nice math/rand.Read API
wasn't added until go 1.6, and we still test on 1.5, so let's just use this
for now.

Some day in the future we can revert this and have our tests go fast again.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>