### PR TITLE
Add support for os.SyscallError in client

### DIFF
--- a/client.go
+++ b/client.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 
 	"github.com/gorilla/websocket"
 
@@ -511,6 +512,47 @@ func (c *Client) GetServerConfig() (*Response, error) {
 	}
 
 	return c.baseGet(c.url(shared.APIVersion))
+}
+
+// GetLocalLXDErr determines whether or not an error is likely due to a
+// local LXD configuration issue, and if so, returns the underlying error.
+// GetLocalLXDErr can be used to provide customized error messages to help
+// the user identify basic system issues, e.g. LXD daemon not running.
+//
+// Returns syscall.ENOENT, syscall.ECONNREFUSED or syscall.EACCES when a
+// local LXD configuration issue is detected, nil otherwise.
+func GetLocalLXDErr(err error) error {
+	t, ok := err.(*url.Error)
+	if !ok {
+		return nil
+	}
+
+	u, ok := t.Err.(*net.OpError)
+	if !ok {
+		return nil
+	}
+
+	if u.Op == "dial" && u.Net == "unix" {
+		var lxdErr error
+
+		sysErr, ok := u.Err.(*os.SyscallError)
+		if ok {
+			lxdErr = sysErr.Err
+		} else {
+			// syscall.Errno may be returned on some systems, e.g. CentOS
+			lxdErr, ok = u.Err.(syscall.Errno)
+			if !ok {
+				return nil
+			}
+		}
+
+		switch lxdErr {
+		case syscall.ENOENT, syscall.ECONNREFUSED, syscall.EACCES:
+			return lxdErr
+		}
+	}
+
+	return nil
 }
 
 func (c *Client) AmTrusted() bool {

--- a/client_test.go
+++ b/client_test.go
@@ -1,0 +1,52 @@
+package lxd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"syscall"
+	"testing"
+)
+
+func assertNoError(t *testing.T, err error, msg string) {
+	if err != nil {
+		t.Fatalf("Error: %s, action: %s", err, msg)
+	}
+}
+
+func TestLocalLXDError(t *testing.T) {
+	f, err := ioutil.TempFile("", "lxd-test.socket")
+	assertNoError(t, err, "ioutil.TempFile to create fake socket file")
+	defer os.RemoveAll(f.Name())
+
+	c := &Client{
+		Name:   "test",
+		Config: DefaultConfig,
+		Remote: &RemoteConfig{
+			Addr:   fmt.Sprintf("unix:/%s", f.Name()),
+			Static: true,
+			Public: false,
+		},
+	}
+	runTest := func(exp error) {
+		lxdErr := GetLocalLXDErr(connectViaUnix(c, c.Remote))
+		if lxdErr != exp {
+			t.Fatalf("GetLocalLXDErr returned the wrong error, EXPECTED: %s, ACTUAL: %s", exp, lxdErr)
+		}
+	}
+
+	// The fake socket file should mimic a socket with nobody listening.
+	runTest(syscall.ECONNREFUSED)
+
+	// Remove R/W permissions to mimic the user not having lxd group permissions.
+	// Skip this test for root, as root ignores permissions and connect will fail
+	// with ECONNREFUSED instead of EACCES.
+	if os.Geteuid() != 0 {
+		assertNoError(t, f.Chmod(0100), "f.Chmod on fake socket file")
+		runTest(syscall.EACCES)
+	}
+
+	// Remove the fake socket to mimic LXD not being installed.
+	assertNoError(t, os.RemoveAll(f.Name()), "osRemoveAll on fake socket file")
+	runTest(syscall.ENOENT)
+}

--- a/po/de.po
+++ b/po/de.po
@@ -542,7 +542,7 @@ msgid "Keep the image up to date after initial copy"
 msgstr ""
 
 #: lxc/main.go:35
-msgid "LXD socket not found; is LXD running?"
+msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
 #: lxc/launch.go:22

--- a/po/fr.po
+++ b/po/fr.po
@@ -467,7 +467,7 @@ msgid "Keep the image up to date after initial copy"
 msgstr ""
 
 #: lxc/main.go:35
-msgid "LXD socket not found; is LXD running?"
+msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
 #: lxc/launch.go:22

--- a/po/ja.po
+++ b/po/ja.po
@@ -509,7 +509,7 @@ msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
 #: lxc/main.go:35
-msgid "LXD socket not found; is LXD running?"
+msgid "LXD socket not found; is LXD installed and running?"
 msgstr "LXD のソケットが見つかりません。LXD が実行されていますか?"
 
 #: lxc/launch.go:22

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-06-02 08:59-0400\n"
+        "POT-Creation-Date: 2016-06-03 07:27-0700\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -192,7 +192,7 @@ msgstr  ""
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/main.go:37
+#: lxc/main.go:29
 msgid   "Connection refused; is LXD running?"
 msgstr  ""
 
@@ -289,11 +289,11 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/main.go:55
+#: lxc/main.go:41
 msgid   "Enables debug mode."
 msgstr  ""
 
-#: lxc/main.go:54
+#: lxc/main.go:40
 msgid   "Enables verbose mode."
 msgstr  ""
 
@@ -353,7 +353,7 @@ msgstr  ""
 msgid   "Force the removal of stopped containers."
 msgstr  ""
 
-#: lxc/main.go:56
+#: lxc/main.go:42
 msgid   "Force using the local unix socket."
 msgstr  ""
 
@@ -361,7 +361,7 @@ msgstr  ""
 msgid   "Format"
 msgstr  ""
 
-#: lxc/main.go:138
+#: lxc/main.go:124
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -377,11 +377,11 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/main.go:146
+#: lxc/main.go:132
 msgid   "If this is your first time using LXD, you should also run: sudo lxd init"
 msgstr  ""
 
-#: lxc/main.go:57
+#: lxc/main.go:43
 msgid   "Ignore aliases when determining what command to run."
 msgstr  ""
 
@@ -439,8 +439,8 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/main.go:35
-msgid   "LXD socket not found; is LXD running?"
+#: lxc/main.go:27
+msgid   "LXD socket not found; is LXD installed and running?"
 msgstr  ""
 
 #: lxc/launch.go:22
@@ -747,7 +747,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
-#: lxc/help.go:63 lxc/main.go:122
+#: lxc/help.go:63 lxc/main.go:108
 msgid   "Options:"
 msgstr  ""
 
@@ -796,7 +796,7 @@ msgstr  ""
 msgid   "Path to an alternate server directory."
 msgstr  ""
 
-#: lxc/main.go:39
+#: lxc/main.go:31
 msgid   "Permisson denied, are you in the lxd group?"
 msgstr  ""
 
@@ -1054,7 +1054,7 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/main.go:147
+#: lxc/main.go:133
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
 
@@ -1093,7 +1093,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/main.go:122
+#: lxc/main.go:108
 #, c-format
 msgid   "Usage: %s"
 msgstr  ""
@@ -1122,7 +1122,7 @@ msgstr  ""
 msgid   "YES"
 msgstr  ""
 
-#: lxc/main.go:66
+#: lxc/main.go:52
 msgid   "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr  ""
 
@@ -1158,12 +1158,12 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/main.go:25 lxc/main.go:159
+#: lxc/main.go:22 lxc/main.go:145
 #, c-format
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/help.go:40 lxc/main.go:117
+#: lxc/help.go:40 lxc/main.go:103
 #, c-format
 msgid   "error: unknown command: %s"
 msgstr  ""
@@ -1184,7 +1184,7 @@ msgstr  ""
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:266 lxc/main.go:270
+#: lxc/main.go:252 lxc/main.go:256
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -1226,7 +1226,7 @@ msgstr  ""
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:199
+#: lxc/main.go:185
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -20,7 +20,7 @@ test_static_analysis() {
     ## Functions starting by empty line
     OUT=$(grep -r "^$" -B1 . | grep "func " | grep -v "}$" || true)
     if [ -n "${OUT}" ]; then
-      echo "${OUT}"
+      echo "ERROR: Functions must not start with an empty line: ${OUT}"
       false
     fi
 


### PR DESCRIPTION
Modify the client's error handling to support os.SyscallErrors.  Move
the error handling to an exported function in the client so that the
code can be reused by other projects, e.g. juju.

Add a message to the 'funcs starting with empty line' test to help
users with bad habits understand what they did wrong.

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>