### PR TITLE
Store and show time when container was last started

### DIFF
--- a/doc/api_extensions.md
+++ b/doc/api_extensions.md
@@ -38,3 +38,11 @@ This indicates support for PKI authentication mode.
 In this mode, the client and server both must use certificates issued by the same PKI.
 
 See lxd-ssl-authentication.md for details.
+
+## container\_last\_used\_at
+A last\_used\_at field was added to the /1.0/containers/\<name\> GET endpoint.
+
+It is a timestamp of the last time the container was started.
+
+If a container has been created but not started yet, last\_used\_at field
+will be 1970-01-01T00:00:00Z

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -546,6 +546,7 @@ Output:
                 "type": "disk"
             }
         },
+        "last_used_at": "2016-02-16T01:05:05Z",
         "name": "my-container",
         "profiles": [
             "default"

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -84,6 +84,7 @@ Columns for table format are:
 * 6 - IPv6 address
 * a - architecture
 * c - creation date
+* l - last used date
 * n - name
 * p - pid of container init process
 * P - profiles
@@ -377,6 +378,7 @@ func (c *listCmd) run(config *lxd.Config, args []string) error {
 		'6': column{i18n.G("IPV6"), c.IP6ColumnData, true, false},
 		'a': column{i18n.G("ARCHITECTURE"), c.ArchitectureColumnData, false, false},
 		'c': column{i18n.G("CREATED AT"), c.CreatedColumnData, false, false},
+		'l': column{i18n.G("LAST USED AT"), c.LastUsedColumnData, false, false},
 		'n': column{i18n.G("NAME"), c.nameColumnData, false, false},
 		'p': column{i18n.G("PID"), c.PIDColumnData, true, false},
 		'P': column{i18n.G("PROFILES"), c.ProfilesColumnData, false, false},
@@ -494,6 +496,16 @@ func (c *listCmd) CreatedColumnData(cInfo shared.ContainerInfo, cState *shared.C
 
 	if cInfo.CreationDate.UTC().Unix() != 0 {
 		return cInfo.CreationDate.UTC().Format(layout)
+	}
+
+	return ""
+}
+
+func (c *listCmd) LastUsedColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
+	layout := "2006/01/02 15:04 UTC"
+
+	if cInfo.LastUsedDate.UTC().Unix() != 0 {
+		return cInfo.LastUsedDate.UTC().Format(layout)
 	}
 
 	return ""

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -504,7 +504,7 @@ func (c *listCmd) CreatedColumnData(cInfo shared.ContainerInfo, cState *shared.C
 func (c *listCmd) LastUsedColumnData(cInfo shared.ContainerInfo, cState *shared.ContainerState, cSnaps []shared.SnapshotInfo) string {
 	layout := "2006/01/02 15:04 UTC"
 
-	if cInfo.LastUsedDate.UTC().Unix() != 0 {
+	if !cInfo.LastUsedDate.IsZero() && cInfo.LastUsedDate.UTC().Unix() != 0 {
 		return cInfo.LastUsedDate.UTC().Format(layout)
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -55,11 +55,11 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		 *  - New HTTPs authentication mechanisms or protocols
 		 */
 		"api_extensions": []string{
-			"container_last_used_at",
 			"storage_zfs_remove_snapshots",
 			"container_host_shutdown_timeout",
 			"container_syscall_filtering",
 			"auth_pki",
+			"container_last_used_at",
 		},
 
 		"api_status":  "stable",

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -55,6 +55,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		 *  - New HTTPs authentication mechanisms or protocols
 		 */
 		"api_extensions": []string{
+			"container_last_used_at",
 			"storage_zfs_remove_snapshots",
 			"container_host_shutdown_timeout",
 			"container_syscall_filtering",

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -358,6 +358,7 @@ type containerArgs struct {
 	BaseImage    string
 	Config       map[string]string
 	CreationDate time.Time
+	LastUsedDate time.Time
 	Ctype        containerType
 	Devices      shared.Devices
 	Ephemeral    bool
@@ -420,6 +421,7 @@ type container interface {
 	Name() string
 	Architecture() int
 	CreationDate() time.Time
+	LastUsedDate() time.Time
 	ExpandedConfig() map[string]string
 	ExpandedDevices() shared.Devices
 	LocalConfig() map[string]string

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -681,6 +681,7 @@ func containerCreateInternal(d *Daemon, args containerArgs) (container, error) {
 		return nil, err
 	}
 	args.CreationDate = dbArgs.CreationDate
+	args.LastUsedDate = time.Unix(0, 0).UTC()
 
 	return containerLXCCreate(d, args)
 }

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -34,7 +34,7 @@ type Profile struct {
 // Profiles will contain a list of all Profiles.
 type Profiles []Profile
 
-const DB_CURRENT_VERSION int = 32
+const DB_CURRENT_VERSION int = 33
 
 // CURRENT_SCHEMA contains the current SQLite SQL Schema.
 const CURRENT_SCHEMA string = `

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS containers (
     ephemeral INTEGER NOT NULL DEFAULT 0,
     stateful INTEGER NOT NULL DEFAULT 0,
     creation_date DATETIME,
+    last_use_date DATETIME,
     UNIQUE (name)
 );
 CREATE TABLE IF NOT EXISTS containers_config (

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -62,14 +62,16 @@ func dbContainerId(db *sql.DB, name string) (int, error) {
 }
 
 func dbContainerGet(db *sql.DB, name string) (containerArgs, error) {
+	var used *time.Time // Hold the db-returned time
+
 	args := containerArgs{}
 	args.Name = name
 
 	ephemInt := -1
 	statefulInt := -1
-	q := "SELECT id, architecture, type, ephemeral, stateful, creation_date FROM containers WHERE name=?"
+	q := "SELECT id, architecture, type, ephemeral, stateful, creation_date, last_use_date FROM containers WHERE name=?"
 	arg1 := []interface{}{name}
-	arg2 := []interface{}{&args.Id, &args.Architecture, &args.Ctype, &ephemInt, &statefulInt, &args.CreationDate}
+	arg2 := []interface{}{&args.Id, &args.Architecture, &args.Ctype, &ephemInt, &statefulInt, &args.CreationDate, &used}
 	err := dbQueryRowScan(db, q, arg1, arg2)
 	if err != nil {
 		return args, err
@@ -85,6 +87,12 @@ func dbContainerGet(db *sql.DB, name string) (containerArgs, error) {
 
 	if statefulInt == 1 {
 		args.Stateful = true
+	}
+
+	if used != nil {
+		args.LastUsedDate = *used
+	} else {
+		args.LastUsedDate = time.Unix(0, 0).UTC()
 	}
 
 	config, err := dbContainerConfig(db, args.Id)
@@ -135,15 +143,16 @@ func dbContainerCreate(db *sql.DB, args containerArgs) (int, error) {
 	}
 
 	args.CreationDate = time.Now().UTC()
+	args.LastUsedDate = time.Unix(0, 0).UTC()
 
-	str := fmt.Sprintf("INSERT INTO containers (name, architecture, type, ephemeral, creation_date, stateful) VALUES (?, ?, ?, ?, ?, ?)")
+	str := fmt.Sprintf("INSERT INTO containers (name, architecture, type, ephemeral, creation_date, last_use_date, stateful) VALUES (?, ?, ?, ?, ?, ?, ?)")
 	stmt, err := tx.Prepare(str)
 	if err != nil {
 		tx.Rollback()
 		return 0, err
 	}
 	defer stmt.Close()
-	result, err := stmt.Exec(args.Name, args.Architecture, args.Ctype, ephemInt, args.CreationDate.Unix(), statefulInt)
+	result, err := stmt.Exec(args.Name, args.Architecture, args.Ctype, ephemInt, args.CreationDate.Unix(), args.LastUsedDate.Unix(), statefulInt)
 	if err != nil {
 		tx.Rollback()
 		return 0, err

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -380,6 +380,12 @@ func dbContainerUpdate(tx *sql.Tx, id int, architecture int, ephemeral bool) err
 	return nil
 }
 
+func dbContainerLastUsedUpdate(db *sql.DB, id int, date time.Time) error {
+	stmt := `UPDATE containers SET last_use_date=? WHERE id=?`
+	_, err := dbExec(db, stmt, date, id)
+	return err
+}
+
 func dbContainerGetSnapshots(db *sql.DB, name string) ([]string, error) {
 	result := []string{}
 

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -17,6 +17,14 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
+func dbUpdateFromV32(db *sql.DB) error {
+	stmt := `
+ALTER TABLE containers ADD COLUMN last_use_date DATETIME;
+INSERT INTO schema (version, updated_at) VALUES (?, strftime("%s"));`
+	_, err := db.Exec(stmt, 33)
+	return err
+}
+
 func dbUpdateFromV31(db *sql.DB) error {
 	stmt := `
 CREATE TABLE IF NOT EXISTS patches (
@@ -1089,6 +1097,12 @@ func dbUpdate(d *Daemon, prevVersion int) error {
 	}
 	if prevVersion < 32 {
 		err = dbUpdateFromV31(db)
+		if err != nil {
+			return err
+		}
+	}
+	if prevVersion < 33 {
+		err = dbUpdateFromV32(db)
 		if err != nil {
 			return err
 		}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-06-03 07:27-0700\n"
+        "POT-Creation-Date: 2016-06-05 01:51-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,7 +98,7 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:378
+#: lxc/list.go:379
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -145,7 +145,7 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/list.go:379
+#: lxc/list.go:380
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -179,7 +179,7 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: lxc/list.go:99 lxc/list.go:100
+#: lxc/list.go:100 lxc/list.go:101
 msgid   "Columns"
 msgstr  ""
 
@@ -281,7 +281,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -330,7 +330,7 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/list.go:102
+#: lxc/list.go:103
 msgid   "Fast mode (same as --columns=nsacPt"
 msgstr  ""
 
@@ -357,7 +357,7 @@ msgstr  ""
 msgid   "Force using the local unix socket."
 msgstr  ""
 
-#: lxc/image.go:160 lxc/list.go:101
+#: lxc/image.go:160 lxc/list.go:102
 msgid   "Format"
 msgstr  ""
 
@@ -365,11 +365,11 @@ msgstr  ""
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/list.go:376
+#: lxc/list.go:377
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:377
+#: lxc/list.go:378
 msgid   "IPV6"
 msgstr  ""
 
@@ -421,7 +421,7 @@ msgstr  ""
 msgid   "Invalid configuration key"
 msgstr  ""
 
-#: lxc/file.go:190
+#: lxc/file.go:195
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
@@ -437,6 +437,10 @@ msgstr  ""
 
 #: lxc/image.go:158
 msgid   "Keep the image up to date after initial copy"
+msgstr  ""
+
+#: lxc/list.go:381
+msgid   "LAST USED AT"
 msgstr  ""
 
 #: lxc/main.go:27
@@ -487,6 +491,7 @@ msgid   "Lists the available resources.\n"
         "* 6 - IPv6 address\n"
         "* a - architecture\n"
         "* c - creation date\n"
+        "* l - last used date\n"
         "* n - name\n"
         "* p - pid of container init process\n"
         "* P - profiles\n"
@@ -696,7 +701,7 @@ msgid   "Monitor activity on the LXD server.\n"
         "lxc monitor --type=logging"
 msgstr  ""
 
-#: lxc/file.go:178
+#: lxc/file.go:183
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
@@ -714,7 +719,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:380 lxc/remote.go:363
+#: lxc/list.go:382 lxc/remote.go:363
 msgid   "NAME"
 msgstr  ""
 
@@ -760,15 +765,15 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid   "PERSISTENT"
 msgstr  ""
 
-#: lxc/list.go:381
+#: lxc/list.go:383
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:382
+#: lxc/list.go:384
 msgid   "PROFILES"
 msgstr  ""
 
@@ -921,11 +926,11 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:383
+#: lxc/list.go:385
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/list.go:384
+#: lxc/list.go:386
 msgid   "STATE"
 msgstr  ""
 
@@ -1021,7 +1026,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/list.go:385
+#: lxc/list.go:387
 msgid   "TYPE"
 msgstr  ""
 

--- a/shared/container.go
+++ b/shared/container.go
@@ -62,6 +62,7 @@ type SnapshotInfo struct {
 	Ephemeral       bool              `json:"ephemeral"`
 	ExpandedConfig  map[string]string `json:"expanded_config"`
 	ExpandedDevices Devices           `json:"expanded_devices"`
+	LastUsedDate    time.Time         `json:"last_used_at"`
 	Name            string            `json:"name"`
 	Profiles        []string          `json:"profiles"`
 	Stateful        bool              `json:"stateful"`
@@ -75,6 +76,7 @@ type ContainerInfo struct {
 	Ephemeral       bool              `json:"ephemeral"`
 	ExpandedConfig  map[string]string `json:"expanded_config"`
 	ExpandedDevices Devices           `json:"expanded_devices"`
+	LastUsedDate    time.Time         `json:"last_used_at"`
 	Name            string            `json:"name"`
 	Profiles        []string          `json:"profiles"`
 	Stateful        bool              `json:"stateful"`

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -202,6 +202,12 @@ test_basic_usage() {
     false
   fi
 
+  # Test last_used_at field is working properly
+  lxc init testimage last-used-at-test
+  lxc list last-used-at-test  --format json | jq -r '.[].last_used_at' | grep '1970-01-01T00:00:00Z'
+  lxc start last-used-at-test
+  lxc list last-used-at-test  --format json | jq -r '.[].last_used_at' | grep -v '1970-01-01T00:00:00Z'
+
   # check that we can set the environment
   lxc exec foo pwd | grep /root
   lxc exec --env BEST_BAND=meshuggah foo env | grep meshuggah


### PR DESCRIPTION
From the `lxc list` command, we have a new column key `l`, that shows the `LAST USED AT` field. The column will be blank of container was never started or lxc client is connecting to an older lxd daemon whose API response doesn't include a `last_used_at` field.

- API documentation was updated. Please let me know if I missed something
- DB schema and migration scripts were updated. Tested by creating DB with older lxd and then running newer lxd, which updated schema and continued functioning properly.
- Tried to keep naming scheme of JSON, DB, and struct fields consistent with existing image last use field

One tricky part with adding this feature was what date should we show if a container has not been started yet. In original issue it was suggested to use 0 EPOCH (1970-01-01T00:00:00Z). However, this is not the 0 value of time.Time, so when the field is missing in an API response, json.Unmarhall will leave the LastUsedDate field at its zero value, which is "0001-01-01T00:00:00Z". After json.Unmarshall, we could iterate through every ContainerInfo object and set to 0 EPOCH, but this did not seem like an optimal thing to do.

Because of this, we currently have this inconsistency:
lxc list --format json to an older remote will show `last_used_at` with value `0001-01-01T00:00:00Z`.
lxc list --format json for a non-started container on a current lxd version will show `last_used_at` with value `1970-01-01T00:00:00Z`

Let me know if this is OK, or if we want to make all last_used_at dates either `1970-01-01T00:00:00Z` or `1970-01-01T00:00:00Z` for consistency.

Closes: https://github.com/lxc/lxd/issues/1958

Below are some manual tests to show sample usage:

lxc list --format json test:
```
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc init alpine last-used-at-test
Creating last-used-at-test
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc list last-used-at-test  --format json | jq -r '.[].last_used_at'
1970-01-01T00:00:00Z
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc start last-used-at-test
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc list last-used-at-test  --format json | jq -r '.[].last_used_at'
2016-06-05T05:06:13.052313996Z
```

Multiple container test:
```
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc init alpine t1
Creating t1
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc init alpine t2
Creating t2
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc init alpine t3
Creating t3
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc list --columns nl
+------+--------------+
| NAME | LAST USED AT |
+------+--------------+
| t1   |              |
+------+--------------+
| t2   |              |
+------+--------------+
| t3   |              |
+------+--------------+
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc start t1 t2 t3
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc list --columns nl
+------+----------------------+
| NAME |     LAST USED AT     |
+------+----------------------+
| t1   | 2016/06/05 05:09 UTC |
+------+----------------------+
| t2   | 2016/06/05 05:09 UTC |
+------+----------------------+
| t3   | 2016/06/05 05:09 UTC |
+------+----------------------+
```

Running against older lxc:
```
vagrant@vagrant:~/go/src/github.com/lxc/lxd$ lxc list --columns nl
+------+--------------+
| NAME | LAST USED AT |
+------+--------------+
| a1   |              |
+------+--------------+
```