### PR TITLE
Tweak TLS cipher list a bit

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -803,8 +803,8 @@ func (d *Daemon) Init() error {
 			MinVersion:         tls.VersionTLS12,
 			MaxVersion:         tls.VersionTLS12,
 			CipherSuites: []uint16{
-				tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 			PreferServerCipherSuites: true,
 		}
 

--- a/shared/network.go
+++ b/shared/network.go
@@ -39,7 +39,9 @@ func initTLSConfig() *tls.Config {
 		MaxVersion: tls.VersionTLS12,
 		CipherSuites: []uint16{
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},
 		PreferServerCipherSuites: true,
 	}
 }


### PR DESCRIPTION
 - This drops the ECDSA ciphers from the announced list by the server as
   since our certificate is RSA, those cannot be used.

 - We also now allow connections using CBC-SHA instead of GCM-SHA256 as
   this is needed by some older clients.

Closes #2034

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>