### PR TITLE
Fix a panic in 'remote add'

### DIFF
--- a/client.go
+++ b/client.go
@@ -255,11 +255,7 @@ func connectViaUnix(c *Client, remote *RemoteConfig) error {
 		//   unix:///path/to/socket
 		//   unix:/path/to/socket
 		//   unix:path/to/socket
-		path := strings.TrimPrefix(remote.Addr, "unix:")
-		if strings.HasPrefix(path, "///") {
-			// translate unix:///path/to, to just "/path/to"
-			path = path[2:]
-		}
+		path := strings.TrimPrefix(strings.TrimPrefix(remote.Addr, "unix:"), "//")
 		raddr, err := net.ResolveUnixAddr("unix", path)
 		if err != nil {
 			return nil, err

--- a/client_test.go
+++ b/client_test.go
@@ -23,7 +23,7 @@ func TestLocalLXDError(t *testing.T) {
 		Name:   "test",
 		Config: DefaultConfig,
 		Remote: &RemoteConfig{
-			Addr:   fmt.Sprintf("unix:/%s", f.Name()),
+			Addr:   fmt.Sprintf("unix:%s", f.Name()),
 			Static: true,
 			Public: false,
 		},

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -126,7 +126,7 @@ func (c *remoteCmd) addServer(config *lxd.Config, server string, addr string, ac
 	} else if addr[0] == '/' {
 		rScheme = "unix"
 	} else {
-		if !shared.PathExists(addr) {
+		if !shared.IsUnixSocket(addr) {
 			rScheme = "https"
 		} else {
 			rScheme = "unix"
@@ -148,17 +148,7 @@ func (c *remoteCmd) addServer(config *lxd.Config, server string, addr string, ac
 	}
 
 	if rScheme == "unix" {
-		if addr[0:5] == "unix:" {
-			if addr[0:7] == "unix://" {
-				if len(addr) > 8 {
-					rHost = addr[8:]
-				} else {
-					rHost = ""
-				}
-			} else {
-				rHost = addr[6:]
-			}
-		}
+		rHost = strings.TrimPrefix(strings.TrimPrefix(addr, "unix:"), "//")
 		rPort = ""
 	}
 
@@ -181,7 +171,7 @@ func (c *remoteCmd) addServer(config *lxd.Config, server string, addr string, ac
 		return err
 	}
 
-	if len(addr) > 5 && addr[0:5] == "unix:" {
+	if strings.HasPrefix(addr, "unix:") {
 		// NewClient succeeded so there was a lxd there (we fingered
 		// it) so just accept it
 		return nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -70,6 +70,16 @@ func IsDir(name string) bool {
 	return stat.IsDir()
 }
 
+// IsUnixSocket returns true if the given path is either a Unix socket
+// or a symbolic link pointing at a Unix socket.
+func IsUnixSocket(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeSocket) == os.ModeSocket
+}
+
 // VarPath returns the provided path elements joined by a slash and
 // appended to the end of $LXD_DIR, which defaults to /var/lib/lxd.
 func VarPath(path ...string) string {


### PR DESCRIPTION
Use strings.TrimPrefix to strip 'unix://' from the URL/path in both
remoteCmd.addServer() and connectViaUnix.  This resolves the direct
cause of the panic and makes the handling of relative paths consistent
in both flows.

Add a check for IsDir when determining whether HTTPS or UNIX should
be assumed.  The UNIX scheme requires a full path to the UNIX socket,
i.e. a directory can never be a valid LXD server.

Fixes #2089

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>