### PR TITLE
Add target path to rootfs tarball in image export

### DIFF
--- a/client.go
+++ b/client.go
@@ -798,7 +798,7 @@ func (c *Client) ExportImage(image string, target string) (string, error) {
 			return "", fmt.Errorf("Invalid multipart image")
 		}
 
-		rootfsTarf, err := os.OpenFile(filepath.Join(part.FileName()), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+		rootfsTarf, err := os.OpenFile(filepath.Join(target, part.FileName()), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 		if err != nil {
 			return "", err
 		}

--- a/test/deps/import-busybox
+++ b/test/deps/import-busybox
@@ -108,7 +108,7 @@ class LXD(object):
             return [image.split("/1.0/images/")[-1]
                     for image in data['metadata']]
 
-    def images_upload(self, path, filename, public):
+    def images_upload(self, path, public, filename=None):
         headers = {}
         if public:
             headers['X-LXD-public'] = "1"
@@ -121,16 +121,16 @@ class LXD(object):
         else:
             meta_path, rootfs_path = path
             boundary = str(uuid.uuid1())
+            filename_entry = " filename=%s" % filename if filename else ""
 
             upload_path = os.path.join(self.workdir, "upload")
             body = open(upload_path, "wb+")
             for name, path in [("metadata", meta_path),
                                ("rootfs", rootfs_path)]:
-                filename = os.path.basename(path)
                 body.write(bytes("--%s\r\n" % boundary, "utf-8"))
                 body.write(bytes("Content-Disposition: form-data; "
-                                 "name=%s; filename=%s\r\n" %
-                                 (name, filename), "utf-8"))
+                                 "name=%s;%s\r\n" % (name, filename_entry),
+                                 "utf-8"))
                 body.write(b"Content-Type: application/octet-stream\r\n")
                 body.write(b"\r\n")
                 with open(path, "rb") as fd:
@@ -314,8 +314,11 @@ if __name__ == "__main__":
             if fingerprint in lxd.images_list():
                 parser.exit(1, "This image is already in the store.\n")
 
-            r = lxd.images_upload((meta_path, rootfs_path),
-                                  meta_path.split("/")[-1], args.public)
+            if args.filename:
+                r = lxd.images_upload((meta_path, rootfs_path), args.public,
+                                      meta_path.split("/")[-1])
+            else:
+                r = lxd.images_upload((meta_path, rootfs_path), args.public)
             print("Image imported as: %s" % r['fingerprint'])
         else:
             path = busybox.create_tarball()
@@ -326,7 +329,7 @@ if __name__ == "__main__":
             if fingerprint in lxd.images_list():
                 parser.exit(1, "This image is already in the store.\n")
 
-            r = lxd.images_upload(path, path.split("/")[-1], args.public)
+            r = lxd.images_upload(path, args.public)
             print("Image imported as: %s" % r['fingerprint'])
 
         setup_alias(args.alias, fingerprint)
@@ -338,6 +341,8 @@ if __name__ == "__main__":
                         default=False, help="Make the image public")
     parser.add_argument("--split", action="store_true",
                         default=False, help="Whether to create a split image")
+    parser.add_argument("--filename", action="store_true",
+                        default=False, help="Set the split image's filename")
     parser.set_defaults(func=import_busybox)
 
     # Call the function

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -24,7 +24,7 @@ test_basic_usage() {
     name=${sum}.tar.xz
   fi
   [ "${sum}" = "$(sha256sum "${LXD_DIR}/${name}" | cut -d' ' -f1)" ]
-
+  
   # Test an alias with slashes
   lxc image show "${sum}"
   lxc image alias create a/b/ "${sum}"
@@ -63,6 +63,34 @@ test_basic_usage() {
   lxc image export testimage "${LXD_DIR}/"
   [ "${sum}" = "$(sha256sum "${LXD_DIR}/testimage.tar.xz" | cut -d' ' -f1)" ]
   rm "${LXD_DIR}/testimage.tar.xz"
+
+
+  # Test image export with a split image.
+  deps/import-busybox --split --alias splitimage
+
+  sum=$(lxc image info splitimage | grep ^Fingerprint | cut -d' ' -f2)
+
+  lxc image export splitimage "${LXD_DIR}"
+  [ "${sum}" = "$(cat "${LXD_DIR}/meta-${sum}.tar.xz" "${LXD_DIR}/${sum}.tar.xz" | sha256sum | cut -d' ' -f1)" ]
+  
+  # Delete the split image and exported files
+  rm "${LXD_DIR}/${sum}.tar.xz"
+  rm "${LXD_DIR}/meta-${sum}.tar.xz"
+  lxc image delete splitimage
+
+  # Redo the split image export test, this time with the --filename flag
+  # to tell import-busybox to set the 'busybox' filename in the upload.
+  # The sum should remain the same as its the same image.
+  deps/import-busybox --split --filename --alias splitimage
+
+  lxc image export splitimage "${LXD_DIR}"
+  [ "${sum}" = "$(cat "${LXD_DIR}/meta-busybox.tar.xz" "${LXD_DIR}/busybox.tar.xz" | sha256sum | cut -d' ' -f1)" ]
+  
+  # Delete the split image and exported files
+  rm "${LXD_DIR}/busybox.tar.xz"
+  rm "${LXD_DIR}/meta-busybox.tar.xz"
+  lxc image delete splitimage
+
 
   # Test container creation
   lxc init testimage foo


### PR DESCRIPTION
The split image path didn't pass in 'target' to the Join call.

Add an integration test to verify exporting split images.  Add an
option to the import-busybox script to control whether or not to
set the filename for split images.  Change the effective filename
to be 'busybox', previously it was being set to 'busybox.rootfs'.

Fixes #1980

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>