### PR TITLE
actually load the LastUsedDate from the database on create

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -681,7 +681,7 @@ func containerCreateInternal(d *Daemon, args containerArgs) (container, error) {
 		return nil, err
 	}
 	args.CreationDate = dbArgs.CreationDate
-	args.LastUsedDate = time.Unix(0, 0).UTC()
+	args.LastUsedDate = dbArgs.LastUsedDate
 
 	return containerLXCCreate(d, args)
 }


### PR DESCRIPTION
In principle these should be the same, but in practice they're different,
because the time.Times are loaded from the database using the local time
zone, giving the error below on non-UTC hosts.

ok  	github.com/lxc/lxd	0.004s
?   	github.com/lxc/lxd/fuidshift	[no test files]
ok  	github.com/lxc/lxd/lxc	0.003s
--- FAIL: TestContainer_LoadFromDB (1.45s)
	Error Trace:	container_test.go:122
	Error:		Not equal: &main.containerLXC{architecture:2, cType:0, creationDate:time.Time{sec:63601175312, nsec:0, loc:(*time.Location)(0x1377f80)}, lastUsedDate:time.Time{sec:62135596800, nsec:0, loc:(*time.Location)(0x1281c00)}, ephemeral:false, id:3, name:"testFoo", stateful:false, expandedConfig:map[string]string{"security.privileged":"true", "volatile.eth0.hwaddr":"00:16:3e:0a:38:39", "volatile.eth0.name":"eth0", "volatile.last_state.idmap":"[]"}, expandedDevices:shared.Devices{"eth0":shared.Device{"type":"nic", "nictype":"bridged", "parent":"unknownbr0"}, "root":shared.Device{"type":"disk", "path":"/"}}, fromHook:false, localConfig:map[string]string{"security.privileged":"true", "volatile.eth0.hwaddr":"00:16:3e:0a:38:39", "volatile.eth0.name":"eth0", "volatile.last_state.idmap":"[]"}, localDevices:shared.Devices{"eth0":shared.Device{"type":"nic", "nictype":"bridged", "parent":"unknownbr0"}, "root":shared.Device{"type":"disk", "path":"/"}}, profiles:[]string{"default"}, c:(*lxc.Container)(0xc820570120), daemon:(*main.Daemon)(0xc82057e8c0), idmapset:(*shared.IdmapSet)(nil), storage:(*main.storageLogWrapper)(0xc820213ea0)} (expected)
			        != &main.containerLXC{architecture:2, cType:0, creationDate:time.Time{sec:63601175312, nsec:0, loc:(*time.Location)(0x1377f80)}, lastUsedDate:time.Time{sec:62135596800, nsec:0, loc:(*time.Location)(0x1377f80)}, ephemeral:false, id:3, name:"testFoo", stateful:false, expandedConfig:map[string]string{"security.privileged":"true", "volatile.eth0.hwaddr":"00:16:3e:0a:38:39", "volatile.eth0.name":"eth0", "volatile.last_state.idmap":"[]"}, expandedDevices:shared.Devices{"eth0":shared.Device{"nictype":"bridged", "parent":"unknownbr0", "type":"nic"}, "root":shared.Device{"path":"/", "type":"disk"}}, fromHook:false, localConfig:map[string]string{"security.privileged":"true", "volatile.eth0.hwaddr":"00:16:3e:0a:38:39", "volatile.eth0.name":"eth0", "volatile.last_state.idmap":"[]"}, localDevices:shared.Devices{"eth0":shared.Device{"nictype":"bridged", "parent":"unknownbr0", "type":"nic"}, "root":shared.Device{"path":"/", "type":"disk"}}, profiles:[]string{"default"}, c:(*lxc.Container)(0xc8205ecfc0), daemon:(*main.Daemon)(0xc82057e8c0), idmapset:(*shared.IdmapSet)(nil), storage:(*main.storageLogWrapper)(0xc820213ea0)} (actual)
	Messages:	The loaded container isn't excactly the same as the created one.

--- FAIL: TestLxdTestSuite (15.14s)
FAIL
FAIL	github.com/lxc/lxd/lxd	31.875s
?   	github.com/lxc/lxd/lxd-bridge/lxd-bridge-proxy	[no test files]
ok  	github.com/lxc/lxd/shared	10.982s
ok  	github.com/lxc/lxd/shared/gnuflag	0.002s
?   	github.com/lxc/lxd/shared/i18n	[no test files]
?   	github.com/lxc/lxd/shared/logging	[no test files]
?   	github.com/lxc/lxd/shared/termios	[no test files]
?   	github.com/lxc/lxd/test/deps	[no test files]
?   	github.com/lxc/lxd/test/lxd-benchmark	[no test files]

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>