### PR TITLE
Build unix-like aliases directly into LXC

### DIFF
--- a/config.go
+++ b/config.go
@@ -80,11 +80,7 @@ var DefaultRemotes = map[string]RemoteConfig{
 
 var DefaultConfig = Config{
 	Remotes:       DefaultRemotes,
-	DefaultRemote: "local",
-	Aliases: map[string]string{
-		"shell": "exec @ARGS@ -- login -f root",
-	},
-}
+	DefaultRemote: "local"}
 
 // LoadConfig reads the configuration from the config path; if the path does
 // not exist, it returns a default configuration.


### PR DESCRIPTION
Move default aliases into the alias checking code itself instead of
making them a property of the default config.  Add unix-like aliases
to the map of default aliases, e.g. cp, ls, mv and rm.

Fixes #1615

Signed-off-by: Sean Christopherson <sean.j.christopherson@intel.com>