### PR TITLE
apparmor: create an apparmor namespace for each container

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -93,7 +93,7 @@ func AANamespace(c container) string {
 	/* / is not allowed in apparmor namespace names; let's also trim the
 	 * leading / so it doesn't look like "-var-lib-lxd"
 	 */
-	lxddir := strings.Replace(shared.VarPath("")[1:], "/", "-", -1)
+	lxddir := strings.Replace(strings.Trim(shared.VarPath(""), "/"), "/", "-", -1)
 	lxddir = mkApparmorName(lxddir)
 	return fmt.Sprintf("lxd-%s_<%s>", c.Name(), lxddir)
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -41,6 +41,7 @@ import (
 var aaAdmin = true
 var aaAvailable = true
 var aaConfined = false
+var aaStacking = false
 
 // CGroup
 var cgBlkioController = false
@@ -623,6 +624,16 @@ func (d *Daemon) Init() error {
 		if profile != "unconfined" && profile != "" {
 			aaConfined = true
 			shared.Log.Warn("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor.")
+		}
+	}
+
+	if aaAvailable {
+		content, err := ioutil.ReadFile("/sys/kernel/security/apparmor/features/domain/stack")
+		if err == nil && string(content) == "yes\n" {
+			aaStacking = true
+			shared.Log.Warn("Enabled apparmor stacking")
+		} else {
+			shared.Log.Warn("Kernel doesn't support apparmor stacking")
 		}
 	}
 

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -299,9 +299,10 @@ test_basic_usage() {
   # check that an apparmor profile is created for this container, that it is
   # unloaded on stop, and that it is deleted when the container is deleted
   lxc launch testimage lxd-apparmor-test
-  aa-status | grep "lxd-lxd-apparmor-test_<${LXD_DIR}>"
+  aa_namespace="lxd-lxd-apparmor-test_<$(echo "${LXD_DIR}" | sed -e 's/\//-/g' -e 's/^.//')>"
+  aa-status | grep ":${aa_namespace}://lxd-default"
   lxc stop lxd-apparmor-test --force
-  ! aa-status | grep -q "lxd-lxd-apparmor-test_<${LXD_DIR}>"
+  ! aa-status | grep -q ":${aa_namespace}://lxd-default"
   lxc delete lxd-apparmor-test
   [ ! -f "${LXD_DIR}/security/apparmor/profiles/lxd-lxd-apparmor-test" ]
 


### PR DESCRIPTION
Note that this only allows privileged containers to load apparmor profiles, and
only then with something like:

diff --git a/config/apparmor/abstractions/container-base b/config/apparmor/abstractions/container-base
index fe24ff3..7138249 100644
--- a/config/apparmor/abstractions/container-base
+++ b/config/apparmor/abstractions/container-base
@@ -93,7 +93,7 @@
   mount fstype=sysfs -> /sys/,
   mount options=(rw, nosuid, nodev, noexec, remount) -> /sys/,
   deny /sys/firmware/efi/efivars/** rwklx,
-  deny /sys/kernel/security/** rwklx,
+  # deny /sys/kernel/security/** rwklx,
   mount options=(move) /sys/fs/cgroup/cgmanager/ -> /sys/fs/cgroup/cgmanager.lower/,
   mount options=(ro, nosuid, nodev, noexec, remount, strictatime) -> /sys/fs/cgroup/,

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>