### PR TITLE
migration: fix tempdir handling

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -540,7 +540,7 @@ func (c *migrationSink) do() error {
 			var err error
 			imagesDir, err = ioutil.TempDir("", "lxd_restore_")
 			if err != nil {
-				os.RemoveAll(imagesDir)
+				restore <- err
 				return
 			}
 


### PR DESCRIPTION
If we fail to create the tempdir, we don't need to delete it. We *do*
however, need to inform the main thread that the restore failed.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>