### PR TITLE
don't fail db upgrade if $LXD_DIR/containers doesn't exist

### DIFF
--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -136,6 +136,13 @@ func dbUpdateFromV30(currentVersion int, version int, d *Daemon) error {
 
 	entries, err := ioutil.ReadDir(shared.VarPath("containers"))
 	if err != nil {
+		/* If the directory didn't exist before, the user had never
+		 * started containers, so we don't need to fix up permissions
+		 * on anything.
+		 */
+		if os.IsNotExist(err) {
+			return nil
+		}
 		return err
 	}
 


### PR DESCRIPTION
The user may not have actually started LXD or imported any containers, so
let's not fail in this case.

Launchpad #1602025

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>