### PR TITLE
list: fix concurrent read/write

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -281,6 +281,8 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 	}
 
 	for _, cInfo := range cinfos {
+		cStatesLock.Lock()
+		cSnapshotsLock.Lock()
 		for _, column := range columns {
 			if column.NeedsState && cInfo.IsActive() {
 				_, ok := cStates[cInfo.Name]
@@ -288,9 +290,7 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 					continue
 				}
 
-				cStatesLock.Lock()
 				cStates[cInfo.Name] = nil
-				cStatesLock.Unlock()
 
 				cStatesQueue <- cInfo.Name
 			}
@@ -301,13 +301,13 @@ func (c *listCmd) listContainers(d *lxd.Client, cinfos []shared.ContainerInfo, f
 					continue
 				}
 
-				cSnapshotsLock.Lock()
 				cSnapshots[cInfo.Name] = nil
-				cSnapshotsLock.Unlock()
 
 				cSnapshotsQueue <- cInfo.Name
 			}
 		}
+		cStatesLock.Unlock()
+		cSnapshotsLock.Unlock()
 	}
 
 	close(cStatesQueue)


### PR DESCRIPTION
We can't concurrently write, but we can't concurrently read either, so let's
extend the lock duration.

Closes #2183

fatal error: concurrent map read and map write

goroutine 1 [running]:
runtime.throw(0x9cd180, 0x21)
	/usr/lib/go-1.6/src/runtime/panic.go:530 +0x90 fp=0xc8200f0fa8 sp=0xc8200f0f90
runtime.mapaccess2_faststr(0x808280, 0xc8201db140, 0xc8201b43d0, 0xb, 0x0, 0xdbf920)
	/usr/lib/go-1.6/src/runtime/hashmap_fast.go:307 +0x5b fp=0xc8200f1008 sp=0xc8200f0fa8
main.(*listCmd).listContainers(0xc82000be30, 0xc8200d0700, 0xc8201e0000, 0x32, 0x50, 0xc820011a50, 0x1, 0x1, 0xc82008ff00, 0x3, ...)
	/build/lxd-ma7bPQ/lxd-2.0.2/obj-x86_64-linux-gnu/src/github.com/lxc/lxd/lxc/list.go:254 +0x651 fp=0xc8200f1750 sp=0xc8200f1008
main.(*listCmd).run(0xc82000be30, 0xc8200f2030, 0x0, 0x0, 0x0, 0x0, 0x0)
	/build/lxd-ma7bPQ/lxd-2.0.2/obj-x86_64-linux-gnu/src/github.com/lxc/lxd/lxc/list.go:401 +0x1324 fp=0xc8200f1ae8 sp=0xc8200f1750
main.run(0x0, 0x0)
	/build/lxd-ma7bPQ/lxd-2.0.2/obj-x86_64-linux-gnu/src/github.com/lxc/lxd/lxc/main.go:151 +0x1098 fp=0xc8200f1df0 sp=0xc8200f1ae8
main.main()
	/build/lxd-ma7bPQ/lxd-2.0.2/obj-x86_64-linux-gnu/src/github.com/lxc/lxd/lxc/main.go:23 +0x3a fp=0xc8200f1f40 sp=0xc8200f1df0
runtime.main()
	/usr/lib/go-1.6/src/runtime/proc.go:188 +0x2b0 fp=0xc8200f1f90 sp=0xc8200f1f40
runtime.goexit()
	/usr/lib/go-1.6/src/runtime/asm_amd64.s:1998 +0x1 fp=0xc8200f1f98 sp=0xc8200f1f90

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>