### PR TITLE
Fixed errors on api examples with curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ curl --unix-socket /var/lib/lxd/unix.socket \
     -H "Content-Type: application/json" \
     -X POST \
     -d @hello-ubuntu.json \
-    "https://127.0.0.1:8443/1.0/containers"
+    lxd/1.0/containers
 ```
 
 #### via TCP
@@ -46,7 +46,7 @@ TCP requires some additional configuration and is not enabled by default.
 lxc config set core.https_address "[::]:8443"
 ```
 ```bash
-curl -k -L -I \
+curl -k -L \
     --cert ~/.config/lxc/client.crt \
     --key ~/.config/lxc/client.key \
     -H "Content-Type: application/json" \


### PR DESCRIPTION
Testing the 1st example "talking over the socket", I got this error: curl: (35) gnutls_handshake() failed: An unexpected TLS packet was received. Because the url is pointing to the TCP and not the socket.
Testing the 2nd example "talking over TCP", I got these warnings:
      1-Warning: You can only select one HTTP request method! You asked for both POST
      2-Warning: (-d, --data) and HEAD (-I, --head).
With these changes both examples run without errors.