### PR TITLE
remove unused "name" argument from {create,remove}UnixDevice

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1084,7 +1084,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	for k, m := range c.expandedDevices {
 		if shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
 			// Unix device
-			devPath, err := c.createUnixDevice(k, m)
+			devPath, err := c.createUnixDevice(m)
 			if err != nil {
 				return "", err
 			}
@@ -2425,7 +2425,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 		// Live update the devices
 		for k, m := range removeDevices {
 			if shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
-				err = c.removeUnixDevice(k, m)
+				err = c.removeUnixDevice(m)
 				if err != nil {
 					return err
 				}
@@ -3542,7 +3542,7 @@ func (c *containerLXC) removeMount(mount string) error {
 }
 
 // Unix devices handling
-func (c *containerLXC) createUnixDevice(name string, m shared.Device) (string, error) {
+func (c *containerLXC) createUnixDevice(m shared.Device) (string, error) {
 	var err error
 	var major, minor int
 
@@ -3654,7 +3654,7 @@ func (c *containerLXC) insertUnixDevice(name string, m shared.Device) error {
 	}
 
 	// Create the device on the host
-	devPath, err := c.createUnixDevice(name, m)
+	devPath, err := c.createUnixDevice(m)
 	if err != nil {
 		return fmt.Errorf("Failed to setup device: %s", err)
 	}
@@ -3679,7 +3679,7 @@ func (c *containerLXC) insertUnixDevice(name string, m shared.Device) error {
 	return nil
 }
 
-func (c *containerLXC) removeUnixDevice(name string, m shared.Device) error {
+func (c *containerLXC) removeUnixDevice(m shared.Device) error {
 	// Check that the container is running
 	pid := c.InitPID()
 	if pid == -1 {


### PR DESCRIPTION
Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>