### PR TITLE
add some reasonable defaults to `lxd init`

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -859,6 +859,9 @@ they otherwise would.
 			}
 
 			networkAddress = askString("Address to bind LXD to (not including port) [default=0.0.0.0]: ", "0.0.0.0", isIPAddress)
+			if net.ParseIP(networkAddress).To4() == nil {
+				networkAddress = fmt.Sprintf("[%s]", networkAddress)
+			}
 			networkPort = askInt("Port to bind LXD to [default=8443]: ", 1, 65535, "8443")
 			trustPassword = askPassword("Trust password for new clients: ")
 		}

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -810,7 +810,7 @@ func cmdInit() error {
 		}
 
 		if storageBackend == "zfs" {
-			if askBool("Create a new ZFS pool (yes/no) [defualt=yes]? ", "yes") {
+			if askBool("Create a new ZFS pool (yes/no) [default=yes]? ", "yes") {
 				storagePool = askString("Name of the new ZFS pool [default=lxd]: ", "lxd", nil)
 				if askBool("Would you like to use an existing block device (yes/no) [default=no]? ", "no") {
 					deviceExists := func(path string) string {


### PR DESCRIPTION
This also adds some validation: namely that ip addresses are valid and that
any block device specified as a ZFS pool is indeed an actual block device.

Closes #1933

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>