### PR TITLE
relax constraints on WebsocketRecvStream args

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -180,10 +180,10 @@ func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan
 	return ch
 }
 
-func WebsocketRecvStream(w io.WriteCloser, conn *websocket.Conn) chan bool {
+func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 	ch := make(chan bool)
 
-	go func(w io.WriteCloser, conn *websocket.Conn) {
+	go func(w io.Writer, conn *websocket.Conn) {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {


### PR DESCRIPTION
We don't use the Close method any more, so let's make these Writers, not
WriteClosers.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>