### PR TITLE
Prevent using invalid profile names

### DIFF
--- a/client.go
+++ b/client.go
@@ -2189,9 +2189,14 @@ func (c *Client) ContainerDeviceDelete(container, devname string) (*Response, er
 		return nil, err
 	}
 
-	delete(st.Devices, devname)
+	for n, _ := range st.Devices {
+		if n == devname {
+			delete(st.Devices, n)
+			return c.put(fmt.Sprintf("containers/%s", container), st, Async)
+		}
+	}
 
-	return c.put(fmt.Sprintf("containers/%s", container), st, Async)
+	return nil, fmt.Errorf("Device doesn't exist.")
 }
 
 func (c *Client) ContainerDeviceAdd(container, devname, devtype string, props []string) (*Response, error) {
@@ -2258,10 +2263,11 @@ func (c *Client) ProfileDeviceDelete(profile, devname string) (*Response, error)
 	for n, _ := range st.Devices {
 		if n == devname {
 			delete(st.Devices, n)
+			return c.put(fmt.Sprintf("profiles/%s", profile), st, Sync)
 		}
 	}
 
-	return c.put(fmt.Sprintf("profiles/%s", profile), st, Sync)
+	return nil, fmt.Errorf("Device doesn't exist.")
 }
 
 func (c *Client) ProfileDeviceAdd(profile, devname, devtype string, props []string) (*Response, error) {

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strings"
 
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
@@ -66,6 +67,14 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 	// Sanity checks
 	if req.Name == "" {
 		return BadRequest(fmt.Errorf("No name provided"))
+	}
+
+	if strings.Contains(req.Name, "/") {
+		return BadRequest(fmt.Errorf("Profile names may not contain slashes"))
+	}
+
+	if shared.StringInSlice(req.Name, []string{".", ".."}) {
+		return BadRequest(fmt.Errorf("Invalid profile name '%s'", req.Name))
 	}
 
 	err := containerValidConfig(d, req.Config, true, false)
@@ -323,6 +332,14 @@ func profilePost(d *Daemon, r *http.Request) Response {
 	// Sanity checks
 	if req.Name == "" {
 		return BadRequest(fmt.Errorf("No name provided"))
+	}
+
+	if strings.Contains(req.Name, "/") {
+		return BadRequest(fmt.Errorf("Profile names may not contain slashes"))
+	}
+
+	if shared.StringInSlice(req.Name, []string{".", ".."}) {
+		return BadRequest(fmt.Errorf("Invalid profile name '%s'", req.Name))
 	}
 
 	err := dbProfileUpdate(d.db, name, req.Name)


### PR DESCRIPTION
Profile names with slashes or called "." or ".." will get mangled/eaten
by the http server, so creating them works, using them works but they
can't be modified or deleted.

This prevents creating such profiles now and also removes any existing
one that already exists (they couldn't have been configured so it should
be safe).

Closes #2274

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>