### PR TITLE
make TestReaderToChannel transfer smaller

### DIFF
--- a/shared/util_test.go
+++ b/shared/util_test.go
@@ -104,7 +104,7 @@ func TestReadLastNLines(t *testing.T) {
 }
 
 func TestReaderToChannel(t *testing.T) {
-	buf := make([]byte, 64*1024*1024)
+	buf := make([]byte, 1*1024*1024)
 	rand.Read(buf)
 
 	offset := 0


### PR DESCRIPTION
We get intermittent failures like the one below. It looks like the problem is
that the test runners don't have enough randomness to fill up a 64 MB buffer,
so they just fail. Since the point of this test really is to test anything >
the default buffer size which is 128k, 1MB should suffice, and will hopefully
cut down on eating all the entropy from the test runners.

=== RUN   TestReaderToChannel
SIGQUIT: quit
PC=0x45fbe1 m=0

goroutine 0 [idle]:
runtime.futex(0x9f3a90, 0x0, 0x0, 0x0, 0x0, 0x9f3360, 0x0, 0x0, 0x7ffe2e658080, 0x40ff52, ...)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/sys_linux_amd64.s:387 +0x21
runtime.futexsleep(0x9f3a90, 0x0, 0xffffffffffffffff)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/os_linux.go:45 +0x62
runtime.notesleep(0x9f3a90)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/lock_futex.go:145 +0x82
runtime.stopm()
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/proc.go:1594 +0xad
runtime.findrunnable(0xc420022000, 0x0)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/proc.go:2021 +0x228
runtime.schedule()
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/proc.go:2120 +0x14c
runtime.park_m(0xc420095040)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/proc.go:2183 +0x123
runtime.mcall(0x7ffe2e658220)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/asm_amd64.s:240 +0x5b

goroutine 1 [chan receive, 9 minutes]:
testing.(*T).Run(0xc42009a0c0, 0x6bedb9, 0x13, 0x6dedf0, 0xc42005bd01)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:647 +0x316
testing.RunTests.func1(0xc42009a0c0)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:793 +0x6d
testing.tRunner(0xc42009a0c0, 0xc42004be30)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:610 +0x81
testing.RunTests(0x6dee70, 0x9d7e20, 0x6, 0x6, 0x9e0d00)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:799 +0x2f5
testing.(*M).Run(0xc42004bef8, 0xc4200d9360)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:743 +0x85
main.main()
	github.com/lxc/lxd/shared/_test/_testmain.go:64 +0xc6

goroutine 17 [syscall, 9 minutes, locked to thread]:
runtime.goexit()
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/runtime/asm_amd64.s:2086 +0x1

goroutine 23 [syscall, 6 minutes]:
syscall.Syscall(0x13e, 0xc4224abfff, 0x2000001, 0x0, 0xc420048c38, 0x499389, 0xa0f538)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/syscall/asm_linux_amd64.s:18 +0x5
internal/syscall/unix.GetRandom(0xc4224abfff, 0x2000001, 0x2000001, 0x0, 0xc420048c90, 0x455b20, 0xc4200162c0)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/internal/syscall/unix/getrandom_linux.go:41 +0xdb
crypto/rand.getRandomLinux(0xc4224abfff, 0x2000001, 0x2000001, 0xc)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/crypto/rand/rand_linux.go:37 +0x73
crypto/rand.(*devReader).Read(0xc4200124b0, 0xc4224abfff, 0x2000001, 0x2000001, 0x0, 0x0, 0x0)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/crypto/rand/rand_unix.go:48 +0x423
io.ReadAtLeast(0x9dbc80, 0xc4200124b0, 0xc4204ac000, 0x4000000, 0x4000000, 0x4000000, 0xc420358e20, 0x1, 0xc420358e68)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/io/io.go:307 +0xa4
io.ReadFull(0x9dbc80, 0xc4200124b0, 0xc4204ac000, 0x4000000, 0x4000000, 0xc4200109a0, 0xc42046e018, 0x2000107)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/io/io.go:325 +0x58
crypto/rand.Read(0xc4204ac000, 0x4000000, 0x4000000, 0xc4204ac000, 0x4000000, 0x4000000)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/crypto/rand/rand.go:23 +0x57
github.com/lxc/lxd/shared.TestReaderToChannel(0xc42009a540)
	/lxd/build/tmp.qQKnZ6Eutl/go/src/github.com/lxc/lxd/shared/util_test.go:108 +0x85
testing.tRunner(0xc42009a540, 0x6dedf0)
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:610 +0x81
created by testing.(*T).Run
	/lxd/build/tmp.qQKnZ6Eutl/go/golang/src/testing/testing.go:646 +0x2ec

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>