### PR TITLE
USB support - major/minor transposed

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -56,12 +56,12 @@ type usbDevice struct {
 }
 
 func createUSBDevice(action string, vendor string, product string, major string, minor string, busnum string, devnum string) (usbDevice, error) {
-	majorInt, err := strconv.Atoi(minor)
+	majorInt, err := strconv.Atoi(major)
 	if err != nil {
 		return usbDevice{}, err
 	}
 
-	minorInt, err := strconv.Atoi(major)
+	minorInt, err := strconv.Atoi(minor)
 	if err != nil {
 		return usbDevice{}, err
 	}


### PR DESCRIPTION
I noticed USB support wasn't working properly so I went digging into the issue and finally tracked it down to a transposition of the major and minor ids in createUSBDevice. 

Steps to reproduce.

```
$ ls -l /dev/bus/usb/001/013
crw-rw-rw- 1 root root 189, 12 Aug 19 21:47 /dev/bus/usb/001/013
$ lxc init ubuntu:16.04 test
$ lxc config device add test sdr usb vendorid=0bda productid=2838
Device sdr added to test
$ lxc start test
$ lxc exec test -- ls -l /dev/bus/usb/001/013
crw-rw---- 1 root root 12, 189 Aug 20 02:08 /dev/bus/usb/001/013
```

 