### PR TITLE
minor USB fixes

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -491,28 +491,18 @@ func deviceUSBEvent(d *Daemon, usb usbDevice) {
 				continue
 			}
 
-			m["major"] = fmt.Sprintf("%d", usb.major)
-			m["minor"] = fmt.Sprintf("%d", usb.minor)
-			m["path"] = usb.path
-
 			if usb.action == "add" {
-				err := c.insertUnixDevice("unused", m)
+				err := c.insertUSBDevice(m, usb)
 				if err != nil {
 					shared.Log.Error("failed to create usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
 				}
 			} else if usb.action == "remove" {
-				err := c.removeUnixDevice(m)
+				err := c.removeUSBDevice(m, usb)
 				if err != nil {
 					shared.Log.Error("failed to remove usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
 				}
-
-				/* ok to fail here, there may be other usb
-				 * devices on this bus still left in the
-				 * container
-				 */
-				os.Remove(filepath.Dir(usb.path))
 			} else {
 				shared.Log.Error("unknown action for usb device", log.Ctx{"usb": usb})
 				continue


### PR DESCRIPTION
* do a deep copy of the device entry so config doesn't accidentally get
  saved in the DB
* remember to remove the bus directory when a USB device goes away
* remove unused param to insertUnixDevice()

Closes #2306
Closes #2312

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>