### PR TITLE
new config option, storage.lvm_mount_options

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -42,7 +42,7 @@ _have lxc && {
       core.https_allowed_credentials core.proxy_https \
       core.proxy_http core.proxy_ignore_host core.trust_password \
       storage.lvm_vg_name storage.lvm_thinpool_name storage.lvm_fstype \
-      storage.lvm_volume_size storage.zfs_pool_name
+      storage.lvm_mount_options storage.lvm_volume_size storage.zfs_pool_name \
       storage.zfs_remove_snapshots images.compression_algorithm \
       images.remot_cache_expiry images.auto_update_interval \
       images.auto_update_cached"

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -31,6 +31,7 @@ core.trust\_password            | string    | -         | -                     
 storage.lvm\_vg\_name           | string    | -         | -                                 | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string    | "LXDPool" | -                                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.
 storage.lvm\_fstype             | string    | ext4      | -                                 | Format LV with filesystem, for now it's value can be only ext4 (default) or xfs.
+storage.lvm\_mount\_options     | string    | discard   | -                                 | Mount options for LV.
 storage.lvm\_volume\_size       | string    | 10GiB     | -                                 | Size of the logical volume
 storage.zfs\_pool\_name         | string    | -         | -                                 | ZFS pool name
 storage.zfs\_remove\_snapshots  | boolean   | false     | storage\_zfs\_remove\_snapshots   | Automatically remove any needed snapshot when attempting a container restore

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -180,6 +180,7 @@ func daemonConfigInit(db *sql.DB) error {
 		"images.remote_cache_expiry":   &daemonConfigKey{valueType: "int", defaultValue: "10", trigger: daemonConfigTriggerExpiry},
 
 		"storage.lvm_fstype":           &daemonConfigKey{valueType: "string", defaultValue: "ext4", validValues: []string{"ext4", "xfs"}},
+		"storage.lvm_mount_options":    &daemonConfigKey{valueType: "string", defaultValue: "discard"},
 		"storage.lvm_thinpool_name":    &daemonConfigKey{valueType: "string", defaultValue: "LXDPool", validator: storageLVMValidateThinPoolName},
 		"storage.lvm_vg_name":          &daemonConfigKey{valueType: "string", validator: storageLVMValidateVolumeGroupName, setter: daemonConfigSetStorage},
 		"storage.lvm_volume_size":      &daemonConfigKey{valueType: "string", defaultValue: "10GiB"},

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -322,7 +322,8 @@ func (s *storageLvm) ContainerCreateFromImage(
 		}
 	}
 
-	err = tryMount(lvpath, destPath, fstype, 0, "discard")
+	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
+	err = tryMount(lvpath, destPath, fstype, 0, mountOptions)
 	if err != nil {
 		s.ContainerDelete(container)
 		return fmt.Errorf("Error mounting snapshot LV: %v", err)
@@ -430,7 +431,8 @@ func (s *storageLvm) ContainerStart(container container) error {
 	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvName)
 	fstype := daemonConfig["storage.lvm_fstype"].Get()
 
-	err := tryMount(lvpath, container.Path(), fstype, 0, "discard")
+	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
+	err := tryMount(lvpath, container.Path(), fstype, 0, mountOptions)
 	if err != nil {
 		return fmt.Errorf(
 			"Error mounting snapshot LV path='%s': %v",
@@ -675,7 +677,8 @@ func (s *storageLvm) ContainerSnapshotStart(container container) error {
 		}
 	}
 
-	err = tryMount(lvpath, container.Path(), fstype, 0, "discard")
+	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
+	err = tryMount(lvpath, container.Path(), fstype, 0, mountOptions)
 	if err != nil {
 		return fmt.Errorf(
 			"Error mounting snapshot LV path='%s': %v",
@@ -730,7 +733,8 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 	}()
 
 	fstype := daemonConfig["storage.lvm_fstype"].Get()
-	err = tryMount(lvpath, tempLVMountPoint, fstype, 0, "discard")
+	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
+	err = tryMount(lvpath, tempLVMountPoint, fstype, 0, mountOptions)
 	if err != nil {
 		shared.Logf("Error mounting image LV for unpacking: %v", err)
 		return fmt.Errorf("Error mounting image LV: %v", err)


### PR DESCRIPTION
It allows to override the default mount options for advanced usage.

Signed-off-by: Nobuto Murata <nobuto.murata@canonical.com>