### PR TITLE
fuidshift: expand symlinks to last path component

### DIFF
--- a/shared/idmapset_linux.go
+++ b/shared/idmapset_linux.go
@@ -223,11 +223,13 @@ func GetOwner(path string) (int, int, error) {
 }
 
 func (set *IdmapSet) doUidshiftIntoContainer(dir string, testmode bool, how string) error {
-	// Expand any symlink in dir and cleanup resulting path
-	dir, err := filepath.EvalSymlinks(dir)
+	// Expand any symlink before the final path component
+	tmp := filepath.Dir(dir)
+	tmp, err := filepath.EvalSymlinks(tmp)
 	if err != nil {
 		return err
 	}
+	dir = filepath.Join(tmp, filepath.Base(dir))
 	dir = strings.TrimRight(dir, "/")
 
 	convert := func(path string, fi os.FileInfo, err error) (e error) {


### PR DESCRIPTION
So far doUidshiftIntoContainer() expanded all symlinks in the path it got
passed. This meant, that when the user created symlinks referring to
non-existing files or referring to paths on the host fuidshift would either fail
in the first case or change files on the host. With this commit, we start to
only resolve the path that gets passed to fuidshift up to the last path
component. This should be safe since shiftowner() in shared/util_linux.go will
a) perform another safety check and b) will only change ownership of the symlink
itself.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>