### PR TITLE
2016 09 15/logging issue 1928

### DIFF
--- a/client.go
+++ b/client.go
@@ -121,7 +121,7 @@ func ParseResponse(r *http.Response) (*Response, error) {
 	if err != nil {
 		return nil, err
 	}
-	shared.Debugf("Raw response: %s", string(s))
+	shared.LogDebugf("Raw response: %s", string(s))
 
 	if err := json.Unmarshal(s, &ret); err != nil {
 		return nil, err
@@ -398,7 +398,7 @@ func (c *Client) put(base string, args interface{}, rtype ResponseType) (*Respon
 		return nil, err
 	}
 
-	shared.Debugf("Putting %s to %s", buf.String(), uri)
+	shared.LogDebugf("Putting %s to %s", buf.String(), uri)
 
 	req, err := http.NewRequest("PUT", uri, &buf)
 	if err != nil {
@@ -424,7 +424,7 @@ func (c *Client) post(base string, args interface{}, rtype ResponseType) (*Respo
 		return nil, err
 	}
 
-	shared.Debugf("Posting %s to %s", buf.String(), uri)
+	shared.LogDebugf("Posting %s to %s", buf.String(), uri)
 
 	req, err := http.NewRequest("POST", uri, &buf)
 	if err != nil {
@@ -474,7 +474,7 @@ func (c *Client) delete(base string, args interface{}, rtype ResponseType) (*Res
 		return nil, err
 	}
 
-	shared.Debugf("Deleting %s to %s", buf.String(), uri)
+	shared.LogDebugf("Deleting %s to %s", buf.String(), uri)
 
 	req, err := http.NewRequest("DELETE", uri, &buf)
 	if err != nil {
@@ -583,7 +583,7 @@ func (c *Client) AmTrusted() bool {
 		return false
 	}
 
-	shared.Debugf("%s", resp)
+	shared.LogDebugf("%s", resp)
 
 	jmap, err := resp.MetadataAsMap()
 	if err != nil {
@@ -604,7 +604,7 @@ func (c *Client) IsPublic() bool {
 		return false
 	}
 
-	shared.Debugf("%s", resp)
+	shared.LogDebugf("%s", resp)
 
 	jmap, err := resp.MetadataAsMap()
 	if err != nil {
@@ -2049,7 +2049,7 @@ func (c *Client) WaitFor(waitURL string) (*shared.Operation, error) {
 	 * "/<version>/operations/" in it; we chop off the leading / and pass
 	 * it to url directly.
 	 */
-	shared.Debugf(path.Join(waitURL[1:], "wait"))
+	shared.LogDebugf(path.Join(waitURL[1:], "wait"))
 	resp, err := c.baseGet(c.url(waitURL, "wait"))
 	if err != nil {
 		return nil, err
@@ -2302,7 +2302,7 @@ func (c *Client) SetProfileConfigItem(profile, key, value string) error {
 
 	st, err := c.ProfileConfig(profile)
 	if err != nil {
-		shared.Debugf("Error getting profile %s to update", profile)
+		shared.LogDebugf("Error getting profile %s to update", profile)
 		return err
 	}
 

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -61,7 +61,7 @@ func (c *execCmd) sendTermSize(control *websocket.Conn) error {
 		return err
 	}
 
-	shared.Debugf("Window size is now: %dx%d", width, height)
+	shared.LogDebugf("Window size is now: %dx%d", width, height)
 
 	w, err := control.NextWriter(websocket.TextMessage)
 	if err != nil {

--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -25,11 +25,11 @@ func (c *execCmd) controlSocketHandler(d *lxd.Client, control *websocket.Conn) {
 	for {
 		sig := <-ch
 
-		shared.Debugf("Received '%s signal', updating window geometry.", sig)
+		shared.LogDebugf("Received '%s signal', updating window geometry.", sig)
 
 		err := c.sendTermSize(control)
 		if err != nil {
-			shared.Debugf("error setting term size %s", err)
+			shared.LogDebugf("error setting term size %s", err)
 			break
 		}
 	}

--- a/lxc/exec_windows.go
+++ b/lxc/exec_windows.go
@@ -34,6 +34,6 @@ func (c *execCmd) controlSocketHandler(d *lxd.Client, control *websocket.Conn) {
 	// won't work quite correctly.
 	err := c.sendTermSize(control)
 	if err != nil {
-		shared.Debugf("error setting term size %s", err)
+		shared.LogDebugf("error setting term size %s", err)
 	}
 }

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -295,7 +295,7 @@ func (c *remoteCmd) addServer(config *lxd.Config, server string, addr string, ac
 
 func (c *remoteCmd) removeCertificate(config *lxd.Config, remote string) {
 	certf := config.ServerCertPath(remote)
-	shared.Debugf("Trying to remove %s", certf)
+	shared.LogDebugf("Trying to remove %s", certf)
 
 	os.Remove(certf)
 }

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -63,20 +63,20 @@ func readSavedClientCAList(d *Daemon) {
 
 	dbCerts, err := dbCertsGet(d.db)
 	if err != nil {
-		shared.Logf("Error reading certificates from database: %s", err)
+		shared.LogInfof("Error reading certificates from database: %s", err)
 		return
 	}
 
 	for _, dbCert := range dbCerts {
 		certBlock, _ := pem.Decode([]byte(dbCert.Certificate))
 		if certBlock == nil {
-			shared.Logf("Error decoding certificate for %s: %s", dbCert.Name, err)
+			shared.LogInfof("Error decoding certificate for %s: %s", dbCert.Name, err)
 			continue
 		}
 
 		cert, err := x509.ParseCertificate(certBlock.Bytes)
 		if err != nil {
-			shared.Logf("Error reading certificate for %s: %s", dbCert.Name, err)
+			shared.LogInfof("Error reading certificate for %s: %s", dbCert.Name, err)
 			continue
 		}
 		d.clientCerts = append(d.clientCerts, *cert)

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -153,39 +153,39 @@ func (s *execWs) Do(op *operation) error {
 				}
 
 				if err != nil {
-					shared.Debugf("Got error getting next reader %s", err)
+					shared.LogDebugf("Got error getting next reader %s", err)
 					break
 				}
 
 				buf, err := ioutil.ReadAll(r)
 				if err != nil {
-					shared.Debugf("Failed to read message %s", err)
+					shared.LogDebugf("Failed to read message %s", err)
 					break
 				}
 
 				command := shared.ContainerExecControl{}
 
 				if err := json.Unmarshal(buf, &command); err != nil {
-					shared.Debugf("Failed to unmarshal control socket command: %s", err)
+					shared.LogDebugf("Failed to unmarshal control socket command: %s", err)
 					continue
 				}
 
 				if command.Command == "window-resize" {
 					winchWidth, err := strconv.Atoi(command.Args["width"])
 					if err != nil {
-						shared.Debugf("Unable to extract window width: %s", err)
+						shared.LogDebugf("Unable to extract window width: %s", err)
 						continue
 					}
 
 					winchHeight, err := strconv.Atoi(command.Args["height"])
 					if err != nil {
-						shared.Debugf("Unable to extract window height: %s", err)
+						shared.LogDebugf("Unable to extract window height: %s", err)
 						continue
 					}
 
 					err = shared.SetSize(int(ptys[0].Fd()), winchWidth, winchHeight)
 					if err != nil {
-						shared.Debugf("Failed to set window size to: %dx%d", winchWidth, winchHeight)
+						shared.LogDebugf("Failed to set window size to: %dx%d", winchWidth, winchHeight)
 						continue
 					}
 				}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1109,7 +1109,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	}
 
 	if !reflect.DeepEqual(idmap, lastIdmap) {
-		shared.Debugf("Container idmap changed, remapping")
+		shared.LogDebugf("Container idmap changed, remapping")
 
 		err := c.StorageStart()
 		if err != nil {
@@ -1410,7 +1410,7 @@ func (c *containerLXC) Start(stateful bool) error {
 	// Capture debug output
 	if string(out) != "" {
 		for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-			shared.Debugf("forkstart: %s", line)
+			shared.LogDebugf("forkstart: %s", line)
 		}
 	}
 
@@ -2758,7 +2758,7 @@ func (c *containerLXC) Export(w io.Writer) error {
 
 	writeToTar := func(path string, fi os.FileInfo, err error) error {
 		if err := c.tarStoreFile(linkmap, offset, tw, path, fi); err != nil {
-			shared.Debugf("Error tarring up %s: %s", path, err)
+			shared.LogDebugf("Error tarring up %s: %s", path, err)
 			return err
 		}
 		return nil
@@ -2820,7 +2820,7 @@ func (c *containerLXC) Export(w io.Writer) error {
 
 		tmpOffset := len(path.Dir(f.Name())) + 1
 		if err := c.tarStoreFile(linkmap, tmpOffset, tw, f.Name(), fi); err != nil {
-			shared.Debugf("Error writing to tarfile: %s", err)
+			shared.LogDebugf("Error writing to tarfile: %s", err)
 			tw.Close()
 			return err
 		}
@@ -2830,13 +2830,13 @@ func (c *containerLXC) Export(w io.Writer) error {
 		// Include metadata.yaml in the tarball
 		fi, err := os.Lstat(fnam)
 		if err != nil {
-			shared.Debugf("Error statting %s during export", fnam)
+			shared.LogDebugf("Error statting %s during export", fnam)
 			tw.Close()
 			return err
 		}
 
 		if err := c.tarStoreFile(linkmap, offset, tw, fnam, fi); err != nil {
-			shared.Debugf("Error writing to tarfile: %s", err)
+			shared.LogDebugf("Error writing to tarfile: %s", err)
 			tw.Close()
 			return err
 		}
@@ -2955,7 +2955,7 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 
 		if string(out) != "" {
 			for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-				shared.Debugf("forkmigrate: %s", line)
+				shared.LogDebugf("forkmigrate: %s", line)
 			}
 		}
 
@@ -3261,7 +3261,7 @@ func (c *containerLXC) FilePull(srcpath string, dstpath string) (int, int, os.Fi
 			continue
 		}
 
-		shared.Debugf("forkgetfile: %s", line)
+		shared.LogDebugf("forkgetfile: %s", line)
 	}
 
 	if err != nil {
@@ -3340,7 +3340,7 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int, gid int
 		}
 
 		for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-			shared.Debugf("forkgetfile: %s", line)
+			shared.LogDebugf("forkgetfile: %s", line)
 		}
 	}
 
@@ -3705,7 +3705,7 @@ func (c *containerLXC) insertMount(source, target, fstype string, flags int) err
 
 	if string(out) != "" {
 		for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-			shared.Debugf("forkmount: %s", line)
+			shared.LogDebugf("forkmount: %s", line)
 		}
 	}
 
@@ -3735,7 +3735,7 @@ func (c *containerLXC) removeMount(mount string) error {
 
 	if string(out) != "" {
 		for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
-			shared.Debugf("forkumount: %s", line)
+			shared.LogDebugf("forkumount: %s", line)
 		}
 	}
 
@@ -3863,7 +3863,7 @@ func (c *containerLXC) createUnixDevice(m shared.Device) (string, error) {
 		if c.idmapset != nil {
 			if err := c.idmapset.ShiftFile(devPath); err != nil {
 				// uidshift failing is weird, but not a big problem.  Log and proceed
-				shared.Debugf("Failed to uidshift device %s: %s\n", m["path"], err)
+				shared.LogDebugf("Failed to uidshift device %s: %s\n", m["path"], err)
 			}
 		}
 	} else {

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -15,7 +15,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 			return SyncResponse(true, result)
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("DBERR: containersGet: error %q", err)
+			shared.LogDebugf("DBERR: containersGet: error %q", err)
 			return InternalError(err)
 		}
 		// 1 s may seem drastic, but we really don't want to thrash
@@ -23,7 +23,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DBERR: containersGet, db is locked")
+	shared.LogDebugf("DBERR: containersGet, db is locked")
 	shared.PrintStack()
 	return InternalError(fmt.Errorf("DB is locked"))
 }

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -386,7 +386,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 }
 
 func containersPost(d *Daemon, r *http.Request) Response {
-	shared.Debugf("Responding to container create")
+	shared.LogDebugf("Responding to container create")
 
 	req := containerPostReq{}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -411,7 +411,7 @@ func containersPost(d *Daemon, r *http.Request) Response {
 				return InternalError(fmt.Errorf("couldn't generate a new unique name after 100 tries"))
 			}
 		}
-		shared.Debugf("No name provided, creating %s", req.Name)
+		shared.LogDebugf("No name provided, creating %s", req.Name)
 	}
 
 	if req.Devices == nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -367,21 +367,21 @@ func (d *Daemon) SetupStorageDriver() error {
 	if lvmVgName != "" {
 		d.Storage, err = newStorage(d, storageTypeLvm)
 		if err != nil {
-			shared.Logf("Could not initialize storage type LVM: %s - falling back to dir", err)
+			shared.LogInfof("Could not initialize storage type LVM: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
 	} else if zfsPoolName != "" {
 		d.Storage, err = newStorage(d, storageTypeZfs)
 		if err != nil {
-			shared.Logf("Could not initialize storage type ZFS: %s - falling back to dir", err)
+			shared.LogInfof("Could not initialize storage type ZFS: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
 	} else if d.BackingFs == "btrfs" {
 		d.Storage, err = newStorage(d, storageTypeBtrfs)
 		if err != nil {
-			shared.Logf("Could not initialize storage type btrfs: %s - falling back to dir", err)
+			shared.LogInfof("Could not initialize storage type btrfs: %s - falling back to dir", err)
 		} else {
 			return nil
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -772,14 +772,14 @@ func (d *Daemon) Init() error {
 	go func() {
 		t := time.NewTicker(24 * time.Hour)
 		for {
-			shared.Debugf("Expiring log files")
+			shared.LogDebugf("Expiring log files")
 
 			err := d.ExpireLogs()
 			if err != nil {
 				shared.Log.Error("Failed to expire logs", log.Ctx{"err": err})
 			}
 
-			shared.Debugf("Done expiring log files")
+			shared.LogDebugf("Done expiring log files")
 			<-t.C
 		}
 	}()
@@ -1098,7 +1098,7 @@ func (d *Daemon) Stop() error {
 
 		syscall.Unmount(shared.VarPath("shmounts"), syscall.MNT_DETACH)
 	} else {
-		shared.Debugf("Not unmounting shmounts (containers are still running)")
+		shared.LogDebugf("Not unmounting shmounts (containers are still running)")
 	}
 
 	shared.Log.Debug("Closing the database")

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -50,7 +50,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 			entry = &imageStreamCacheEntry{ss: ss, expiry: time.Now().Add(time.Hour)}
 			imageStreamCache[server] = entry
 		} else {
-			shared.Debugf("Using SimpleStreams cache entry for %s, expires at %s", server, entry.expiry)
+			shared.LogDebugf("Using SimpleStreams cache entry for %s, expires at %s", server, entry.expiry)
 			ss = entry.ss
 		}
 		imageStreamCacheLock.Unlock()

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -284,13 +284,13 @@ func dbBegin(db *sql.DB) (*sql.Tx, error) {
 			return tx, nil
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("DbBegin: error %q", err)
+			shared.LogDebugf("DbBegin: error %q", err)
 			return nil, err
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DbBegin: DB still locked")
+	shared.LogDebugf("DbBegin: DB still locked")
 	shared.PrintStack()
 	return nil, fmt.Errorf("DB is locked")
 }
@@ -302,13 +302,13 @@ func txCommit(tx *sql.Tx) error {
 			return nil
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("Txcommit: error %q", err)
+			shared.LogDebugf("Txcommit: error %q", err)
 			return err
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("Txcommit: db still locked")
+	shared.LogDebugf("Txcommit: db still locked")
 	shared.PrintStack()
 	return fmt.Errorf("DB is locked")
 }
@@ -328,7 +328,7 @@ func dbQueryRowScan(db *sql.DB, q string, args []interface{}, outargs []interfac
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DbQueryRowScan: query %q args %q, DB still locked", q, args)
+	shared.LogDebugf("DbQueryRowScan: query %q args %q, DB still locked", q, args)
 	shared.PrintStack()
 	return fmt.Errorf("DB is locked")
 }
@@ -340,13 +340,13 @@ func dbQuery(db *sql.DB, q string, args ...interface{}) (*sql.Rows, error) {
 			return result, nil
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("DbQuery: query %q error %q", q, err)
+			shared.LogDebugf("DbQuery: query %q error %q", q, err)
 			return nil, err
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DbQuery: query %q args %q, DB still locked", q, args)
+	shared.LogDebugf("DbQuery: query %q args %q, DB still locked", q, args)
 	shared.PrintStack()
 	return nil, fmt.Errorf("DB is locked")
 }
@@ -415,13 +415,13 @@ func dbQueryScan(db *sql.DB, q string, inargs []interface{}, outfmt []interface{
 			return result, nil
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("DbQuery: query %q error %q", q, err)
+			shared.LogDebugf("DbQuery: query %q error %q", q, err)
 			return nil, err
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DbQueryscan: query %q inargs %q, DB still locked", q, inargs)
+	shared.LogDebugf("DbQueryscan: query %q inargs %q, DB still locked", q, inargs)
 	shared.PrintStack()
 	return nil, fmt.Errorf("DB is locked")
 }
@@ -433,13 +433,13 @@ func dbExec(db *sql.DB, q string, args ...interface{}) (sql.Result, error) {
 			return result, nil
 		}
 		if !isDbLockedError(err) {
-			shared.Debugf("DbExec: query %q error %q", q, err)
+			shared.LogDebugf("DbExec: query %q error %q", q, err)
 			return nil, err
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	shared.Debugf("DbExec: query %q args %q, DB still locked", q, args)
+	shared.LogDebugf("DbExec: query %q args %q, DB still locked", q, args)
 	shared.PrintStack()
 	return nil, fmt.Errorf("DB is locked")
 }

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -215,7 +215,7 @@ func dbContainerConfigInsert(tx *sql.Tx, id int, config map[string]string) error
 	for k, v := range config {
 		_, err := stmt.Exec(id, k, v)
 		if err != nil {
-			shared.Debugf("Error adding configuration item %s = %s to container %d",
+			shared.LogDebugf("Error adding configuration item %s = %s to container %d",
 				k, v, id)
 			return err
 		}
@@ -251,7 +251,7 @@ func dbContainerProfilesInsert(tx *sql.Tx, id int, profiles []string) error {
 	for _, p := range profiles {
 		_, err = stmt.Exec(id, p, applyOrder)
 		if err != nil {
-			shared.Debugf("Error adding profile %s to container: %s",
+			shared.LogDebugf("Error adding profile %s to container: %s",
 				p, err)
 			return err
 		}

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -77,7 +77,7 @@ type dbUpdate struct {
 func (u *dbUpdate) apply(currentVersion int, d *Daemon) error {
 	// Get the current schema version
 
-	shared.Debugf("Updating DB schema from %d to %d", currentVersion, u.version)
+	shared.LogDebugf("Updating DB schema from %d to %d", currentVersion, u.version)
 
 	err := u.run(currentVersion, u.version, d)
 	if err != nil {
@@ -315,7 +315,7 @@ func dbUpdateFromV18(currentVersion int, version int, d *Daemon) error {
 		// Deal with completely broken values
 		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
-			shared.Debugf("Invalid container memory limit, id=%d value=%s, removing.", id, value)
+			shared.LogDebugf("Invalid container memory limit, id=%d value=%s, removing.", id, value)
 			_, err = d.db.Exec("DELETE FROM containers_config WHERE id=?;", id)
 			if err != nil {
 				return err
@@ -352,7 +352,7 @@ func dbUpdateFromV18(currentVersion int, version int, d *Daemon) error {
 		// Deal with completely broken values
 		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
-			shared.Debugf("Invalid profile memory limit, id=%d value=%s, removing.", id, value)
+			shared.LogDebugf("Invalid profile memory limit, id=%d value=%s, removing.", id, value)
 			_, err = d.db.Exec("DELETE FROM profiles_config WHERE id=?;", id)
 			if err != nil {
 				return err
@@ -576,7 +576,7 @@ func dbUpdateFromV10(currentVersion int, version int, d *Daemon) error {
 			return err
 		}
 
-		shared.Debugf("Restarting all the containers following directory rename")
+		shared.LogDebugf("Restarting all the containers following directory rename")
 		containersShutdown(d)
 		containersRestart(d)
 	}

--- a/lxd/debug.go
+++ b/lxd/debug.go
@@ -12,7 +12,7 @@ import (
 func doMemDump(memProfile string) {
 	f, err := os.Create(memProfile)
 	if err != nil {
-		shared.Debugf("Error opening memory profile file '%s': %s", err)
+		shared.LogDebugf("Error opening memory profile file '%s': %s", err)
 		return
 	}
 	pprof.WriteHeapProfile(f)
@@ -24,7 +24,7 @@ func memProfiler(memProfile string) {
 	signal.Notify(ch, syscall.SIGUSR1)
 	for {
 		sig := <-ch
-		shared.Debugf("Received '%s signal', dumping memory.", sig)
+		shared.LogDebugf("Received '%s signal', dumping memory.", sig)
 		doMemDump(memProfile)
 	}
 }

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -530,7 +530,7 @@ func deviceEventListener(d *Daemon) {
 				continue
 			}
 
-			shared.Debugf("Scheduler: cpu: %s is now %s: re-balancing", e[0], e[1])
+			shared.LogDebugf("Scheduler: cpu: %s is now %s: re-balancing", e[0], e[1])
 			deviceTaskBalance(d)
 		case e := <-chNetlinkNetwork:
 			if len(e) != 2 {
@@ -542,7 +542,7 @@ func deviceEventListener(d *Daemon) {
 				continue
 			}
 
-			shared.Debugf("Scheduler: network: %s has been added: updating network priorities", e[0])
+			shared.LogDebugf("Scheduler: network: %s has been added: updating network priorities", e[0])
 			deviceNetworkPriority(d, e[0])
 		case e := <-chUSB:
 			deviceUSBEvent(d, e)
@@ -556,7 +556,7 @@ func deviceEventListener(d *Daemon) {
 				continue
 			}
 
-			shared.Debugf("Scheduler: %s %s %s: re-balancing", e[0], e[1], e[2])
+			shared.LogDebugf("Scheduler: %s %s %s: re-balancing", e[0], e[1], e[2])
 			deviceTaskBalance(d)
 		}
 	}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -217,7 +217,7 @@ func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
 	case http.StateNew:
 		cred, err := getCred(unixConn)
 		if err != nil {
-			shared.Debugf("Error getting ucred for conn %s", err)
+			shared.LogDebugf("Error getting ucred for conn %s", err)
 		} else {
 			m.m[unixConn] = cred
 		}
@@ -238,7 +238,7 @@ func (m *ConnPidMapper) ConnStateHandler(conn net.Conn, state http.ConnState) {
 	case http.StateClosed:
 		delete(m.m, unixConn)
 	default:
-		shared.Debugf("Unknown state for connection %s", state)
+		shared.LogDebugf("Unknown state for connection %s", state)
 	}
 }
 

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -87,7 +87,7 @@ func eventsSocket(r *http.Request, w http.ResponseWriter) error {
 	eventListeners[listener.id] = &listener
 	eventsLock.Unlock()
 
-	shared.Debugf("New events listener: %s", listener.id)
+	shared.LogDebugf("New events listener: %s", listener.id)
 
 	<-listener.active
 
@@ -96,7 +96,7 @@ func eventsSocket(r *http.Request, w http.ResponseWriter) error {
 	eventsLock.Unlock()
 
 	listener.connection.Close()
-	shared.Debugf("Disconnected events listener: %s", listener.id)
+	shared.LogDebugf("Disconnected events listener: %s", listener.id)
 
 	return nil
 }

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -107,8 +107,8 @@ func unpack(file string, path string) error {
 	output, err := exec.Command(command, args...).CombinedOutput()
 	if err != nil {
 		co := string(output)
-		shared.Debugf("Unpacking failed")
-		shared.Debugf(co)
+		shared.LogDebugf("Unpacking failed")
+		shared.LogDebugf(co)
 
 		// Truncate the output to a single line for inclusion in the error
 		// message.  The first line isn't guaranteed to pinpoint the issue,
@@ -662,7 +662,7 @@ func imagesPost(d *Daemon, r *http.Request) Response {
 		}
 
 		if err := os.RemoveAll(path); err != nil {
-			shared.Debugf("Error deleting temporary directory \"%s\": %s", path, err)
+			shared.LogDebugf("Error deleting temporary directory \"%s\": %s", path, err)
 		}
 	}
 
@@ -844,7 +844,7 @@ func imagesGet(d *Daemon, r *http.Request) Response {
 var imagesCmd = Command{name: "images", post: imagesPost, untrustedGet: true, get: imagesGet}
 
 func autoUpdateImages(d *Daemon) {
-	shared.Debugf("Updating images")
+	shared.LogDebugf("Updating images")
 
 	images, err := dbImagesGet(d.db, false)
 	if err != nil {
@@ -903,11 +903,11 @@ func autoUpdateImages(d *Daemon) {
 		}
 	}
 
-	shared.Debugf("Done updating images")
+	shared.LogDebugf("Done updating images")
 }
 
 func pruneExpiredImages(d *Daemon) {
-	shared.Debugf("Pruning expired images")
+	shared.LogDebugf("Pruning expired images")
 
 	// Get the list of expires images
 	expiry := daemonConfig["images.remote_cache_expiry"].GetInt64()
@@ -924,7 +924,7 @@ func pruneExpiredImages(d *Daemon) {
 		}
 	}
 
-	shared.Debugf("Done pruning expired images")
+	shared.LogDebugf("Done pruning expired images")
 }
 
 func doDeleteImage(d *Daemon, fingerprint string) error {
@@ -950,7 +950,7 @@ func doDeleteImage(d *Daemon, fingerprint string) error {
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			shared.Debugf("Error deleting image file %s: %s", fname, err)
+			shared.LogDebugf("Error deleting image file %s: %s", fname, err)
 		}
 	}
 
@@ -959,7 +959,7 @@ func doDeleteImage(d *Daemon, fingerprint string) error {
 	if shared.PathExists(fname) {
 		err = os.Remove(fname)
 		if err != nil {
-			shared.Debugf("Error deleting image file %s: %s", fname, err)
+			shared.LogDebugf("Error deleting image file %s: %s", fname, err)
 		}
 	}
 

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -496,7 +496,7 @@ func cmdActivateIfNeeded() error {
 	// Look for network socket
 	value := daemonConfig["core.https_address"].Get()
 	if value != "" {
-		shared.Debugf("Daemon has core.https_address set, activating...")
+		shared.LogDebugf("Daemon has core.https_address set, activating...")
 		_, err := lxd.NewClient(&lxd.DefaultConfig, "local")
 		return err
 	}
@@ -523,19 +523,19 @@ func cmdActivateIfNeeded() error {
 		autoStart := config["boot.autostart"]
 
 		if c.IsRunning() {
-			shared.Debugf("Daemon has running containers, activating...")
+			shared.LogDebugf("Daemon has running containers, activating...")
 			_, err := lxd.NewClient(&lxd.DefaultConfig, "local")
 			return err
 		}
 
 		if lastState == "RUNNING" || lastState == "Running" || shared.IsTrue(autoStart) {
-			shared.Debugf("Daemon has auto-started containers, activating...")
+			shared.LogDebugf("Daemon has auto-started containers, activating...")
 			_, err := lxd.NewClient(&lxd.DefaultConfig, "local")
 			return err
 		}
 	}
 
-	shared.Debugf("No need to start the daemon now.")
+	shared.LogDebugf("No need to start the daemon now.")
 	return nil
 }
 

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -136,7 +136,7 @@ func (c *migrationFields) controlChannel() <-chan MigrationControl {
 		msg := MigrationControl{}
 		err := c.recv(&msg)
 		if err != nil {
-			shared.Debugf("Got error reading migration control socket %s", err)
+			shared.LogDebugf("Got error reading migration control socket %s", err)
 			close(ch)
 			return
 		}
@@ -439,7 +439,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 			return abort(err)
 		/* the dump finished, let's continue on to the restore */
 		case <-dumpDone:
-			shared.Debugf("Dump finished, continuing with restore...")
+			shared.LogDebugf("Dump finished, continuing with restore...")
 		}
 
 		/*
@@ -699,7 +699,7 @@ func (c *migrationSink) do() error {
 				// The source can only tell us it failed (e.g. if
 				// checkpointing failed). We have to tell the source
 				// whether or not the restore was successful.
-				shared.Debugf("Unknown message %v from source", msg)
+				shared.LogDebugf("Unknown message %v from source", msg)
 			}
 		}
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -116,7 +116,7 @@ func (op *operation) Run() (chan error, error) {
 				op.done()
 				chanRun <- err
 
-				shared.Debugf("Failure for %s operation: %s: %s", op.class.String(), op.id, err)
+				shared.LogDebugf("Failure for %s operation: %s: %s", op.class.String(), op.id, err)
 
 				_, md, _ := op.Render()
 				eventSend("operation", md)
@@ -130,7 +130,7 @@ func (op *operation) Run() (chan error, error) {
 			chanRun <- nil
 
 			op.lock.Lock()
-			shared.Debugf("Success for %s operation: %s", op.class.String(), op.id)
+			shared.LogDebugf("Success for %s operation: %s", op.class.String(), op.id)
 			_, md, _ := op.Render()
 			eventSend("operation", md)
 			op.lock.Unlock()
@@ -138,7 +138,7 @@ func (op *operation) Run() (chan error, error) {
 	}
 	op.lock.Unlock()
 
-	shared.Debugf("Started %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Started %s operation: %s", op.class.String(), op.id)
 	_, md, _ := op.Render()
 	eventSend("operation", md)
 
@@ -170,7 +170,7 @@ func (op *operation) Cancel() (chan error, error) {
 				op.lock.Unlock()
 				chanCancel <- err
 
-				shared.Debugf("Failed to cancel %s operation: %s: %s", op.class.String(), op.id, err)
+				shared.LogDebugf("Failed to cancel %s operation: %s: %s", op.class.String(), op.id, err)
 				_, md, _ := op.Render()
 				eventSend("operation", md)
 				return
@@ -182,13 +182,13 @@ func (op *operation) Cancel() (chan error, error) {
 			op.done()
 			chanCancel <- nil
 
-			shared.Debugf("Cancelled %s operation: %s", op.class.String(), op.id)
+			shared.LogDebugf("Cancelled %s operation: %s", op.class.String(), op.id)
 			_, md, _ := op.Render()
 			eventSend("operation", md)
 		}(op, oldStatus, chanCancel)
 	}
 
-	shared.Debugf("Cancelling %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Cancelling %s operation: %s", op.class.String(), op.id)
 	_, md, _ := op.Render()
 	eventSend("operation", md)
 
@@ -200,7 +200,7 @@ func (op *operation) Cancel() (chan error, error) {
 		chanCancel <- nil
 	}
 
-	shared.Debugf("Cancelled %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Cancelled %s operation: %s", op.class.String(), op.id)
 	_, md, _ = op.Render()
 	eventSend("operation", md)
 
@@ -225,17 +225,17 @@ func (op *operation) Connect(r *http.Request, w http.ResponseWriter) (chan error
 		if err != nil {
 			chanConnect <- err
 
-			shared.Debugf("Failed to handle %s operation: %s: %s", op.class.String(), op.id, err)
+			shared.LogDebugf("Failed to handle %s operation: %s: %s", op.class.String(), op.id, err)
 			return
 		}
 
 		chanConnect <- nil
 
-		shared.Debugf("Handled %s operation: %s", op.class.String(), op.id)
+		shared.LogDebugf("Handled %s operation: %s", op.class.String(), op.id)
 	}(op, chanConnect)
 	op.lock.Unlock()
 
-	shared.Debugf("Connected %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Connected %s operation: %s", op.class.String(), op.id)
 
 	return chanConnect, nil
 }
@@ -320,7 +320,7 @@ func (op *operation) UpdateResources(opResources map[string][]string) error {
 	op.resources = opResources
 	op.lock.Unlock()
 
-	shared.Debugf("Updated resources for %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Updated resources for %s operation: %s", op.class.String(), op.id)
 	_, md, _ := op.Render()
 	eventSend("operation", md)
 
@@ -346,7 +346,7 @@ func (op *operation) UpdateMetadata(opMetadata interface{}) error {
 	op.metadata = newMetadata
 	op.lock.Unlock()
 
-	shared.Debugf("Updated metadata for %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("Updated metadata for %s operation: %s", op.class.String(), op.id)
 	_, md, _ := op.Render()
 	eventSend("operation", md)
 
@@ -401,7 +401,7 @@ func operationCreate(opClass operationClass, opResources map[string][]string, op
 	operations[op.id] = &op
 	operationsLock.Unlock()
 
-	shared.Debugf("New %s operation: %s", op.class.String(), op.id)
+	shared.LogDebugf("New %s operation: %s", op.class.String(), op.id)
 	_, md, _ := op.Render()
 	eventSend("operation", md)
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -36,7 +36,7 @@ type patch struct {
 }
 
 func (p *patch) apply(d *Daemon) error {
-	shared.Debugf("Applying patch: %s", p.name)
+	shared.LogDebugf("Applying patch: %s", p.name)
 
 	err := p.run(p.name, d)
 	if err != nil {

--- a/lxd/rsync.go
+++ b/lxd/rsync.go
@@ -37,13 +37,13 @@ func rsyncWebsocket(path string, cmd *exec.Cmd, conn *websocket.Conn) error {
 	readDone, writeDone := shared.WebsocketMirror(conn, stdin, stdout)
 	data, err2 := ioutil.ReadAll(stderr)
 	if err2 != nil {
-		shared.Debugf("error reading rsync stderr: %s", err2)
+		shared.LogDebugf("error reading rsync stderr: %s", err2)
 		return err2
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		shared.Debugf("rsync recv error for path %s: %s: %s", path, err, string(data))
+		shared.LogDebugf("rsync recv error for path %s: %s: %s", path, err, string(data))
 	}
 
 	<-readDone
@@ -139,12 +139,12 @@ func RsyncSend(path string, conn *websocket.Conn) error {
 
 	output, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		shared.Debugf("problem reading rsync stderr %s", err)
+		shared.LogDebugf("problem reading rsync stderr %s", err)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		shared.Debugf("problem with rsync send of %s: %s: %s", path, err, string(output))
+		shared.LogDebugf("problem with rsync send of %s: %s: %s", path, err, string(output))
 	}
 
 	<-readDone

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -53,7 +53,7 @@ func filesystemDetect(path string) (string, error) {
 	case filesystemSuperMagicNfs:
 		return "nfs", nil
 	default:
-		shared.Debugf("Unknown backing filesystem type: 0x%x", fs.Type)
+		shared.LogDebugf("Unknown backing filesystem type: 0x%x", fs.Type)
 		return string(fs.Type), nil
 	}
 }
@@ -320,7 +320,7 @@ func (ss *storageShared) shiftRootfs(c container) error {
 
 	err := idmapset.ShiftRootfs(rpath)
 	if err != nil {
-		shared.Debugf("Shift of rootfs %s failed: %s", rpath, err)
+		shared.LogDebugf("Shift of rootfs %s failed: %s", rpath, err)
 		return err
 	}
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1028,7 +1028,7 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 
 		output, err := ioutil.ReadAll(stderr)
 		if err != nil {
-			shared.Debugf("problem reading btrfs receive stderr %s", err)
+			shared.LogDebugf("problem reading btrfs receive stderr %s", err)
 		}
 
 		err = cmd.Wait()

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -732,7 +732,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 	fstype := daemonConfig["storage.lvm_fstype"].Get()
 	err = tryMount(lvpath, tempLVMountPoint, fstype, 0, "discard")
 	if err != nil {
-		shared.Logf("Error mounting image LV for unpacking: %v", err)
+		shared.LogInfof("Error mounting image LV for unpacking: %v", err)
 		return fmt.Errorf("Error mounting image LV: %v", err)
 	}
 

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1397,7 +1397,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []c
 
 		output, err := ioutil.ReadAll(stderr)
 		if err != nil {
-			shared.Debugf("problem reading zfs recv stderr %s", "err", err)
+			shared.LogDebugf("problem reading zfs recv stderr %s", "err", err)
 		}
 
 		err = cmd.Wait()

--- a/shared/json.go
+++ b/shared/json.go
@@ -51,11 +51,11 @@ func (m Jmap) GetBool(key string) (bool, error) {
 func DebugJson(r *bytes.Buffer) {
 	pretty := &bytes.Buffer{}
 	if err := json.Indent(pretty, r.Bytes(), "\t", "\t"); err != nil {
-		Debugf("error indenting json: %s", err)
+		LogDebugf("error indenting json: %s", err)
 		return
 	}
 
 	// Print the JSON without the last "\n"
 	str := pretty.String()
-	Debugf("\n\t%s", str[0:len(str)-1])
+	LogDebugf("\n\t%s", str[0:len(str)-1])
 }

--- a/shared/log.go
+++ b/shared/log.go
@@ -2,6 +2,7 @@ package shared
 
 import (
 	"fmt"
+	log "gopkg.in/inconshreveable/log15.v2"
 	"runtime"
 )
 
@@ -25,6 +26,37 @@ func (nl nullLogger) Crit(msg string, ctx ...interface{})  {}
 
 func init() {
 	Log = nullLogger{}
+}
+
+// Wrapper function for functions in the Logger interface.
+func LogDebug(msg string, ctx map[string]interface{}) {
+	if Log != nil {
+		Log.Warn(msg, log.Ctx(ctx))
+	}
+}
+
+func LogInfo(msg string, ctx map[string]interface{}) {
+	if Log != nil {
+		Log.Info(msg, log.Ctx(ctx))
+	}
+}
+
+func LogWarn(msg string, ctx map[string]interface{}) {
+	if Log != nil {
+		Log.Warn(msg, log.Ctx(ctx))
+	}
+}
+
+func LogError(msg string, ctx map[string]interface{}) {
+	if Log != nil {
+		Log.Error(msg, log.Ctx(ctx))
+	}
+}
+
+func LogCrit(msg string, ctx map[string]interface{}) {
+	if Log != nil {
+		Log.Crit(msg, log.Ctx(ctx))
+	}
 }
 
 // Logf sends to the logger registered via SetLogger the string resulting

--- a/shared/log.go
+++ b/shared/log.go
@@ -28,7 +28,7 @@ func init() {
 	Log = nullLogger{}
 }
 
-// Wrapper function for functions in the Logger interface.
+// General wrappers around Logger interface functions.
 func LogDebug(msg string, ctx map[string]interface{}) {
 	if Log != nil {
 		Log.Warn(msg, log.Ctx(ctx))
@@ -59,25 +59,40 @@ func LogCrit(msg string, ctx map[string]interface{}) {
 	}
 }
 
-// Logf sends to the logger registered via SetLogger the string resulting
-// from running format and args through Sprintf.
-func Logf(format string, args ...interface{}) {
+// Wrappers around Logger interface functions that send a string to the Logger
+// by running it through fmt.Sprintf().
+func LogInfof(format string, args ...interface{}) {
 	if Log != nil {
 		Log.Info(fmt.Sprintf(format, args...))
 	}
 }
 
-// Debugf sends to the logger registered via SetLogger the string resulting
-// from running format and args through Sprintf, but only if debugging was
-// enabled via SetDebug.
-func Debugf(format string, args ...interface{}) {
+func LogDebugf(format string, args ...interface{}) {
 	if Log != nil {
 		Log.Debug(fmt.Sprintf(format, args...))
+	}
+}
+
+func LogWarnf(format string, args ...interface{}) {
+	if Log != nil {
+		Log.Warn(fmt.Sprintf(format, args...))
+	}
+}
+
+func LogErrorf(format string, args ...interface{}) {
+	if Log != nil {
+		Log.Error(fmt.Sprintf(format, args...))
+	}
+}
+
+func LogCritf(format string, args ...interface{}) {
+	if Log != nil {
+		Log.Crit(fmt.Sprintf(format, args...))
 	}
 }
 
 func PrintStack() {
 	buf := make([]byte, 1<<16)
 	runtime.Stack(buf, true)
-	Debugf("%s", buf)
+	LogDebugf("%s", buf)
 }

--- a/shared/network.go
+++ b/shared/network.go
@@ -162,14 +162,14 @@ func WebsocketSendStream(conn *websocket.Conn, r io.Reader, bufferSize int) chan
 
 			w, err := conn.NextWriter(websocket.BinaryMessage)
 			if err != nil {
-				Debugf("Got error getting next writer %s", err)
+				LogDebugf("Got error getting next writer %s", err)
 				break
 			}
 
 			_, err = w.Write(buf)
 			w.Close()
 			if err != nil {
-				Debugf("Got err writing %s", err)
+				LogDebugf("Got err writing %s", err)
 				break
 			}
 		}
@@ -187,23 +187,23 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 		for {
 			mt, r, err := conn.NextReader()
 			if mt == websocket.CloseMessage {
-				Debugf("Got close message for reader")
+				LogDebugf("Got close message for reader")
 				break
 			}
 
 			if mt == websocket.TextMessage {
-				Debugf("got message barrier")
+				LogDebugf("got message barrier")
 				break
 			}
 
 			if err != nil {
-				Debugf("Got error getting next reader %s, %s", err, w)
+				LogDebugf("Got error getting next reader %s, %s", err, w)
 				break
 			}
 
 			buf, err := ioutil.ReadAll(r)
 			if err != nil {
-				Debugf("Got error writing to writer %s", err)
+				LogDebugf("Got error writing to writer %s", err)
 				break
 			}
 
@@ -213,11 +213,11 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 
 			i, err := w.Write(buf)
 			if i != len(buf) {
-				Debugf("Didn't write all of buf")
+				LogDebugf("Didn't write all of buf")
 				break
 			}
 			if err != nil {
-				Debugf("Error writing buf %s", err)
+				LogDebugf("Error writing buf %s", err)
 				break
 			}
 		}
@@ -239,32 +239,32 @@ func WebsocketMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser) (c
 		for {
 			mt, r, err := conn.NextReader()
 			if err != nil {
-				Debugf("Got error getting next reader %s, %s", err, w)
+				LogDebugf("Got error getting next reader %s, %s", err, w)
 				break
 			}
 
 			if mt == websocket.CloseMessage {
-				Debugf("Got close message for reader")
+				LogDebugf("Got close message for reader")
 				break
 			}
 
 			if mt == websocket.TextMessage {
-				Debugf("Got message barrier, resetting stream")
+				LogDebugf("Got message barrier, resetting stream")
 				break
 			}
 
 			buf, err := ioutil.ReadAll(r)
 			if err != nil {
-				Debugf("Got error writing to writer %s", err)
+				LogDebugf("Got error writing to writer %s", err)
 				break
 			}
 			i, err := w.Write(buf)
 			if i != len(buf) {
-				Debugf("Didn't write all of buf")
+				LogDebugf("Didn't write all of buf")
 				break
 			}
 			if err != nil {
-				Debugf("Error writing buf %s", err)
+				LogDebugf("Error writing buf %s", err)
 				break
 			}
 		}
@@ -282,21 +282,21 @@ func WebsocketMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser) (c
 			buf, ok := <-in
 			if !ok {
 				r.Close()
-				Debugf("sending write barrier")
+				LogDebugf("sending write barrier")
 				conn.WriteMessage(websocket.TextMessage, []byte{})
 				readDone <- true
 				return
 			}
 			w, err := conn.NextWriter(websocket.BinaryMessage)
 			if err != nil {
-				Debugf("Got error getting next writer %s", err)
+				LogDebugf("Got error getting next writer %s", err)
 				break
 			}
 
 			_, err = w.Write(buf)
 			w.Close()
 			if err != nil {
-				Debugf("Got err writing %s", err)
+				LogDebugf("Got err writing %s", err)
 				break
 			}
 		}


### PR DESCRIPTION
This is just partial work done on the logging. The logging levels have not yet been adapted. The interesting commits are first two which introduce usable wrappers. I've gone with two types of wrappers now:

1. Wrappers with `ctx map[string]interface{}` arguments like Stéphane suggested:
```
func LogCrit(msg string, ctx map[string]interface{}) {
 	if Log != nil {
 		Log.Crit(msg, log.Ctx(ctx))
 	}
 }
```

2. Wrapper with send their output through `fmt.Sprintf()`:
```
func LogCritf(format string, args ...interface{}) {
 	if Log != nil {
 		Log.Crit(fmt.Sprintf(format, args...))
 	}
}
```

Given the codebase so far it looks like we want both options. The other commits just adapt naming from `Debugf()` --> `LogDebugf()` and `Logf()` --> `LogInfof()`.