### PR TITLE
Tweak squashfs for low-memory systems

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -99,6 +99,13 @@ func unpack(file string, path string) error {
 	} else if strings.HasPrefix(extension, ".squashfs") {
 		command = "unsquashfs"
 		args = append(args, "-f", "-d", path, "-n")
+
+		mem, err := deviceTotalMemory()
+		mem = mem / 1024 / 1024 / 10
+		if err == nil && mem < 256 {
+			args = append(args, "-da", fmt.Sprintf("%d", mem), "-fr", fmt.Sprintf("%d", mem), "-p", "1")
+		}
+
 		args = append(args, file)
 	} else {
 		return fmt.Errorf("Unsupported image format: %s", extension)


### PR DESCRIPTION
On low-memory systems (below 2GB of RAM), limit unsquashfs to a single
CPU and to 10% of the RAM for its fragment size.

Closes #2382

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>