### PR TITLE
2016 09 17/logging issue 1928

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -325,7 +325,7 @@ func runApparmor(command string, c container) error {
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
-		shared.Log.Error("Running apparmor",
+		shared.LogError("Running apparmor",
 			log.Ctx{"action": command, "output": string(output), "err": err})
 	}
 

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -335,7 +335,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 		metadata := shared.Jmap{"return": cmdResult}
 		err = op.UpdateMetadata(metadata)
 		if err != nil {
-			shared.Log.Error("error updating metadata for cmd", log.Ctx{"err": err, "cmd": post.Command})
+			shared.LogError("error updating metadata for cmd", log.Ctx{"err": err, "cmd": post.Command})
 		}
 		return cmdErr
 	}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -291,7 +291,7 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 		err = sink()
 		if err != nil {
 			c.StorageStop()
-			shared.Log.Error("Error during migration sink", "err", err)
+			shared.LogError("Error during migration sink", log.Ctx{"err": err})
 			c.Delete()
 			return fmt.Errorf("Error transferring container data: %s", err)
 		}
@@ -336,7 +336,7 @@ func createFromCopy(d *Daemon, req *containerPostReq) Response {
 
 	for key, value := range sourceConfig {
 		if len(key) > 8 && key[0:8] == "volatile" && key[9:] != "base_image" {
-			shared.Log.Debug("Skipping volatile key from copy source",
+			shared.LogDebug("Skipping volatile key from copy source",
 				log.Ctx{"key": key})
 			continue
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -573,13 +573,13 @@ func (d *Daemon) Init() error {
 
 	/* Print welcome message */
 	if d.MockMode {
-		shared.LogDebug("LXD is starting in mock mode",
+		shared.LogInfo("LXD is starting in mock mode",
 			log.Ctx{"path": shared.VarPath("")})
 	} else if d.SetupMode {
-		shared.LogDebug("LXD is starting in setup mode",
+		shared.LogInfo("LXD is starting in setup mode",
 			log.Ctx{"path": shared.VarPath("")})
 	} else {
-		shared.LogDebug("LXD is starting in normal mode",
+		shared.LogInfo("LXD is starting in normal mode",
 			log.Ctx{"path": shared.VarPath("")})
 	}
 
@@ -736,9 +736,9 @@ func (d *Daemon) Init() error {
 		shared.LogWarn("Error reading idmap", log.Ctx{"err": err.Error()})
 		shared.LogWarnf("Only privileged containers will be able to run")
 	} else {
-		shared.LogDebugf("Default uid/gid map:")
+		shared.LogInfof("Default uid/gid map:")
 		for _, lxcmap := range d.IdmapSet.ToLxcString() {
-			shared.LogDebugf(strings.TrimRight(" - "+lxcmap, "\n"))
+			shared.LogInfof(strings.TrimRight(" - "+lxcmap, "\n"))
 		}
 	}
 
@@ -779,7 +779,7 @@ func (d *Daemon) Init() error {
 				shared.LogError("Failed to expire logs", log.Ctx{"err": err})
 			}
 
-			shared.LogDebugf("Done expiring log files")
+			shared.LogInfof("Done expiring log files")
 			<-t.C
 		}
 	}()
@@ -835,7 +835,7 @@ func (d *Daemon) Init() error {
 			tlsConfig.RootCAs = caPool
 			tlsConfig.ClientCAs = caPool
 
-			shared.LogDebugf("LXD is in CA mode, only CA-signed certificates will be allowed")
+			shared.LogInfof("LXD is in CA mode, only CA-signed certificates will be allowed")
 		}
 
 		tlsConfig.BuildNameToCertificate()
@@ -863,14 +863,14 @@ func (d *Daemon) Init() error {
 	}
 
 	d.mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		shared.LogDebug("Sending top level 404", log.Ctx{"url": r.URL})
+		shared.LogInfo("Sending top level 404", log.Ctx{"url": r.URL})
 		w.Header().Set("Content-Type", "application/json")
 		NotFound.Render(w)
 	})
 
 	listeners := d.GetListeners()
 	if len(listeners) > 0 {
-		shared.LogDebugf("LXD is socket activated")
+		shared.LogInfof("LXD is socket activated")
 
 		for _, listener := range listeners {
 			if shared.PathExists(listener.Addr().String()) {
@@ -881,7 +881,7 @@ func (d *Daemon) Init() error {
 			}
 		}
 	} else {
-		shared.LogDebugf("LXD isn't socket activated")
+		shared.LogInfof("LXD isn't socket activated")
 
 		localSocketPath := shared.VarPath("unix.socket")
 
@@ -945,7 +945,7 @@ func (d *Daemon) Init() error {
 			shared.LogError("cannot listen on https socket, skipping...", log.Ctx{"err": err})
 		} else {
 			if d.TCPSocket != nil {
-				shared.LogDebugf("Replacing inherited TCP socket with configured one")
+				shared.LogInfof("Replacing inherited TCP socket with configured one")
 				d.TCPSocket.Socket.Close()
 			}
 			d.TCPSocket = &Socket{Socket: tcpl, CloseOnExit: true}
@@ -953,14 +953,14 @@ func (d *Daemon) Init() error {
 	}
 
 	d.tomb.Go(func() error {
-		shared.LogDebugf("REST API daemon:")
+		shared.LogInfof("REST API daemon:")
 		if d.UnixSocket != nil {
-			shared.LogDebug(" - binding Unix socket", log.Ctx{"socket": d.UnixSocket.Socket.Addr()})
+			shared.LogInfo(" - binding Unix socket", log.Ctx{"socket": d.UnixSocket.Socket.Addr()})
 			d.tomb.Go(func() error { return http.Serve(d.UnixSocket.Socket, &lxdHttpServer{d.mux, d}) })
 		}
 
 		if d.TCPSocket != nil {
-			shared.LogDebug(" - binding TCP socket", log.Ctx{"socket": d.TCPSocket.Socket.Addr()})
+			shared.LogInfo(" - binding TCP socket", log.Ctx{"socket": d.TCPSocket.Socket.Addr()})
 			d.tomb.Go(func() error { return http.Serve(d.TCPSocket.Socket, &lxdHttpServer{d.mux, d}) })
 		}
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -367,21 +367,21 @@ func (d *Daemon) SetupStorageDriver() error {
 	if lvmVgName != "" {
 		d.Storage, err = newStorage(d, storageTypeLvm)
 		if err != nil {
-			shared.LogDebugf("Could not initialize storage type LVM: %s - falling back to dir", err)
+			shared.LogErrorf("Could not initialize storage type LVM: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
 	} else if zfsPoolName != "" {
 		d.Storage, err = newStorage(d, storageTypeZfs)
 		if err != nil {
-			shared.LogDebugf("Could not initialize storage type ZFS: %s - falling back to dir", err)
+			shared.LogErrorf("Could not initialize storage type ZFS: %s - falling back to dir", err)
 		} else {
 			return nil
 		}
 	} else if d.BackingFs == "btrfs" {
 		d.Storage, err = newStorage(d, storageTypeBtrfs)
 		if err != nil {
-			shared.LogDebugf("Could not initialize storage type btrfs: %s - falling back to dir", err)
+			shared.LogErrorf("Could not initialize storage type btrfs: %s - falling back to dir", err)
 		} else {
 			return nil
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1078,17 +1078,17 @@ func (d *Daemon) Stop() error {
 	forceStop := false
 
 	d.tomb.Kill(errStop)
-	shared.LogDebugf("Stopping REST API handler:")
+	shared.LogInfof("Stopping REST API handler:")
 	for _, socket := range []*Socket{d.TCPSocket, d.UnixSocket} {
 		if socket == nil {
 			continue
 		}
 
 		if socket.CloseOnExit {
-			shared.LogDebug(" - closing socket", log.Ctx{"socket": socket.Socket.Addr()})
+			shared.LogInfo(" - closing socket", log.Ctx{"socket": socket.Socket.Addr()})
 			socket.Socket.Close()
 		} else {
-			shared.LogDebug(" - skipping socket-activated socket", log.Ctx{"socket": socket.Socket.Addr()})
+			shared.LogInfo(" - skipping socket-activated socket", log.Ctx{"socket": socket.Socket.Addr()})
 			forceStop = true
 		}
 	}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -92,7 +92,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		// We already download the image
 		d.imagesDownloadingLock.RUnlock()
 
-		shared.LogInfo(
+		shared.LogDebug(
 			"Already downloading the image, waiting for it to succeed",
 			log.Ctx{"image": fp})
 
@@ -109,7 +109,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 			return "", fmt.Errorf("Previous download didn't succeed")
 		}
 
-		shared.LogInfo(
+		shared.LogDebug(
 			"Previous download succeeded",
 			log.Ctx{"image": fp})
 
@@ -401,7 +401,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		}
 	}
 
-	shared.LogInfo(
+	shared.LogDebug(
 		"Download succeeded",
 		log.Ctx{"image": fp})
 

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -82,10 +82,6 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		return fp, nil
 	}
 
-	shared.LogInfo(
-		"Image not in the db, downloading it",
-		log.Ctx{"image": fp, "server": server})
-
 	// Now check if we already downloading the image
 	d.imagesDownloadingLock.RLock()
 	if waitChannel, ok := d.imagesDownloading[fp]; ok {
@@ -119,8 +115,8 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	d.imagesDownloadingLock.RUnlock()
 
 	shared.LogInfo(
-		"Downloading the image",
-		log.Ctx{"image": fp})
+		"Downloading image",
+		log.Ctx{"trigger": op.url, "image": fp, "operation": op.id, "alias": alias, "server": server})
 
 	// Add the download to the queue
 	d.imagesDownloadingLock.Lock()
@@ -236,6 +232,10 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 				return "", err
 			}
 		}
+
+		shared.LogInfo(
+			"Image downloaded",
+			log.Ctx{"image": fp, "fingerprint": fp, "operation": op.id, "alias": alias, "server": server})
 
 		if forContainer {
 			return fp, dbImageLastAccessInit(d.db, fp)
@@ -401,9 +401,9 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		}
 	}
 
-	shared.LogDebug(
-		"Download succeeded",
-		log.Ctx{"image": fp})
+	shared.LogInfo(
+		"Image downloaded",
+		log.Ctx{"image": fp, "operation": op.id, "alias": alias, "server": server})
 
 	if forContainer {
 		return fp, dbImageLastAccessInit(d.db, fp)

--- a/lxd/db_update.go
+++ b/lxd/db_update.go
@@ -418,11 +418,11 @@ func dbUpdateFromV15(currentVersion int, version int, d *Daemon) error {
 		newLVName = strings.Replace(newLVName, shared.SnapshotDelimiter, "-", -1)
 
 		if cName == newLVName {
-			shared.Log.Debug("No need to rename, skipping", log.Ctx{"cName": cName, "newLVName": newLVName})
+			shared.LogDebug("No need to rename, skipping", log.Ctx{"cName": cName, "newLVName": newLVName})
 			continue
 		}
 
-		shared.Log.Debug("About to rename cName in lv upgrade", log.Ctx{"lvLinkPath": lvLinkPath, "cName": cName, "newLVName": newLVName})
+		shared.LogDebug("About to rename cName in lv upgrade", log.Ctx{"lvLinkPath": lvLinkPath, "cName": cName, "newLVName": newLVName})
 
 		output, err := exec.Command("lvrename", vgName, cName, newLVName).CombinedOutput()
 		if err != nil {
@@ -508,7 +508,7 @@ func dbUpdateFromV11(currentVersion int, version int, d *Daemon) error {
 		oldPath := shared.VarPath("containers", snappieces[0], "snapshots", snappieces[1])
 		newPath := shared.VarPath("snapshots", snappieces[0], snappieces[1])
 		if shared.PathExists(oldPath) && !shared.PathExists(newPath) {
-			shared.Log.Info(
+			shared.LogInfo(
 				"Moving snapshot",
 				log.Ctx{
 					"snapshot": cName,
@@ -521,7 +521,7 @@ func dbUpdateFromV11(currentVersion int, version int, d *Daemon) error {
 			// snapshots/<container>/<snap0>
 			output, err := storageRsyncCopy(oldPath, newPath)
 			if err != nil {
-				shared.Log.Error(
+				shared.LogError(
 					"Failed rsync snapshot",
 					log.Ctx{
 						"snapshot": cName,
@@ -533,7 +533,7 @@ func dbUpdateFromV11(currentVersion int, version int, d *Daemon) error {
 
 			// Remove containers/<container>/snapshots/<snap0>
 			if err := os.RemoveAll(oldPath); err != nil {
-				shared.Log.Error(
+				shared.LogError(
 					"Failed to remove the old snapshot path",
 					log.Ctx{
 						"snapshot": cName,

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -857,14 +857,14 @@ func autoUpdateImages(d *Daemon) {
 
 	images, err := dbImagesGet(d.db, false)
 	if err != nil {
-		shared.Log.Error("Unable to retrieve the list of images", log.Ctx{"err": err})
+		shared.LogError("Unable to retrieve the list of images", log.Ctx{"err": err})
 		return
 	}
 
 	for _, fp := range images {
 		id, info, err := dbImageGet(d.db, fp, false, true)
 		if err != nil {
-			shared.Log.Error("Error loading image", log.Ctx{"err": err, "fp": fp})
+			shared.LogError("Error loading image", log.Ctx{"err": err, "fp": fp})
 			continue
 		}
 
@@ -877,38 +877,38 @@ func autoUpdateImages(d *Daemon) {
 			continue
 		}
 
-		shared.Log.Debug("Processing image", log.Ctx{"fp": fp, "server": source.Server, "protocol": source.Protocol, "alias": source.Alias})
+		shared.LogDebug("Processing image", log.Ctx{"fp": fp, "server": source.Server, "protocol": source.Protocol, "alias": source.Alias})
 
 		hash, err := d.ImageDownload(nil, source.Server, source.Protocol, "", "", source.Alias, false, true)
 		if hash == fp {
-			shared.Log.Debug("Already up to date", log.Ctx{"fp": fp})
+			shared.LogDebug("Already up to date", log.Ctx{"fp": fp})
 			continue
 		} else if err != nil {
-			shared.Log.Error("Failed to update the image", log.Ctx{"err": err, "fp": fp})
+			shared.LogError("Failed to update the image", log.Ctx{"err": err, "fp": fp})
 			continue
 		}
 
 		newId, _, err := dbImageGet(d.db, hash, false, true)
 		if err != nil {
-			shared.Log.Error("Error loading image", log.Ctx{"err": err, "fp": hash})
+			shared.LogError("Error loading image", log.Ctx{"err": err, "fp": hash})
 			continue
 		}
 
 		err = dbImageLastAccessUpdate(d.db, hash, info.LastUsedDate)
 		if err != nil {
-			shared.Log.Error("Error setting last use date", log.Ctx{"err": err, "fp": hash})
+			shared.LogError("Error setting last use date", log.Ctx{"err": err, "fp": hash})
 			continue
 		}
 
 		err = dbImageAliasesMove(d.db, id, newId)
 		if err != nil {
-			shared.Log.Error("Error moving aliases", log.Ctx{"err": err, "fp": hash})
+			shared.LogError("Error moving aliases", log.Ctx{"err": err, "fp": hash})
 			continue
 		}
 
 		err = doDeleteImage(d, fp)
 		if err != nil {
-			shared.Log.Error("Error deleting image", log.Ctx{"err": err, "fp": fp})
+			shared.LogError("Error deleting image", log.Ctx{"err": err, "fp": fp})
 		}
 	}
 
@@ -922,14 +922,14 @@ func pruneExpiredImages(d *Daemon) {
 	expiry := daemonConfig["images.remote_cache_expiry"].GetInt64()
 	images, err := dbImagesGetExpired(d.db, expiry)
 	if err != nil {
-		shared.Log.Error("Unable to retrieve the list of expired images", log.Ctx{"err": err})
+		shared.LogError("Unable to retrieve the list of expired images", log.Ctx{"err": err})
 		return
 	}
 
 	// Delete them
 	for _, fp := range images {
 		if err := doDeleteImage(d, fp); err != nil {
-			shared.Log.Error("Error deleting image", log.Ctx{"err": err, "fp": fp})
+			shared.LogError("Error deleting image", log.Ctx{"err": err, "fp": fp})
 		}
 	}
 
@@ -946,11 +946,11 @@ func doDeleteImage(d *Daemon, fingerprint string) error {
 	// look at the path
 	s, err := storageForImage(d, imgInfo)
 	if err != nil {
-		shared.Log.Error("error detecting image storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
+		shared.LogError("error detecting image storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
 	} else {
 		// Remove the image from storage backend
 		if err = s.ImageDelete(imgInfo.Fingerprint); err != nil {
-			shared.Log.Error("error deleting the image from storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
+			shared.LogError("error deleting the image from storage backend", log.Ctx{"fingerprint": imgInfo.Fingerprint, "err": err})
 		}
 	}
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -372,7 +372,7 @@ func (lw *storageLogWrapper) Init(config map[string]interface{}) (storage, error
 		log.Ctx{"driver": fmt.Sprintf("storage/%s", lw.w.GetStorageTypeName())},
 	)
 
-	lw.log.Info("Init")
+	lw.log.Debug("Init")
 	return lw, err
 }
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -854,12 +854,12 @@ func (s *btrfsMigrationSourceDriver) send(conn *websocket.Conn, btrfsPath string
 
 	output, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		shared.Log.Error("problem reading btrfs send stderr", "err", err)
+		shared.LogError("problem reading btrfs send stderr", log.Ctx{"err": err})
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		shared.Log.Error("problem with btrfs send", "output", string(output))
+		shared.LogError("problem with btrfs send", log.Ctx{"output": string(output)})
 	}
 	return err
 }


### PR DESCRIPTION
Relates to #1928.

- Switch a bunch of log instructions to new log functions I've missed before.

- Demotes a bunch of server messages from `LogInfo*()` to `LogDebug*()`. Now, when doing

```
lxc launch images:ubuntu/xenial test
```

while having started `LXD` with

```
lxd --verbose --group lxd
```
Should take care of outputting (See commit `lxd/daemon_images: improve log for image downloads`):

- Downloading image {trigger: "/1.0/containers/abc", operation: UUID, image: ...}
- Image downloaded {operation: UUID, fingerprint: HASH, image:...}