### PR TITLE
lxd/container_lxc: improve log for container start

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1399,6 +1399,13 @@ func (c *containerLXC) Start(stateful bool) error {
 		}
 	}
 
+	shared.LogInfo("Starting container",
+		log.Ctx{"name": c.name,
+			"action":        op.action,
+			"creation date": c.creationDate,
+			"ephemeral":     c.ephemeral,
+			"last used":     c.lastUsedDate})
+
 	// Start the LXC container
 	out, err := exec.Command(
 		execPath,
@@ -1416,7 +1423,7 @@ func (c *containerLXC) Start(stateful bool) error {
 
 	if err != nil && !c.IsRunning() {
 		// Attempt to extract the LXC errors
-		log := ""
+		lxcLog := ""
 		logPath := filepath.Join(c.LogPath(), "lxc.log")
 		if shared.PathExists(logPath) {
 			logContent, err := ioutil.ReadFile(logPath)
@@ -1433,14 +1440,21 @@ func (c *containerLXC) Start(stateful bool) error {
 					}
 
 					// Prepend the line break
-					if len(log) == 0 {
-						log += "\n"
+					if len(lxcLog) == 0 {
+						lxcLog += "\n"
 					}
 
-					log += fmt.Sprintf("  %s\n", strings.Join(fields[0:], " "))
+					lxcLog += fmt.Sprintf("  %s\n", strings.Join(fields[0:], " "))
 				}
 			}
 		}
+
+		shared.LogError("Failed starting container",
+			log.Ctx{"name": c.name,
+				"action":        op.action,
+				"creation date": c.creationDate,
+				"ephemeral":     c.ephemeral,
+				"last used":     c.lastUsedDate})
 
 		// Return the actual error
 		return fmt.Errorf(
@@ -1448,8 +1462,15 @@ func (c *containerLXC) Start(stateful bool) error {
 			c.name,
 			c.daemon.lxcpath,
 			filepath.Join(c.LogPath(), "lxc.conf"),
-			err, log)
+			err, lxcLog)
 	}
+
+	shared.LogInfo("Started container",
+		log.Ctx{"name": c.name,
+			"action":        op.action,
+			"creation date": c.creationDate,
+			"ephemeral":     c.ephemeral,
+			"last used":     c.lastUsedDate})
 
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

Running `LXD` with `--verbose` will now show the following on *successful* container start:

```
INFO[09-18|02:12:26] Starting container                       last used=2016-09-16T12:25:29+0000 name=test1 action=start creation date=2016-09-14T19:38:10+0000 ephemeral=false
INFO[09-18|02:12:27] Started container                        name=test1 action=start creation date=2016-09-14T19:38:10+0000 ephemeral=false last used=2016-09-16T12:25:29+0000
```
and on *failed* container start:

```
INFO[09-18|02:14:52] Starting container                       name=test action=start creation date=2016-09-12T12:29:34+0000 ephemeral=false last used=2016-09-18T00:08:32+0000
EROR[09-18|02:14:57] Failed starting container                name=test action=start creation date=2016-09-12T12:29:34+0000 ephemeral=false last used=2016-09-18T00:08:32+0000
```