### PR TITLE
lxc/info: show remote in lxc info output

### DIFF
--- a/lxc/info.go
+++ b/lxc/info.go
@@ -87,6 +87,9 @@ func (c *infoCmd) containerInfo(d *lxd.Client, name string, showLog bool) error 
 	const layout = "2006/01/02 15:04 UTC"
 
 	fmt.Printf(i18n.G("Name: %s")+"\n", ct.Name)
+	if d.Remote != nil && d.Remote.Addr != "" {
+		fmt.Printf(i18n.G("Remote: %s")+"\n", d.Remote.Addr)
+	}
 	fmt.Printf(i18n.G("Architecture: %s")+"\n", ct.Architecture)
 	if ct.CreationDate.UTC().Unix() != 0 {
 		fmt.Printf(i18n.G("Created: %s")+"\n", ct.CreationDate.UTC().Format(layout))

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-09-08 23:48+0200\n"
+        "POT-Creation-Date: 2016-09-19 18:00+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,23 +16,23 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/info.go:151
+#: lxc/info.go:154
 msgid   "  CPU usage:"
 msgstr  ""
 
-#: lxc/info.go:140
+#: lxc/info.go:143
 msgid   "  Disk usage:"
 msgstr  ""
 
-#: lxc/info.go:174
+#: lxc/info.go:177
 msgid   "  Memory usage:"
 msgstr  ""
 
-#: lxc/info.go:191
+#: lxc/info.go:194
 msgid   "  Network usage:"
 msgstr  ""
 
-#: lxc/config.go:37
+#: lxc/config.go:36
 msgid   "### This is a yaml representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -61,7 +61,7 @@ msgid   "### This is a yaml representation of the image properties.\n"
         "###  description: My custom image"
 msgstr  ""
 
-#: lxc/profile.go:27
+#: lxc/profile.go:26
 msgid   "### This is a yaml representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -90,7 +90,7 @@ msgstr  ""
 msgid   "'/' not allowed in snapshot name"
 msgstr  ""
 
-#: lxc/profile.go:254
+#: lxc/profile.go:253
 msgid   "(none)"
 msgstr  ""
 
@@ -106,11 +106,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:53
+#: lxc/remote.go:52
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/remote.go:269
+#: lxc/remote.go:268
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -123,7 +123,7 @@ msgstr  ""
 msgid   "An environment variable of the form HOME=/home/foo"
 msgstr  ""
 
-#: lxc/image.go:348 lxc/info.go:90
+#: lxc/image.go:348 lxc/info.go:93
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -137,19 +137,19 @@ msgstr  ""
 msgid   "Available commands:"
 msgstr  ""
 
-#: lxc/info.go:183
+#: lxc/info.go:186
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:184
+#: lxc/info.go:187
 msgid   "Bytes sent"
 msgstr  ""
 
-#: lxc/config.go:274
+#: lxc/config.go:273
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/info.go:147
+#: lxc/info.go:150
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
@@ -157,21 +157,21 @@ msgstr  ""
 msgid   "CREATED AT"
 msgstr  ""
 
-#: lxc/config.go:114
+#: lxc/config.go:113
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/config.go:127 lxc/config.go:160 lxc/config.go:182
+#: lxc/config.go:126 lxc/config.go:159 lxc/config.go:181
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
 
-#: lxc/profile.go:420
+#: lxc/profile.go:419
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: lxc/remote.go:219
+#: lxc/remote.go:218
 #, c-format
 msgid   "Certificate fingerprint: %x"
 msgstr  ""
@@ -183,7 +183,7 @@ msgid   "Changes state of one or more containers to %s.\n"
         "lxc %s <name> [<name>...]%s"
 msgstr  ""
 
-#: lxc/remote.go:292
+#: lxc/remote.go:291
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -195,7 +195,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:531 lxc/config.go:596 lxc/image.go:734 lxc/profile.go:218
+#: lxc/config.go:530 lxc/config.go:595 lxc/image.go:734 lxc/profile.go:217
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -233,7 +233,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:234
+#: lxc/remote.go:233
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -257,7 +257,7 @@ msgstr  ""
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: lxc/image.go:353 lxc/info.go:92
+#: lxc/image.go:353 lxc/info.go:95
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -287,12 +287,12 @@ msgid   "Delete containers or container snapshots.\n"
         "Destroy containers or snapshots with any attached data (configuration, snapshots, ...)."
 msgstr  ""
 
-#: lxc/config.go:648
+#: lxc/config.go:647
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config.go:835
+#: lxc/config.go:834
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -301,7 +301,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/config.go:276
+#: lxc/config.go:275
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -342,7 +342,7 @@ msgstr  ""
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/config.go:273 lxc/image.go:639 lxc/image.go:681
+#: lxc/config.go:272 lxc/image.go:639 lxc/image.go:681
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -377,7 +377,7 @@ msgstr  ""
 msgid   "Format"
 msgstr  ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:66
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -389,7 +389,7 @@ msgstr  ""
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config.go:275
+#: lxc/config.go:274
 msgid   "ISSUE DATE"
 msgstr  ""
 
@@ -433,12 +433,12 @@ msgid   "Initialize a container from a particular image.\n"
         "lxc init ubuntu u1"
 msgstr  ""
 
-#: lxc/remote.go:137
+#: lxc/remote.go:136
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
 
-#: lxc/config.go:254
+#: lxc/config.go:253
 msgid   "Invalid certificate"
 msgstr  ""
 
@@ -456,7 +456,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:121
+#: lxc/info.go:124
 msgid   "Ips:"
 msgstr  ""
 
@@ -547,7 +547,7 @@ msgid   "Lists the available resources.\n"
         "Example: lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:MAC\n"
 msgstr  ""
 
-#: lxc/info.go:236
+#: lxc/info.go:239
 msgid   "Log:"
 msgstr  ""
 
@@ -559,7 +559,7 @@ msgstr  ""
 msgid   "Make the image public"
 msgstr  ""
 
-#: lxc/profile.go:48
+#: lxc/profile.go:47
 msgid   "Manage configuration profiles.\n"
         "\n"
         "lxc profile list [filters]                     List available profiles.\n"
@@ -600,7 +600,7 @@ msgid   "Manage configuration profiles.\n"
         "    using the specified profile."
 msgstr  ""
 
-#: lxc/config.go:58
+#: lxc/config.go:57
 msgid   "Manage configuration.\n"
         "\n"
         "lxc config device add <[remote:]container> <name> <type> [key=value]...     Add a device to a container.\n"
@@ -656,7 +656,7 @@ msgid   "Manage files on a container.\n"
         "  lxc file pull foo/etc/hosts .\n"
 msgstr  ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:38
 msgid   "Manage remote LXD servers.\n"
         "\n"
         "lxc remote add <name> <url> [--accept-certificate] [--password=PASSWORD]\n"
@@ -737,11 +737,11 @@ msgid   "Manipulate container images.\n"
         "    List the aliases. Filters may be part of the image hash or part of the image alias name.\n"
 msgstr  ""
 
-#: lxc/info.go:158
+#: lxc/info.go:161
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:162
+#: lxc/info.go:165
 msgid   "Memory (peak)"
 msgstr  ""
 
@@ -767,7 +767,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/move.go:17
+#: lxc/move.go:16
 msgid   "Move containers within or in between lxd instances.\n"
         "\n"
         "lxc move [remote:]<source container> [remote:]<destination container>\n"
@@ -781,11 +781,11 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:428 lxc/remote.go:376
+#: lxc/list.go:428 lxc/remote.go:375
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/remote.go:350 lxc/remote.go:355
+#: lxc/remote.go:349 lxc/remote.go:354
 msgid   "NO"
 msgstr  ""
 
@@ -798,15 +798,15 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/config.go:285
+#: lxc/config.go:284
 msgid   "No certificate provided to add"
 msgstr  ""
 
-#: lxc/config.go:308
+#: lxc/config.go:307
 msgid   "No fingerprint specified."
 msgstr  ""
 
-#: lxc/remote.go:122
+#: lxc/remote.go:121
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -839,19 +839,19 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:377
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:640 lxc/remote.go:379
+#: lxc/image.go:640 lxc/remote.go:378
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:185
+#: lxc/info.go:188
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:186
+#: lxc/info.go:189
 msgid   "Packets sent"
 msgstr  ""
 
@@ -867,7 +867,7 @@ msgstr  ""
 msgid   "Permission denied, are you in the lxd group?"
 msgstr  ""
 
-#: lxc/info.go:103
+#: lxc/info.go:106
 #, c-format
 msgid   "Pid: %d"
 msgstr  ""
@@ -878,11 +878,11 @@ msgid   "Presents details on how to use LXD.\n"
         "lxd help [--all]"
 msgstr  ""
 
-#: lxc/profile.go:219
+#: lxc/profile.go:218
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:532 lxc/config.go:597 lxc/image.go:735
+#: lxc/config.go:531 lxc/config.go:596 lxc/image.go:735
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -908,27 +908,27 @@ msgid   "Prints the version number of this client tool.\n"
         "lxc version"
 msgstr  ""
 
-#: lxc/info.go:127
+#: lxc/info.go:130
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
 
-#: lxc/profile.go:275
+#: lxc/profile.go:274
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:170
+#: lxc/profile.go:169
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:239
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:306
+#: lxc/profile.go:305
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
@@ -937,12 +937,12 @@ msgstr  ""
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
-#: lxc/profile.go:256
+#: lxc/profile.go:255
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/info.go:101
+#: lxc/info.go:104
 #, c-format
 msgid   "Profiles: %s"
 msgstr  ""
@@ -951,7 +951,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/remote.go:56
+#: lxc/remote.go:55
 msgid   "Public image server"
 msgstr  ""
 
@@ -970,8 +970,13 @@ msgstr  ""
 msgid   "Recursively push or pull files"
 msgstr  ""
 
-#: lxc/remote.go:54
+#: lxc/remote.go:53
 msgid   "Remote admin password"
+msgstr  ""
+
+#: lxc/info.go:91
+#, c-format
+msgid   "Remote: %s"
 msgstr  ""
 
 #: lxc/delete.go:42
@@ -983,7 +988,7 @@ msgstr  ""
 msgid   "Require user confirmation."
 msgstr  ""
 
-#: lxc/info.go:124
+#: lxc/info.go:127
 msgid   "Resources:"
 msgstr  ""
 
@@ -1004,19 +1009,19 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:380
+#: lxc/remote.go:379
 msgid   "STATIC"
 msgstr  ""
 
-#: lxc/remote.go:227
+#: lxc/remote.go:226
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:289
+#: lxc/remote.go:288
 msgid   "Server doesn't trust us after adding our cert"
 msgstr  ""
 
-#: lxc/remote.go:55
+#: lxc/remote.go:54
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -1062,7 +1067,7 @@ msgstr  ""
 msgid   "Size: %.2fMB"
 msgstr  ""
 
-#: lxc/info.go:205
+#: lxc/info.go:208
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -1075,7 +1080,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:95
+#: lxc/info.go:98
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -1092,11 +1097,11 @@ msgstr  ""
 msgid   "Store the container state (only for stop)."
 msgstr  ""
 
-#: lxc/info.go:166
+#: lxc/info.go:169
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:170
+#: lxc/info.go:173
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -1112,7 +1117,7 @@ msgstr  ""
 msgid   "The container is currently running. Use --force to have it stopped and restarted."
 msgstr  ""
 
-#: lxc/config.go:676 lxc/config.go:688 lxc/config.go:721 lxc/config.go:739 lxc/config.go:777 lxc/config.go:795
+#: lxc/config.go:675 lxc/config.go:687 lxc/config.go:720 lxc/config.go:738 lxc/config.go:776 lxc/config.go:794
 msgid   "The device doesn't exist"
 msgstr  ""
 
@@ -1151,11 +1156,11 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:97
+#: lxc/info.go:100
 msgid   "Type: ephemeral"
 msgstr  ""
 
-#: lxc/info.go:99
+#: lxc/info.go:102
 msgid   "Type: persistent"
 msgstr  ""
 
@@ -1163,11 +1168,11 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/remote.go:377
+#: lxc/remote.go:376
 msgid   "URL"
 msgstr  ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:96
 msgid   "Unable to read remote TLS certificate"
 msgstr  ""
 
@@ -1197,11 +1202,11 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/config.go:33
+#: lxc/config.go:32
 msgid   "Whether to show the expanded configuration"
 msgstr  ""
 
-#: lxc/remote.go:352 lxc/remote.go:357
+#: lxc/remote.go:351 lxc/remote.go:356
 msgid   "YES"
 msgstr  ""
 
@@ -1225,7 +1230,7 @@ msgstr  ""
 msgid   "can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/remote.go:340
+#: lxc/remote.go:339
 msgid   "can't remove the default remote"
 msgstr  ""
 
@@ -1233,7 +1238,7 @@ msgstr  ""
 msgid   "can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/remote.go:366
+#: lxc/remote.go:365
 msgid   "default"
 msgstr  ""
 
@@ -1271,7 +1276,7 @@ msgstr  ""
 msgid   "not all the profiles from the source exist on the target"
 msgstr  ""
 
-#: lxc/remote.go:220
+#: lxc/remote.go:219
 msgid   "ok (y/n)?"
 msgstr  ""
 
@@ -1284,35 +1289,35 @@ msgstr  ""
 msgid   "recursive edit doesn't make sense :("
 msgstr  ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:401
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:332 lxc/remote.go:394 lxc/remote.go:429 lxc/remote.go:445
+#: lxc/remote.go:331 lxc/remote.go:393 lxc/remote.go:428 lxc/remote.go:444
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:315
+#: lxc/remote.go:314
 #, c-format
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:336 lxc/remote.go:398 lxc/remote.go:433
+#: lxc/remote.go:335 lxc/remote.go:397 lxc/remote.go:432
 #, c-format
 msgid   "remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/info.go:216
+#: lxc/info.go:219
 msgid   "stateful"
 msgstr  ""
 
-#: lxc/info.go:218
+#: lxc/info.go:221
 msgid   "stateless"
 msgstr  ""
 
-#: lxc/info.go:212
+#: lxc/info.go:215
 #, c-format
 msgid   "taken at %s"
 msgstr  ""


### PR DESCRIPTION
Name: test
Remote: unix:/var/lib/lxd/unix.socket
Architecture: x86_64
Created: 2016/09/12 12:29 UTC
Status: Stopped
Type: persistent
Profiles: default

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>

This is quite helpful in my eyes and has been requested in #1843. (Although this was probably also about showing the remote in the log.)