### PR TITLE
include remote name in pretty printed error message

### DIFF
--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -129,7 +129,12 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 
 	err = d.WaitForSuccess(resp.Operation)
 	if err != nil {
-		return fmt.Errorf("%s\n"+i18n.G("Try `lxc info --show-log %s` for more info"), err, name)
+		prettyName := name
+		if remote != "" {
+			prettyName = fmt.Sprintf("%s:%s", remote, name)
+		}
+
+		return fmt.Errorf("%s\n"+i18n.G("Try `lxc info --show-log %s` for more info"), err, prettyName)
 	}
 
 	return nil


### PR DESCRIPTION
output now looks like:

~/packages/go/src/github.com/lxc/lxd master lxc start kernel:foo2
error: Missing parent 'lxcbr0' for nic 'eth0'
Try `lxc info --show-log kernel:foo2` for more info

Closes #1843

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>