### PR TITLE
2016 09 20/logging issue 1928

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -772,7 +772,7 @@ func (d *Daemon) Init() error {
 	go func() {
 		t := time.NewTicker(24 * time.Hour)
 		for {
-			shared.LogDebugf("Expiring log files")
+			shared.LogInfof("Expiring log files")
 
 			err := d.ExpireLogs()
 			if err != nil {
@@ -792,6 +792,7 @@ func (d *Daemon) Init() error {
 	)
 
 	/* Setup /dev/lxd */
+	shared.LogInfof("Starting /dev/lxd handler")
 	d.devlxd, err = createAndBindDevLxd()
 	if err != nil {
 		return err
@@ -1094,18 +1095,21 @@ func (d *Daemon) Stop() error {
 	}
 
 	if n, err := d.numRunningContainers(); err != nil || n == 0 {
-		shared.LogDebugf("Unmounting shmounts")
+		shared.LogInfof("Unmounting shmounts")
 
 		syscall.Unmount(shared.VarPath("shmounts"), syscall.MNT_DETACH)
+
+		shared.LogInfof("Done unmounting shmounts")
 	} else {
 		shared.LogDebugf("Not unmounting shmounts (containers are still running)")
 	}
 
-	shared.LogDebugf("Closing the database")
+	shared.LogInfof("Closing the database")
 	d.db.Close()
 
-	shared.LogDebugf("Stopping /dev/lxd handler")
+	shared.LogInfof("Stopping /dev/lxd handler")
 	d.devlxd.Close()
+	shared.LogInfof("Stopped /dev/lxd handler")
 
 	if d.MockMode || forceStop {
 		return nil

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -853,7 +853,7 @@ func imagesGet(d *Daemon, r *http.Request) Response {
 var imagesCmd = Command{name: "images", post: imagesPost, untrustedGet: true, get: imagesGet}
 
 func autoUpdateImages(d *Daemon) {
-	shared.LogDebugf("Updating images")
+	shared.LogInfof("Updating images")
 
 	images, err := dbImagesGet(d.db, false)
 	if err != nil {
@@ -912,11 +912,11 @@ func autoUpdateImages(d *Daemon) {
 		}
 	}
 
-	shared.LogDebugf("Done updating images")
+	shared.LogInfof("Done updating images")
 }
 
 func pruneExpiredImages(d *Daemon) {
-	shared.LogDebugf("Pruning expired images")
+	shared.LogInfof("Pruning expired images")
 
 	// Get the list of expires images
 	expiry := daemonConfig["images.remote_cache_expiry"].GetInt64()
@@ -933,7 +933,7 @@ func pruneExpiredImages(d *Daemon) {
 		}
 	}
 
-	shared.LogDebugf("Done pruning expired images")
+	shared.LogInfof("Done pruning expired images")
 }
 
 func doDeleteImage(d *Daemon, fingerprint string) error {


### PR DESCRIPTION
Relates to #1928.

Adapt log levels and add complimentary start/stop logging if missing.