### PR TITLE
WIP: Forward port from container to client

### DIFF
--- a/client.go
+++ b/client.go
@@ -2813,3 +2813,11 @@ func (c *Client) ListNetworks() ([]shared.NetworkConfig, error) {
 
 	return networks, nil
 }
+
+func (c *Client) Teleport() (string, error) {
+	if c.Remote.Public {
+		return "", fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	return "No signal from remote\n", nil
+}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -204,6 +204,7 @@ var commands = map[string]command{
 		name:       "stop",
 		timeout:    -1,
 	},
+	"teleport": &teleportCmd{},
 	"version": &versionCmd{},
 }
 

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"fmt"
+
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared/i18n"
 )
@@ -16,7 +18,7 @@ func (c *teleportCmd) usage() string {
 	return i18n.G(
 		`Make port from inside container available on local interface.
 
-lxd teleport [remote:]container there=:<port> here=<host>:<port>
+lxd teleport [remote:]container [there=:<port> here=<host>:<port>]
 `)
 }
 
@@ -24,8 +26,18 @@ func (c *teleportCmd) flags() {
 }
 
 func (c *teleportCmd) run(config *lxd.Config, args []string) error {
-	if len(args) == 0 {
+	// [ ] param parsing
+	if len(args) < 1 {
 		return errArgs
 	}
+
+	remote, name := config.ParseRemoteAndContainer(args[0])
+	d, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+	fmt.Println(`New client: ` + d.Name)
+	fmt.Println("Teleporting: " + name)
+
 	return nil
 }

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/i18n"
+)
+
+type teleportCmd struct {
+}
+
+func (c *teleportCmd) showByDefault() bool {
+	return true
+}
+
+func (c *teleportCmd) usage() string {
+	return i18n.G(
+		`Makes port from inside container available on local interface.
+
+lxd teleport [remote:]container there=:<port> here=<host>:<port>
+`)
+
+}

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"fmt"
-	"strings"
-
 	"github.com/lxc/lxd"
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/i18n"
 )
 
@@ -18,9 +14,18 @@ func (c *teleportCmd) showByDefault() bool {
 
 func (c *teleportCmd) usage() string {
 	return i18n.G(
-		`Makes port from inside container available on local interface.
+		`Make port from inside container available on local interface.
 
 lxd teleport [remote:]container there=:<port> here=<host>:<port>
 `)
+}
 
+func (c *teleportCmd) flags() {
+}
+
+func (c *teleportCmd) run(config *lxd.Config, args []string) error {
+	if len(args) == 0 {
+		return errArgs
+	}
+	return nil
 }

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -28,6 +28,8 @@ func (c *teleportCmd) flags() {
 
 func (c *teleportCmd) forward(conn net.Conn) {
 	fmt.Printf("New connection from: %s\n", conn.RemoteAddr())
+	defer conn.Close()
+	conn.Write([]byte("No signal from remote\n"))
 }
 
 func (c *teleportCmd) run(config *lxd.Config, args []string) error {

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -26,6 +26,10 @@ lxd teleport [remote:]container [there=:<port> here=<host>:<port>]
 func (c *teleportCmd) flags() {
 }
 
+func (c *teleportCmd) forward(conn net.Conn) {
+	fmt.Printf("New connection from: %s\n", conn.RemoteAddr())
+}
+
 func (c *teleportCmd) run(config *lxd.Config, args []string) error {
 	// [ ] param parsing
 	if len(args) < 1 {
@@ -56,8 +60,7 @@ func (c *teleportCmd) run(config *lxd.Config, args []string) error {
 			return err
 		}
 		// [ ] go handle forward request
-		//handle(conn)
-		fmt.Printf("New connection from: %s\n", conn.RemoteAddr())
+		go c.forward(conn)
 	}
 
 	return nil

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -31,7 +31,8 @@ func (c *teleportCmd) forward(conn net.Conn, client *lxd.Client) {
 	defer conn.Close()
 
 	// [ ] if no signal, write debug message
-	conn.Write([]byte("No signal from remote\n"))
+	out, _ := client.Teleport()
+	conn.Write([]byte(out))
 }
 
 func (c *teleportCmd) run(config *lxd.Config, args []string) error {

--- a/lxc/teleport.go
+++ b/lxc/teleport.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"net"
 
 	"github.com/lxc/lxd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -32,12 +33,32 @@ func (c *teleportCmd) run(config *lxd.Config, args []string) error {
 	}
 
 	remote, name := config.ParseRemoteAndContainer(args[0])
+	// client provides websocket to container
 	d, err := lxd.NewClient(config, remote)
 	if err != nil {
 		return err
 	}
 	fmt.Println(`New client: ` + d.Name)
-	fmt.Println("Teleporting: " + name)
+	fmt.Println("Connecting to: " + name)
+
+	// creating local server for listening on specified port
+	// [ ] no hardcoded value
+	listenon := "localhost:1337"
+	fmt.Println("Listening on: " + listenon)
+	acceptor, err := net.Listen("tcp", listenon)
+	if err != nil {
+		return err
+	}
+	for {
+		conn, err := acceptor.Accept()
+		if err != nil {
+			// [ ] doesn't seem to be the right strategy
+			return err
+		}
+		// [ ] go handle forward request
+		//handle(conn)
+		fmt.Printf("New connection from: %s\n", conn.RemoteAddr())
+	}
 
 	return nil
 }

--- a/teleport.progress.md
+++ b/teleport.progress.md
@@ -1,0 +1,25 @@
+ * [x] teleport command
+ * [ ] passing teleport parameters
+   * [ ] parsing and setting port number
+ * [ ] client-side command handler
+   * [ ] accepting local connections
+   * [ ] getting back result 
+   * [ ] handle errors
+   * [ ] handle multiple connections simultaneously (or limit them)
+   * [ ] wrap request over websocket to the server side
+    * [ ] create websocket tunnel
+    * [ ] forward request over websocket and listen for reply
+   * [ ] write tests
+ * [ ] server-side handler
+  * [ ] check that port on container is open
+    * [ ] wait or no wait
+  * [ ] accept connection over the websocket
+  * [ ] read from container port
+    * [ ] send reply stream through websocket
+  * [ ] handle errors, what to do (and how to pass errrors)
+   * [ ] port is closed
+   * [ ] port doesn't accept connections
+   * [ ] wrapped connection is reset
+   * [ ] client connection is reset
+   * [ ] some websocket error
+ * [ ] draw diagram how it is wrapped

--- a/teleport.progress.md
+++ b/teleport.progress.md
@@ -2,7 +2,7 @@
  * [ ] passing teleport parameters
    * [ ] parsing and setting port number
  * [ ] client-side command handler
-   * [ ] accepting local connections
+   * [x] accepting local connections
    * [ ] getting back result 
    * [ ] handle errors
    * [ ] handle multiple connections simultaneously (or limit them)

--- a/teleport.progress.md
+++ b/teleport.progress.md
@@ -3,7 +3,7 @@
    * [ ] parsing and setting port number
  * [ ] client-side command handler
    * [x] accepting local connections
-   * [ ] getting back result 
+   * [x] getting back result 
    * [ ] handle errors
    * [ ] handle multiple connections simultaneously (or limit them)
    * [ ] wrap request over websocket to the server side


### PR DESCRIPTION
This is an ongoing work to enable port forwarding for LXD through its own channel. It's been slow as I study networking in Go after Python, and some concepts need more time to settle down.
- [x] teleport command
- [x] passing teleport parameters
  - [ ] parsing and setting port number
- [x] client-side command handler
  - [x] accepting local connections
  - [ ] getting back result 
  - [ ] handle errors
  - [ ] handle multiple connections simultaneously (or limit them)
  - [ ] wrap request over websocket to the server side
  - [ ] create websocket tunnel
  - [ ] forward request over websocket and listen for reply
  - [ ] write tests
- [ ] server-side handler
  - [ ] check that port on container is open
    - [ ] wait or no wait
  - [ ] accept connection over the websocket
  - [ ] read from container port
    - [ ] send reply stream through websocket
  - [ ] handle errors, what to do (and how to pass errrors)
  - [ ] port is closed
  - [ ] port doesn't accept connections
  - [ ] wrapped connection is reset
  - [ ] client connection is reset
  - [ ] some websocket error
- [ ] draw diagram how it is wrapped

Right now the stumbling block is the server side - how can I debug it without packaging and reinstalling the daemon every time?
