### PR TITLE
Introduce security.mac_filtering

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -114,3 +114,4 @@ This includes:
  * DELETE /1.0/networks/<entry> (see rest-api.md for details)
  * ipv4.address property on "nic" type devices (when nictype is "bridged")
  * ipv6.address property on "nic" type devices (when nictype is "bridged")
+ * security.mac\_filtering property on "nic" type devices (when nictype is "bridged")

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -195,19 +195,20 @@ LXD supports different kind of network devices:
 
 Different network interface types have different additional properties, the current list is:
 
-Key             | Type      | Default           | Required  | Used by                       | API extension | Description
-:--             | :--       | :--               | :--       | :--                           | :--           | :--
-nictype         | string    | -                 | yes       | all                           | -             | The device type, one of "physical", "bridged", "macvlan" or "p2p"
-limits.ingress  | string    | -                 | no        | bridged, p2p                  | -             | I/O limit in bit/s (supports kbit, Mbit, Gbit suffixes)
-limits.egress   | string    | -                 | no        | bridged, p2p                  | -             | I/O limit in bit/s (supports kbit, Mbit, Gbit suffixes)
-limits.max      | string    | -                 | no        | bridged, p2p                  | -             | Same as modifying both limits.read and limits.write
-name            | string    | kernel assigned   | no        | all                           | -             | The name of the interface inside the container
-host\_name      | string    | randomly assigned | no        | bridged, p2p, macvlan         | -             | The name of the interface inside the host
-hwaddr          | string    | randomly assigned | no        | all                           | -             | The MAC address of the new interface
-mtu             | integer   | parent MTU        | no        | all                           | -             | The MTU of the new interface
-parent          | string    | -                 | yes       | physical, bridged, macvlan    | -             | The name of the host device or bridge
-ipv4.address    | string    | -                 | no        | bridged                       | network       | An IPv4 address to assign to the container through DHCP
-ipv6.address    | string    | -                 | no        | bridged                       | network       | An IPv6 address to assign to the container through DHCP
+Key                     | Type      | Default           | Required  | Used by                       | API extension | Description
+:--                     | :--       | :--               | :--       | :--                           | :--           | :--
+nictype                 | string    | -                 | yes       | all                           | -             | The device type, one of "physical", "bridged", "macvlan" or "p2p"
+limits.ingress          | string    | -                 | no        | bridged, p2p                  | -             | I/O limit in bit/s (supports kbit, Mbit, Gbit suffixes)
+limits.egress           | string    | -                 | no        | bridged, p2p                  | -             | I/O limit in bit/s (supports kbit, Mbit, Gbit suffixes)
+limits.max              | string    | -                 | no        | bridged, p2p                  | -             | Same as modifying both limits.read and limits.write
+name                    | string    | kernel assigned   | no        | all                           | -             | The name of the interface inside the container
+host\_name              | string    | randomly assigned | no        | bridged, p2p, macvlan         | -             | The name of the interface inside the host
+hwaddr                  | string    | randomly assigned | no        | all                           | -             | The MAC address of the new interface
+mtu                     | integer   | parent MTU        | no        | all                           | -             | The MTU of the new interface
+parent                  | string    | -                 | yes       | physical, bridged, macvlan    | -             | The name of the host device or bridge
+ipv4.address            | string    | -                 | no        | bridged                       | network       | An IPv4 address to assign to the container through DHCP
+ipv6.address            | string    | -                 | no        | bridged                       | network       | An IPv6 address to assign to the container through DHCP
+security.mac\_filtering | boolean   | false             | no        | bridged                       | network       | Prevent the container from spoofing another's MAC address
 
 ### Type: disk
 Disk entries are essentially mountpoints inside the container. They can

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -106,6 +106,8 @@ func containerValidDeviceConfigKey(t, k string) bool {
 			return true
 		case "ipv6.address":
 			return true
+		case "security.mac_filtering":
+			return true
 		default:
 			return false
 		}


### PR DESCRIPTION
This option for bridged nic devices turns on MAC filtering on the host,
preventing the container from sending traffic for a MAC other than the
one known by LXD.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>