### PR TITLE
Makefile: Don't recursively include test deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,18 +55,20 @@ gccgo:
 
 .PHONY: dist
 dist:
+	$(eval TMP := $(shell mktemp -d))
 	rm -Rf lxd-$(VERSION) $(ARCHIVE) $(ARCHIVE).gz
-	mkdir -p lxd-$(VERSION)/dist
-	-GOPATH=$(shell pwd)/lxd-$(VERSION)/dist go get -t -v -d ./...
-	-GOPATH=$(shell pwd)/lxd-$(VERSION)/dist go get -t -v -d ./...
-	-GOPATH=$(shell pwd)/lxd-$(VERSION)/dist go get -t -v -d ./...
-	GOPATH=$(shell pwd)/lxd-$(VERSION)/dist go get -t -v -d ./...
-	rm -rf $(shell pwd)/lxd-$(VERSION)/dist/src/github.com/lxc/lxd
-	ln -s ../../../.. ./lxd-$(VERSION)/dist/src/github.com/lxc/lxd
+	mkdir -p lxd-$(VERSION)/
+	-GOPATH=$(TMP) go get -t -v -d ./...
+	-GOPATH=$(TMP) go get -t -v -d ./...
+	-GOPATH=$(TMP) go get -t -v -d ./...
+	GOPATH=$(TMP) go get -t -v -d ./...
+	rm -rf $(TMP)/src/github.com/lxc/lxd
+	ln -s ../../../.. $(TMP)/src/github.com/lxc/lxd
+	mv $(TMP)/ lxd-$(VERSION)/dist
 	git archive --prefix=lxd-$(VERSION)/ --output=$(ARCHIVE) HEAD
 	tar -uf $(ARCHIVE) --exclude-vcs lxd-$(VERSION)/
 	gzip -9 $(ARCHIVE)
-	rm -Rf dist lxd-$(VERSION) $(ARCHIVE)
+	rm -Rf lxd-$(VERSION) $(ARCHIVE)
 
 .PHONY: i18n update-po update-pot build-mo static-analysis
 i18n: update-pot

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -568,7 +568,7 @@ func networkFanAddress(underlay *net.IPNet, overlay *net.IPNet) (string, string,
 	}
 
 	if overlaySize+(32-underlaySize)+8 > 32 {
-		return "", "", "", fmt.Errorf("Underlay or overlay networks too large to accomodate the FAN")
+		return "", "", "", fmt.Errorf("Underlay or overlay networks too large to accommodate the FAN")
 	}
 
 	// Get the IP


### PR DESCRIPTION
We only want LXD's own test dependencies, not the ones for every single
package we use.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>