### PR TITLE
push support

### DIFF
--- a/client.go
+++ b/client.go
@@ -2000,14 +2000,20 @@ func (c *Client) MigrateFrom(name string, operation string, certificate string,
 
 	source := shared.Jmap{
 		"type":       "migration",
-		"secrets":    sourceSecrets,
 		"base-image": baseImage,
 	}
 
 	if push {
 		source["mode"] = "push"
+		source["live"] = false
+		// If the criu secret is present we know that live migration is
+		// required.
+		if _, ok := sourceSecrets["criu"]; ok {
+			source["live"] = true
+		}
 	} else {
 		source["mode"] = "pull"
+		source["secrets"] = sourceSecrets
 		source["operation"] = operation
 		source["certificate"] = certificate
 	}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -118,3 +118,9 @@ This includes:
 
 ## profile\_usedby
 Adds a new used\_by field to profile entries listing the containers that are using it.
+
+## container\_push
+When a container is created in push mode, the client serves as a proxy between
+the source and target server. This is useful in cases where the target server
+is behind a NAT or firewall and cannot directly communicate with the source
+server and operate in pull mode.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -518,6 +518,30 @@ Input (using a local container):
                    "source": "my-old-container"}                                        # Name of the source container
     }
 
+Input (using a remote container, in push mode sent over the migration websocket via client proxying):
+
+    {
+        "name": "my-new-container",                                                     # 64 chars max, ASCII, no slash, no colon and no comma
+        "architecture": "x86_64",
+        "profiles": ["default"],                                                        # List of profiles
+        "ephemeral": true,                                                              # Whether to destroy the container on shutdown
+        "config": {"limits.cpu": "2"},                                                  # Config override.
+        "devices": {                                                                    # optional list of devices the container should have
+            "rootfs": {
+                "path": "/dev/kvm",
+                "type": "unix-char"
+            },
+        },
+        "source": {"type": "migration",                                                 # Can be: "image", "migration", "copy" or "none"
+                   "mode": "push",                                                      # Only "pull" is supported for now
+                   "operation": "https://10.0.2.3:8443/1.0/operations/<UUID>",          # Full URL to the remote operation
+                   "certificate": "PEM certificate",                                    # Optional PEM certificate. If not mentioned, system CA is used.
+                   "base-image": "<fingerprint>",                                       # Optional, the base image the container was created from
+                   "secrets": {"control": "my-secret-string",                           # Secrets to use when talking to the migration source
+                               "criu":    "my-other-secret",
+                               "fs":      "my third secret"},
+    }
+
 ## /1.0/containers/\<name\>
 ### GET
  * Description: Container information

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -497,7 +497,7 @@ Input (using a remote container, sent over the migration websocket):
             },
         },
         "source": {"type": "migration",                                                 # Can be: "image", "migration", "copy" or "none"
-                   "mode": "pull",                                                      # Only "pull" is supported for now
+                   "mode": "pull",                                                      # "pull" and "push" is supported for now
                    "operation": "https://10.0.2.3:8443/1.0/operations/<UUID>",          # Full URL to the remote operation (pull mode only)
                    "certificate": "PEM certificate",                                    # Optional PEM certificate. If not mentioned, system CA is used.
                    "base-image": "<fingerprint>",                                       # Optional, the base image the container was created from
@@ -533,13 +533,9 @@ Input (using a remote container, in push mode sent over the migration websocket 
             },
         },
         "source": {"type": "migration",                                                 # Can be: "image", "migration", "copy" or "none"
-                   "mode": "push",                                                      # Only "pull" is supported for now
-                   "operation": "https://10.0.2.3:8443/1.0/operations/<UUID>",          # Full URL to the remote operation
-                   "certificate": "PEM certificate",                                    # Optional PEM certificate. If not mentioned, system CA is used.
+                   "mode": "push",                                                      # "pull" and "push" are supported
                    "base-image": "<fingerprint>",                                       # Optional, the base image the container was created from
-                   "secrets": {"control": "my-secret-string",                           # Secrets to use when talking to the migration source
-                               "criu":    "my-other-secret",
-                               "fs":      "my third secret"},
+                   "live": true                                                         # Whether migration is performed live
     }
 
 ## /1.0/containers/\<name\>

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -215,15 +215,11 @@ func (c *copyCmd) copyContainer(config *lxd.Config, sourceResource string, destR
 			continue
 		}
 
-		migMap, err := migration.MetadataAsMap()
-		if err != nil {
+		// If push mode is implemented then MigrateFrom will return a
+		// non-waitable operation. So this needs to be conditionalized
+		// on pull mode.
+		if err = dest.WaitForSuccess(migration.Operation); err != nil {
 			return err
-		}
-
-		if v, ok := (*migMap)["mode"]; ok && v == "pull" {
-			if err = dest.WaitForSuccess(migration.Operation); err != nil {
-				return err
-			}
 		}
 
 		if destResource == "" {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -71,6 +71,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"storage_lvm_mount_options",
 			"network",
 			"profile_usedby",
+			"container_push",
 		},
 
 		"api_status":  "stable",

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -43,6 +43,8 @@ type containerImageSource struct {
 
 	/* for "copy" type */
 	Source string `json:"source"`
+	/* for "migration" type. Whether the migration is live. */
+	Live bool `json:"live"`
 }
 
 type containerPostReq struct {
@@ -281,6 +283,7 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 		Container: c,
 		Secrets:   req.Source.Websockets,
 		Push:      push,
+		Live:      req.Source.Live,
 	}
 
 	sink, err := NewMigrationSink(&migrationArgs)

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -530,6 +530,7 @@ type MigrationSinkArgs struct {
 	Dialer    websocket.Dialer
 	Container container
 	Secrets   map[string]string
+	Push      bool
 }
 
 func NewMigrationSink(args *MigrationSinkArgs) (*migrationSink, error) {

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -514,9 +514,15 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 type migrationSink struct {
 	// We are pulling the container from src in pull mode.
 	src migrationFields
+	// The container is pushed to dest in push mode. Note that websocket
+	// connections are not set in push mode. Only the secret fields are
+	// used since the client will connect to the sockets.
+	dest migrationFields
 
-	url    string
-	dialer websocket.Dialer
+	url          string
+	dialer       websocket.Dialer
+	allConnected chan bool
+	push         bool
 }
 
 type MigrationSinkArgs struct {

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -595,6 +595,19 @@ func (c *migrationSink) connectWithSecret(secret string) (*websocket.Conn, error
 	return lxd.WebsocketDial(c.dialer, wsUrl)
 }
 
+func (s *migrationSink) Metadata() interface{} {
+	secrets := shared.Jmap{
+		"control": s.dest.controlSecret,
+		"fs":      s.dest.fsSecret,
+	}
+
+	if s.dest.criuSecret != "" {
+		secrets["criu"] = s.dest.criuSecret
+	}
+
+	return secrets
+}
+
 func (c *migrationSink) Do(migrateOp *operation) error {
 	var err error
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-09-30 22:18-0400\n"
+        "POT-Creation-Date: 2016-10-04 15:54+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -227,7 +227,7 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:140 lxc/copy.go:234 lxc/init.go:227
+#: lxc/copy.go:140 lxc/copy.go:237 lxc/init.go:227
 #, c-format
 msgid   "Container name is: %s"
 msgstr  ""
@@ -1333,7 +1333,7 @@ msgstr  ""
 msgid   "default"
 msgstr  ""
 
-#: lxc/copy.go:131 lxc/copy.go:136 lxc/copy.go:225 lxc/copy.go:230 lxc/init.go:217 lxc/init.go:222 lxc/launch.go:111 lxc/launch.go:116
+#: lxc/copy.go:131 lxc/copy.go:136 lxc/copy.go:228 lxc/copy.go:233 lxc/init.go:217 lxc/init.go:222 lxc/launch.go:111 lxc/launch.go:116
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 


### PR DESCRIPTION
This series of commits adds push support to container creation via migration.

In one sentence:
- The client serves as a proxy between source and target server.

As a short story:
- The client does a `POST` on the source server and requests a set of websockets and secrets. This is step is the same irrespective of `push` or `pull` mode. The affected code is located in `lxd/container_post.go`.
- Afterwards, the client do a `POST` on the target server. The target server will be informed that `push` mode is being used and that it should expect a websocket connection. The target server will then respond by sending back an `async` `operationClassWebsocket` operation. A set of websockets and secrets will be sent back to the client as part of the metadata. The set of websockets and secrets received from the target server has the same cardinality as the set of websockets received from the source server. Specifically, this means that two websockets and secrets are received on non-live migration and three websockets and secrets on live migration. The affected code is located in `lxd/containers_post.go`. Specifically, `createFromMigration()` is affected the most.
- Aforementioned `POST` operations are done from `client.go:MigrateFrom()`.
- Proxying: The client will then connect to the source server websockets and target server websockets and relay any data received from the source server websockets to the matching target server websockets. For this to work extensive modifications to `lxd/migrate.go` are needed. Most changes are needed to the `migrationSink` struct. It gains two new methods `Connect()`, `Metadata()`, and now exports its formerly unexported `Do()` method. Various code-paths have been introduced that are conditionalized on `push` mode; other code-paths have been conditionalized on `pull` mode.

Testing the branch:
- This branch contains a commit that is not intended for inclusion in `LXD`. As such it is marked with `[DO NOT MERGE]`. The commit tries to make testing the branch easier. `lxc copy` gains a temporary flag `--push` which can be used to test `push` mode. This means using:

    `lxc copy source:c target:c --push`

      will cause `lxc copy` to operate in `push` mode. Not using the flag causes `lxc copy` to operate in standard `pull` mode.