### PR TITLE
network: Fix rare race condition with sysctl

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -839,12 +839,12 @@ func (n *network) Start() error {
 				}
 
 				err := networkSysctl(fmt.Sprintf("ipv6/conf/%s/accept_ra", entry.Name()), "2")
-				if err != nil {
+				if err != nil && err != os.ErrNotExist {
 					return err
 				}
 
 				err = networkSysctl(fmt.Sprintf("ipv6/conf/%s/forwarding", entry.Name()), "1")
-				if err != nil {
+				if err != nil && err != os.ErrNotExist {
 					return err
 				}
 			}


### PR DESCRIPTION
On very busy systems (like our Jenkins), a network interface may
disappear between the time we list the interfaces and the time we
attempt to set the sysctl, so just ignore ENOENT.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>