### PR TITLE
remove logging import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ protobuf:
 
 .PHONY: check
 check: default
+	go get -v -x github.com/rogpeppe/godeps
 	go get -v -x github.com/remyoudompheng/go-misc/deadcode
 	go test -v ./...
 	cd test && ./main.sh

--- a/shared/log.go
+++ b/shared/log.go
@@ -2,7 +2,6 @@ package shared
 
 import (
 	"fmt"
-	log "gopkg.in/inconshreveable/log15.v2"
 	"runtime"
 )
 
@@ -29,33 +28,33 @@ func init() {
 }
 
 // General wrappers around Logger interface functions.
-func LogDebug(msg string, ctx map[string]interface{}) {
+func LogDebug(msg string, ctx interface{}) {
 	if Log != nil {
-		Log.Debug(msg, log.Ctx(ctx))
+		Log.Debug(msg, ctx)
 	}
 }
 
-func LogInfo(msg string, ctx map[string]interface{}) {
+func LogInfo(msg string, ctx interface{}) {
 	if Log != nil {
-		Log.Info(msg, log.Ctx(ctx))
+		Log.Info(msg, ctx)
 	}
 }
 
-func LogWarn(msg string, ctx map[string]interface{}) {
+func LogWarn(msg string, ctx interface{}) {
 	if Log != nil {
-		Log.Warn(msg, log.Ctx(ctx))
+		Log.Warn(msg, ctx)
 	}
 }
 
-func LogError(msg string, ctx map[string]interface{}) {
+func LogError(msg string, ctx interface{}) {
 	if Log != nil {
-		Log.Error(msg, log.Ctx(ctx))
+		Log.Error(msg, ctx)
 	}
 }
 
-func LogCrit(msg string, ctx map[string]interface{}) {
+func LogCrit(msg string, ctx interface{}) {
 	if Log != nil {
-		Log.Crit(msg, log.Ctx(ctx))
+		Log.Crit(msg, ctx)
 	}
 }
 

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -47,10 +47,12 @@ test_static_analysis() {
       done
     fi
 
-    OUT=$(godeps . ./shared | cut -f1)
-    if [ "${OUT}" != "$(printf "github.com/gorilla/websocket\ngopkg.in/yaml.v2\n")" ]; then
-      echo "ERROR: you added a new dependency to the client or shared; please make sure this is what you want"
-      echo "${OUT}"
+    if which godeps >/dev/null 2>&1; then
+      OUT=$(godeps . ./shared | cut -f1)
+      if [ "${OUT}" != "$(printf "github.com/gorilla/websocket\ngopkg.in/yaml.v2\n")" ]; then
+        echo "ERROR: you added a new dependency to the client or shared; please make sure this is what you want"
+        echo "${OUT}"
+      fi
     fi
 
     # Skip the tests which require git

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -47,6 +47,12 @@ test_static_analysis() {
       done
     fi
 
+    OUT=$(godeps . ./shared | cut -f1)
+    if [ "${OUT}" != "$(printf "github.com/gorilla/websocket\ngopkg.in/yaml.v2\n")" ]; then
+      echo "ERROR: you added a new dependency to the client or shared; please make sure this is what you want"
+      echo "${OUT}"
+    fi
+
     # Skip the tests which require git
     if ! git status; then
       return


### PR DESCRIPTION
downstream users of shared/ (i.e. juju) don't want to have a log15
dependency.

log.Ctx() is defined as a map[string]interface{}, but the log15 package
does some fancy stuff to normalize it when it gets passed, which is why we
needed to wrap it in a log.Ctx() again. Instead, let's just not unwrap the
type in the first place, which means log15's machinery will see the log.Ctx
users passed us and behave correctly.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>