### PR TITLE
usb: vendorid is mandatory, productid isn't

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -270,8 +270,8 @@ The following properties exist:
 
 Key         | Type      | Default           | Required  | Description
 :--         | :--       | :--               | :--       | :--
-productid   | string    | -                 | yes       | The product id of the USB device.
-vendorid    | string    | -                 | no        | The vendor id of the USB device.
+vendorid    | string    | -                 | yes       | The vendor id of the USB device.
+productid   | string    | -                 | no        | The product id of the USB device.
 uid         | int       | 0                 | no        | UID of the device owner in the container
 gid         | int       | 0                 | no        | GID of the device owner in the container
 mode        | int       | 0660              | no        | Mode of the device in the container

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -250,8 +250,8 @@ func containerValidDevices(devices shared.Devices, profile bool, expanded bool) 
 				return fmt.Errorf("Unix device entry is missing the required \"path\" property.")
 			}
 		} else if m["type"] == "usb" {
-			if m["productid"] == "" {
-				return fmt.Errorf("Missing productid for USB device.")
+			if m["vendorid"] == "" {
+				return fmt.Errorf("Missing vendorid for USB device.")
 			}
 		} else if m["type"] == "none" {
 			continue


### PR DESCRIPTION
The code was doing the right thing, skipping devices that didn't match
vendorid and allowing devices that don't have a productid set to still
be passed through.

But the documentation and configuration parser were doing things the
other way around, requiring a productid and considering vendorid
optional.

So fix the documentation and config parser to do the right thing.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>