### PR TITLE
shared/cert: be more thorough when parsing ip addr

### DIFF
--- a/shared/cert.go
+++ b/shared/cert.go
@@ -177,8 +177,10 @@ func GenerateMemCert(client bool) ([]byte, []byte, error) {
 	}
 
 	for _, h := range hosts {
-		if ip := net.ParseIP(h); ip != nil {
-			template.IPAddresses = append(template.IPAddresses, ip)
+		if ip, _, err := net.ParseCIDR(h); err == nil {
+			if !ip.IsLinkLocalUnicast() && !ip.IsLinkLocalMulticast() {
+				template.IPAddresses = append(template.IPAddresses, ip)
+			}
 		} else {
 			template.DNSNames = append(template.DNSNames, h)
 		}


### PR DESCRIPTION
- check that IPv6 and IPv4 is no link-local address
- skip prefix length
- use IP for IP addresses

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>