### PR TITLE
disable keepalives in http.Transports

### DIFF
--- a/client.go
+++ b/client.go
@@ -272,7 +272,10 @@ func connectViaUnix(c *Client, remote *RemoteConfig) error {
 		}
 		return net.DialUnix("unix", nil, raddr)
 	}
-	c.Http.Transport = &http.Transport{Dial: uDial}
+	c.Http.Transport = &http.Transport{
+		Dial:              uDial,
+		DisableKeepAlives: true,
+	}
 	c.websocketDialer.NetDial = uDial
 	c.Remote = remote
 
@@ -291,9 +294,10 @@ func connectViaHttp(c *Client, remote *RemoteConfig, clientCert, clientKey, clie
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: tlsconfig,
-		Dial:            shared.RFC3493Dialer,
-		Proxy:           shared.ProxyFromEnvironment,
+		TLSClientConfig:   tlsconfig,
+		Dial:              shared.RFC3493Dialer,
+		Proxy:             shared.ProxyFromEnvironment,
+		DisableKeepAlives: true,
 	}
 
 	c.websocketDialer.NetDial = shared.RFC3493Dialer

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -129,9 +129,10 @@ func (d *Daemon) httpGetSync(url string, certificate string) (*lxd.Response, err
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-		Dial:            shared.RFC3493Dialer,
-		Proxy:           d.proxy,
+		TLSClientConfig:   tlsConfig,
+		Dial:              shared.RFC3493Dialer,
+		Proxy:             d.proxy,
+		DisableKeepAlives: true,
 	}
 
 	myhttp := http.Client{
@@ -184,9 +185,10 @@ func (d *Daemon) httpGetFile(url string, certificate string) (*http.Response, er
 	}
 
 	tr := &http.Transport{
-		TLSClientConfig: tlsConfig,
-		Dial:            shared.RFC3493Dialer,
-		Proxy:           d.proxy,
+		TLSClientConfig:   tlsConfig,
+		Dial:              shared.RFC3493Dialer,
+		Proxy:             d.proxy,
+		DisableKeepAlives: true,
 	}
 	myhttp := http.Client{
 		Transport: tr,


### PR DESCRIPTION
http/transport.go says:

// By default, Transport caches connections for future re-use.
// This may leave many open connections when accessing many hosts.
// This behavior can be managed using Transport's CloseIdleConnections
// method
// and the MaxIdleConnsPerHost and DisableKeepAlives fields.

In particular,

babbageclunk | Yeah - we end up leaking 10 goroutines everytime we destroy a model.

juju uses the client from a long running daemon, which creates a new
http.Transport for each call to the API, which creates a new
http.Transport, which leaks these goroutines.

Perhaps we can fix this more better with the client rewrite, but for now
let's just not do the keepalive, since that's how we're using
http.Transport anyway.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>