### PR TITLE
Forward signals to executing process

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -141,3 +141,9 @@ Adds the following to the REST API:
  * ETag header on GET of a certificate
  * PUT of certificate entries
  * PATCH of certificate entries
+
+## container\_exec\_signal_handling
+Adds support /1.0/containers/<name>/exec for forwarding signals sent to the
+client to the processes executing in the container. Currently SIGTERM and
+SIGHUP are forwarded. Further signals that can be forwarded might be added
+later.

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -84,6 +84,28 @@ func (c *execCmd) sendTermSize(control *websocket.Conn) error {
 	return err
 }
 
+func (c *execCmd) forwardSignal(control *websocket.Conn, sig syscall.Signal) error {
+	shared.LogDebugf("Forwarding signal: %s", sig)
+
+	w, err := control.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+
+	msg := shared.ContainerExecControl{}
+	msg.Command = "signal"
+	msg.Signal = sig
+
+	buf, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(buf)
+
+	w.Close()
+	return err
+}
+
 func (c *execCmd) run(config *lxd.Config, args []string) error {
 	if len(args) < 2 {
 		return errArgs

--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -20,20 +20,120 @@ func (c *execCmd) getStdout() io.WriteCloser {
 
 func (c *execCmd) controlSocketHandler(d *lxd.Client, control *websocket.Conn) {
 	ch := make(chan os.Signal)
-	signal.Notify(ch, syscall.SIGWINCH)
+	signal.Notify(ch,
+		syscall.SIGWINCH,
+		syscall.SIGTERM,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGQUIT,
+		syscall.SIGABRT,
+		syscall.SIGTSTP,
+		syscall.SIGTTIN,
+		syscall.SIGTTOU,
+		syscall.SIGUSR1,
+		syscall.SIGUSR2,
+		syscall.SIGSEGV,
+		syscall.SIGCONT)
+
+	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+	defer control.WriteMessage(websocket.CloseMessage, closeMsg)
 
 	for {
 		sig := <-ch
-
-		shared.LogDebugf("Received '%s signal', updating window geometry.", sig)
-
-		err := c.sendTermSize(control)
-		if err != nil {
-			shared.LogDebugf("error setting term size %s", err)
+		switch sig {
+		case syscall.SIGWINCH:
+			shared.LogDebugf("Received '%s signal', updating window geometry.", sig)
+			err := c.sendTermSize(control)
+			if err != nil {
+				shared.LogDebugf("error setting term size %s", err)
+				return
+			}
+		case syscall.SIGTERM:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGTERM)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGTERM)
+				return
+			}
+		case syscall.SIGHUP:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGHUP)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGHUP)
+				return
+			}
+		case syscall.SIGINT:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGINT)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGINT)
+				return
+			}
+		case syscall.SIGQUIT:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGQUIT)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGQUIT)
+				return
+			}
+		case syscall.SIGABRT:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGABRT)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGABRT)
+				return
+			}
+		case syscall.SIGTSTP:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGTSTP)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGTSTP)
+				return
+			}
+		case syscall.SIGTTIN:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGTTIN)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGTTIN)
+				return
+			}
+		case syscall.SIGTTOU:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGTTOU)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGTTOU)
+				return
+			}
+		case syscall.SIGUSR1:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGUSR1)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGUSR1)
+				return
+			}
+		case syscall.SIGUSR2:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGUSR2)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGUSR2)
+				return
+			}
+		case syscall.SIGSEGV:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGSEGV)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGSEGV)
+				return
+			}
+		case syscall.SIGCONT:
+			shared.LogDebugf("Received '%s signal', forwarding to executing program.", sig)
+			err := c.forwardSignal(control, syscall.SIGCONT)
+			if err != nil {
+				shared.LogDebugf("Failed to forward signal '%s'.", syscall.SIGCONT)
+				return
+			}
+		default:
 			break
 		}
 	}
-
-	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
-	control.WriteMessage(websocket.CloseMessage, closeMsg)
 }

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -74,6 +74,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"container_push",
 			"container_exec_recording",
 			"certificate_update",
+			"container_exec_signal_handling",
 		},
 
 		"api_status":  "stable",

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"strings"
 	"time"
 
@@ -328,8 +329,16 @@ type container interface {
 	FilePull(srcpath string, dstpath string) (int, int, os.FileMode, string, []string, error)
 	FilePush(srcpath string, dstpath string, uid int, gid int, mode int) error
 
-	// Command execution
+	// Command execution: Execute command and wait for it to exit.
 	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error)
+
+	// Command execution: Returns a command. If called as exec.Cmd.Start()
+	// ExecNoWait() does not wait for the process to exit. Callers are
+	// expected to pass the write end of a pipe to the pidPipe argument. So
+	// they can read the PID of the executing process from the read end. The
+	// PID read cannot be directly waited upon since it is a child of lxd
+	// forkexec. It can however be used to e.g. send signals.
+	ExecNoWait(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, pidPipe *os.File) (*exec.Cmd, error)
 
 	// Status
 	Render() (interface{}, interface{}, error)

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3620,14 +3620,24 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int, gid int
 	return nil
 }
 
-func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error) {
+func (c *containerLXC) prepareExec(waitOnPid bool, command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) ([]string, *exec.Cmd) {
 	envSlice := []string{}
 
 	for k, v := range env {
 		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	args := []string{execPath, "forkexec", c.name, c.daemon.lxcpath, filepath.Join(c.LogPath(), "lxc.conf")}
+	// Setting "wait"/"nowait" as the second argument in cmd.Args allows us
+	// to tell execContainer() that it should call an appropriate go-lxc
+	// wrapper for c->attach() that executes the command we requested in the
+	// container and, depending on whether we passed "wait" or "nowait" does
+	// wait or not wait for it to exit.
+	var args []string
+	if waitOnPid {
+		args = []string{execPath, "forkexec", "wait", c.name, c.daemon.lxcpath, filepath.Join(c.LogPath(), "lxc.conf")}
+	} else {
+		args = []string{execPath, "forkexec", "nowait", c.name, c.daemon.lxcpath, filepath.Join(c.LogPath(), "lxc.conf")}
+	}
 
 	args = append(args, "--")
 	args = append(args, "env")
@@ -3645,23 +3655,27 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 	cmd.Stderr = stderr
 
 	shared.LogInfo("Executing command", log.Ctx{"environment": envSlice, "args": args})
+	return envSlice, &cmd
+}
 
+func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File) (int, error) {
+	envSlice, cmd := c.prepareExec(true, command, env, stdin, stdout, stderr)
 	err := cmd.Run()
 	if err != nil {
 		exitErr, ok := err.(*exec.ExitError)
 		if ok {
 			status, ok := exitErr.Sys().(syscall.WaitStatus)
 			if ok {
-				shared.LogInfo("Executed command", log.Ctx{"environment": envSlice, "args": args, "exit_status": status.ExitStatus()})
+				shared.LogInfo("Executed command", log.Ctx{"environment": envSlice, "args": cmd.Args, "exit_status": status.ExitStatus()})
 				return status.ExitStatus(), nil
 			}
 		}
 
-		shared.LogInfo("Failed executing command", log.Ctx{"environment": envSlice, "args": args, "err": err})
+		shared.LogInfo("Failed executing command", log.Ctx{"environment": envSlice, "args": cmd.Args, "err": err})
 		return -1, err
 	}
 
-	shared.LogInfo("Executed command", log.Ctx{"environment": envSlice, "args": args})
+	shared.LogInfo("Executed command", log.Ctx{"environment": envSlice, "args": cmd.Args})
 	return 0, nil
 }
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3679,6 +3679,12 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 	return 0, nil
 }
 
+func (c *containerLXC) ExecNoWait(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, pidPipe *os.File) (*exec.Cmd, error) {
+	_, cmd := c.prepareExec(false, command, env, stdin, stdout, stderr)
+	cmd.ExtraFiles = []*os.File{pidPipe}
+	return cmd, nil
+}
+
 func (c *containerLXC) cpuState() shared.ContainerStateCPU {
 	cpu := shared.ContainerStateCPU{}
 

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"sort"
@@ -281,9 +282,13 @@ func execContainer(args []string) (int, error) {
 		return -1, fmt.Errorf("Bad arguments: %q", args)
 	}
 
-	name := args[1]
-	lxcpath := args[2]
-	configPath := args[3]
+	wait := true
+	if args[1] == "nowait" {
+		wait = false
+	}
+	name := args[2]
+	lxcpath := args[3]
+	configPath := args[4]
 
 	c, err := lxc.NewContainer(name, lxcpath)
 	if err != nil {
@@ -351,9 +356,55 @@ func execContainer(args []string) (int, error) {
 
 	opts.Env = env
 
-	status, err := c.RunCommandStatus(cmd, opts)
-	if err != nil {
-		return -1, fmt.Errorf("Failed running command: %q", err)
+	var status int
+	if wait {
+		status, err = c.RunCommandStatus(cmd, opts)
+		if err != nil {
+			return -1, fmt.Errorf("Failed running command and waiting for it to exit: %q", err)
+		}
+	} else {
+		status, err = c.RunCommandNoWait(cmd, opts)
+		if err != nil {
+			return -1, fmt.Errorf("Failed running command: %q", err)
+		}
+		// Send the PID of the executing process.
+		w := os.NewFile(uintptr(3), "attachedPid")
+		defer w.Close()
+
+		err = json.NewEncoder(w).Encode(status)
+		if err != nil {
+			return -1, fmt.Errorf("Failed sending PID of executing command: %q", err)
+		}
+
+		proc, err := os.FindProcess(status)
+		if err != nil {
+			return -1, fmt.Errorf("Failed finding process: %q", err)
+		}
+
+		procState, err := proc.Wait()
+		if err != nil {
+			return -1, fmt.Errorf("Failed waiting on process %d: %q", status, err)
+		}
+
+		if procState.Success() {
+			return 0, nil
+		}
+
+		status, ok := procState.Sys().(syscall.WaitStatus)
+		if ok {
+			if status.Exited() {
+				return status.ExitStatus(), nil
+			}
+			// Backwards compatible behavior. Report success when we exited
+			// due to a signal. Otherwise this may break Jenkins, e.g. when
+			// lxc exec foo reboot receives SIGTERM and status.Exitstats()
+			// would report -1.
+			if status.Signaled() {
+				return 0, nil
+			}
+		}
+
+		return -1, fmt.Errorf("Command failed")
 	}
 
 	return status >> 8, nil

--- a/shared/container.go
+++ b/shared/container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
 
@@ -60,6 +61,7 @@ type ContainerStateNetworkCounters struct {
 type ContainerExecControl struct {
 	Command string            `json:"command"`
 	Args    map[string]string `json:"args"`
+	Signal  syscall.Signal    `json:"signal"`
 }
 
 type SnapshotInfo struct {


### PR DESCRIPTION
This series of commits is part of: https://github.com/lxc/lxd/issues/1830.

- lxd/container_lxc: add prepareExec() helper fun

    We will add another Exec*() style function that does the same setup operations
    as Exec(). So let's create a common helper that does the setup for both.

- lxd/container_lxc, lxd/container: add ExecNoWait()

    ExecNoWait() constructs a lxd forkexec command that calls a go-lxc binding which
    in turn calls low-level liblxc's c->attach(). In contrast to Exec() ExecNoWait()
    calls a go-lxc wraper that does not wait on the command to exit. Rather,
    the go-lxc wrapper will simply return the PID it receives from low-level
    liblxc's c->attach(). Hence, it returns the PID of the attached process. To
    retrieve the attached PID from the go-lxc wrapper ExecNoWait() passes a pipe fd
    to lxd forkexec which will allow it to write the PID of the attached process to
    the pipe so we can retrieve it ExecNoWait() again.

-  shared/util_linux: add Prctl() and SetSubReaper()

    - Add Prctl() to allow various operations on processes.
    - Add SetSubReaper() to mark a process as subreaper.

- 
 lxd/containers: call RunCommandNoWait()

    When lxd forkexec is called as

            lxd forkexec wait ...

    then we call

            RunCommandStatus()

    when lxd forkexec is called as

            lxd forkexec nowait ...

    then we call

            RunCommandNoWait()

    The difference is that RunCommandStatus() is a wrapper that runs and waits for
    the command to exit whereas RunCommandNoWait() runs the command, returns its PID
    but does not wait for it to exit.

- lxd/container_exec: switch to ExecNoWait()

    In order to forward signals to the program we are executing we need a function
    that hands us the PID of the executing process. After ExecNoWait() has been
    called we want to be able to wait on the process whose PID we return in
    attachedPid. But since this process is a child of lxd forkexec the caller cannot
    directly wait on it. Luckily, in the case of ExecNoWait() lxd forkexec will
    call a go-lxc binding that calls plain c->attach() which only starts the process
    and the immediately exits. Which in turn causes lxd forkexec to immediately
    exit. So in order for the caller of ExecNoWait() to be able to wait on said
    returned PID we can simply mark us as the subreaper for forkexec and its
    descendants. The code tries to ensure that we are only a temporary subreaper,
    i.e. we mark us as subreaper before the command and unset us as subreaper before
    we return.