### PR TITLE
lxd/container_lxc: record the err from go-lxc

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1878,12 +1878,14 @@ func (c *containerLXC) Freeze() error {
 	// Load the go-lxc struct
 	err := c.initLXC()
 	if err != nil {
+		ctxMap["err"] = err
 		shared.LogError("Failed freezing container", ctxMap)
 		return err
 	}
 
 	err = c.c.Freeze()
 	if err != nil {
+		ctxMap["err"] = err
 		shared.LogError("Failed freezing container", ctxMap)
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@canonical.com>