### PR TITLE
Store the simplestreams cache to disk

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -748,6 +748,9 @@ func (d *Daemon) Init() error {
 	d.lxcpath = shared.VarPath("containers")
 
 	/* Make sure all our directories are available */
+	if err := os.MkdirAll(shared.CachePath(), 0700); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(shared.VarPath("containers"), 0711); err != nil {
 		return err
 	}
@@ -818,6 +821,12 @@ func (d *Daemon) Init() error {
 
 		/* Setup the networks */
 		err = networkStartup(d)
+		if err != nil {
+			return err
+		}
+
+		/* Restore simplestreams cache */
+		err = imageLoadStreamCache(d)
 		if err != nil {
 			return err
 		}
@@ -1165,6 +1174,10 @@ func (d *Daemon) Stop() error {
 	shared.LogInfof("Stopping /dev/lxd handler")
 	d.devlxd.Close()
 	shared.LogInfof("Stopped /dev/lxd handler")
+
+	shared.LogInfof("Saving simplestreams cache")
+	imageSaveStreamCache()
+	shared.LogInfof("Saved simplestreams cache")
 
 	if d.MockMode || forceStop {
 		return nil

--- a/shared/util.go
+++ b/shared/util.go
@@ -93,6 +93,19 @@ func VarPath(path ...string) string {
 	return filepath.Join(items...)
 }
 
+// CachePath returns the directory that LXD should its cache under. If LXD_DIR is
+// set, this path is $LXD_DIR/cache, otherwise it is /var/cache/lxd.
+func CachePath(path ...string) string {
+	varDir := os.Getenv("LXD_DIR")
+	logDir := "/var/cache/lxd"
+	if varDir != "" {
+		logDir = filepath.Join(varDir, "cache")
+	}
+	items := []string{logDir}
+	items = append(items, path...)
+	return filepath.Join(items...)
+}
+
 // LogPath returns the directory that LXD should put logs under. If LXD_DIR is
 // set, this path is $LXD_DIR/logs, otherwise it is /var/log/lxd.
 func LogPath(path ...string) string {


### PR DESCRIPTION
Right now, we store simplestreams data for up to an hour. This is done
through a simple memory cache in LXD.

The goal of this was to decrease load on the simplestreams servers and
that's been working pretty well so far.

One thing that this cache doesn't help much with is dealing with
simplestreams servers being offline or the client being temporarily
disconnected from the internet.

Right now once the cache times out, LXD will refresh it, if that fails,
then the cache is gone.

This commit makes it so that our cache persists across LXD restarts by
serializing it to disk. It also changes its use a bit, so that if we
fail to refresh the cache, we log a warning and bump its expiry for
another hour.

This effectively allows LXD to be used completely offline and work fine
with any image that's already in the local cache.

Closes #2487

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>