### PR TITLE
lxd/container_lxc: check if container is running

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1690,6 +1690,12 @@ func (c *containerLXC) Stop(stateful bool) error {
 		return err
 	}
 
+	if !c.IsRunning() {
+		op.Done(nil)
+		shared.LogDebug("Not stopping container as it is not running.", ctxMap)
+		return nil
+	}
+
 	// Attempt to freeze the container first, helps massively with fork bombs
 	c.Freeze()
 
@@ -1881,6 +1887,11 @@ func (c *containerLXC) Freeze() error {
 		ctxMap["err"] = err
 		shared.LogError("Failed freezing container", ctxMap)
 		return err
+	}
+
+	if !c.IsRunning() {
+		shared.LogDebug("Not freezing container as it is not running.", ctxMap)
+		return nil
 	}
 
 	err = c.c.Freeze()


### PR DESCRIPTION
Only try to Freeze() or Stop() if the container is running. Otherwise we will
cause unnecessary errors when users e.g. reboot the container via

	lxc exec foo reboot

in which case the init systems does the work and we would be trying to
Freeze()/Stop() a container that is not running anymore.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>