### PR TITLE
lxc/exec_unix: use buffered chan in sig forwarding

### DIFF
--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -19,7 +19,7 @@ func (c *execCmd) getStdout() io.WriteCloser {
 }
 
 func (c *execCmd) controlSocketHandler(d *lxd.Client, control *websocket.Conn) {
-	ch := make(chan os.Signal)
+	ch := make(chan os.Signal, 10)
 	signal.Notify(ch,
 		syscall.SIGWINCH,
 		syscall.SIGTERM,


### PR DESCRIPTION
We should use a buffered channel since we might miss signals otherwise.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>