### PR TITLE
add gpu device type

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -147,3 +147,6 @@ Adds support /1.0/containers/<name>/exec for forwarding signals sent to the
 client to the processes executing in the container. Currently SIGTERM and
 SIGHUP are forwarded. Further signals that can be forwarded might be added
 later.
+
+## gpu\_devices
+Enables adding GPUs to a container.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -65,6 +65,9 @@ Add support for the HTTP PATCH method.
 
 PATCH allows for partial update of an object in place of PUT.
 
+## usb\_devices
+Add support for USB hotplug.
+
 ## https\_allowed\_credentials
 To use LXD API with all Web Browsers (via SPAs) you must send credentials
 (certificate) with each XHR (in order for this to happen, you should set

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -277,6 +277,21 @@ gid         | int       | 0                 | no        | GID of the device owne
 mode        | int       | 0660              | no        | Mode of the device in the container
 required    | boolean   | false             | no        | Whether or not this device is required to start the container. (The default is no, and all devices are hot-pluggable.)
 
+### Type: gpu
+GPU device entries simply make the requested gpu device appear in the
+container.
+
+The following properties exist:
+
+Key         | Type      | Default           | Required  | Description
+:--         | :--       | :--               | :--       | :--
+vendorid    | string    | -                 | no        | The vendor id of the GPU device.
+productid   | string    | -                 | no        | The product id of the GPU device.
+id          | string    | -                 | no        | The card id of the GPU device.
+uid         | int       | 0                 | no        | UID of the device owner in the container
+gid         | int       | 0                 | no        | GID of the device owner in the container
+mode        | int       | 0660              | no        | Mode of the device in the container
+
 ## Profiles
 Profiles can store any configuration that a container can (key/value or devices)
 and any number of profiles can be applied to a container.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -75,6 +75,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"container_exec_recording",
 			"certificate_update",
 			"container_exec_signal_handling",
+			"gpu_devices",
 		},
 
 		"api_status":  "stable",

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -152,6 +152,25 @@ func containerValidDeviceConfigKey(t, k string) bool {
 		default:
 			return false
 		}
+	case "gpu":
+		switch k {
+		case "vendorid":
+			return true
+		case "productid":
+			return true
+		case "id":
+			return true
+		case "pci":
+			return true
+		case "mode":
+			return true
+		case "gid":
+			return true
+		case "uid":
+			return true
+		default:
+			return false
+		}
 	case "none":
 		return false
 	default:
@@ -204,7 +223,7 @@ func containerValidDevices(devices shared.Devices, profile bool, expanded bool) 
 			return fmt.Errorf("Missing device type for device '%s'", name)
 		}
 
-		if !shared.StringInSlice(m["type"], []string{"none", "nic", "disk", "unix-char", "unix-block", "usb"}) {
+		if !shared.StringInSlice(m["type"], []string{"none", "nic", "disk", "unix-char", "unix-block", "usb", "gpu"}) {
 			return fmt.Errorf("Invalid device type for device '%s'", name)
 		}
 
@@ -254,6 +273,9 @@ func containerValidDevices(devices shared.Devices, profile bool, expanded bool) 
 			if m["vendorid"] == "" {
 				return fmt.Errorf("Missing vendorid for USB device.")
 			}
+		} else if m["type"] == "gpu" {
+			// Probably no checks needed, since we allow users to
+			// pass in all GPUs.
 		} else if m["type"] == "none" {
 			continue
 		} else {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2943,6 +2943,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 					}
 				}
 
+				sawNvidia := false
 				for _, gpu := range gpus {
 					if (m["vendorid"] != "" && gpu.vendorid != m["vendorid"]) ||
 						(m["pci"] != "" && gpu.pci != m["pci"]) ||
@@ -2966,19 +2967,11 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 						shared.LogError("failed to insert gpu device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
+
+					sawNvidia = true
 				}
 
-				nvidiaExists := false
-				for _, gpu := range gpus {
-					if gpu.nvidia.path != "" {
-						if c.deviceExists(gpu.path) {
-							nvidiaExists = true
-							break
-						}
-					}
-				}
-
-				if nvidiaExists {
+				if sawNvidia {
 					for _, gpu := range nvidiaDevices {
 						if c.deviceExists(gpu.path) {
 							continue

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2864,6 +2864,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 
 					err := c.removeUnixDeviceNum(m, gpu.major, gpu.minor, gpu.path)
 					if err != nil {
+						shared.LogError("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -2873,6 +2874,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 
 					err = c.removeUnixDeviceNum(m, gpu.nvidia.major, gpu.nvidia.minor, gpu.nvidia.path)
 					if err != nil {
+						shared.LogError("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 				}
@@ -2894,7 +2896,8 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 						}
 						err = c.removeUnixDeviceNum(m, gpu.major, gpu.minor, gpu.path)
 						if err != nil {
-							shared.LogError("failed to remove gpu device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							shared.LogError("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							return err
 						}
 					}
 				}
@@ -2954,7 +2957,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 
 					err = c.insertUnixDeviceNum(m, gpu.major, gpu.minor, gpu.path)
 					if err != nil {
-						shared.LogError("failed to insert gpu device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						shared.LogError("Failed to insert GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -2964,7 +2967,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 
 					err = c.insertUnixDeviceNum(m, gpu.nvidia.major, gpu.nvidia.minor, gpu.nvidia.path)
 					if err != nil {
-						shared.LogError("failed to insert gpu device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						shared.LogError("Failed to insert GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -2978,7 +2981,8 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 						}
 						err = c.insertUnixDeviceNum(m, gpu.major, gpu.minor, gpu.path)
 						if err != nil {
-							shared.LogError("failed to insert gpu device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							shared.LogError("failed to insert GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							return err
 						}
 					}
 				}

--- a/lxd/db_devices.go
+++ b/lxd/db_devices.go
@@ -23,6 +23,8 @@ func dbDeviceTypeToString(t int) (string, error) {
 		return "unix-block", nil
 	case 5:
 		return "usb", nil
+	case 6:
+		return "gpu", nil
 	default:
 		return "", fmt.Errorf("Invalid device type %d", t)
 	}
@@ -42,6 +44,8 @@ func dbDeviceTypeToInt(t string) (int, error) {
 		return 4, nil
 	case "usb":
 		return 5, nil
+	case "gpu":
+		return 6, nil
 	default:
 		return -1, fmt.Errorf("Invalid device type %s", t)
 	}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -107,9 +107,9 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 	ents, err := ioutil.ReadDir(DRI_PATH)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return gpus, nvidiaDevices, nil
+			return nil, nil, nil
 		}
-		return gpus, nvidiaDevices, err
+		return nil, nil, err
 	}
 
 	isNvidia := false
@@ -186,7 +186,7 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 			tmpGpu.major = majorInt
 			tmpGpu.minor = minorInt
 
-			isCard, err := regexp.MatchString("^card", drmEnt.Name())
+			isCard, err := regexp.MatchString("^card[0-9]+", drmEnt.Name())
 			if isCard {
 				// If it is a card it's minor number will be its id.
 				tmpGpu.id = strconv.Itoa(minorInt)
@@ -222,12 +222,12 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 		nvidiaEnts, err := ioutil.ReadDir("/dev")
 		if err != nil {
 			if os.IsNotExist(err) {
-				return []gpuDevice{}, []nvidiaGpuDevices{}, err
+				return nil, nil, err
 			}
 		}
 		validNvidia, err := regexp.Compile(`^nvidia[^0-9]+`)
 		if err != nil {
-			return gpus, nil, nil
+			return nil, nil, err
 		}
 		for _, nvidiaEnt := range nvidiaEnts {
 			if !validNvidia.MatchString(nvidiaEnt.Name()) {
@@ -252,9 +252,9 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 	// Since we'll give users to ability to specify and id we need to group
 	// devices on the same PCI that belong to the same card by id.
 	for _, card := range cards {
-		for _, gpu := range gpus {
-			if gpu.pci == card.pci {
-				gpu.id = card.id
+		for i := 0; i < len(gpus); i++ {
+			if gpus[i].pci == card.pci {
+				gpus[i].id = card.id
 			}
 		}
 	}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -89,8 +89,8 @@ type gpuDevice struct {
 	minor int
 }
 
-func isNvidiaGpu(vendorId string) bool {
-	return strings.EqualFold(vendorId, "10de")
+func (g *gpuDevice) isNvidiaGpu() bool {
+	return strings.EqualFold(g.vendorid, "10de")
 }
 
 type cardIds struct {
@@ -197,7 +197,7 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 				cards = append(cards, tmp)
 			}
 			// Find matching /dev/nvidia* entry for /dev/dri/card*
-			if isNvidiaGpu(tmpGpu.vendorid) && isCard {
+			if tmpGpu.isNvidiaGpu() && isCard {
 				if !isNvidia {
 					isNvidia = true
 				}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -53,6 +54,212 @@ type usbDevice struct {
 	path  string
 	major int
 	minor int
+}
+
+// /dev/nvidia[0-9]+
+type nvidiaGpuCards struct {
+	path  string
+	major int
+	minor int
+	id    string
+}
+
+// {/dev/nvidiactl, /dev/nvidia-uvm, ...}
+type nvidiaGpuDevices struct {
+	path  string
+	major int
+	minor int
+}
+
+// /dev/dri/card0. If we detect that vendor == nvidia, then nvidia will contain
+// the corresponding nvidia car, e.g. {/dev/dri/card1 --> /dev/nvidia1}.
+type gpuDevice struct {
+	vendorid  string
+	productid string
+	id        string // card id e.g. 0
+	// If related devices have the same PCI address as the GPU we should
+	// mount them all. Meaning if we detect /dev/dri/card0,
+	// /dev/dri/controlD64, and /dev/dri/renderD128 with the same PCI
+	// address, then they should all be made available in the container.
+	pci    string
+	nvidia nvidiaGpuCards
+
+	path  string
+	major int
+	minor int
+}
+
+func isNvidiaGpu(vendorId string) bool {
+	return strings.EqualFold(vendorId, "10de")
+}
+
+type cardIds struct {
+	id  string
+	pci string
+}
+
+func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
+	const DRI_PATH = "/sys/bus/pci/devices"
+	var gpus []gpuDevice
+	var nvidiaDevices []nvidiaGpuDevices
+	var cards []cardIds
+
+	ents, err := ioutil.ReadDir(DRI_PATH)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return gpus, nvidiaDevices, nil
+		}
+		return gpus, nvidiaDevices, err
+	}
+
+	isNvidia := false
+	for _, ent := range ents {
+		// The pci address == the name of the directory. So let's use
+		// this cheap way of retrieving it.
+		pciAddr := ent.Name()
+
+		// Make sure that we are dealing with a GPU by looking whether
+		// the "drm" subfolder exists.
+		drm := filepath.Join(DRI_PATH, pciAddr, "drm")
+		drmEnts, err := ioutil.ReadDir(drm)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+		}
+
+		// Retrieve vendor ID.
+		vendorIdPath := filepath.Join(DRI_PATH, pciAddr, "vendor")
+		vendorId, err := ioutil.ReadFile(vendorIdPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+		}
+
+		// Retrieve device ID.
+		productIdPath := filepath.Join(DRI_PATH, pciAddr, "device")
+		productId, err := ioutil.ReadFile(productIdPath)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+		}
+
+		// Store all associated subdevices, e.g. controlD64, renderD128.
+		// The name of the directory == the last part of the
+		// /dev/dri/controlD64 path. So ent.Name() will give us
+		// controlD64.
+		for _, drmEnt := range drmEnts {
+			vendorTmp := strings.TrimSpace(string(vendorId))
+			productTmp := strings.TrimSpace(string(productId))
+			vendorTmp = strings.TrimPrefix(vendorTmp, "0x")
+			productTmp = strings.TrimPrefix(productTmp, "0x")
+			tmpGpu := gpuDevice{
+				pci:       pciAddr,
+				vendorid:  vendorTmp,
+				productid: productTmp,
+				path:      filepath.Join("/dev/dri", drmEnt.Name()),
+			}
+
+			majMinPath := filepath.Join(drm, drmEnt.Name(), "dev")
+			majMinByte, err := ioutil.ReadFile(majMinPath)
+			if err != nil {
+				if os.IsNotExist(err) {
+					continue
+				}
+			}
+			majMin := strings.TrimSpace(string(majMinByte))
+			majMinSlice := strings.Split(string(majMin), ":")
+			if len(majMinSlice) != 2 {
+				continue
+			}
+			majorInt, err := strconv.Atoi(majMinSlice[0])
+			if err != nil {
+				continue
+			}
+			minorInt, err := strconv.Atoi(majMinSlice[1])
+			if err != nil {
+				continue
+			}
+
+			tmpGpu.major = majorInt
+			tmpGpu.minor = minorInt
+
+			isCard, err := regexp.MatchString("^card", drmEnt.Name())
+			if isCard {
+				// If it is a card it's minor number will be its id.
+				tmpGpu.id = strconv.Itoa(minorInt)
+				tmp := cardIds{
+					id:  tmpGpu.id,
+					pci: tmpGpu.pci,
+				}
+				cards = append(cards, tmp)
+			}
+			// Find matching /dev/nvidia* entry for /dev/dri/card*
+			if isNvidiaGpu(tmpGpu.vendorid) && isCard {
+				if !isNvidia {
+					isNvidia = true
+				}
+				nvidiaPath := "/dev/nvidia" + strconv.Itoa(tmpGpu.minor)
+				stat := syscall.Stat_t{}
+				err := syscall.Stat(nvidiaPath, &stat)
+				if err != nil {
+					continue
+				}
+				tmpGpu.nvidia.path = nvidiaPath
+				tmpGpu.nvidia.major = int(stat.Rdev / 256)
+				tmpGpu.nvidia.minor = int(stat.Rdev % 256)
+				tmpGpu.nvidia.id = strconv.Itoa(tmpGpu.nvidia.minor)
+			}
+			gpus = append(gpus, tmpGpu)
+		}
+	}
+
+	// We detected a Nvidia card, so let's collect all other nvidia devices
+	// that are not /dev/nvidia[0-9]+.
+	if isNvidia {
+		nvidiaEnts, err := ioutil.ReadDir("/dev")
+		if err != nil {
+			if os.IsNotExist(err) {
+				return []gpuDevice{}, []nvidiaGpuDevices{}, err
+			}
+		}
+		validNvidia, err := regexp.Compile(`^nvidia[^0-9]+`)
+		if err != nil {
+			return gpus, nil, nil
+		}
+		for _, nvidiaEnt := range nvidiaEnts {
+			if !validNvidia.MatchString(nvidiaEnt.Name()) {
+				continue
+			}
+			nvidiaPath := filepath.Join("/dev", nvidiaEnt.Name())
+			stat := syscall.Stat_t{}
+			err = syscall.Stat(nvidiaPath, &stat)
+			if err != nil {
+				continue
+			}
+			tmpNividiaGpu := nvidiaGpuDevices{
+				path:  nvidiaPath,
+				major: int(stat.Rdev / 256),
+				minor: int(stat.Rdev % 256),
+			}
+			nvidiaDevices = append(nvidiaDevices, tmpNividiaGpu)
+		}
+
+	}
+
+	// Since we'll give users to ability to specify and id we need to group
+	// devices on the same PCI that belong to the same card by id.
+	for _, card := range cards {
+		for _, gpu := range gpus {
+			if gpu.pci == card.pci {
+				gpu.id = card.id
+			}
+		}
+	}
+
+	return gpus, nvidiaDevices, nil
 }
 
 func createUSBDevice(action string, vendor string, product string, major string, minor string, busnum string, devnum string, devname string) (usbDevice, error) {
@@ -504,13 +711,13 @@ func deviceUSBEvent(d *Daemon, usb usbDevice) {
 			}
 
 			if usb.action == "add" {
-				err := c.insertUSBDevice(m, usb)
+				err := c.insertUnixDeviceNum(m, usb.major, usb.minor, usb.path)
 				if err != nil {
 					shared.LogError("failed to create usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
 				}
 			} else if usb.action == "remove" {
-				err := c.removeUSBDevice(m, usb)
+				err := c.removeUnixDeviceNum(m, usb.major, usb.minor, usb.path)
 				if err != nil {
 					shared.LogError("failed to remove usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return


### PR DESCRIPTION
- lxc config device add c1 gpu0 gpu => Pass everything we have
- lxc config device add c1 gpu0 gpu vendor=10de => Pass whatever we have from nvidia
- lxc config device add c1 gpu0 gpu vendor=10de id=1 => Pass the second nvidia GPU
- lxc config device add c1 gpu0 gpu pci=0000:02:08.0 => Pass whatever GPU is at that PCI address

This parses /sys/bus/pci/devices/* and looks for the drm subfolder. All
subfolders under that, e.g.

	card0
	controlD64
	renderD128

belong to the same PCI address and probably all need to be handed to the
container when the user somehow selects card0.
We then retrieve the vendor ID, and if available the device ID from

	/sys/bus/pci/devices/*/vendor
	/sys/bus/pci/devices/*/device

The major and minor number for each device can be gathered from the

	card0/dev
	controlD64/dev
	renderD128/dev

files.

If we detect that the vendor ID is Nvidia, we also parse /dev and look for

	/dev/nvidia[0-9]+

entries. We thereby associate the correct /dev/nvidia* entry with the correct
/dev/card* entry, e.g. we correlate

	/dev/card0
and

    /dev/nvidia0.

Finally, we store any residual /dev/nvidia[^0-9]+ mounts that are not cards
because we need to assume that if /dev/nvidia[0-9]+ is requested then the other
files are necessary for correct functionality of that card and need to be
mounted into every container that also mounts that card.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>