### PR TITLE
migration: start migration storage at the right time

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -293,19 +293,13 @@ func createFromMigration(d *Daemon, req *containerPostReq) Response {
 	}
 
 	run := func(op *operation) error {
-		// Start the storage for this container (LVM mount/umount)
-		c.StorageStart()
-
 		// And finaly run the migration.
 		err = sink.Do(op)
 		if err != nil {
-			c.StorageStop()
 			shared.LogError("Error during migration sink", log.Ctx{"err": err})
 			c.Delete()
 			return fmt.Errorf("Error transferring container data: %s", err)
 		}
-
-		defer c.StorageStop()
 
 		err = c.TemplateApply("copy")
 		if err != nil {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -702,6 +702,11 @@ func rsyncMigrationSink(live bool, container container, snapshots []*Snapshot, c
 			return err
 		}
 	} else {
+		if err := container.StorageStart(); err != nil {
+			return err
+		}
+		defer container.StorageStop()
+
 		for _, snap := range snapshots {
 			if err := RsyncRecv(shared.AddSlash(container.Path()), conn); err != nil {
 				return err


### PR DESCRIPTION
In particular: the migration storage might have been in use after a
migration, so it's not safe to stop it like we were before (presumably it
was giving EBUSY, but since we didn't cehck the return code it was ok).

Instead, let's only start it before we need it, and stop it when we're
done. The OnStart hook will start the storage again if it is needed by the
actual container, so we don't need to take care of that.

Closes #2505

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>