### PR TITLE
stateful start: start storage when necessary

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3406,8 +3406,19 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 		 * namespace.
 		 */
 		if !c.IsPrivileged() {
-			if err := c.IdmapSet().ShiftRootfs(stateDir); err != nil {
+			err = c.StorageStart()
+			if err != nil {
 				return err
+			}
+
+			err = c.IdmapSet().ShiftRootfs(stateDir)
+			err2 := c.StorageStop()
+			if err != nil {
+				return err
+			}
+
+			if err2 != nil {
+				return err2
 			}
 		}
 


### PR DESCRIPTION
Similar to 38d794806a8ca781a0ed69798c8a6e9ea8ea7a70, we need to start the
storage at the right time for stateful start and stop. In particular, the
onstart hook will start the storage for us, but we need to be sure and
start it so that we can uidshift the images.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>