### PR TITLE
Clean up path handling for push

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -168,7 +167,7 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 		}
 
 		if c.mkdirs {
-			if err := d.MkdirP(container, filepath.Dir(fpath), mode); err != nil {
+			if err := d.MkdirP(container, path.Dir(fpath), mode); err != nil {
 				return err
 			}
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -77,9 +77,10 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 	remote, container := config.ParseRemoteAndContainer(pathSpec[0])
 
 	targetIsDir := strings.HasSuffix(target, "/")
-
-	pathSpec[1] = c.normalize(pathSpec[1], target)
-	targetPath := pathSpec[1]
+	// re-add leading / that got stripped by the SplitN
+	targetPath := "/" + pathSpec[1]
+	// clean various /./, /../, /////, etc. that users add (#2557)
+	targetPath = path.Clean(targetPath)
 
 	shared.LogDebugf("Pushing to: %s  (isdir: %t)", targetPath, targetIsDir)
 

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -115,13 +115,13 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 		}
 
 		if c.mkdirs {
-			if err := d.MkdirP(container, pathSpec[1], mode); err != nil {
+			if err := d.MkdirP(container, targetPath, mode); err != nil {
 				return err
 			}
 		}
 
 		for _, fname := range sourcefilenames {
-			if err := d.RecursivePushFile(container, fname, pathSpec[1]); err != nil {
+			if err := d.RecursivePushFile(container, fname, targetPath); err != nil {
 				return err
 			}
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -76,8 +76,12 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 
 	remote, container := config.ParseRemoteAndContainer(pathSpec[0])
 
+	targetIsDir := strings.HasSuffix(target, "/")
+
 	pathSpec[1] = c.normalize(pathSpec[1], target)
 	targetPath := pathSpec[1]
+
+	shared.LogDebugf("Pushing to: %s  (isdir: %t)", targetPath, targetIsDir)
 
 	d, err := lxd.NewClient(config, remote)
 	if err != nil {
@@ -134,9 +138,7 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 		gid = c.gid
 	}
 
-	_, targetfilename := filepath.Split(targetPath)
-
-	if (targetfilename != "") && (len(sourcefilenames) > 1) {
+	if (len(sourcefilenames) > 1) && !targetIsDir {
 		return errArgs
 	}
 
@@ -160,7 +162,7 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 
 	for _, f := range files {
 		fpath := targetPath
-		if targetfilename == "" {
+		if targetIsDir {
 			fpath = path.Join(fpath, path.Base(f.Name()))
 		}
 

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -74,10 +74,10 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 		return fmt.Errorf(i18n.G("Invalid target %s"), target)
 	}
 
-	pathSpec[1] = c.normalize(pathSpec[1], target)
-
-	targetPath := pathSpec[1]
 	remote, container := config.ParseRemoteAndContainer(pathSpec[0])
+
+	pathSpec[1] = c.normalize(pathSpec[1], target)
+	targetPath := pathSpec[1]
 
 	d, err := lxd.NewClient(config, remote)
 	if err != nil {

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -80,6 +80,10 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 	targetPath := "/" + pathSpec[1]
 	// clean various /./, /../, /////, etc. that users add (#2557)
 	targetPath = path.Clean(targetPath)
+	// normalization may reveal that path is still a dir, e.g. /.
+	if strings.HasSuffix(targetPath, "/") {
+		targetIsDir = true
+	}
 
 	shared.LogDebugf("Pushing to: %s  (isdir: %t)", targetPath, targetIsDir)
 

--- a/lxc/file_unix.go
+++ b/lxc/file_unix.go
@@ -25,13 +25,8 @@ func (c *fileCmd) normalize(path string, target string) string {
 	/* Fix up the path. Let's:
 	 * 1. re-add the leading / that got stripped from the SplitN
 	 * 2. clean it and remove any /./, /../, /////, etc.
-	 * 3. keep the trailing slash if it had one, since we use it via
-	 *    filepath.Split below
 	 */
 	path = filepath.Clean("/" + path)
-	if target[len(target)-1] == '/' {
-		path = path + "/"
-	}
 
 	return path
 }

--- a/lxc/file_unix.go
+++ b/lxc/file_unix.go
@@ -20,13 +20,3 @@ func (c *fileCmd) getOwner(f *os.File) (os.FileMode, int, int, error) {
 
 	return mode, uid, gid, nil
 }
-
-func (c *fileCmd) normalize(path string, target string) string {
-	/* Fix up the path. Let's:
-	 * 1. re-add the leading / that got stripped from the SplitN
-	 * 2. clean it and remove any /./, /../, /////, etc.
-	 */
-	path = filepath.Clean("/" + path)
-
-	return path
-}

--- a/lxc/file_unix.go
+++ b/lxc/file_unix.go
@@ -4,7 +4,6 @@ package main
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 )
 

--- a/lxc/file_windows.go
+++ b/lxc/file_windows.go
@@ -9,7 +9,3 @@ import (
 func (c *fileCmd) getOwner(f *os.File) (os.FileMode, int, int, error) {
 	return os.FileMode(0), -1, -1, nil
 }
-
-func (c *fileCmd) normalize(path string, target string) string {
-	return path
-}


### PR DESCRIPTION
This removes system dependent path manipulations (path/filepath) as target path uses forward slashes always. A better fix for #2565.
