### PR TITLE
raw LXC: skip leading whitespace

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -99,6 +99,9 @@ func lxcValidConfig(rawLxc string) error {
 			continue
 		}
 
+		// Skip whitespace {"\t", " "}
+		line = strings.TrimLeft(line, "\t ")
+
 		// Ignore comments
 		if strings.HasPrefix(line, "#") {
 			continue


### PR DESCRIPTION
We do the same in LXC itself. If we don't we might unnecessarily check comment
that have leading whitespace.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>