### PR TITLE
correctly set liblxc loglevel to debug when in --debug mode

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -537,12 +537,11 @@ func (c *containerLXC) initLXC() error {
 
 	logLevel := "warn"
 	if debug {
-		logLevel = "debug"
+		logLevel = "trace"
 	} else if verbose {
 		logLevel = "info"
-	} else {
-		logLevel = "trace"
 	}
+
 	err = lxcSetConfigItem(cc, "lxc.loglevel", logLevel)
 	if err != nil {
 		return err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -537,6 +537,7 @@ func (c *containerLXC) initLXC() error {
 
 	logLevel := "warn"
 	if debug {
+		logLevel = "debug"
 	} else if verbose {
 		logLevel = "info"
 	} else {


### PR DESCRIPTION
Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>