### PR TITLE
exec: remove ExecNoWait() and improve Exec()

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -351,17 +351,18 @@ type container interface {
 	FilePush(srcpath string, dstpath string, uid int, gid int, mode int) error
 
 	/* Command execution:
-	 * 1. passing in nil for attachedPid
-	 *    - equivalent to calling cmd.Run()
-	 * 2. passing in non-nil for attachedPid
-	 *    - return PID of the lxd forkexec command and store the PID of the
-	 *      executing process in attachedPid. It's the callers
-	 *      responsibility to wait on the command. (Note. The PID returned
-	 *      in attachedPid can not be waited upon since it's a child of the
-	 *      lxd forkexec command. It can however be used to e.g. forward
-	 *      signals.)
-	 */
-	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, attachedPid *int) (int, error)
+		 * 1. passing in false for wait
+		 *    - equivalent to calling cmd.Run()
+		 * 2. passing in true for wait
+	         *    - start the command and return its PID in the first return
+	         *      argument and the PID of the attached process in the second
+	         *      argument. It's the callers responsibility to wait on the
+	         *      command. (Note. The returned PID of the attached process can not
+	         *      be waited upon since it's a child of the lxd forkexec command
+	         *      (the PID returned in the first return argument). It can however
+	         *      be used to e.g. forward signals.)
+	*/
+	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool) (int, int, error)
 
 	// Status
 	Render() (interface{}, interface{}, error)

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -253,8 +253,7 @@ func (s *execWs) Do(op *operation) error {
 		return cmdErr
 	}
 
-	attachedPid := -1
-	pid, err := s.container.Exec(s.command, s.env, stdin, stdout, stderr, &attachedPid)
+	pid, attachedPid, err := s.container.Exec(s.command, s.env, stdin, stdout, stderr, false)
 	if err != nil {
 		return err
 	}
@@ -403,7 +402,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 			defer stderr.Close()
 
 			// Run the command
-			cmdResult, cmdErr = c.Exec(post.Command, env, nil, stdout, stderr, nil)
+			cmdResult, _, cmdErr = c.Exec(post.Command, env, nil, stdout, stderr, true)
 
 			// Update metadata with the right URLs
 			metadata["return"] = cmdResult
@@ -412,7 +411,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 				"2": fmt.Sprintf("/%s/containers/%s/logs/%s", shared.APIVersion, c.Name(), filepath.Base(stderr.Name())),
 			}
 		} else {
-			cmdResult, cmdErr = c.Exec(post.Command, env, nil, nil, nil, nil)
+			cmdResult, _, cmdErr = c.Exec(post.Command, env, nil, nil, nil, true)
 			metadata["return"] = cmdResult
 		}
 


### PR DESCRIPTION
ExecNoWait() was an unnecessary method addition to the containerLXC struct. It
also complicated the lxd forkexec command. I mainly added it because I
considered the methods defined on the containerLXC struct to be part of our API.
Now that I know better, let's simplify this code.

- Exec() gains an additional int pointer argument attachedPid.
  1. passing in nil for attachedPid
     - equivalent to calling cmd.Run()
   2. passing in non-nil for attachedPid
      - return PID of the lxd forkexec command and store the PID of the
	executing process in attachedPid. It's the callers responsibility to
	wait on the command. (Note. The PID returned in attachedPid can not be
	waited upon since it's a child of the lxd forkexec command. It can
	however be used to e.g. forward signals.)
- Move all the pipe magic into Exec() itself. This way we avoid exposing callers
  to internals and take away the responsibility to retrieve the PID themselves.

Signed-off-by: Christian Brauner <christian.brauner@canonical.com>