### PR TITLE
Bugfixes

### DIFF
--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -924,20 +925,33 @@ func (s *storageZfs) zfsGet(path string, key string) (string, error) {
 }
 
 func (s *storageZfs) zfsRename(source string, dest string) error {
-	output, err := tryExec(
-		"zfs",
-		"rename",
-		"-p",
-		fmt.Sprintf("%s/%s", s.zfsPool, source),
-		fmt.Sprintf("%s/%s", s.zfsPool, dest))
-	if err != nil {
-		if s.zfsExists(source) || !s.zfsExists(dest) {
-			s.log.Error("zfs rename failed", log.Ctx{"output": string(output)})
-			return fmt.Errorf("Failed to rename ZFS filesystem: %s", output)
+	var err error
+	var output []byte
+
+	for i := 0; i < 20; i++ {
+		output, err = exec.Command(
+			"zfs",
+			"rename",
+			"-p",
+			fmt.Sprintf("%s/%s", s.zfsPool, source),
+			fmt.Sprintf("%s/%s", s.zfsPool, dest)).CombinedOutput()
+
+		// Success
+		if err == nil {
+			return nil
 		}
+
+		// zfs rename can fail because of descendants, yet still manage the rename
+		if !s.zfsExists(source) && s.zfsExists(dest) {
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond)
 	}
 
-	return nil
+	// Timeout
+	s.log.Error("zfs rename failed", log.Ctx{"output": string(output)})
+	return fmt.Errorf("Failed to rename ZFS filesystem: %s", output)
 }
 
 func (s *storageZfs) zfsSet(path string, key string, value string) error {


### PR DESCRIPTION
For some reason "zfs rename" attempts to unmount and remount all
descendants. This behavior, combined with what looks like lack of
support for mount namespaces in ZFS, causes "zfs rename" to fail despite
having succesfuly renamed the dataset.

So instead of believing the return code, always check if the rename happened.

Closes #2617

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>