### PR TITLE
More clean filter for container names in bashcompl

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -5,12 +5,12 @@ _have lxc && {
     {
       local state=$1
       local keys=$2
-      
+
       local cmd="lxc list --fast"
       [ -n "$state" ] && cmd="$cmd | grep -E '$state'"
 
       COMPREPLY=( $( compgen -W \
-        "$( eval $cmd | grep -Ev '(+--|NAME)' | awk '{print $2}' ) $keys" "$cur" )
+        "$( eval $cmd | grep -Ev '(\+--|NAME)' | awk '{print $2}' ) $keys" "$cur" )
       )
     }
 


### PR DESCRIPTION
Removed extra whitespaces +
lxd_names grep fix, symbol + needs to be backslashed.
We could have e.g. profile named 'test--test', so `lxc list --fast` result would be:
```
+-----------------------+---------+--------------+----------------------+--------------+------------+
|         NAME          |  STATE  | ARCHITECTURE |      CREATED AT      |   PROFILES   |    TYPE    |
+-----------------------+---------+--------------+----------------------+--------------+------------+
| aarseniev-test-media  | RUNNING | x86_64       | 2016/11/23 17:22 UTC | test--test   | PERSISTENT |
|                       |         |              |                      | base         |            |
+-----------------------+---------+--------------+----------------------+--------------+------------+
```
this result wouldn't be matched by `grep -Ev '(+--|NAME)'`, but would be matched by `grep -Ev '(\+--|NAME)'`

so, after fix, bash completion would work with such cases
Sorry for my english :)

Signed-off-by: Aleksei Arsenev <aarseniev@yandex-team.ru>