### PR TITLE
blacklist lxc.syslog and lxc.ephemeral

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -137,6 +137,14 @@ func lxcValidConfig(rawLxc string) error {
 			return fmt.Errorf("Setting lxc.logfile is not allowed")
 		}
 
+		if key == "lxc.syslog" {
+			return fmt.Errorf("Setting lxc.syslog is not allowed")
+		}
+
+		if key == "lxc.ephemeral" {
+			return fmt.Errorf("Setting lxc.ephemeral is not allowed")
+		}
+
 		if strings.HasPrefix(key, "lxc.network.") {
 			fields := strings.Split(key, ".")
 			if len(fields) == 4 && shared.StringInSlice(fields[3], []string{"ipv4", "ipv6"}) {


### PR DESCRIPTION
- lxc.syslog: syslog() calls localtime() internally given that LXD is
	      multithreaded disallow it for now.
- lxc.ephemeral: Destroys containers on shutdown via the LXC API but this job
		 should __only__ be done by LXD. If not, then we end up with
		 containers in the database that have been destroyed already.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>