### PR TITLE
save slurp file after a snapshot is created

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -566,6 +566,12 @@ func containerCreateAsSnapshot(d *Daemon, args containerArgs, sourceContainer co
 		return nil, err
 	}
 
+	err = writeSlurpFile(sourceContainer)
+	if err != nil {
+		c.Delete()
+		return nil, err
+	}
+
 	// Once we're done, remove the state directory
 	if args.Stateful {
 		os.RemoveAll(sourceContainer.StatePath())

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -26,6 +26,7 @@ test_migration() {
     lxc_remote init testimage backup
     lxc_remote snapshot backup
     sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='backup'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='backup/snap0'"
     lxd import backup
     lxc_remote info backup | grep snap0
   fi


### PR DESCRIPTION
Otherwise, we won't have this snapshot in the list of snapshots in the
slurp file, and we'll miss it.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>