### PR TITLE
lxc-to-lxd: switch to using whitelist

### DIFF
--- a/scripts/lxc-to-lxd
+++ b/scripts/lxc-to-lxd
@@ -9,6 +9,86 @@ import subprocess
 import sys
 
 
+# Whitelist of keys we either need to check or allow setting in LXD. The latter
+# is strictly only true for 'lxc.aa_profile'.
+keys_to_check = [
+    'lxc.pts',
+    # 'lxc.tty',
+    # 'lxc.devttydir',
+    # 'lxc.kmsg',
+    'lxc.aa_profile',
+    # 'lxc.cgroup.',
+    'lxc.loglevel',
+    # 'lxc.logfile',
+    'lxc.mount.auto',
+    'lxc.mount',
+    # 'lxc.rootfs.mount',
+    # 'lxc.rootfs.options',
+    # 'lxc.pivotdir',
+    # 'lxc.hook.pre-start',
+    # 'lxc.hook.pre-mount',
+    # 'lxc.hook.mount',
+    # 'lxc.hook.autodev',
+    # 'lxc.hook.start',
+    # 'lxc.hook.stop',
+    # 'lxc.hook.post-stop',
+    # 'lxc.hook.clone',
+    # 'lxc.hook.destroy',
+    # 'lxc.hook',
+    'lxc.network.type',
+    'lxc.network.flags',
+    'lxc.network.link',
+    'lxc.network.name',
+    'lxc.network.macvlan.mode',
+    'lxc.network.veth.pair',
+    # 'lxc.network.script.up',
+    # 'lxc.network.script.down',
+    'lxc.network.hwaddr',
+    'lxc.network.mtu',
+    # 'lxc.network.vlan.id',
+    # 'lxc.network.ipv4.gateway',
+    # 'lxc.network.ipv4',
+    # 'lxc.network.ipv6.gateway',
+    # 'lxc.network.ipv6',
+    # 'lxc.network.',
+    # 'lxc.network',
+    # 'lxc.console.logfile',
+    # 'lxc.console',
+    'lxc.include',
+    'lxc.start.auto',
+    'lxc.start.delay',
+    'lxc.start.order',
+    # 'lxc.monitor.unshare',
+    # 'lxc.group',
+    'lxc.environment',
+    # 'lxc.init_cmd',
+    # 'lxc.init_uid',
+    # 'lxc.init_gid',
+    # 'lxc.ephemeral',
+    # 'lxc.syslog',
+    # 'lxc.no_new_privs',
+
+    # Additional keys that are either set by this script or are used to report
+    # helpful errors to users.
+    'lxc.arch',
+    'lxc.id_map',
+    'lxd.migrated',
+    'lxc.rootfs.backend',
+    'lxc.rootfs',
+    'lxc.utsname',
+    'lxc.aa_allow_incomplete',
+    'lxc.autodev',
+    'lxc.haltsignal',
+    'lxc.rebootsignal',
+    'lxc.stopsignal',
+    'lxc.mount.entry',
+    'lxc.cap.drop'
+    # 'lxc.cap.keep',
+    # 'lxc.seccomp',
+    # 'lxc.se_context',
+    ]
+
+
 # Unix connection to LXD
 class UnixHTTPConnection(http.client.HTTPConnection):
     def __init__(self, path):
@@ -33,6 +113,17 @@ def config_get(config, key, default=None):
         return default
     else:
         return result
+
+
+def config_keys(config):
+    keys = []
+    for line in config:
+        fields = line.split("=", 1)
+        cur = fields[0].strip()
+        if cur and not cur.startswith("#") and cur.startswith("lxc."):
+            keys.append(cur)
+
+    return keys
 
 
 # Parse a LXC configuration file, called recursively for includes
@@ -72,12 +163,13 @@ def config_parse(path):
                 with open(value, "r") as fd:
                     for line in fd:
                         line = line.strip()
-                        if line and not line.startswith("#"):
+                        if (line and not line.startswith("#") and
+                                line.startswith("lxc.")):
                             config.append("lxc.mount.entry = %s" % line)
                 continue
 
             # Proces normal configuration keys
-            if line and not line.startswith("#"):
+            if line and not line.strip().startswith("#"):
                 config.append(line)
 
     return config
@@ -128,6 +220,17 @@ def convert_container(lxd_socket, container_name, args):
     # As some keys can't be queried over the API, parse the config ourselves
     print("Parsing LXC configuration")
     lxc_config = config_parse(container.config_file_name)
+    found_keys = config_keys(lxc_config)
+
+    # Generic check for any invalid LXC configuration keys.
+    print("Checking for unsupported LXC configuration keys")
+    diff = list(set(found_keys) - set(keys_to_check))
+    for d in diff:
+        if (not d.startswith('lxc.network.') and not
+                d.startswith('lxc.cgroup.')):
+            print("Found at least one unsupported config key %s: " % d)
+            print("Not importing this container, skipping...")
+            return False
 
     if args.debug:
         print("Container configuration:")
@@ -135,6 +238,8 @@ def convert_container(lxd_socket, container_name, args):
         print("\n ".join(lxc_config))
         print("")
 
+    # Check for keys that have values differing from the LXD defaults.
+    print("Checking whether container has already been migrated")
     if config_get(lxc_config, "lxd.migrated"):
         print("Container has already been migrated, skipping...")
         return False
@@ -145,6 +250,12 @@ def convert_container(lxd_socket, container_name, args):
         print("Container already exists, skipping...")
         return False
 
+    # Validating lxc.id_map: must be unset.
+    print("Validating container mode")
+    if config_get(lxc_config, "lxc.id_map"):
+        print("Unprivileged containers aren't supported, skipping...")
+        return False
+
     # Validate lxc.utsname
     print("Validating container name")
     value = config_get(lxc_config, "lxc.utsname")
@@ -152,17 +263,40 @@ def convert_container(lxd_socket, container_name, args):
         print("Container name doesn't match lxc.utsname, skipping...")
         return False
 
-    # Detect privileged containers
-    print("Validating container mode")
-    if config_get(lxc_config, "lxc.id_map"):
-        print("Unprivileged containers aren't supported, skipping...")
+    # Validate lxc.aa_allow_incomplete: must be set to 0 or unset.
+    print("Validating whether incomplete AppArmor support is enabled")
+    value = config_get(lxc_config, "lxc.aa_allow_incomplete")
+    if value and int(value[0]) != 0:
+        print("Container allows incomplete AppArmor support, skipping...")
         return False
 
-    # Detect hooks in config
-    for line in lxc_config:
-        if line.startswith("lxc.hook."):
-            print("Hooks aren't supported, skipping...")
-            return False
+    # Validate lxc.autodev: must be set to 1 or unset.
+    print("Validating whether mounting a minimal /dev is enabled")
+    value = config_get(lxc_config, "lxc.autodev")
+    if value and int(value[0]) != 1:
+        print("Container doesn't mount a minimal /dev filesystem, skipping...")
+        return False
+
+    # Validate lxc.haltsignal: must be unset.
+    print("Validating that no custom haltsignal is set")
+    value = config_get(lxc_config, "lxc.haltsignal")
+    if value:
+        print("Container sets custom halt signal, skipping...")
+        return False
+
+    # Validate lxc.rebootsignal: must be unset.
+    print("Validating that no custom rebootsignal is set")
+    value = config_get(lxc_config, "lxc.rebootsignal")
+    if value:
+        print("Container sets custom reboot signal, skipping...")
+        return False
+
+    # Validate lxc.stopsignal: must be unset.
+    print("Validating that no custom stopsignal is set")
+    value = config_get(lxc_config, "lxc.stopsignal")
+    if value:
+        print("Container sets custom stop signal, skipping...")
+        return False
 
     # Extract and valid rootfs key
     print("Validating container rootfs")
@@ -339,27 +473,6 @@ def convert_container(lxd_socket, container_name, args):
     value = config_get(lxc_config, "lxc.cap.keep")
     if value:
         print("Custom capabilities aren't supported, skipping...")
-        return False
-
-    # Skip ephemeral
-    print("Processing container ephemeral configuration")
-    value = config_get(lxc_config, "lxc.ephemeral")
-    if value:
-        print("Setting lxc.ephemeral is not supported, skipping...")
-        return False
-
-    # Skip syslog
-    print("Processing container syslog configuration")
-    value = config_get(lxc_config, "lxc.syslog")
-    if value:
-        print("Setting lxc.syslog is not supported, skipping...")
-        return False
-
-    # Skip logfile
-    print("Processing container syslog configuration")
-    value = config_get(lxc_config, "lxc.logfile")
-    if value:
-        print("Setting lxc.logfile is not supported, skipping...")
         return False
 
     # Setup the container creation request

--- a/scripts/lxc-to-lxd
+++ b/scripts/lxc-to-lxd
@@ -528,7 +528,16 @@ def convert_container(lxd_socket, container_name, args):
     lxd_rootfs = os.path.join(args.lxdpath, "containers",
                               container_name, "rootfs")
 
-    if args.copy_rootfs:
+    if args.move_rootfs:
+        if os.path.exists(lxd_rootfs):
+            os.rmdir(lxd_rootfs)
+
+        if subprocess.call(["mv", rootfs, lxd_rootfs]) != 0:
+            print("Failed to move the container rootfs, skipping...")
+            return False
+
+        os.mkdir(rootfs)
+    else:
         print("Copying container rootfs")
         if not os.path.exists(lxd_rootfs):
             os.mkdir(lxd_rootfs)
@@ -538,15 +547,6 @@ def convert_container(lxd_socket, container_name, args):
                             "%s/" % rootfs, "%s/" % lxd_rootfs]) != 0:
             print("Failed to transfer the container rootfs, skipping...")
             return False
-    else:
-        if os.path.exists(lxd_rootfs):
-            os.rmdir(lxd_rootfs)
-
-        if subprocess.call(["mv", rootfs, lxd_rootfs]) != 0:
-            print("Failed to move the container rootfs, skipping...")
-            return False
-
-        os.mkdir(rootfs)
 
     # Delete the source
     if args.delete:
@@ -570,7 +570,7 @@ parser.add_argument("--all", action="store_true", default=False,
                     help="Import all containers")
 parser.add_argument("--delete", action="store_true", default=False,
                     help="Delete the source container")
-parser.add_argument("--copy-rootfs", action="store_true", default=False,
+parser.add_argument("--move-rootfs", action="store_true", default=False,
                     help="Copy the container rootfs rather than moving it")
 parser.add_argument("--lxcpath", type=str, default=False,
                     help="Alternate LXC path")


### PR DESCRIPTION
We keep a whitelist for supported configuration keys. We then perform a check
whether the container sets any unsupported configuration keys. We report the
first unsupported configuration key we found back to the user and the error out.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>