### PR TITLE
disable insecure TLS in CA mode

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -878,11 +878,10 @@ func (d *Daemon) Init() error {
 		}
 
 		tlsConfig := &tls.Config{
-			InsecureSkipVerify: true,
-			ClientAuth:         tls.RequestClientCert,
-			Certificates:       []tls.Certificate{cert},
-			MinVersion:         tls.VersionTLS12,
-			MaxVersion:         tls.VersionTLS12,
+			ClientAuth:   tls.RequestClientCert,
+			Certificates: []tls.Certificate{cert},
+			MinVersion:   tls.VersionTLS12,
+			MaxVersion:   tls.VersionTLS12,
 			CipherSuites: []uint16{
 				tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 				tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA},


### PR DESCRIPTION
I'm not sure if this actually matters or not, but it's implementation
dependent and might matter.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>