### PR TITLE
lxd/container_lxc: ensure Done() is always called

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2145,12 +2145,14 @@ func (c *containerLXC) Shutdown(timeout time.Duration) error {
 
 	err = op.Wait()
 	if err != nil && c.IsRunning() {
+		op.Done(err)
 		shared.LogError("Failed shutting down container", ctxMap)
 		return err
 	}
 
 	shared.LogInfo("Shut down container", ctxMap)
 
+	op.Done(nil)
 	return nil
 }
 


### PR DESCRIPTION
This commit ensures that we call Done() in all cases to actually report that the
operation is done. If I'm correct, this should fix any remaining hanging lxc
restart commands that are not explained by the fixes I pushed to liblxc.
A reproducer would be:

for i in {1..100}; do for c in foo{1..50}; do lxc restart $c & done; wait; done

A new enough liblxc version together with this commit in the LXD version should
not leave to any hanging commands.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>