### PR TITLE
file push: fix off by one error

### DIFF
--- a/client.go
+++ b/client.go
@@ -1903,7 +1903,12 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 			return fmt.Errorf("got error sending path %s: %s", p, err)
 		}
 
-		targetPath := path.Join(target, p[len(sourceDir):])
+		appendLen := len(sourceDir)
+		if sourceDir == "." {
+			appendLen--
+		}
+
+		targetPath := path.Join(target, p[appendLen:])
 		if fInfo.IsDir() {
 			return c.Mkdir(container, targetPath, fInfo.Mode())
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"syscall"
@@ -79,7 +80,10 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 	// re-add leading / that got stripped by the SplitN
 	targetPath := "/" + pathSpec[1]
 	// clean various /./, /../, /////, etc. that users add (#2557)
-	targetPath = path.Clean(targetPath)
+	targetPath, err := filepath.Abs(targetPath)
+	if err != nil {
+		return fmt.Errorf(i18n.G("Could not sanitize path %s"), targetPath)
+	}
 	// normalization may reveal that path is still a dir, e.g. /.
 	if strings.HasSuffix(targetPath, "/") {
 		targetIsDir = true

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2016-11-24 20:15-0500\n"
+        "POT-Creation-Date: 2016-12-06 14:45+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -262,6 +262,11 @@ msgstr  ""
 msgid   "Could not create server cert dir"
 msgstr  ""
 
+#: lxc/file.go:85
+#, c-format
+msgid   "Could not sanitize path %s"
+msgstr  ""
+
 #: lxc/snapshot.go:21
 msgid   "Create a read-only snapshot of a container.\n"
         "\n"
@@ -278,7 +283,7 @@ msgid   "Create a read-only snapshot of a container.\n"
         "lxc snapshot u1 snap0"
 msgstr  ""
 
-#: lxc/file.go:60 lxc/file.go:61
+#: lxc/file.go:61 lxc/file.go:62
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -465,12 +470,12 @@ msgstr  ""
 msgid   "Invalid configuration key"
 msgstr  ""
 
-#: lxc/file.go:247
+#: lxc/file.go:251
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:73
+#: lxc/file.go:74
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -661,7 +666,7 @@ msgid   "Manage configuration.\n"
         "    lxc config set core.trust_password blah"
 msgstr  ""
 
-#: lxc/file.go:35
+#: lxc/file.go:36
 msgid   "Manage files on a container.\n"
         "\n"
         "lxc file pull [-r|--recursive] <source> [<source>...] <target>\n"
@@ -812,7 +817,7 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name."
 msgstr  ""
 
-#: lxc/file.go:235
+#: lxc/file.go:239
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
@@ -1033,7 +1038,7 @@ msgid   "Publish containers as images.\n"
         "lxc publish [remote:]container [remote:] [--alias=ALIAS]... [prop-key=prop-value]..."
 msgstr  ""
 
-#: lxc/file.go:58 lxc/file.go:59
+#: lxc/file.go:59 lxc/file.go:60
 msgid   "Recursively push or pull files"
 msgstr  ""
 
@@ -1105,15 +1110,15 @@ msgid   "Set the current state of a container back to a snapshot.\n"
         "lxc restore u1 snap0 # restore the snapshot"
 msgstr  ""
 
-#: lxc/file.go:56
+#: lxc/file.go:57
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:57
+#: lxc/file.go:58
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:55
+#: lxc/file.go:56
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -1317,7 +1322,7 @@ msgstr  ""
 msgid   "can't copy to the same container name"
 msgstr  ""
 
-#: lxc/file.go:270
+#: lxc/file.go:274
 msgid   "can't pull a directory without --recursive"
 msgstr  ""
 
@@ -1325,7 +1330,7 @@ msgstr  ""
 msgid   "can't remove the default remote"
 msgstr  ""
 
-#: lxc/file.go:117
+#: lxc/file.go:121
 msgid   "can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -1376,7 +1381,7 @@ msgstr  ""
 msgid   "processing aliases failed %s\n"
 msgstr  ""
 
-#: lxc/file.go:311
+#: lxc/file.go:315
 msgid   "recursive edit doesn't make sense :("
 msgstr  ""
 


### PR DESCRIPTION
If filepath.Dir(someDir) returns "." we need to substract minus one to include
the first letter of the directory we want to create. This seems to only affect
recursive mode.

Also this adds two tests: One for when we are in the same working directory as
the directory we want to push (This will cover filepath.Dir(someDir) returning
".".). And one for when we give a directory via "../".

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>