### PR TITLE
tests: Fix shellcheck being confused by cd

### DIFF
--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
 test_filemanip() {
+  # Workaround for shellcheck getting confused by "cd"
+  set -e
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>