### PR TITLE
add a done signal to Monitor API

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -270,7 +270,7 @@ func (c *initCmd) initProgressTracker(d *lxd.Client, progress *ProgressRenderer,
 			progress.Update(opMd["download_progress"].(string))
 		}
 	}
-	go d.Monitor([]string{"operation"}, handler)
+	go d.Monitor([]string{"operation"}, handler, nil)
 }
 
 func (c *initCmd) guessImage(config *lxd.Config, d *lxd.Client, remote string, iremote string, image string) (string, string) {

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -84,5 +84,5 @@ func (c *monitorCmd) run(config *lxd.Config, args []string) error {
 		fmt.Printf("%s\n\n", render)
 	}
 
-	return d.Monitor(c.typeArgs, handler)
+	return d.Monitor(c.typeArgs, handler, nil)
 }

--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -34,7 +34,7 @@ func cmdShutdown() error {
 
 	monitor := make(chan error, 1)
 	go func() {
-		monitor <- c.Monitor(nil, func(m interface{}) {})
+		monitor <- c.Monitor(nil, func(m interface{}) {}, nil)
 	}()
 
 	select {


### PR DESCRIPTION
Otherwise there is no way to close these connections.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>