### PR TITLE
Move Device/Devices types to lxd package

### DIFF
--- a/client.go
+++ b/client.go
@@ -1317,7 +1317,7 @@ func (c *Client) GetAlias(alias string) string {
 
 // Init creates a container from either a fingerprint or an alias; you must
 // provide at least one.
-func (c *Client) Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, devices shared.Devices, ephem bool) (*Response, error) {
+func (c *Client) Init(name string, imgremote string, image string, profiles *[]string, config map[string]string, devices map[string]map[string]string, ephem bool) (*Response, error) {
 	if c.Remote.Public {
 		return nil, fmt.Errorf("This function isn't supported by public remotes.")
 	}
@@ -2019,7 +2019,7 @@ func (c *Client) GetMigrationSourceWS(container string) (*Response, error) {
 
 func (c *Client) MigrateFrom(name string, operation string, certificate string,
 	sourceSecrets map[string]string, architecture string, config map[string]string,
-	devices shared.Devices, profiles []string,
+	devices map[string]map[string]string, profiles []string,
 	baseImage string, ephemeral bool, push bool, sourceClient *Client,
 	sourceOperation string) (*Response, error) {
 	if c.Remote.Public {
@@ -2572,7 +2572,7 @@ func (c *Client) ContainerDeviceAdd(container, devname, devtype string, props []
 		return nil, err
 	}
 
-	newdev := shared.Device{}
+	newdev := map[string]string{}
 	for _, p := range props {
 		results := strings.SplitN(p, "=", 2)
 		if len(results) != 2 {
@@ -2583,13 +2583,13 @@ func (c *Client) ContainerDeviceAdd(container, devname, devtype string, props []
 		newdev[k] = v
 	}
 
-	if st.Devices != nil && st.Devices.ContainsName(devname) {
+	if st.Devices != nil && st.Devices[devname] != nil {
 		return nil, fmt.Errorf("device already exists")
 	}
 
 	newdev["type"] = devtype
 	if st.Devices == nil {
-		st.Devices = shared.Devices{}
+		st.Devices = map[string]map[string]string{}
 	}
 
 	st.Devices[devname] = newdev
@@ -2643,7 +2643,7 @@ func (c *Client) ProfileDeviceAdd(profile, devname, devtype string, props []stri
 		return nil, err
 	}
 
-	newdev := shared.Device{}
+	newdev := map[string]string{}
 	for _, p := range props {
 		results := strings.SplitN(p, "=", 2)
 		if len(results) != 2 {
@@ -2653,13 +2653,16 @@ func (c *Client) ProfileDeviceAdd(profile, devname, devtype string, props []stri
 		v := results[1]
 		newdev[k] = v
 	}
-	if st.Devices != nil && st.Devices.ContainsName(devname) {
+
+	if st.Devices != nil && st.Devices[devname] != nil {
 		return nil, fmt.Errorf("device already exists")
 	}
+
 	newdev["type"] = devtype
 	if st.Devices == nil {
-		st.Devices = shared.Devices{}
+		st.Devices = map[string]map[string]string{}
 	}
+
 	st.Devices[devname] = newdev
 
 	return c.put(fmt.Sprintf("profiles/%s", profile), st, Sync)

--- a/lxc/config.go
+++ b/lxc/config.go
@@ -872,7 +872,7 @@ func (c *configCmd) deviceShow(config *lxd.Config, which string, args []string) 
 		return err
 	}
 
-	var devices map[string]shared.Device
+	var devices map[string]map[string]string
 	if which == "profile" {
 		resp, err := client.ProfileConfig(name)
 		if err != nil {

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -55,7 +55,7 @@ func (c *copyCmd) copyContainer(config *lxd.Config, sourceResource string, destR
 
 	var status struct {
 		Architecture string
-		Devices      shared.Devices
+		Devices      map[string]map[string]string
 		Config       map[string]string
 		Profiles     []string
 	}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -182,7 +182,7 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 
 	iremote, image = c.guessImage(config, d, remote, iremote, image)
 
-	devicesMap := map[string]shared.Device{}
+	devicesMap := map[string]map[string]string{}
 	if c.network != "" {
 		network, err := d.NetworkGet(c.network)
 		if err != nil {
@@ -190,9 +190,9 @@ func (c *initCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		if network.Type == "bridge" {
-			devicesMap[c.network] = shared.Device{"type": "nic", "nictype": "bridged", "parent": c.network}
+			devicesMap[c.network] = map[string]string{"type": "nic", "nictype": "bridged", "parent": c.network}
 		} else {
-			devicesMap[c.network] = shared.Device{"type": "nic", "nictype": "macvlan", "parent": c.network}
+			devicesMap[c.network] = map[string]string{"type": "nic", "nictype": "macvlan", "parent": c.network}
 		}
 	}
 

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -70,7 +70,7 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 
 	iremote, image = c.init.guessImage(config, d, remote, iremote, image)
 
-	devicesMap := map[string]shared.Device{}
+	devicesMap := map[string]map[string]string{}
 	if c.init.network != "" {
 		network, err := d.NetworkGet(c.init.network)
 		if err != nil {
@@ -78,9 +78,9 @@ func (c *launchCmd) run(config *lxd.Config, args []string) error {
 		}
 
 		if network.Type == "bridge" {
-			devicesMap[c.init.network] = shared.Device{"type": "nic", "nictype": "bridged", "parent": c.init.network}
+			devicesMap[c.init.network] = map[string]string{"type": "nic", "nictype": "bridged", "parent": c.init.network}
 		} else {
-			devicesMap[c.init.network] = shared.Device{"type": "nic", "nictype": "macvlan", "parent": c.init.network}
+			devicesMap[c.init.network] = map[string]string{"type": "nic", "nictype": "macvlan", "parent": c.init.network}
 		}
 	}
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/lxc/go-lxc.v2"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/osarch"
 )
@@ -215,7 +216,7 @@ func containerValidConfig(d *Daemon, config map[string]string, profile bool, exp
 	return nil
 }
 
-func containerValidDevices(devices shared.Devices, profile bool, expanded bool) error {
+func containerValidDevices(devices types.Devices, profile bool, expanded bool) error {
 	// Empty device list
 	if devices == nil {
 		return nil
@@ -315,7 +316,7 @@ type containerArgs struct {
 	CreationDate time.Time
 	LastUsedDate time.Time
 	Ctype        containerType
-	Devices      shared.Devices
+	Devices      types.Devices
 	Ephemeral    bool
 	Name         string
 	Profiles     []string
@@ -393,9 +394,9 @@ type container interface {
 	CreationDate() time.Time
 	LastUsedDate() time.Time
 	ExpandedConfig() map[string]string
-	ExpandedDevices() shared.Devices
+	ExpandedDevices() types.Devices
 	LocalConfig() map[string]string
-	LocalDevices() shared.Devices
+	LocalDevices() types.Devices
 	Profiles() []string
 	InitPID() int
 	State() string
@@ -596,7 +597,7 @@ func containerCreateInternal(d *Daemon, args containerArgs) (container, error) {
 	}
 
 	if args.Devices == nil {
-		args.Devices = shared.Devices{}
+		args.Devices = types.Devices{}
 	}
 
 	if args.Architecture == 0 {

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/osarch"
 
@@ -17,7 +18,7 @@ import (
 type containerPutReq struct {
 	Architecture string            `json:"architecture"`
 	Config       map[string]string `json:"config"`
-	Devices      shared.Devices    `json:"devices"`
+	Devices      types.Devices     `json:"devices"`
 	Ephemeral    bool              `json:"ephemeral"`
 	Profiles     []string          `json:"profiles"`
 	Restore      string            `json:"restore"`

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -36,7 +37,7 @@ func (suite *lxdTestSuite) TestContainer_ProfilesMulti() {
 		"unprivileged",
 		"unprivileged",
 		map[string]string{"security.privileged": "true"},
-		shared.Devices{})
+		types.Devices{})
 
 	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
 	defer func() {
@@ -70,8 +71,8 @@ func (suite *lxdTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 		Ctype:     cTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
-		Devices: shared.Devices{
-			"eth0": shared.Device{
+		Devices: types.Devices{
+			"eth0": types.Device{
 				"type":    "nic",
 				"nictype": "bridged",
 				"parent":  "unknownbr0"}},
@@ -100,8 +101,8 @@ func (suite *lxdTestSuite) TestContainer_LoadFromDB() {
 		Ctype:     cTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
-		Devices: shared.Devices{
-			"eth0": shared.Device{
+		Devices: types.Devices{
+			"eth0": types.Device{
 				"type":    "nic",
 				"nictype": "bridged",
 				"parent":  "unknownbr0"}},

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -11,6 +11,7 @@ import (
 	"github.com/dustinkirkland/golang-petname"
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/osarch"
 
@@ -52,7 +53,7 @@ type containerImageSource struct {
 type containerPostReq struct {
 	Architecture string               `json:"architecture"`
 	Config       map[string]string    `json:"config"`
-	Devices      shared.Devices       `json:"devices"`
+	Devices      types.Devices        `json:"devices"`
 	Ephemeral    bool                 `json:"ephemeral"`
 	Name         string               `json:"name"`
 	Profiles     []string             `json:"profiles"`
@@ -431,7 +432,7 @@ func containersPost(d *Daemon, r *http.Request) Response {
 	}
 
 	if req.Devices == nil {
-		req.Devices = shared.Devices{}
+		req.Devices = types.Devices{}
 	}
 
 	if req.Config == nil {

--- a/lxd/db_containers.go
+++ b/lxd/db_containers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -108,7 +109,7 @@ func dbContainerGet(db *sql.DB, name string) (containerArgs, error) {
 	args.Profiles = profiles
 
 	/* get container_devices */
-	args.Devices = shared.Devices{}
+	args.Devices = types.Devices{}
 	newdevs, err := dbDevices(db, name, false)
 	if err != nil {
 		return args, err

--- a/lxd/db_devices.go
+++ b/lxd/db_devices.go
@@ -6,7 +6,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/lxd/types"
 )
 
 func dbDeviceTypeToString(t int) (string, error) {
@@ -51,7 +51,7 @@ func dbDeviceTypeToInt(t string) (int, error) {
 	}
 }
 
-func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices shared.Devices) error {
+func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices types.Devices) error {
 	// Prepare the devices entry SQL
 	str1 := fmt.Sprintf("INSERT INTO %ss_devices (%s_id, name, type) VALUES (?, ?, ?)", w, w)
 	stmt1, err := tx.Prepare(str1)
@@ -102,10 +102,10 @@ func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices shared.Devices) error
 	return nil
 }
 
-func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (shared.Device, error) {
+func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (types.Device, error) {
 	var query string
 	var key, value string
-	newdev := shared.Device{} // That's a map[string]string
+	newdev := types.Device{} // That's a map[string]string
 	inargs := []interface{}{id}
 	outfmt := []interface{}{key, value}
 
@@ -130,7 +130,7 @@ func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (shared.Device, error) {
 	return newdev, nil
 }
 
-func dbDevices(db *sql.DB, qName string, isprofile bool) (shared.Devices, error) {
+func dbDevices(db *sql.DB, qName string, isprofile bool) (types.Devices, error) {
 	var q string
 	if isprofile {
 		q = `SELECT profiles_devices.id, profiles_devices.name, profiles_devices.type
@@ -152,7 +152,7 @@ func dbDevices(db *sql.DB, qName string, isprofile bool) (shared.Devices, error)
 		return nil, err
 	}
 
-	devices := shared.Devices{}
+	devices := types.Devices{}
 	for _, r := range results {
 		id = r[0].(int)
 		name = r[1].(string)

--- a/lxd/db_profiles.go
+++ b/lxd/db_profiles.go
@@ -6,6 +6,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -59,7 +60,7 @@ func dbProfileGet(db *sql.DB, profile string) (int64, *shared.ProfileConfig, err
 }
 
 func dbProfileCreate(db *sql.DB, profile string, description string, config map[string]string,
-	devices shared.Devices) (int64, error) {
+	devices types.Devices) (int64, error) {
 
 	tx, err := dbBegin(db)
 	if err != nil {
@@ -104,7 +105,7 @@ func dbProfileCreateDefault(db *sql.DB) error {
 		return nil
 	}
 
-	id, err := dbProfileCreate(db, "default", "Default LXD profile", map[string]string{}, shared.Devices{})
+	id, err := dbProfileCreate(db, "default", "Default LXD profile", map[string]string{}, types.Devices{})
 	if err != nil {
 		return err
 	}
@@ -128,7 +129,7 @@ func dbProfileCreateDocker(db *sql.DB) error {
 		"type":   "disk",
 		"source": "/dev/null",
 	}
-	devices := map[string]shared.Device{"aadisable": aadisable}
+	devices := map[string]map[string]string{"aadisable": aadisable}
 
 	_, err = dbProfileCreate(db, "docker", "Profile supporting docker in containers", config, devices)
 	return err

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logging"
 )
@@ -580,9 +581,9 @@ func Test_dbContainerProfiles(t *testing.T) {
 func Test_dbDevices_profiles(t *testing.T) {
 	var db *sql.DB
 	var err error
-	var result shared.Devices
-	var subresult shared.Device
-	var expected shared.Device
+	var result types.Devices
+	var subresult types.Device
+	var expected types.Device
 
 	db = createTestDb(t)
 	defer db.Close()
@@ -592,7 +593,7 @@ func Test_dbDevices_profiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected = shared.Device{"type": "nic", "devicekey": "devicevalue"}
+	expected = types.Device{"type": "nic", "devicekey": "devicevalue"}
 	subresult = result["devicename"]
 
 	for key, value := range expected {
@@ -606,9 +607,9 @@ func Test_dbDevices_profiles(t *testing.T) {
 func Test_dbDevices_containers(t *testing.T) {
 	var db *sql.DB
 	var err error
-	var result shared.Devices
-	var subresult shared.Device
-	var expected shared.Device
+	var result types.Devices
+	var subresult types.Device
+	var expected types.Device
 
 	db = createTestDb(t)
 	defer db.Close()
@@ -618,7 +619,7 @@ func Test_dbDevices_containers(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected = shared.Device{"type": "nic", "configkey": "configvalue"}
+	expected = types.Device{"type": "nic", "configkey": "configvalue"}
 	subresult = result["somename"]
 
 	for key, value := range expected {

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/version"
 
@@ -23,7 +24,7 @@ type profilesPostReq struct {
 	Name        string            `json:"name"`
 	Config      map[string]string `json:"config"`
 	Description string            `json:"description"`
-	Devices     shared.Devices    `json:"devices"`
+	Devices     types.Devices     `json:"devices"`
 }
 
 func profilesGet(d *Daemon, r *http.Request) Response {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logging"
@@ -654,7 +655,7 @@ func snapshotProtobufToContainerArgs(containerName string, snap *Snapshot) conta
 		config[ent.GetKey()] = ent.GetValue()
 	}
 
-	devices := shared.Devices{}
+	devices := types.Devices{}
 	for _, ent := range snap.LocalDevices {
 		props := map[string]string{}
 		for _, prop := range ent.Config {

--- a/lxd/types/devices.go
+++ b/lxd/types/devices.go
@@ -1,11 +1,13 @@
-package shared
+package types
 
 import (
 	"sort"
+
+	"github.com/lxc/lxd/shared"
 )
 
 type Device map[string]string
-type Devices map[string]Device
+type Devices map[string]map[string]string
 
 func (list Devices) ContainsName(k string) bool {
 	if list[k] != nil {
@@ -66,14 +68,14 @@ func (old Devices) Update(newlist Devices) (map[string]Device, map[string]Device
 	for key, d := range addlist {
 		srcOldDevice := rmlist[key]
 		var oldDevice Device
-		err := DeepCopy(&srcOldDevice, &oldDevice)
+		err := shared.DeepCopy(&srcOldDevice, &oldDevice)
 		if err != nil {
 			continue
 		}
 
 		srcNewDevice := newlist[key]
 		var newDevice Device
-		err = DeepCopy(&srcNewDevice, &newDevice)
+		err = shared.DeepCopy(&srcNewDevice, &newDevice)
 		if err != nil {
 			continue
 		}

--- a/lxd/types/devices_test.go
+++ b/lxd/types/devices_test.go
@@ -1,4 +1,4 @@
-package shared
+package types
 
 import (
 	"reflect"

--- a/shared/container.go
+++ b/shared/container.go
@@ -65,33 +65,33 @@ type ContainerExecControl struct {
 }
 
 type SnapshotInfo struct {
-	Architecture    string            `json:"architecture"`
-	Config          map[string]string `json:"config"`
-	CreationDate    time.Time         `json:"created_at"`
-	Devices         Devices           `json:"devices"`
-	Ephemeral       bool              `json:"ephemeral"`
-	ExpandedConfig  map[string]string `json:"expanded_config"`
-	ExpandedDevices Devices           `json:"expanded_devices"`
-	LastUsedDate    time.Time         `json:"last_used_at"`
-	Name            string            `json:"name"`
-	Profiles        []string          `json:"profiles"`
-	Stateful        bool              `json:"stateful"`
+	Architecture    string                       `json:"architecture"`
+	Config          map[string]string            `json:"config"`
+	CreationDate    time.Time                    `json:"created_at"`
+	Devices         map[string]map[string]string `json:"devices"`
+	Ephemeral       bool                         `json:"ephemeral"`
+	ExpandedConfig  map[string]string            `json:"expanded_config"`
+	ExpandedDevices map[string]map[string]string `json:"expanded_devices"`
+	LastUsedDate    time.Time                    `json:"last_used_at"`
+	Name            string                       `json:"name"`
+	Profiles        []string                     `json:"profiles"`
+	Stateful        bool                         `json:"stateful"`
 }
 
 type ContainerInfo struct {
-	Architecture    string            `json:"architecture"`
-	Config          map[string]string `json:"config"`
-	CreationDate    time.Time         `json:"created_at"`
-	Devices         Devices           `json:"devices"`
-	Ephemeral       bool              `json:"ephemeral"`
-	ExpandedConfig  map[string]string `json:"expanded_config"`
-	ExpandedDevices Devices           `json:"expanded_devices"`
-	LastUsedDate    time.Time         `json:"last_used_at"`
-	Name            string            `json:"name"`
-	Profiles        []string          `json:"profiles"`
-	Stateful        bool              `json:"stateful"`
-	Status          string            `json:"status"`
-	StatusCode      StatusCode        `json:"status_code"`
+	Architecture    string                       `json:"architecture"`
+	Config          map[string]string            `json:"config"`
+	CreationDate    time.Time                    `json:"created_at"`
+	Devices         map[string]map[string]string `json:"devices"`
+	Ephemeral       bool                         `json:"ephemeral"`
+	ExpandedConfig  map[string]string            `json:"expanded_config"`
+	ExpandedDevices map[string]map[string]string `json:"expanded_devices"`
+	LastUsedDate    time.Time                    `json:"last_used_at"`
+	Name            string                       `json:"name"`
+	Profiles        []string                     `json:"profiles"`
+	Stateful        bool                         `json:"stateful"`
+	Status          string                       `json:"status"`
+	StatusCode      StatusCode                   `json:"status_code"`
 }
 
 func (c ContainerInfo) IsActive() bool {
@@ -110,11 +110,11 @@ func (c ContainerInfo) IsActive() bool {
  * ContainerState, namely those which a user may update
  */
 type BriefContainerInfo struct {
-	Name      string            `json:"name"`
-	Profiles  []string          `json:"profiles"`
-	Config    map[string]string `json:"config"`
-	Devices   Devices           `json:"devices"`
-	Ephemeral bool              `json:"ephemeral"`
+	Name      string                       `json:"name"`
+	Profiles  []string                     `json:"profiles"`
+	Config    map[string]string            `json:"config"`
+	Devices   map[string]map[string]string `json:"devices"`
+	Ephemeral bool                         `json:"ephemeral"`
 }
 
 func (c *ContainerInfo) Brief() BriefContainerInfo {
@@ -146,11 +146,11 @@ const (
 )
 
 type ProfileConfig struct {
-	Name        string            `json:"name"`
-	Config      map[string]string `json:"config"`
-	Description string            `json:"description"`
-	Devices     Devices           `json:"devices"`
-	UsedBy      []string          `json:"used_by"`
+	Name        string                       `json:"name"`
+	Config      map[string]string            `json:"config"`
+	Description string                       `json:"description"`
+	Devices     map[string]map[string]string `json:"devices"`
+	UsedBy      []string                     `json:"used_by"`
 }
 
 type NetworkConfig struct {


### PR DESCRIPTION
We don't need any of their functions in the client code so move them to
be daemon-only and instead use generic go types in the client.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>