### PR TITLE
Run dnsmasq with lower privilege

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -720,7 +720,7 @@ func (n *network) Start() error {
 	}
 
 	// Start building the dnsmasq command line
-	dnsmasqCmd := []string{"dnsmasq", "-u", "root", "--strict-order", "--bind-interfaces",
+	dnsmasqCmd := []string{"dnsmasq", "-u", "nobody", "--strict-order", "--bind-interfaces",
 		fmt.Sprintf("--pid-file=%s", shared.VarPath("networks", n.name, "dnsmasq.pid")),
 		"--except-interface=lo",
 		fmt.Sprintf("--interface=%s", n.name)}


### PR DESCRIPTION
Should fix #2765 
I tested this change for 12 days (build in [ppa:hda-me/lxd-dnsmasq-test](http://launchpad.net/~hda-me/+archive/ubuntu/lxd-dnsmasq-test)), and didn't spotted any backdrops.
There no any exploits in the wild, but it not he reason to avoid it or wait for it to happen. Also we can't warranty there no any exploits for dnsmasq in NSA briefcase. 
Summary to someone who not in theme: Currently all dnsmasq processes run with root privileges, and dnsmasq port accessible from containers and this slight change fix it. As for lxd user, lxd user have more privileges, then nobody, and it works without a problem with nobody. 

