### PR TITLE
shared/util: ParseByteSizeString() deal with bytes

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 const SnapshotDelimiter = "/"
@@ -619,6 +620,18 @@ func ParseMetadata(metadata interface{}) (map[string]interface{}, error) {
 func ParseByteSizeString(input string) (int64, error) {
 	if input == "" {
 		return 0, nil
+	}
+
+	// COMMENT(brauner): In case the last character is a number we assume
+	// that we are passed a simple integer which we interpret as being in
+	// bytes. So we parse it directly and return.
+	if unicode.IsNumber(rune(input[len(input)-1])) {
+		valueInt, err := strconv.ParseInt(input, 10, 64)
+		if err != nil {
+			return -1, fmt.Errorf("Invalid integer: %s", input)
+		}
+
+		return valueInt, nil
 	}
 
 	if len(input) < 3 {


### PR DESCRIPTION
When we are passed in a number with a suffix, assume it is already in bytes.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

(Not sure if this is the most idiomatic way to do it.)