### PR TITLE
Introduced storage.dir_force_usage to force usage of storage backend dir

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -54,6 +54,7 @@ _have lxc && {
       core.https_allowed_methods core.https_allowed_headers  \
       core.https_allowed_credentials core.proxy_https \
       core.proxy_http core.proxy_ignore_host core.trust_password \
+      storage.dir_force_usage \
       storage.lvm_vg_name storage.lvm_thinpool_name storage.lvm_fstype \
       storage.lvm_volume_size storage.lvm_mount_options storage.zfs_pool_name \
       storage.zfs_remove_snapshots storage.zfs_use_refquota \

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -28,6 +28,7 @@ core.proxy\_https               | string    | -         | -                     
 core.proxy\_http                | string    | -         | -                                 | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
 core.proxy\_ignore\_hosts       | string    | -         | -                                 | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)
 core.trust\_password            | string    | -         | -                                 | Password to be provided by clients to setup a trust
+storage.dir\_force\_usage       | boolean   | false     | -                                 | Flag to force usage of storage backend "dir".
 storage.lvm\_vg\_name           | string    | -         | -                                 | LVM Volume Group name to be used for container and image storage. A default Thin Pool is created using 100% of the free space in the Volume Group, unless `storage.lvm_thinpool_name` is set.
 storage.lvm\_thinpool\_name     | string    | "LXDPool" | -                                 | LVM Thin Pool to use within the Volume Group specified in `storage.lvm_vg_name`, if the default pool parameters are undesirable.
 storage.lvm\_fstype             | string    | ext4      | -                                 | Format LV with filesystem, for now it's value can be only ext4 (default) or xfs.

--- a/doc/storage-backends.md
+++ b/doc/storage-backends.md
@@ -38,7 +38,7 @@ rsync is used to transfer the container content across.
 
  - The btrfs backend is automatically used if /var/lib/lxd is on a btrfs filesystem.
  - Uses a subvolume per container, image and snapshot, creating btrfs snapshots when creating a new object.
- - When using for nesting, the host btrfs filesystem must be mounted with the "user\_subvol\_rm\_allowed" mount option.
+ - When using for nesting, the host btrfs filesystem must be mounted with the "user\_subvol\_rm\_allowed" mount option or the "storage.dir\_force\_usage" flag of the nesting container needs to be set to "true"
 
 ### LVM
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -355,6 +355,12 @@ func (d *Daemon) createCmd(version string, c Command) {
 func (d *Daemon) SetupStorageDriver() error {
 	var err error
 
+	dirForceUsage := daemonConfig["storage.dir_force_usage"].GetBool()
+	if dirForceUsage == true {
+		d.Storage, err = newStorage(d, storageTypeDir)
+		return err
+	}
+
 	lvmVgName := daemonConfig["storage.lvm_vg_name"].Get()
 	zfsPoolName := daemonConfig["storage.zfs_pool_name"].Get()
 

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -188,6 +188,7 @@ func daemonConfigInit(db *sql.DB) error {
 		"images.compression_algorithm": {valueType: "string", validator: daemonConfigValidateCompression, defaultValue: "gzip"},
 		"images.remote_cache_expiry":   {valueType: "int", defaultValue: "10", trigger: daemonConfigTriggerExpiry},
 
+		"storage.dir_force_usage":      {valueType: "bool", defaultValue: "false", setter: daemonConfigSetStorage},
 		"storage.lvm_fstype":           {valueType: "string", defaultValue: "ext4", validValues: []string{"ext4", "xfs"}},
 		"storage.lvm_mount_options":    {valueType: "string", defaultValue: "discard"},
 		"storage.lvm_thinpool_name":    {valueType: "string", defaultValue: "LXDPool", validator: storageLVMValidateThinPoolName},


### PR DESCRIPTION
I wanted to use nesting on a btrfs filesystem but don't want allow the user to delete btrfs subvolumes. So I introduced the flag "storage.dir_force_usage" to force usage of "dir" storage backend.