### PR TITLE
exec: report exit code when we got killed by signal

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -284,7 +284,8 @@ func (s *execWs) Do(op *operation) error {
 		}
 
 		if status.Signaled() {
-			return finisher(-1, nil)
+			// COMMENT(brauner): 128 + n == Fatal error signal "n"
+			return finisher(128+int(status.Signal()), nil)
 		}
 	}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4556,6 +4556,11 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 			if ok {
 				return status.ExitStatus(), attachedPid, nil
 			}
+
+			if status.Signaled() {
+				// COMMENT(brauner): 128 + n == Fatal error signal "n"
+				return 128 + int(status.Signal()), attachedPid, nil
+			}
 		}
 		return -1, -1, err
 	}

--- a/lxd/main_forkexec.go
+++ b/lxd/main_forkexec.go
@@ -119,12 +119,13 @@ func cmdForkExec(args []string) (int, error) {
 
 	exCode, ok := procState.Sys().(syscall.WaitStatus)
 	if ok {
-		if exCode.Exited() {
-			return exCode.ExitStatus(), nil
+		if exCode.Signaled() {
+			// COMMENT(brauner): 128 + n == Fatal error signal "n"
+			return 128 + int(exCode.Signal()), nil
 		}
 
-		if exCode.Signaled() {
-			return -1, nil
+		if exCode.Exited() {
+			return exCode.ExitStatus(), nil
 		}
 	}
 


### PR DESCRIPTION
The standard shell convention is to report 128 + n where n := signal that killed
the process. This signal number is usually within a reasonable range so that the
magic 8-bit wall of sound is not breached. Essentially, we now report exit codes
like a standard shell would:

1.
	chb@conventiont|~/source/go/bin
	> ./lxc exec zest1 sleep 100
	chb@conventiont|~/source/go/bin
	> echo $?
	143

caused by sending:

	kill -15 $(pidof sleep 100)

2.
	chb@conventiont|~/source/go/bin
	> ./lxc exec zest1 sleep 100
	chb@conventiont|~/source/go/bin
	> echo $?
	129

caused by sending:

	kill -HUP $(pidof sleep 100)

3.
	chb@conventiont|~/source/go/bin
	> ./lxc exec zest1 sleep 100
	chb@conventiont|~/source/go/bin
	> echo $?
	137

caused by sending:

	kill -KILL $(pidof sleep 100)

This is way more fine-grained than what ssh does and more in line with standard
shell exit codes. Also, this allows us to even report back SIGKILL in the sense
that we can tell the user, "Hey, this was the grim 137 aka the ultimate 9.".

Note that there is a caveat: If a user were to write a program that uses one of
those 128 + n exit codes as exit code than being killed by a signal would be
indistinguishable for him from success. However, the user would face the same
problem running the program in a local shell or otherwise. So I wouldn't count
this as a counter-argument. (Also, there is the fact that these exit codes are
actually reserved.)

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>