### PR TITLE
LXD storage API

### DIFF
--- a/client.go
+++ b/client.go
@@ -2801,3 +2801,166 @@ func (c *Client) ListNetworks() ([]api.Network, error) {
 
 	return networks, nil
 }
+
+// Storage functions
+func (c *Client) ListStoragePools() ([]api.StoragePool, error) {
+	if c.Remote.Public {
+		return nil, fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	resp, err := c.get("storage-pools?recursion=1")
+	if err != nil {
+		return nil, err
+	}
+
+	pools := []api.StoragePool{}
+	if err := json.Unmarshal(resp.Metadata, &pools); err != nil {
+		return nil, err
+	}
+
+	return pools, nil
+}
+
+func (c *Client) StoragePoolCreate(name string, driver string, config map[string]string) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	body := shared.Jmap{"name": name, "driver": driver, "config": config}
+
+	_, err := c.post("storage-pools", body, api.SyncResponse)
+	return err
+}
+
+func (c *Client) StoragePoolDelete(name string) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	_, err := c.delete(fmt.Sprintf("storage-pools/%s", name), nil, api.SyncResponse)
+	return err
+}
+
+func (c *Client) StoragePoolGet(name string) (api.StoragePool, error) {
+	if c.Remote.Public {
+		return api.StoragePool{}, fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	resp, err := c.get(fmt.Sprintf("storage-pools/%s", name))
+	if err != nil {
+		return api.StoragePool{}, err
+	}
+
+	pools := api.StoragePool{}
+	if err := json.Unmarshal(resp.Metadata, &pools); err != nil {
+		return api.StoragePool{}, err
+	}
+
+	return pools, nil
+}
+
+func (c *Client) StoragePoolPut(name string, pool api.StoragePool) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	if pool.Name != name {
+		return fmt.Errorf("Cannot change storage pool name")
+	}
+
+	_, err := c.put(fmt.Sprintf("storage-pools/%s", name), pool, api.SyncResponse)
+	return err
+}
+
+// /1.0/storage-pools/{name}/volumes
+func (c *Client) StoragePoolVolumesList(pool string) ([]api.StorageVolume, error) {
+	if c.Remote.Public {
+		return nil, fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	resp, err := c.get(fmt.Sprintf("storage-pools/%s/volumes?recursion=1", pool))
+	if err != nil {
+		return nil, err
+	}
+
+	volumes := []api.StorageVolume{}
+	if err := json.Unmarshal(resp.Metadata, &volumes); err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}
+
+// /1.0/storage-pools/{name}/volumes/{type}
+func (c *Client) StoragePoolVolumesTypeList(pool string, volumeType string) ([]api.StorageVolume, error) {
+	if c.Remote.Public {
+		return nil, fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	resp, err := c.get(fmt.Sprintf("storage-pools/%s/volumes/%s?recursion=1", pool, volumeType))
+	if err != nil {
+		return nil, err
+	}
+
+	volumes := []api.StorageVolume{}
+	if err := json.Unmarshal(resp.Metadata, &volumes); err != nil {
+		return nil, err
+	}
+
+	return volumes, nil
+}
+
+// /1.0/storage-pools/{pool}/volumes/{volume_type}
+func (c *Client) StoragePoolVolumeTypeCreate(pool string, volume string, volumeType string, config map[string]string) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	body := shared.Jmap{"pool": pool, "name": volume, "type": volumeType, "config": config}
+
+	_, err := c.post(fmt.Sprintf("storage-pools/%s/volumes/%s", pool, volumeType), body, api.SyncResponse)
+	return err
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func (c *Client) StoragePoolVolumeTypeGet(pool string, volume string, volumeType string) (api.StorageVolume, error) {
+	if c.Remote.Public {
+		return api.StorageVolume{}, fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	resp, err := c.get(fmt.Sprintf("storage-pools/%s/volumes/%s/%s", pool, volumeType, volume))
+	if err != nil {
+		return api.StorageVolume{}, err
+	}
+
+	vol := api.StorageVolume{}
+	if err := json.Unmarshal(resp.Metadata, &vol); err != nil {
+		return api.StorageVolume{}, err
+	}
+
+	return vol, nil
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func (c *Client) StoragePoolVolumeTypePut(pool string, volume string, volumeType string, volumeConfig api.StorageVolume) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	if volumeConfig.Name != volume {
+		return fmt.Errorf("Cannot change storage volume name")
+	}
+
+	_, err := c.put(fmt.Sprintf("storage-pools/%s/volumes/%s/%s", pool, volumeType, volume), volumeConfig, api.SyncResponse)
+	return err
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func (c *Client) StoragePoolVolumeTypeDelete(pool string, volume string, volumeType string) error {
+	if c.Remote.Public {
+		return fmt.Errorf("This function isn't supported by public remotes.")
+	}
+
+	_, err := c.delete(fmt.Sprintf("storage-pools/%s/volumes/%s/%s", pool, volumeType, volume), nil, api.SyncResponse)
+	return err
+}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -176,3 +176,29 @@ dnsmasq is enabled on the bridge.
 
 ## network\_routes
 Introduces "ipv4.routes" and "ipv6.routes" which allow routing additional subnets to a LXD bridge.
+
+## storage
+Storage management API for LXD.
+
+This includes:
+* GET /1.0/storage-pools
+* POST /1.0/storage-pools (see rest-api.md for details)
+
+* GET /1.0/storage-pools/<name> (see rest-api.md for details)
+* POST /1.0/storage-pools/<name> (see rest-api.md for details)
+* PUT /1.0/storage-pools/<name> (see rest-api.md for details)
+* PATCH /1.0/storage-pools/<name> (see rest-api.md for details)
+* DELETE /1.0/storage-pools/<name> (see rest-api.md for details)
+
+* GET /1.0/storage-pools/<name>/volumes (see rest-api.md for details)
+
+* GET /1.0/storage-pools/<name>/volumes/<volume_type> (see rest-api.md for details)
+* POST /1.0/storage-pools/<name>/volumes/<volume_type> (see rest-api.md for details)
+
+* GET /1.0/storage-pools/<pool>/volumes/<volume_type>/<name> (see rest-api.md for details)
+* POST /1.0/storage-pools/<pool>/volumes/<volume_type>/<name> (see rest-api.md for details)
+* PUT /1.0/storage-pools/<pool>/volumes/<volume_type>/<name> (see rest-api.md for details)
+* PATCH /1.0/storage-pools/<pool>/volumes/<volume_type>/<name> (see rest-api.md for details)
+* DELETE /1.0/storage-pools/<pool>/volumes/<volume_type>/<name> (see rest-api.md for details)
+
+- All storage configuration options (see configuration.md for details)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -36,6 +36,7 @@ storage.lvm\_volume\_size       | string    | 10GiB     | -                     
 storage.zfs\_pool\_name         | string    | -         | -                                 | ZFS pool name
 storage.zfs\_remove\_snapshots  | boolean   | false     | storage\_zfs\_remove\_snapshots   | Automatically remove any needed snapshot when attempting a container restore
 storage.zfs\_use\_refquota      | boolean   | false     | storage\_zfs\_use\_refquota       | Don't include snapshots as part of container quota (size property) or in reported disk usage
+storage.default_pool            | string    | -         | storage                           | The default storage pool on which to create containers.
 images.compression\_algorithm   | string    | gzip      | -                                 | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
 images.remote\_cache\_expiry    | integer   | 10        | -                                 | Number of days after which an unused cached remote image will be flushed
 images.auto\_update\_interval   | integer   | 6         | -                                 | Interval in hours at which to look for update to cached images (0 disables it)
@@ -374,3 +375,41 @@ raw.dnsmasq                     | string    | -                     | -         
 Those keys can be set using the lxc tool with:
 
     lxc network set <network> <key> <value>
+
+# Storage configuration
+LXD supports creating and managing storage pools and storage volumes.
+General keys are top-level. Driver specific keys are namespaced by driver name.
+Volume keys apply to any volume created in the pool unless the value is
+overridden on a per-volume basis.
+
+## Storage pool configuration
+
+Key                         | Type   | Condition                     | Default          | Description
+:--                         | :--    | :--                           | :--              | :--
+size                        | string | appropriate driver and source | 0                | Size of the storage pool in bytes (suffixes supported). (Currently valid for loop based pools and zfs.)
+source                      | string | -                             | -                | Path to block device or loop file or filesystem entry
+volume.block.filesystem     | string | block based driver (lvm)      | ext4             | Filesystem to use for new volumes
+volume.block.mount_options  | string | block based driver (lvm)      | discard          | Mount options for block devices
+volume.lvm.thinpool_name    | string | lvm driver                    | LXDPool          | Thin pool where images and containers are created.
+volume.size                 | string | appropriate driver            | 0                | Default volume size
+volume.zfs.remove_snapshots | bool   | zfs driver                    | false            | Remove snapshots as needed
+volume.zfs.use_refquota     | bool   | zfs driver                    | false            | Use refquota instead of quota for space.
+zfs.pool_name               | string | zfs driver                    | name of the pool | Name of the zpool
+
+Storage pool configuration keys can be set using the lxc tool with:
+
+    lxc storage set [<remote>:]<pool> <key> <value>
+
+## Storage volume configuration
+
+Key                  | Type   | Condition                | Default                             | Description
+:--                  | :--    | :--                      | :--                                 | :--
+size                 | string | appropriate driver       | 0                                   | Mount options for block devices
+block.filesystem     | string | block based driver (lvm) | ext4                                | Path to block device or loop file or filesystem entry
+block.mount_options  | string |                          | discard                             | Name of the storage driver (btrfs, dir, lvm, zfs)
+zfs.remove_snapshots | string | zfs driver               | same as volume.zfs.remove_snapshots | Default volume size
+zfs.use_refquota     | string | zfs driver               | same as volume.zfs.zfs_requota      | Filesystem to use for new volumes
+
+Storage volume configuration keys can be set using the lxc tool with:
+
+    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>

--- a/doc/database.md
+++ b/doc/database.md
@@ -335,3 +335,38 @@ version         | INTEGER       | -             | NOT NULL          | Schema ver
 updated\_at     | DATETIME      | -             | NOT NULL          | When the schema update was done
 
 Index: UNIQUE ON id AND version
+
+## storage\_pools
+
+Column                  | Type          | Default       | Constraint        | Description
+:-----                  | :---          | :------       | :---------        | :----------
+id                      | INTEGER       | SERIAL        | NOT NULL          | SERIAL
+name                    | VARCHAR(255)  | -             | NOT NULL          | storage pool name
+driver                  | VARCHAR(255)  | -             | NOT NULL          | storage pool driver
+
+## storage\_pools\_config
+
+Column                  | Type          | Default       | Constraint        | Description
+:-----                  | :---          | :------       | :---------        | :----------
+id                      | INTEGER       | SERIAL        | NOT NULL          | SERIAL
+storage\_pool\_id       | INTEGER       | -             | NOT NULL          | storage\_pools.id FK
+key                     | VARCHAR(255)  | -             | NOT NULL          | Configuration key
+value                   | TEXT          | -             |                   | Configuration value (NULL for unset)
+
+## storage\_volumes
+
+Column                  | Type          | Default       | Constraint        | Description
+:-----                  | :---          | :------       | :---------        | :----------
+id                      | INTEGER       | SERIAL        | NOT NULL          | SERIAL
+storage\_pool\_id       | INTEGER       | -             | NOT NULL          | storage\_pools.id FK
+name                    | VARCHAR(255)  | -             | NOT NULL          | storage volume name
+type                    | INTEGER       | -             | NOT NULL          | storage volume type
+
+## storage\_volumes\_config
+
+Column                  | Type          | Default       | Constraint        | Description
+:-----                  | :---          | :------       | :---------        | :----------
+id                      | INTEGER       | SERIAL        | NOT NULL          | SERIAL
+storage\_volume\_id     | INTEGER       | -             | NOT NULL          | storage\_volumes.id FK
+key                     | VARCHAR(255)  | -             | NOT NULL          | Configuration key
+value                   | TEXT          | -             |                   | Configuration value (NULL for unset)

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1818,3 +1818,309 @@ Input (none at present):
     }
 
 HTTP code for this should be 202 (Accepted).
+
+## /1.0/storage-pools
+### GET
+ * Description: list of storage pools
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: list of storage pools that are currently defined on the host
+
+    [
+        "/1.0/storage-pools/default",
+        "/1.0/storage-pools/pool1"
+        "/1.0/storage-pools/pool2"
+        "/1.0/storage-pools/pool3"
+        "/1.0/storage-pools/pool4"
+    ]
+
+### POST
+ * Description: create a new storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input:
+
+    {
+        "config": {
+            "size": "10GB"
+        },
+        "driver": "zfs",
+        "name": "pool1"
+    }
+
+## /1.0/storage-pools/<name>
+### GET
+ * Description: information about a storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: dict representing a storage pool
+
+    {
+        "type": "sync",
+        "status": "Success",
+        "status_code": 200,
+        "operation": "",
+        "error_code": 0,
+        "error": "",
+        "metadata": {
+            "name": "default",
+            "driver": "zfs",
+            "used_by": [
+                "/1.0/containers/alp1",
+                "/1.0/containers/alp10",
+                "/1.0/containers/alp11",
+                "/1.0/containers/alp12",
+                "/1.0/containers/alp13",
+                "/1.0/containers/alp14",
+                "/1.0/containers/alp15",
+                "/1.0/containers/alp16",
+                "/1.0/containers/alp17",
+                "/1.0/containers/alp18",
+                "/1.0/containers/alp19",
+                "/1.0/containers/alp2",
+                "/1.0/containers/alp20",
+                "/1.0/containers/alp3",
+                "/1.0/containers/alp4",
+                "/1.0/containers/alp5",
+                "/1.0/containers/alp6",
+                "/1.0/containers/alp7",
+                "/1.0/containers/alp8",
+                "/1.0/containers/alp9",
+                "/1.0/images/62e850a334bb9d99cac00b2e618e0291e5e7bb7db56c4246ecaf8e46fa0631a6"
+            ],
+            "config": {
+                "size": "61203283968",
+                "source": "/home/chb/mnt/l2/disks/default.img",
+                "volume.size": "0",
+                "zfs.pool_name": "default"
+            }
+        }
+    }
+
+### PUT (ETag supported)
+ * Description: replace the storage pool information
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+ Input:
+
+    {
+        "config": {
+            "size": "15032385536",
+            "source": "pool1",
+            "volume.block.filesystem": "xfs",
+            "volume.block.mount_options": "discard",
+            "volume.lvm.thinpool_name": "LXDPool",
+            "volume.size": "10737418240"
+        }
+    }
+
+### PATCH
+ * Description: update the storage pool configuration
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input:
+
+    {
+        "config": {
+            "volume.block.filesystem": "xfs",
+        }
+    }
+
+### DELETE
+ * Description: delete a storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input (none at present):
+
+    {
+    }
+
+## /1.0/storage-pools/<name>/volumes
+### GET
+ * Description: list of storage volumes
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: list of storage volumes that currently exist on a given storage pool
+
+    [
+        "/1.0/storage-pools/default/volumes/containers/alp1",
+        "/1.0/storage-pools/default/volumes/containers/alp10",
+        "/1.0/storage-pools/default/volumes/containers/alp11",
+        "/1.0/storage-pools/default/volumes/containers/alp12",
+        "/1.0/storage-pools/default/volumes/containers/alp13",
+        "/1.0/storage-pools/default/volumes/containers/alp14",
+        "/1.0/storage-pools/default/volumes/containers/alp15",
+        "/1.0/storage-pools/default/volumes/containers/alp16",
+        "/1.0/storage-pools/default/volumes/containers/alp17",
+        "/1.0/storage-pools/default/volumes/containers/alp18",
+        "/1.0/storage-pools/default/volumes/containers/alp19",
+        "/1.0/storage-pools/default/volumes/containers/alp2",
+        "/1.0/storage-pools/default/volumes/containers/alp20",
+        "/1.0/storage-pools/default/volumes/containers/alp3",
+        "/1.0/storage-pools/default/volumes/containers/alp4",
+        "/1.0/storage-pools/default/volumes/containers/alp5",
+        "/1.0/storage-pools/default/volumes/containers/alp6",
+        "/1.0/storage-pools/default/volumes/containers/alp7",
+        "/1.0/storage-pools/default/volumes/containers/alp8",
+        "/1.0/storage-pools/default/volumes/containers/alp9",
+        "/1.0/storage-pools/default/volumes/images/62e850a334bb9d99cac00b2e618e0291e5e7bb7db56c4246ecaf8e46fa0631a6"
+    ]
+
+## /1.0/storage-pools/<pool>/volumes
+### GET
+ * Description: list all storage volumes on a storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+    {
+        "type": "sync",
+        "status": "Success",
+        "status_code": 200,
+        "error_code": 0,
+        "error": "",
+        "metadata": [
+            {
+                "type": "container",
+                "used_by": [],
+                "name": "alp1",
+                "config": {
+                "size": "0"
+                }
+            },
+            {
+                "type": "container",
+                "used_by": [],
+                "name": "alp1/snap0",
+                "config": {
+                    "size": "0"
+                }
+            },
+            {
+                "type": "image",
+                "used_by": [],
+                "name": "ade3a9bcd7ba27456673611304238c424ced1772f69d7c6b031356831d94e8ee",
+                "config": {
+                    "size": "0"
+                }
+            },
+            {
+                "type": "custom",
+                "used_by": [],
+                "name": "bla",
+                "config": {
+                    "size": "0"
+                }
+            }
+        ]
+    }
+
+
+### POST
+ * Description: create a new storage volume on a given storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input:
+
+    {
+        "config": {},
+        "pool": "pool1",
+        "name": "vol1",
+        "type": "custom"
+    }
+
+
+## /1.0/storage-pools/<pool>/volumes/<type>/<name>
+### GET
+ * Description: information about a storage volume of a given type on a storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: dict representing a storage volume
+
+    {
+        "type": "sync",
+        "status": "Success",
+        "status_code": 200,
+        "error_code": 0,
+        "error": "",
+        "metadata": {
+            "type": "custom",
+            "used_by": [],
+            "name": "vol1",
+            "config": {
+                "block.filesystem": "ext4",
+                "block.mount_options": "discard",
+                "lvm.thinpool_name": "LXDPool",
+                "size": "10737418240"
+            }
+        }
+    }
+
+
+### PUT (ETag supported)
+ * Description: replace the storage volume information
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+ Input:
+
+    {
+        "config": {
+            "size": "15032385536",
+            "source": "pool1",
+            "used_by": "",
+            "volume.block.filesystem": "xfs",
+            "volume.block.mount_options": "discard",
+            "volume.lvm.thinpool_name": "LXDPool",
+            "volume.size": "10737418240"
+        }
+    }
+
+### PATCH (ETag supported)
+ * Description: update the storage volume information
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+ Input:
+
+    {
+        "config": {
+            "volume.block.mount_options": "",
+        }
+    }
+
+### DELETE
+ * Description: delete a storage volume of a given type on a given storage pool
+ * Introduced: with API extension "storage"
+ * Authentication: trusted
+ * Operation: sync
+ * Return: standard return value or standard error
+
+Input (none at present):
+
+    {
+    }

--- a/doc/storage-backends.md
+++ b/doc/storage-backends.md
@@ -18,6 +18,9 @@ Nesting support                             | yes       | yes   | no    | no
 Restore from older snapshots (not latest)   | yes       | yes   | yes   | no
 Storage quotas                              | no        | yes   | no    | yes
 
+With the implementation of the new storage api it is possible to use multiple
+storage drivers (e.g. BTRFS and ZFS) at the same time.
+
 ## Mixed storage
 When switching storage backend after some containers or images already exist, LXD will create any new container  
 using the new backend and converting older images to the new backend as needed.
@@ -29,29 +32,22 @@ rsync is used to transfer the container content across.
 ## Notes
 ### Directory
 
- - The directory backend is the fallback backend when nothing else is configured or detected.
  - While this backend is fully functional, it's also much slower than
    all the others due to it having to unpack images or do instant copies of
    containers, snapshots and images.
 
 ### Btrfs
 
- - The btrfs backend is automatically used if /var/lib/lxd is on a btrfs filesystem.
  - Uses a subvolume per container, image and snapshot, creating btrfs snapshots when creating a new object.
  - When using for nesting, the host btrfs filesystem must be mounted with the "user\_subvol\_rm\_allowed" mount option.
 
 ### LVM
 
- - A LVM VG must be created and then storage.lvm\_vg\_name set to point to it.
- - If a thinpool doesn't already exist, one will be created, the name of the thinpool can be set with storage.lvm\_thinpool\_name .
  - Uses LVs for images, then LV snapshots for containers and container snapshots.
  - The filesystem used for the LVs is ext4 (can be configured to use xfs instead).
- - LVs are created with a default size of 10GiB (can be configured through).
 
 ### ZFS
 
- - LXD can use any zpool or part of a zpool. storage.zfs\_pool\_name must be set to the path to be used.
- - ZFS doesn't have to (and shouldn't be) mounted on /var/lib/lxd
  - Uses ZFS filesystems for images, then snapshots and clones to create containers and snapshots.
  - Due to the way copy-on-write works in ZFS, parent filesystems can't
    be removed until all children are gone. As a result, LXD will

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -91,6 +91,7 @@ Pre-defined shorthand chars:
 * 4 - IPv4 address
 * 6 - IPv6 address
 * a - architecture
+* b - storage pool
 * c - creation date
 * l - last used date
 * n - name
@@ -433,6 +434,7 @@ func (c *listCmd) parseColumns() ([]column, error) {
 		'S': {i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
 		's': {i18n.G("STATE"), c.statusColumnData, false, false},
 		't': {i18n.G("TYPE"), c.typeColumnData, false, false},
+		'b': {i18n.G("STORAGE POOL"), c.StoragePoolColumnData, false, false},
 	}
 
 	if c.fast {
@@ -595,6 +597,16 @@ func (c *listCmd) PIDColumnData(cInfo api.Container, cState *api.ContainerState,
 
 func (c *listCmd) ArchitectureColumnData(cInfo api.Container, cState *api.ContainerState, cSnaps []api.ContainerSnapshot) string {
 	return cInfo.Architecture
+}
+
+func (c *listCmd) StoragePoolColumnData(cInfo api.Container, cState *api.ContainerState, cSnaps []api.ContainerSnapshot) string {
+	for _, v := range cInfo.ExpandedDevices {
+		if v["type"] == "disk" && v["path"] == "/" {
+			return v["pool"]
+		}
+	}
+
+	return ""
 }
 
 func (c *listCmd) ProfilesColumnData(cInfo api.Container, cState *api.ContainerState, cSnaps []api.ContainerSnapshot) string {

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,7 +52,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46aclnpPsSt"
+const shorthand = "46abclnpPsSt"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -204,6 +204,7 @@ var commands = map[string]command{
 		name:       "stop",
 		timeout:    -1,
 	},
+	"storage": &storageCmd{},
 	"version": &versionCmd{},
 }
 

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -1,0 +1,841 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/olekukonko/tablewriter"
+	"gopkg.in/yaml.v2"
+
+	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/i18n"
+	"github.com/lxc/lxd/shared/termios"
+)
+
+// This command is only allowed to create custom storage volumes.
+const defaultStoragePoolVolumeType = "custom"
+
+type storageCmd struct {
+}
+
+func (c *storageCmd) showByDefault() bool {
+	return true
+}
+
+func (c *storageCmd) storagePoolEditHelp() string {
+	return i18n.G(
+		`### This is a yaml representation of a storage pool.
+### Any line starting with a '# will be ignored.
+###
+### A storage pool consists of a set of configuration items.
+###
+### An example would look like:
+### name: default
+### driver: zfs
+### used_by: []
+### config:
+###   size: "61203283968"
+###   source: /home/chb/mnt/lxd_test/default.img
+###   zfs.pool_name: default`)
+}
+
+func (c *storageCmd) storagePoolVolumeEditHelp() string {
+	return i18n.G(
+		`### This is a yaml representation of a storage volume.
+### Any line starting with a '# will be ignored.
+###
+### A storage volume consists of a set of configuration items.
+###
+### name: vol1
+### type: custom
+### used_by: []
+### config:
+###   size: "61203283968"`)
+}
+
+func (c *storageCmd) usage() string {
+	return i18n.G(
+		`Manage storage.
+
+lxc storage list [<remote>:]                           List available storage pools.
+lxc storage show [<remote>:]<pool>                     Show details of a storage pool.
+lxc storage create [<remote>:]<pool> [key=value]...    Create a storage pool.
+lxc storage get [<remote>:]<pool> <key>                Get storage pool configuration.
+lxc storage set [<remote>:]<pool> <key> <value>        Set storage pool configuration.
+lxc storage unset [<remote>:]<pool> <key>              Unset storage pool configuration.
+lxc storage delete [<remote>:]<pool>                   Delete a storage pool.
+lxc storage edit [<remote>:]<pool>
+    Edit storage pool, either by launching external editor or reading STDIN.
+    Example: lxc storage edit [<remote>:]<pool> # launch editor
+             cat pool.yaml | lxc storage edit [<remote>:]<pool> # read from pool.yaml
+
+lxc storage volume list [<remote>:]<pool>                              List available storage volumes on a storage pool.
+lxc storage volume show [<remote>:]<pool> <volume>			Show details of a storage volume on a storage pool.
+lxc storage volume create [<remote>:]<pool> <volume> [key=value]...    Create a storage volume on a storage pool.
+lxc storage volume get [<remote>:]<pool> <volume> <key>                Get storage volume configuration on a storage pool.
+lxc storage volume set [<remote>:]<pool> <volume> <key> <value>        Set storage volume configuration on a storage pool.
+lxc storage volume unset [<remote>:]<pool> <volume> <key>              Unset storage volume configuration on a storage pool.
+lxc storage volume delete [<remote>:]<pool> <volume>                   Delete a storage volume on a storage pool.
+lxc storage volume edit [<remote>:]<pool> <volume>
+    Edit storage pool, either by launching external editor or reading STDIN.
+    Example: lxc storage volume edit [<remote>:]<pool> <volume> # launch editor
+             cat pool.yaml | lxc storage volume edit [<remote>:]<pool> <volume> # read from pool.yaml
+
+lxc storage volume attach [<remote>:]<pool> <volume> <container> [device name] <path>
+lxc storage volume attach-profile [<remote:>]<pool> <volume> <profile> [device name] <path>
+
+lxc storage volume detach [<remote>:]<pool> <volume> <container> [device name]
+lxc storage volume detach-profile [<remote:>]<pool> <volume> <profile> [device name]
+`)
+}
+
+func (c *storageCmd) flags() {}
+
+func (c *storageCmd) run(config *lxd.Config, args []string) error {
+	if len(args) < 1 {
+		return errArgs
+	}
+
+	if args[0] == "list" {
+		return c.doStoragePoolsList(config, args)
+	}
+
+	if len(args) < 2 {
+		return errArgs
+	}
+
+	remote, sub := config.ParseRemoteAndContainer(args[1])
+	client, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	if args[0] == "volume" {
+		switch args[1] {
+		case "attach":
+			if len(args) < 5 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeAttach(client, pool, volume, args[4:])
+		case "attach-profile":
+			if len(args) < 5 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeAttachProfile(client, pool, volume, args[4:])
+		case "create":
+			if len(args) < 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeCreate(client, pool, volume, args[4:])
+		case "delete":
+			if len(args) != 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeDelete(client, pool, volume)
+		case "detach":
+			if len(args) < 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeDetach(client, pool, volume, args[4:])
+		case "detach-profile":
+			if len(args) < 5 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeDetachProfile(client, pool, volume, args[4:])
+		case "edit":
+			if len(args) != 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeEdit(client, pool, volume)
+		case "get":
+			if len(args) < 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeGet(client, pool, volume, args[3:])
+		case "list":
+			if len(args) != 3 {
+				return errArgs
+			}
+			pool := args[2]
+			return c.doStoragePoolVolumesList(config, remote, pool, args)
+		case "set":
+			if len(args) < 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeSet(client, pool, volume, args[3:])
+		case "unset":
+			if len(args) < 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeSet(client, pool, volume, args[3:])
+		case "show":
+			if len(args) != 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volume := args[3]
+			return c.doStoragePoolVolumeShow(client, pool, volume)
+		default:
+			return errArgs
+		}
+	} else {
+		pool := sub
+		switch args[0] {
+		case "create":
+			if len(args) < 3 {
+				return errArgs
+			}
+			driver := strings.Join(args[2:3], "")
+			return c.doStoragePoolCreate(client, pool, driver, args[3:])
+		case "delete":
+			return c.doStoragePoolDelete(client, pool)
+		case "edit":
+			return c.doStoragePoolEdit(client, pool)
+		case "get":
+			if len(args) < 2 {
+				return errArgs
+			}
+			return c.doStoragePoolGet(client, pool, args[2:])
+		case "list":
+			if len(args) != 4 {
+				return errArgs
+			}
+			pool := args[2]
+			volumeType := args[3]
+			return c.doStoragePoolVolumesTypeList(config, remote, pool, volumeType, args)
+		case "set":
+			if len(args) < 2 {
+				return errArgs
+			}
+			return c.doStoragePoolSet(client, pool, args[2:])
+		case "unset":
+			if len(args) < 2 {
+				return errArgs
+			}
+			return c.doStoragePoolSet(client, pool, args[2:])
+		case "show":
+			if len(args) < 2 {
+				return errArgs
+			}
+			return c.doStoragePoolShow(client, pool)
+		default:
+			return errArgs
+		}
+	}
+}
+
+func (c *storageCmd) doStoragePoolVolumeAttach(client *lxd.Client, pool string, volume string, args []string) error {
+	if len(args) < 2 || len(args) > 3 {
+		return errArgs
+	}
+
+	container := args[0]
+	devPath := ""
+	devName := ""
+	if len(args) == 2 {
+		// Only the path has been given to us.
+		devPath = args[1]
+		devName = volume
+	} else if len(args) == 3 {
+		// Path and device name have been given to us.
+		devName = args[1]
+		devPath = args[2]
+	}
+
+	// Check if the requested storage volume actually
+	// exists on the requested storage pool.
+	vol, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	props := []string{fmt.Sprintf("pool=%s", pool), fmt.Sprintf("path=%s", devPath), fmt.Sprintf("source=%s", vol.Name)}
+	fmt.Println(props)
+	resp, err := client.ContainerDeviceAdd(container, devName, "disk", props)
+	if err != nil {
+		return err
+	}
+
+	return client.WaitForSuccess(resp.Operation)
+}
+
+func (c *storageCmd) doStoragePoolVolumeDetach(client *lxd.Client, pool string, volume string, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return errArgs
+	}
+
+	containerName := args[0]
+	devName := ""
+	if len(args) == 2 {
+		devName = args[1]
+	}
+
+	container, err := client.ContainerInfo(containerName)
+	if err != nil {
+		return err
+	}
+
+	if devName == "" {
+		for n, d := range container.Devices {
+			if d["type"] == "disk" && d["pool"] == pool && d["source"] == volume {
+				if devName != "" {
+					return fmt.Errorf(i18n.G("More than one device matches, specify the device name."))
+				}
+
+				devName = n
+			}
+		}
+	}
+
+	if devName == "" {
+		return fmt.Errorf(i18n.G("No device found for this storage volume."))
+	}
+
+	_, ok := container.Devices[devName]
+	if !ok {
+		return fmt.Errorf(i18n.G("The specified device doesn't exist"))
+	}
+
+	resp, err := client.ContainerDeviceDelete(containerName, devName)
+	if err != nil {
+		return err
+	}
+
+	return client.WaitForSuccess(resp.Operation)
+}
+
+func (c *storageCmd) doStoragePoolVolumeAttachProfile(client *lxd.Client, pool string, volume string, args []string) error {
+	if len(args) < 2 || len(args) > 3 {
+		return errArgs
+	}
+
+	profile := args[0]
+	devPath := ""
+	devName := ""
+	if len(args) == 2 {
+		// Only the path has been given to us.
+		devPath = args[1]
+		devName = volume
+	} else if len(args) == 3 {
+		// Path and device name have been given to us.
+		devName = args[1]
+		devPath = args[2]
+	}
+
+	// Check if the requested storage volume actually
+	// exists on the requested storage pool.
+	vol, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	props := []string{fmt.Sprintf("pool=%s", pool), fmt.Sprintf("path=%s", devPath), fmt.Sprintf("source=%s", vol.Name)}
+	fmt.Println(props)
+
+	_, err = client.ProfileDeviceAdd(profile, devName, "disk", props)
+	return err
+}
+
+func (c *storageCmd) doStoragePoolCreate(client *lxd.Client, name string, driver string, args []string) error {
+	config := map[string]string{}
+
+	for i := 0; i < len(args); i++ {
+		entry := strings.SplitN(args[i], "=", 2)
+		if len(entry) < 2 {
+			return errArgs
+		}
+		config[entry[0]] = entry[1]
+	}
+
+	err := client.StoragePoolCreate(name, driver, config)
+	if err == nil {
+		fmt.Printf(i18n.G("Storage pool %s created")+"\n", name)
+	}
+
+	return err
+}
+
+func (c *storageCmd) doStoragePoolVolumeDetachProfile(client *lxd.Client, pool string, volume string, args []string) error {
+	if len(args) < 1 || len(args) > 2 {
+		return errArgs
+	}
+
+	profileName := args[0]
+	devName := ""
+	if len(args) > 1 {
+		devName = args[1]
+	}
+
+	profile, err := client.ProfileConfig(profileName)
+	if err != nil {
+		return err
+	}
+
+	if devName == "" {
+		for n, d := range profile.Devices {
+			if d["type"] == "disk" && d["pool"] == pool && d["source"] == volume {
+				if devName != "" {
+					return fmt.Errorf(i18n.G("More than one device matches, specify the device name."))
+				}
+
+				devName = n
+			}
+		}
+	}
+
+	if devName == "" {
+		return fmt.Errorf(i18n.G("No device found for this storage volume."))
+	}
+
+	_, ok := profile.Devices[devName]
+	if !ok {
+		return fmt.Errorf(i18n.G("The specified device doesn't exist"))
+	}
+
+	_, err = client.ProfileDeviceDelete(profileName, devName)
+	return err
+}
+
+func (c *storageCmd) doStoragePoolDelete(client *lxd.Client, name string) error {
+	err := client.StoragePoolDelete(name)
+	if err == nil {
+		fmt.Printf(i18n.G("Storage pool %s deleted")+"\n", name)
+	}
+
+	return err
+}
+
+func (c *storageCmd) doStoragePoolEdit(client *lxd.Client, name string) error {
+	// If stdin isn't a terminal, read text from it
+	if !termios.IsTerminal(int(syscall.Stdin)) {
+		contents, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		newdata := api.StoragePool{}
+		err = yaml.Unmarshal(contents, &newdata)
+		if err != nil {
+			return err
+		}
+		return client.StoragePoolPut(name, newdata)
+	}
+
+	// Extract the current value
+	pool, err := client.StoragePoolGet(name)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(&pool)
+	if err != nil {
+		return err
+	}
+
+	// Spawn the editor
+	content, err := shared.TextEditor("", []byte(c.storagePoolEditHelp()+"\n\n"+string(data)))
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Parse the text received from the editor
+		newdata := api.StoragePool{}
+		err = yaml.Unmarshal(content, &newdata)
+		if err == nil {
+			err = client.StoragePoolPut(name, newdata)
+		}
+
+		// Respawn the editor
+		if err != nil {
+			fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
+			fmt.Println(i18n.G("Press enter to open the editor again"))
+
+			_, err := os.Stdin.Read(make([]byte, 1))
+			if err != nil {
+				return err
+			}
+
+			content, err = shared.TextEditor("", content)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		break
+	}
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolGet(client *lxd.Client, name string, args []string) error {
+	// we shifted @args so so it should read "<key>"
+	if len(args) != 1 {
+		return errArgs
+	}
+
+	resp, err := client.StoragePoolGet(name)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range resp.Config {
+		if k == args[0] {
+			fmt.Printf("%s\n", v)
+		}
+	}
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolsList(config *lxd.Config, args []string) error {
+	var remote string
+	if len(args) > 1 {
+		var name string
+		remote, name = config.ParseRemoteAndContainer(args[1])
+		if name != "" {
+			return fmt.Errorf(i18n.G("Cannot provide container name to list"))
+		}
+	} else {
+		remote = config.DefaultRemote
+	}
+
+	client, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	pools, err := client.ListStoragePools()
+	if err != nil {
+		return err
+	}
+
+	data := [][]string{}
+	for _, pool := range pools {
+		usedby := strconv.Itoa(len(pool.UsedBy))
+
+		data = append(data, []string{pool.Name, pool.Driver, pool.Config["source"], usedby})
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetRowLine(true)
+	table.SetHeader([]string{
+		i18n.G("NAME"),
+		i18n.G("DRIVER"),
+		i18n.G("SOURCE"),
+		i18n.G("USED BY")})
+	sort.Sort(byName(data))
+	table.AppendBulk(data)
+	table.Render()
+
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolSet(client *lxd.Client, name string, args []string) error {
+	// we shifted @args so so it should read "<key> [<value>]"
+	if len(args) < 1 {
+		return errArgs
+	}
+
+	pool, err := client.StoragePoolGet(name)
+	if err != nil {
+		return err
+	}
+
+	key := args[0]
+	var value string
+	if len(args) < 2 {
+		value = ""
+	} else {
+		value = args[1]
+	}
+
+	if !termios.IsTerminal(int(syscall.Stdin)) && value == "-" {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("Can't read from stdin: %s", err)
+		}
+		value = string(buf[:])
+	}
+
+	pool.Config[key] = value
+
+	return client.StoragePoolPut(name, pool)
+}
+
+func (c *storageCmd) doStoragePoolShow(client *lxd.Client, name string) error {
+	pool, err := client.StoragePoolGet(name)
+	if err != nil {
+		return err
+	}
+
+	sz, err := strconv.ParseUint(pool.Config["size"], 10, 64)
+	if err == nil {
+		pool.Config["size"] = shared.GetByteSizeString(int64(sz), 0)
+	}
+
+	sort.Strings(pool.UsedBy)
+
+	data, err := yaml.Marshal(&pool)
+	fmt.Printf("%s", data)
+
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolVolumesList(config *lxd.Config, remote string, pool string, args []string) error {
+	client, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	volumes, err := client.StoragePoolVolumesList(pool)
+	if err != nil {
+		return err
+	}
+
+	data := [][]string{}
+	for _, volume := range volumes {
+		usedby := strconv.Itoa(len(volume.UsedBy))
+
+		shortName := volume.Name
+		if volume.Type == "image" {
+			shortName = volume.Name[0:12]
+		}
+
+		data = append(data, []string{shortName, volume.Type, usedby})
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetRowLine(true)
+	table.SetHeader([]string{
+		i18n.G("NAME"),
+		i18n.G("TYPE"),
+		i18n.G("USED BY")})
+	sort.Sort(byName(data))
+	table.AppendBulk(data)
+	table.Render()
+
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolVolumesTypeList(config *lxd.Config, remote string, pool string, volumeType string, args []string) error {
+	client, err := lxd.NewClient(config, remote)
+	if err != nil {
+		return err
+	}
+
+	volumes, err := client.StoragePoolVolumesTypeList(pool, volumeType)
+	if err != nil {
+		return err
+	}
+
+	data := [][]string{}
+	for _, volume := range volumes {
+		usedby := strconv.Itoa(len(volume.UsedBy))
+
+		data = append(data, []string{volume.Name, volume.Type, usedby})
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetRowLine(true)
+	table.SetHeader([]string{
+		i18n.G("NAME"),
+		i18n.G("TYPE"),
+		i18n.G("USED BY")})
+	sort.Sort(byName(data))
+	table.AppendBulk(data)
+	table.Render()
+
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolVolumeCreate(client *lxd.Client, pool string, volume string, args []string) error {
+	config := map[string]string{}
+
+	for i := 0; i < len(args); i++ {
+		entry := strings.SplitN(args[i], "=", 2)
+		if len(entry) < 2 {
+			return errArgs
+		}
+		config[entry[0]] = entry[1]
+	}
+
+	err := client.StoragePoolVolumeTypeCreate(pool, volume, defaultStoragePoolVolumeType, config)
+	if err == nil {
+		fmt.Printf(i18n.G("Storage volume %s created")+"\n", volume)
+	}
+
+	return err
+}
+
+func (c *storageCmd) doStoragePoolVolumeDelete(client *lxd.Client, pool string, volume string) error {
+	err := client.StoragePoolVolumeTypeDelete(pool, volume, defaultStoragePoolVolumeType)
+	if err == nil {
+		fmt.Printf(i18n.G("Storage volume %s deleted")+"\n", volume)
+	}
+
+	return err
+}
+
+func (c *storageCmd) doStoragePoolVolumeGet(client *lxd.Client, pool string, volume string, args []string) error {
+	// we shifted @args so so it should read "<key>"
+	if len(args) != 2 {
+		return errArgs
+	}
+
+	resp, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	for k, v := range resp.Config {
+		if k == args[1] {
+			fmt.Printf("%s\n", v)
+		}
+	}
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolVolumeSet(client *lxd.Client, pool string, volume string, args []string) error {
+	// we shifted @args so so it should read "<key> [<value>]"
+	if len(args) < 2 {
+		return errArgs
+	}
+
+	volumeConfig, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	key := args[1]
+	var value string
+	if len(args) < 3 {
+		value = ""
+	} else {
+		value = args[2]
+	}
+
+	if !termios.IsTerminal(int(syscall.Stdin)) && value == "-" {
+		buf, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return fmt.Errorf("Can't read from stdin: %s", err)
+		}
+		value = string(buf[:])
+	}
+
+	volumeConfig.Config[key] = value
+
+	return client.StoragePoolVolumeTypePut(pool, volume, defaultStoragePoolVolumeType, volumeConfig)
+}
+
+func (c *storageCmd) doStoragePoolVolumeShow(client *lxd.Client, pool string, volume string) error {
+	volumeStruct, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	sz, err := strconv.ParseUint(volumeStruct.Config["size"], 10, 64)
+	if err == nil {
+		volumeStruct.Config["size"] = shared.GetByteSizeString(int64(sz), 0)
+	}
+
+	sort.Strings(volumeStruct.UsedBy)
+
+	data, err := yaml.Marshal(&volumeStruct)
+	fmt.Printf("%s", data)
+
+	return nil
+}
+
+func (c *storageCmd) doStoragePoolVolumeEdit(client *lxd.Client, pool string, volume string) error {
+	// If stdin isn't a terminal, read text from it
+	if !termios.IsTerminal(int(syscall.Stdin)) {
+		contents, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+
+		newdata := api.StorageVolume{}
+		err = yaml.Unmarshal(contents, &newdata)
+		if err != nil {
+			return err
+		}
+		return client.StoragePoolVolumeTypePut(pool, volume, defaultStoragePoolVolumeType, newdata)
+	}
+
+	// Extract the current value
+	vol, err := client.StoragePoolVolumeTypeGet(pool, volume, defaultStoragePoolVolumeType)
+	if err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(&vol)
+	if err != nil {
+		return err
+	}
+
+	// Spawn the editor
+	content, err := shared.TextEditor("", []byte(c.storagePoolVolumeEditHelp()+"\n\n"+string(data)))
+	if err != nil {
+		return err
+	}
+
+	for {
+		// Parse the text received from the editor
+		newdata := api.StorageVolume{}
+		err = yaml.Unmarshal(content, &newdata)
+		if err == nil {
+			err = client.StoragePoolVolumeTypePut(pool, volume, defaultStoragePoolVolumeType, newdata)
+		}
+
+		// Respawn the editor
+		if err != nil {
+			fmt.Fprintf(os.Stderr, i18n.G("Config parsing error: %s")+"\n", err)
+			fmt.Println(i18n.G("Press enter to open the editor again"))
+
+			_, err := os.Stdin.Read(make([]byte, 1))
+			if err != nil {
+				return err
+			}
+
+			content, err = shared.TextEditor("", content)
+			if err != nil {
+				return err
+			}
+			continue
+		}
+		break
+	}
+	return nil
+}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -284,7 +284,7 @@ func (s *execWs) Do(op *operation) error {
 		}
 
 		if status.Signaled() {
-			// COMMENT(brauner): 128 + n == Fatal error signal "n"
+			// 128 + n == Fatal error signal "n"
 			return finisher(128+int(status.Signal()), nil)
 		}
 	}

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -119,6 +119,8 @@ func (suite *lxdTestSuite) TestContainer_LoadFromDB() {
 	c2, err := containerLoadByName(suite.d, "testFoo")
 	c2.IsRunning()
 	suite.Req.Nil(err)
+	err = c2.StorageStart()
+	suite.Req.Nil(err)
 
 	suite.Exactly(
 		c,
@@ -188,7 +190,6 @@ func (suite *lxdTestSuite) TestContainer_IsPrivileged_Privileged() {
 
 	c, err := containerCreateInternal(suite.d, args)
 	suite.Req.Nil(err)
-	defer c.Delete()
 
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
 	suite.Req.Nil(c.Delete(), "Failed to delete the container.")
@@ -204,7 +205,6 @@ func (suite *lxdTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 
 	c, err := containerCreateInternal(suite.d, args)
 	suite.Req.Nil(err)
-	defer c.Delete()
 
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
 	suite.Req.Nil(c.Delete(), "Failed to delete the container.")

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -179,6 +179,36 @@ CREATE TABLE IF NOT EXISTS schema (
     version INTEGER NOT NULL,
     updated_at DATETIME NOT NULL,
     UNIQUE (version)
+);
+CREATE TABLE IF NOT EXISTS storage_pools (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    driver VARCHAR(255) NOT NULL,
+    UNIQUE (name)
+);
+CREATE TABLE IF NOT EXISTS storage_pools_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    storage_pool_id INTEGER NOT NULL,
+    key VARCHAR(255) NOT NULL,
+    value TEXT,
+    UNIQUE (storage_pool_id, key),
+    FOREIGN KEY (storage_pool_id) REFERENCES storage_pools (id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS storage_volumes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    storage_pool_id INTEGER NOT NULL,
+    type INTEGER NOT NULL,
+    UNIQUE (storage_pool_id, name, type),
+    FOREIGN KEY (storage_pool_id) REFERENCES storage_pools (id) ON DELETE CASCADE
+);
+CREATE TABLE IF NOT EXISTS storage_volumes_config (
+    id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    storage_volume_id INTEGER NOT NULL,
+    key VARCHAR(255) NOT NULL,
+    value TEXT,
+    UNIQUE (storage_volume_id, key),
+    FOREIGN KEY (storage_volume_id) REFERENCES storage_volumes (id) ON DELETE CASCADE
 );`
 
 func enableForeignKeys(conn *sqlite3.SQLiteConn) error {

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -448,3 +448,46 @@ func dbImageInsert(db *sql.DB, fp string, fname string, sz int64, public bool, a
 
 	return nil
 }
+
+// Get the names of all storage pools on which a given image exists.
+func dbImageGetPools(db *sql.DB, imageFingerprint string) ([]int64, error) {
+	poolID := int64(-1)
+	query := "SELECT storage_pool_id FROM storage_volumes WHERE name=? AND type=?"
+	inargs := []interface{}{imageFingerprint, storagePoolVolumeTypeImage}
+	outargs := []interface{}{poolID}
+
+	result, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return []int64{}, err
+	}
+
+	poolIDs := []int64{}
+	for _, r := range result {
+		poolIDs = append(poolIDs, r[0].(int64))
+	}
+
+	return poolIDs, nil
+}
+
+// Get the names of all storage pools on which a given image exists.
+func dbImageGetPoolNamesFromIDs(db *sql.DB, poolIDs []int64) ([]string, error) {
+	var poolName string
+	query := "SELECT name FROM storage_pools WHERE id=?"
+
+	poolNames := []string{}
+	for _, poolID := range poolIDs {
+		inargs := []interface{}{poolID}
+		outargs := []interface{}{poolName}
+
+		result, err := dbQueryScan(db, query, inargs, outargs)
+		if err != nil {
+			return []string{}, err
+		}
+
+		for _, r := range result {
+			poolNames = append(poolNames, r[0].(string))
+		}
+	}
+
+	return poolNames, nil
+}

--- a/lxd/db_storage_pools.go
+++ b/lxd/db_storage_pools.go
@@ -1,0 +1,463 @@
+package main
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// Get all storage pools.
+func dbStoragePools(db *sql.DB) ([]string, error) {
+	var name string
+	query := "SELECT name FROM storage_pools"
+	inargs := []interface{}{}
+	outargs := []interface{}{name}
+
+	result, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(result) == 0 {
+		return []string{}, NoSuchObjectError
+	}
+
+	pools := []string{}
+	for _, r := range result {
+		pools = append(pools, r[0].(string))
+	}
+
+	return pools, nil
+}
+
+// Get the names of all storage volumes attached to a given storage pool.
+func dbStoragePoolsGetDrivers(db *sql.DB) ([]string, error) {
+	var poolDriver string
+	query := "SELECT DISTINCT driver FROM storage_pools"
+	inargs := []interface{}{}
+	outargs := []interface{}{poolDriver}
+
+	result, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(result) == 0 {
+		return []string{}, NoSuchObjectError
+	}
+
+	drivers := []string{}
+	for _, driver := range result {
+		drivers = append(drivers, driver[0].(string))
+	}
+
+	return drivers, nil
+}
+
+// Get id of a single storage pool.
+func dbStoragePoolGetID(db *sql.DB, poolName string) (int64, error) {
+	poolID := int64(-1)
+	query := "SELECT id FROM storage_pools WHERE name=?"
+	inargs := []interface{}{poolName}
+	outargs := []interface{}{&poolID}
+
+	err := dbQueryRowScan(db, query, inargs, outargs)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return -1, NoSuchObjectError
+		}
+	}
+
+	return poolID, nil
+}
+
+// Get a single storage pool.
+func dbStoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, error) {
+	var poolDriver string
+	poolID := int64(-1)
+	query := "SELECT id, driver FROM storage_pools WHERE name=?"
+	inargs := []interface{}{poolName}
+	outargs := []interface{}{&poolID, &poolDriver}
+
+	err := dbQueryRowScan(db, query, inargs, outargs)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	config, err := dbStoragePoolConfigGet(db, poolID)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	storagePool := api.StoragePool{
+		Name:   poolName,
+		Driver: poolDriver,
+	}
+	storagePool.Config = config
+
+	return poolID, &storagePool, nil
+}
+
+// Get config of a storage pool.
+func dbStoragePoolConfigGet(db *sql.DB, poolID int64) (map[string]string, error) {
+	var key, value string
+	query := "SELECT key, value FROM storage_pools_config WHERE storage_pool_id=?"
+	inargs := []interface{}{poolID}
+	outargs := []interface{}{key, value}
+
+	results, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return nil, err
+	}
+
+	config := map[string]string{}
+
+	for _, r := range results {
+		key = r[0].(string)
+		value = r[1].(string)
+
+		config[key] = value
+	}
+
+	return config, nil
+}
+
+// Create new storage pool.
+func dbStoragePoolCreate(db *sql.DB, poolName string, poolDriver string, poolConfig map[string]string) (int64, error) {
+	tx, err := dbBegin(db)
+	if err != nil {
+		return -1, err
+	}
+
+	result, err := tx.Exec("INSERT INTO storage_pools (name, driver) VALUES (?, ?)", poolName, poolDriver)
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	err = dbStoragePoolConfigAdd(tx, id, poolConfig)
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	err = txCommit(tx)
+	if err != nil {
+		return -1, err
+	}
+
+	// Update the storage drivers cache in api_1.0.go.
+	storagePoolDriversCacheLock.Lock()
+	drivers := readStoragePoolDriversCache()
+	if !shared.StringInSlice(poolDriver, drivers) {
+		drivers = append(drivers, poolDriver)
+	}
+	storagePoolDriversCacheVal.Store(drivers)
+	storagePoolDriversCacheLock.Unlock()
+
+	return id, nil
+}
+
+// Add new storage pool config.
+func dbStoragePoolConfigAdd(tx *sql.Tx, poolID int64, poolConfig map[string]string) error {
+	str := "INSERT INTO storage_pools_config (storage_pool_id, key, value) VALUES(?, ?, ?)"
+	stmt, err := tx.Prepare(str)
+	defer stmt.Close()
+
+	for k, v := range poolConfig {
+		if v == "" {
+			continue
+		}
+
+		_, err = stmt.Exec(poolID, k, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Update storage pool.
+func dbStoragePoolUpdate(db *sql.DB, poolName string, poolConfig map[string]string) error {
+	poolID, _, err := dbStoragePoolGet(db, poolName)
+	if err != nil {
+		return err
+	}
+
+	tx, err := dbBegin(db)
+	if err != nil {
+		return err
+	}
+
+	err = dbStoragePoolConfigClear(tx, poolID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = dbStoragePoolConfigAdd(tx, poolID, poolConfig)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return txCommit(tx)
+}
+
+// Delete storage pool config.
+func dbStoragePoolConfigClear(tx *sql.Tx, poolID int64) error {
+	_, err := tx.Exec("DELETE FROM storage_pools_config WHERE storage_pool_id=?", poolID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Delete storage pool.
+func dbStoragePoolDelete(db *sql.DB, poolName string) error {
+	poolID, pool, err := dbStoragePoolGet(db, poolName)
+	if err != nil {
+		return err
+	}
+
+	_, err = dbExec(db, "DELETE FROM storage_pools WHERE id=?", poolID)
+	if err != nil {
+		return err
+	}
+
+	// Update the storage drivers cache in api_1.0.go.
+	storagePoolDriversCacheLock.Lock()
+	drivers := readStoragePoolDriversCache()
+	for i := 0; i < len(drivers); i++ {
+		if drivers[i] == pool.Driver {
+			drivers[i] = drivers[len(drivers)-1]
+			drivers[len(drivers)-1] = ""
+			drivers = drivers[:len(drivers)-1]
+			break
+		}
+	}
+	storagePoolDriversCacheVal.Store(drivers)
+	storagePoolDriversCacheLock.Unlock()
+
+	return nil
+}
+
+// Get the names of all storage volumes attached to a given storage pool.
+func dbStoragePoolVolumesGetNames(db *sql.DB, poolID int64) (int, error) {
+	var volumeName string
+	query := "SELECT name FROM storage_volumes WHERE storage_pool_id=?"
+	inargs := []interface{}{poolID}
+	outargs := []interface{}{volumeName}
+
+	result, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return -1, err
+	}
+
+	if len(result) == 0 {
+		return 0, nil
+	}
+
+	return len(result), nil
+}
+
+// Get all storage volumes attached to a given storage pool.
+func dbStoragePoolVolumesGet(db *sql.DB, poolID int64) ([]*api.StorageVolume, error) {
+	// Get all storage volumes of all types attached to a given storage
+	// pool.
+	result := []*api.StorageVolume{}
+	for _, volumeType := range supportedVolumeTypes {
+		volumeNames, err := dbStoragePoolVolumesGetType(db, volumeType, poolID)
+		if err != nil && err != sql.ErrNoRows {
+			return nil, err
+		}
+		for _, volumeName := range volumeNames {
+			_, volume, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, volume)
+		}
+	}
+
+	if len(result) == 0 {
+		return result, NoSuchObjectError
+	}
+
+	return result, nil
+}
+
+// Get all storage volumes attached to a given storage pool of a given volume
+// type.
+func dbStoragePoolVolumesGetType(db *sql.DB, volumeType int, poolID int64) ([]string, error) {
+	var poolName string
+	query := "SELECT name FROM storage_volumes WHERE storage_pool_id=? AND type=?"
+	inargs := []interface{}{poolID, volumeType}
+	outargs := []interface{}{poolName}
+
+	result, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return []string{}, err
+	}
+
+	response := []string{}
+	for _, r := range result {
+		response = append(response, r[0].(string))
+	}
+
+	return response, nil
+}
+
+// Get a single storage volume attached to a given storage pool of a given type.
+func dbStoragePoolVolumeGetType(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, *api.StorageVolume, error) {
+	volumeID, err := dbStoragePoolVolumeGetTypeID(db, volumeName, volumeType, poolID)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	volumeConfig, err := dbStorageVolumeConfigGet(db, volumeID)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	volumeTypeName, err := storagePoolVolumeTypeToName(volumeType)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	storageVolume := api.StorageVolume{
+		Type: volumeTypeName,
+	}
+	storageVolume.Name = volumeName
+	storageVolume.Config = volumeConfig
+
+	return volumeID, &storageVolume, nil
+}
+
+// Update storage volume attached to a given storage pool.
+func dbStoragePoolVolumeUpdate(db *sql.DB, volumeName string, volumeType int, poolID int64, volumeConfig map[string]string) error {
+	volumeID, _, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+	if err != nil {
+		return err
+	}
+
+	tx, err := dbBegin(db)
+	if err != nil {
+		return err
+	}
+
+	err = dbStorageVolumeConfigClear(tx, volumeID)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = dbStorageVolumeConfigAdd(tx, volumeID, volumeConfig)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return txCommit(tx)
+}
+
+// Delete storage volume attached to a given storage pool.
+func dbStoragePoolVolumeDelete(db *sql.DB, volumeName string, volumeType int, poolID int64) error {
+	volumeID, _, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+	if err != nil {
+		return err
+	}
+
+	_, err = dbExec(db, "DELETE FROM storage_volumes WHERE id=?", volumeID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Rename storage volume attached to a given storage pool.
+func dbStoragePoolVolumeRename(db *sql.DB, oldVolumeName string, newVolumeName string, volumeType int, poolID int64) error {
+	volumeID, _, err := dbStoragePoolVolumeGetType(db, oldVolumeName, volumeType, poolID)
+	if err != nil {
+		return err
+	}
+
+	tx, err := dbBegin(db)
+	if err != nil {
+		return err
+	}
+
+	_, err = tx.Exec("UPDATE storage_volumes SET name=? WHERE id=? AND type=?", newVolumeName, volumeID, volumeType)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return txCommit(tx)
+}
+
+// Create new storage volume attached to a given storage pool.
+func dbStoragePoolVolumeCreate(db *sql.DB, volumeName string, volumeType int, poolID int64, volumeConfig map[string]string) (int64, error) {
+	tx, err := dbBegin(db)
+	if err != nil {
+		return -1, err
+	}
+
+	result, err := tx.Exec("INSERT INTO storage_volumes (storage_pool_id, type, name) VALUES (?, ?, ?)", poolID, volumeType, volumeName)
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	volumeID, err := result.LastInsertId()
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	err = dbStorageVolumeConfigAdd(tx, volumeID, volumeConfig)
+	if err != nil {
+		tx.Rollback()
+		return -1, err
+	}
+
+	err = txCommit(tx)
+	if err != nil {
+		return -1, err
+	}
+
+	return volumeID, nil
+}
+
+// Get ID of a storage volume on a given storage pool of a given storage volume
+// type.
+func dbStoragePoolVolumeGetTypeID(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, error) {
+	volumeID := int64(-1)
+	query := `SELECT storage_volumes.id
+FROM storage_volumes
+JOIN storage_pools
+ON storage_volumes.storage_pool_id = storage_pools.id
+WHERE storage_volumes.storage_pool_id=?
+AND storage_volumes.name=? AND storage_volumes.type=?`
+	inargs := []interface{}{poolID, volumeName, volumeType}
+	outargs := []interface{}{&volumeID}
+
+	err := dbQueryRowScan(db, query, inargs, outargs)
+	if err != nil {
+		return -1, NoSuchObjectError
+	}
+
+	return volumeID, nil
+}

--- a/lxd/db_storage_volumes.go
+++ b/lxd/db_storage_volumes.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"database/sql"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// Get config of a storage volume.
+func dbStorageVolumeConfigGet(db *sql.DB, volumeID int64) (map[string]string, error) {
+	var key, value string
+	query := "SELECT key, value FROM storage_volumes_config WHERE storage_volume_id=?"
+	inargs := []interface{}{volumeID}
+	outargs := []interface{}{key, value}
+
+	results, err := dbQueryScan(db, query, inargs, outargs)
+	if err != nil {
+		return nil, err
+	}
+
+	config := map[string]string{}
+
+	for _, r := range results {
+		key = r[0].(string)
+		value = r[1].(string)
+
+		config[key] = value
+	}
+
+	return config, nil
+}
+
+// Add new storage volume config into database.
+func dbStorageVolumeConfigAdd(tx *sql.Tx, volumeID int64, volumeConfig map[string]string) error {
+	str := "INSERT INTO storage_volumes_config (storage_volume_id, key, value) VALUES(?, ?, ?)"
+	stmt, err := tx.Prepare(str)
+	defer stmt.Close()
+
+	for k, v := range volumeConfig {
+		if v == "" {
+			continue
+		}
+
+		_, err = stmt.Exec(volumeID, k, v)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Delete storage volume config.
+func dbStorageVolumeConfigClear(tx *sql.Tx, volumeID int64) error {
+	_, err := tx.Exec("DELETE FROM storage_volumes_config WHERE storage_volume_id=?", volumeID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -27,7 +27,7 @@ const DB_FIXTURES string = `
     INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (2, 'devicekey', 'devicevalue');
     `
 
-//  This Helper will initialize a test in-memory DB.
+// This Helper will initialize a test in-memory DB.
 func createTestDb(t *testing.T) (db *sql.DB) {
 	// Setup logging if main() hasn't been called/when testing
 	if shared.Log == nil {

--- a/lxd/main_forkexec.go
+++ b/lxd/main_forkexec.go
@@ -120,7 +120,7 @@ func cmdForkExec(args []string) (int, error) {
 	exCode, ok := procState.Sys().(syscall.WaitStatus)
 	if ok {
 		if exCode.Signaled() {
-			// COMMENT(brauner): 128 + n == Fatal error signal "n"
+			// 128 + n == Fatal error signal "n"
 			return 128 + int(exCode.Signal()), nil
 		}
 

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -25,13 +25,6 @@ func mockStartDaemon() (*Daemon, error) {
 		{Isgid: true, Hostid: 100000, Nsid: 0, Maprange: 500000},
 	}}
 
-	// Call this after Init so we have a log object.
-	storageConfig := make(map[string]interface{})
-	d.Storage = &storageLogWrapper{w: &storageMock{d: d}}
-	if _, err := d.Storage.Init(storageConfig); err != nil {
-		return nil, err
-	}
-
 	return d, nil
 }
 
@@ -41,6 +34,8 @@ type lxdTestSuite struct {
 	Req    *require.Assertions
 	tmpdir string
 }
+
+const lxdTestSuiteDefaultStoragePool string = "lxdTestrunPool"
 
 func (suite *lxdTestSuite) SetupSuite() {
 	tmpdir, err := ioutil.TempDir("", "lxd_testrun_")
@@ -54,6 +49,45 @@ func (suite *lxdTestSuite) SetupSuite() {
 	}
 
 	suite.d, err = mockStartDaemon()
+	if err != nil {
+		os.Exit(1)
+	}
+
+	// Create default storage pool. Make sure that we don't pass a nil to
+	// the next function.
+	poolConfig := map[string]string{}
+
+	mockStorage, _ := storageTypeToString(storageTypeMock)
+	// Create the database entry for the storage pool.
+	_, err = dbStoragePoolCreate(suite.d.db, lxdTestSuiteDefaultStoragePool, mockStorage, poolConfig)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	rootDev := map[string]string{}
+	rootDev["type"] = "disk"
+	rootDev["path"] = "/"
+	rootDev["pool"] = lxdTestSuiteDefaultStoragePool
+	devicesMap := map[string]map[string]string{}
+	devicesMap["root"] = rootDev
+
+	defaultID, _, err := dbProfileGet(suite.d.db, "default")
+	if err != nil {
+		os.Exit(1)
+	}
+
+	tx, err := dbBegin(suite.d.db)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	err = dbDevicesAdd(tx, "profile", defaultID, devicesMap)
+	if err != nil {
+		tx.Rollback()
+		os.Exit(1)
+	}
+
+	err = tx.Commit()
 	if err != nil {
 		os.Exit(1)
 	}

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -292,14 +292,15 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 	criuType := CRIUType_CRIU_RSYNC.Enum()
 	if !s.live {
 		criuType = nil
-
-		err := s.container.StorageStart()
-		if err != nil {
-			return err
-		}
-
-		defer s.container.StorageStop()
 	}
+
+	// Storage needs to start unconditionally now, since we need to
+	// initialize a new storage interface.
+	err := s.container.StorageStart()
+	if err != nil {
+		return err
+	}
+	defer s.container.StorageStop()
 
 	idmaps := make([]*IDMapType, 0)
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/lxc/lxd/shared"
@@ -30,6 +33,7 @@ var patches = []patch{
 	{name: "invalid_profile_names", run: patchInvalidProfileNames},
 	{name: "leftover_profile_config", run: patchLeftoverProfileConfig},
 	{name: "network_permissions", run: patchNetworkPermissions},
+	{name: "storage_api", run: patchStorageApi},
 }
 
 type patch struct {
@@ -136,6 +140,809 @@ func patchNetworkPermissions(name string, d *Daemon) error {
 			if err != nil {
 				return err
 			}
+		}
+	}
+
+	return nil
+}
+
+func patchStorageApi(name string, d *Daemon) error {
+	lvmVgName := daemonConfig["storage.lvm_vg_name"].Get()
+	zfsPoolName := daemonConfig["storage.zfs_pool_name"].Get()
+	defaultPoolName := "default"
+	preStorageApiStorageType := storageTypeDir
+
+	if lvmVgName != "" {
+		preStorageApiStorageType = storageTypeLvm
+		defaultPoolName = lvmVgName
+	} else if zfsPoolName != "" {
+		preStorageApiStorageType = storageTypeZfs
+		defaultPoolName = zfsPoolName
+	} else if d.BackingFs == "btrfs" {
+		preStorageApiStorageType = storageTypeBtrfs
+	} else {
+		// Dir storage pool.
+	}
+
+	defaultStorageTypeName, err := storageTypeToString(preStorageApiStorageType)
+	if err != nil {
+		return err
+	}
+
+	// In case we detect that an lvm name or a zfs name exists it makes
+	// sense to create a storage pool in the database, independent of
+	// whether anything currently exists on that pool. We can still probably
+	// safely assume that the user at least once used that pool.
+	// However, when we detect {dir, btrfs}, we can't rely on that guess
+	// since the daemon doesn't record any name for the pool anywhere.  So
+	// in the {dir, btrfs} case we check whether anything exists on the
+	// pool, if not, then we don't create a default pool. The user will then
+	// be forced to run lxd init again and can start from a pristine state.
+	// Check if this LXD instace currently has any containers, snapshots, or
+	// images configured. If so, we create a default storage pool in the
+	// database. Otherwise, the user will have to run LXD init.
+	cRegular, err := dbContainersList(d.db, cTypeRegular)
+	if err != nil {
+		return err
+	}
+
+	// Get list of existing snapshots.
+	cSnapshots, err := dbContainersList(d.db, cTypeSnapshot)
+	if err != nil {
+		return err
+	}
+
+	// Get list of existing public images.
+	imgPublic, err := dbImagesGet(d.db, true)
+	if err != nil {
+		return err
+	}
+
+	// Get list of existing private images.
+	imgPrivate, err := dbImagesGet(d.db, false)
+	if err != nil {
+		return err
+	}
+
+	// Nothing exists on the pool so we're not creating a default one,
+	// thereby forcing the user to run lxd init.
+	if len(cRegular) == 0 && len(cSnapshots) == 0 && len(imgPublic) == 0 && len(imgPrivate) == 0 {
+		return nil
+	}
+
+	switch preStorageApiStorageType {
+	case storageTypeBtrfs:
+		err = upgradeFromStorageTypeBtrfs(name, d, defaultPoolName, defaultStorageTypeName, cRegular, cSnapshots, imgPublic, imgPrivate)
+	case storageTypeDir:
+		err = upgradeFromStorageTypeDir(name, d, defaultPoolName, defaultStorageTypeName, cRegular, cSnapshots, imgPublic, imgPrivate)
+	case storageTypeLvm:
+		err = upgradeFromStorageTypeLvm(name, d, defaultPoolName, defaultStorageTypeName, cRegular, cSnapshots, imgPublic, imgPrivate)
+	case storageTypeZfs:
+		err = upgradeFromStorageTypeZfs(name, d, defaultPoolName, defaultStorageTypeName, cRegular, []string{}, imgPublic, imgPrivate)
+	default: // Shouldn't happen.
+		return fmt.Errorf("Invalid storage type. Upgrading not possible.")
+	}
+	if err != nil {
+		return err
+	}
+
+	defaultID, defaultProfile, err := dbProfileGet(d.db, "default")
+	if err == nil {
+		foundRoot := false
+		for k, v := range defaultProfile.Devices {
+			if v["type"] == "disk" && v["path"] == "/" && v["source"] == "" {
+				defaultProfile.Devices[k]["pool"] = defaultPoolName
+				foundRoot = true
+			}
+		}
+
+		if !foundRoot {
+			rootDev := map[string]string{}
+			rootDev["type"] = "disk"
+			rootDev["path"] = "/"
+			rootDev["pool"] = defaultPoolName
+			if defaultProfile.Devices == nil {
+				defaultProfile.Devices = map[string]map[string]string{}
+			}
+			defaultProfile.Devices["root"] = rootDev
+		}
+	}
+
+	tx, err := dbBegin(d.db)
+	if err != nil {
+		return err
+	}
+
+	err = dbDevicesAdd(tx, "profile", defaultID, defaultProfile.Devices)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	err = tx.Commit()
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	// Unset deprecated storage keys.
+	daemonConfig["storage.lvm_fstype"].Set(d, "")
+	daemonConfig["storage.lvm_mount_options"].Set(d, "")
+	daemonConfig["storage.lvm_thinpool_name"].Set(d, "")
+	daemonConfig["storage.lvm_vg_name"].Set(d, "")
+	daemonConfig["storage.lvm_volume_size"].Set(d, "")
+	daemonConfig["storage.zfs_pool_name"].Set(d, "")
+	daemonConfig["storage.zfs_remove_snapshots"].Set(d, "")
+	daemonConfig["storage.zfs_use_refquota"].Set(d, "")
+
+	return d.SetupStorageDriver()
+}
+
+func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {
+	poolConfig := map[string]string{}
+	poolSubvolumePath := getStoragePoolMountPoint(defaultPoolName)
+	poolConfig["source"] = poolSubvolumePath
+
+	poolID, err := dbStoragePoolCreate(d.db, defaultPoolName, defaultStorageTypeName, poolConfig)
+	if err != nil {
+		return err
+	}
+
+	s, err := storagePoolInit(d, defaultPoolName)
+	if err != nil {
+		return err
+	}
+
+	err = s.StoragePoolCreate()
+	if err != nil {
+		return err
+	}
+
+	// Create storage volumes in the database.
+	volumeConfig := map[string]string{}
+
+	if len(cRegular) > 0 {
+		// ${LXD_DIR}/storage-pools/<name>
+		containersSubvolumePath := getContainerMountPoint(defaultPoolName, "")
+		err := os.MkdirAll(containersSubvolumePath, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, ct := range cRegular {
+		// Create new db entry in the storage volumes table for the
+		// container.
+		_, err := dbStoragePoolVolumeCreate(d.db, ct, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for container \"%s\".", ct)
+			continue
+		}
+
+		// Rename the btrfs subvolume and making it a
+		// subvolume of the subvolume of the storage pool:
+		// mv ${LXD_DIR}/containers/<container_name> ${LXD_DIR}/storage-pools/<pool>/<container_name>
+		oldContainerMntPoint := shared.VarPath("containers", ct)
+		newContainerMntPoint := getContainerMountPoint(defaultPoolName, ct)
+		err = os.Rename(oldContainerMntPoint, newContainerMntPoint)
+		if err != nil {
+			return err
+		}
+
+		// Create a symlink to the mountpoint of the container:
+		// ${LXD_DIR}/containers/<container_name> ->
+		// ${LXD_DIR}/storage-pools/<pool>/containers/<container_name>
+		doesntMatter := false
+		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
+		if err != nil {
+			return err
+		}
+
+		// Check if we need to account for snapshots for this container.
+		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		if err != nil {
+			return err
+		}
+
+		if len(ctSnapshots) > 0 {
+			// Create the snapshots directory in
+			// the new storage pool:
+			// ${LXD_DIR}/storage-pools/<pool>/snapshots
+			newSnapshotsMntPoint := getSnapshotMountPoint(defaultPoolName, ct)
+			err = os.MkdirAll(newSnapshotsMntPoint, 0700)
+			if err != nil {
+				return err
+			}
+		}
+
+		for _, cs := range ctSnapshots {
+			// Insert storage volumes for snapshots into the
+			// database. Note that snapshots have already been moved
+			// and symlinked above. So no need to do any work here.
+			_, err := dbStoragePoolVolumeCreate(d.db, cs, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+			if err != nil {
+				shared.LogWarnf("Could not insert a storage volume for snapshot \"%s\".", cs)
+				continue
+			}
+
+			// We need to create a new snapshot since we can't move
+			// readonly snapshots.
+			oldSnapshotMntPoint := shared.VarPath("snapshots", cs)
+			newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, cs)
+			err = exec.Command(
+				"btrfs",
+				"subvolume",
+				"snapshot",
+				"-r",
+				oldSnapshotMntPoint,
+				newSnapshotMntPoint).Run()
+			if err != nil {
+				return err
+			}
+
+			// Delete the old subvolume.
+			err = exec.Command(
+				"btrfs",
+				"subvolume",
+				"delete",
+				oldSnapshotMntPoint,
+			).Run()
+			if err != nil {
+				return err
+			}
+		}
+
+		if len(ctSnapshots) > 0 {
+			// Create a new symlink from the snapshots directory of
+			// the container to the snapshots directory on the
+			// storage pool:
+			// ${LXD_DIR}/snapshots/<container_name> -> ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
+			snapshotsPath := shared.VarPath("snapshots", ct)
+			newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, ct)
+			if shared.PathExists(snapshotsPath) {
+				err := os.Remove(snapshotsPath)
+				if err != nil {
+					return err
+				}
+			}
+			err = os.Symlink(newSnapshotMntPoint, snapshotsPath)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	// Insert storage volumes for images into the database. Images don't
+	// move. The tarballs remain in their original location.
+	images := append(imgPublic, imgPrivate...)
+	for _, img := range images {
+		_, err := dbStoragePoolVolumeCreate(d.db, img, storagePoolVolumeTypeImage, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for image \"%s\".", img)
+			continue
+		}
+
+		imagesMntPoint := getImageMountPoint(defaultPoolName, "")
+		err = os.MkdirAll(imagesMntPoint, 0700)
+		if err != nil {
+			return err
+		}
+
+		oldImageMntPoint := shared.VarPath("images", img+".btrfs")
+		newImageMntPoint := getImageMountPoint(defaultPoolName, img)
+		err = os.Rename(oldImageMntPoint, newImageMntPoint)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {
+	poolConfig := map[string]string{}
+	poolConfig["source"] = shared.VarPath("storage-pools", defaultPoolName)
+
+	poolID, err := dbStoragePoolCreate(d.db, defaultPoolName, defaultStorageTypeName, poolConfig)
+	if err != nil {
+		return err
+	}
+
+	s, err := storagePoolInit(d, defaultPoolName)
+	if err != nil {
+		return err
+	}
+
+	err = s.StoragePoolCreate()
+	if err != nil {
+		return err
+	}
+
+	// Create storage volumes in the database.
+	volumeConfig := map[string]string{}
+	// Insert storage volumes for containers into the database.
+	for _, ct := range cRegular {
+		_, err := dbStoragePoolVolumeCreate(d.db, ct, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for container \"%s\".", ct)
+			continue
+		}
+
+		// Create the new path where containers will be located on the
+		// new storage api.
+		containersMntPoint := getContainerMountPoint(defaultPoolName, "")
+		err = os.MkdirAll(containersMntPoint, 0711)
+		if err != nil {
+			return err
+		}
+
+		// Simply rename the container when they are directories.
+		oldContainerMntPoint := shared.VarPath("containers", ct)
+		newContainerMntPoint := getContainerMountPoint(defaultPoolName, ct)
+		err = os.Rename(oldContainerMntPoint, newContainerMntPoint)
+		if err != nil {
+			return err
+		}
+
+		doesntMatter := false
+		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
+		if err != nil {
+			return err
+		}
+
+		// Check if we need to account for snapshots for this container.
+		oldSnapshotMntPoint := shared.VarPath("snapshots", ct)
+		if !shared.PathExists(oldSnapshotMntPoint) {
+			continue
+		}
+
+		// If the snapshots directory for that container is empty,
+		// remove it.
+		isEmpty, err := shared.PathIsEmpty(oldSnapshotMntPoint)
+		if isEmpty {
+			os.Remove(oldSnapshotMntPoint)
+			continue
+		}
+
+		// Create the new path where snapshots will be located on the
+		// new storage api.
+		snapshotsMntPoint := shared.VarPath("storage-pools", defaultPoolName, "snapshots")
+		err = os.MkdirAll(snapshotsMntPoint, 0711)
+		if err != nil {
+			return err
+		}
+
+		// Now simply rename the snapshots directory as well.
+		newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, ct)
+		err = os.Rename(oldSnapshotMntPoint, newSnapshotMntPoint)
+		if err != nil {
+			return err
+		}
+
+		// Create a symlink for this container.  snapshots.
+		err = createSnapshotMountpoint(newSnapshotMntPoint, newSnapshotMntPoint, oldSnapshotMntPoint)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Insert storage volumes for snapshots into the database. Note that
+	// snapshots have already been moved and symlinked above. So no need to
+	// do any work here.
+	for _, cs := range cSnapshots {
+		_, err := dbStoragePoolVolumeCreate(d.db, cs, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for snapshot \"%s\".", cs)
+			continue
+		}
+	}
+
+	// Insert storage volumes for images into the database. Images don't
+	// move. The tarballs remain in their original location.
+	images := append(imgPublic, imgPrivate...)
+	for _, img := range images {
+		_, err := dbStoragePoolVolumeCreate(d.db, img, storagePoolVolumeTypeImage, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for image \"%s\".", img)
+			continue
+		}
+	}
+
+	return nil
+}
+
+func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {
+	poolConfig := map[string]string{}
+	poolConfig["source"] = defaultPoolName
+	poolConfig["volume.lvm.thinpool_name"] = daemonConfig["storage.lvm_thinpool_name"].Get()
+	poolConfig["volume.block.filesystem"] = daemonConfig["storage.lvm_fstype"].Get()
+	poolConfig["volume.block.mount_options"] = daemonConfig["storage.lvm_mount_options"].Get()
+
+	// Get size of the volume group.
+	output, err := tryExec("vgs", "--nosuffix", "--units", "g", "--noheadings", "-o", "size", defaultPoolName)
+	if err != nil {
+		return err
+	}
+	tmp := string(output)
+	tmp = strings.TrimSpace(tmp)
+	szFloat, err := strconv.ParseFloat(tmp, 32)
+	if err != nil {
+		return err
+	}
+	szInt64 := shared.Round(szFloat)
+	poolConfig["size"] = fmt.Sprintf("%dGB", szInt64)
+
+	err = storagePoolValidateConfig(defaultPoolName, "lvm", poolConfig)
+	if err != nil {
+		return err
+	}
+
+	poolID, err := dbStoragePoolCreate(d.db, defaultPoolName, defaultStorageTypeName, poolConfig)
+	if err != nil {
+		return err
+	}
+
+	poolMntPoint := getStoragePoolMountPoint(defaultPoolName)
+	err = os.MkdirAll(poolMntPoint, 0711)
+	if err != nil {
+		return err
+	}
+
+	// Create storage volumes in the database.
+	volumeConfig := map[string]string{}
+
+	if len(cRegular) > 0 {
+		newContainersMntPoint := getContainerMountPoint(defaultPoolName, "")
+		err = os.MkdirAll(newContainersMntPoint, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Insert storage volumes for containers into the database.
+	for _, ct := range cRegular {
+		_, err := dbStoragePoolVolumeCreate(d.db, ct, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for container \"%s\".", ct)
+			continue
+		}
+
+		// Unmount the logical volume.
+		oldContainerMntPoint := shared.VarPath("containers", ct)
+		if shared.IsMountPoint(oldContainerMntPoint) {
+			err := tryUnmount(oldContainerMntPoint, 0)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Create the new path where containers will be located on the
+		// new storage api. We do os.Rename() here to preserve
+		// permissions and ownership.
+		newContainerMntPoint := getContainerMountPoint(defaultPoolName, ct)
+		err = os.Rename(oldContainerMntPoint, newContainerMntPoint)
+		if err != nil {
+			return err
+		}
+
+		if shared.PathExists(oldContainerMntPoint + ".lv") {
+			err := os.Remove(oldContainerMntPoint + ".lv")
+			if err != nil {
+				return err
+			}
+		}
+
+		// Rename the logical volume device.
+		ctLvName := containerNameToLVName(ct)
+		newContainerLvName := fmt.Sprintf("%s_%s", storagePoolVolumeApiEndpointContainers, ctLvName)
+		_, err = tryExec("lvrename", defaultPoolName, ctLvName, newContainerLvName)
+		if err != nil {
+			return err
+		}
+
+		// Create the new container mountpoint.
+		doesntMatter := false
+		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
+		if err != nil {
+			return err
+		}
+
+		lvFsType := poolConfig["volume.block.filesystem"]
+		mountOptions := poolConfig["volume.block.mount_options"]
+		containerLvDevPath := fmt.Sprintf("/dev/%s/%s_%s", defaultPoolName, storagePoolVolumeApiEndpointContainers, ctLvName)
+		err = tryMount(containerLvDevPath, newContainerMntPoint, lvFsType, 0, mountOptions)
+		if err != nil {
+			return err
+		}
+
+		// Check if we need to account for snapshots for this container.
+		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		if err != nil {
+			return err
+		}
+
+		for _, cs := range ctSnapshots {
+			// Insert storage volumes for snapshots.
+			_, err := dbStoragePoolVolumeCreate(d.db, cs, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+			if err != nil {
+				shared.LogWarnf("Could not insert a storage volume for snapshot \"%s\".", cs)
+				continue
+			}
+
+			// Create the snapshots directory in the new storage
+			// pool:
+			// ${LXD_DIR}/storage-pools/<pool>/snapshots
+			newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, cs)
+			err = os.MkdirAll(newSnapshotMntPoint, 0700)
+			if err != nil {
+				return err
+			}
+
+			// Unmount the logical volume.
+			oldSnapshotMntPoint := shared.VarPath("snapshots", cs)
+			if shared.IsMountPoint(oldSnapshotMntPoint) {
+				err := tryUnmount(oldSnapshotMntPoint, 0)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Rename the snapshot mountpoint to preserve acl's and
+			// so on.
+			err = os.Rename(oldSnapshotMntPoint, newSnapshotMntPoint)
+			if err != nil {
+				return err
+			}
+
+			err = os.Remove(oldSnapshotMntPoint + ".lv")
+			if err != nil {
+				return err
+			}
+
+			// Make sure we use a valid lv name.
+			csLvName := containerNameToLVName(cs)
+			newSnapshotLvName := fmt.Sprintf("%s_%s", storagePoolVolumeApiEndpointContainers, csLvName)
+			_, err = tryExec("lvrename", defaultPoolName, csLvName, newSnapshotLvName)
+			if err != nil {
+				return err
+			}
+
+		}
+
+		if len(ctSnapshots) > 0 {
+			// Create a new symlink from the snapshots directory of
+			// the container to the snapshots directory on the
+			// storage pool:
+			// ${LXD_DIR}/snapshots/<container_name> -> ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
+			snapshotsPath := shared.VarPath("snapshots", ct)
+			newSnapshotsPath := getSnapshotMountPoint(defaultPoolName, ct)
+			if shared.PathExists(snapshotsPath) {
+				err := os.Remove(snapshotsPath)
+				if err != nil {
+					return err
+				}
+			}
+			err = os.Symlink(newSnapshotsPath, snapshotsPath)
+			if err != nil {
+				return err
+			}
+		}
+
+	}
+
+	images := append(imgPublic, imgPrivate...)
+	if len(images) > 0 {
+		imagesMntPoint := getImageMountPoint(defaultPoolName, "")
+		err := os.MkdirAll(imagesMntPoint, 0700)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, img := range images {
+		_, err := dbStoragePoolVolumeCreate(d.db, img, storagePoolVolumeTypeImage, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for image \"%s\".", img)
+			continue
+		}
+
+		// Unmount the logical volume.
+		oldImageMntPoint := shared.VarPath("images", img+".lv")
+		if shared.IsMountPoint(oldImageMntPoint) {
+			err := tryUnmount(oldImageMntPoint, 0)
+			if err != nil {
+				return err
+			}
+		}
+
+		if shared.PathExists(oldImageMntPoint) {
+			err := os.Remove(oldImageMntPoint)
+			if err != nil {
+				return err
+			}
+		}
+
+		newImageMntPoint := getImageMountPoint(defaultPoolName, img)
+		err = os.MkdirAll(newImageMntPoint, 0700)
+		if err != nil {
+			return err
+		}
+
+		// Rename the logical volume device.
+		newImageLvName := fmt.Sprintf("%s_%s", storagePoolVolumeApiEndpointImages, img)
+		_, err = tryExec("lvrename", defaultPoolName, img, newImageLvName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {
+	poolConfig := map[string]string{}
+	oldLoopFilePath := shared.VarPath("zfs.img")
+	if shared.PathExists(oldLoopFilePath) {
+		// This is a loop file pool.
+		poolConfig["source"] = shared.VarPath("disks", defaultPoolName+".img")
+		err := os.Rename(oldLoopFilePath, poolConfig["source"])
+		if err != nil {
+			return err
+		}
+	} else {
+		// This is a block device pool.
+		poolConfig["source"] = defaultPoolName
+	}
+	output, err := exec.Command("zpool", "get", "size", "-p", "-H", defaultPoolName).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to set ZFS config: %s", output)
+	}
+	lidx := strings.LastIndex(string(output), "\t")
+	fidx := strings.LastIndex(string(output)[:lidx-1], "\t")
+	poolConfig["size"] = string(output)[fidx+1 : lidx]
+
+	poolID, err := dbStoragePoolCreate(d.db, defaultPoolName, defaultStorageTypeName, poolConfig)
+	if err != nil {
+		return err
+	}
+
+	// Create storage volumes in the database.
+	volumeConfig := map[string]string{}
+
+	if len(cRegular) > 0 {
+		containersSubvolumePath := getContainerMountPoint(defaultPoolName, "")
+		err := os.MkdirAll(containersSubvolumePath, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	for _, ct := range cRegular {
+
+		// Insert storage volumes for containers into the database.
+		_, err := dbStoragePoolVolumeCreate(d.db, ct, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for container \"%s\".", ct)
+			continue
+		}
+
+		// Unmount the container zfs doesn't really seem to care if we
+		// do this.
+		ctDataset := fmt.Sprintf("%s/containers/%s", defaultPoolName, ct)
+		oldContainerMntPoint := shared.VarPath("containers", ct)
+		if shared.IsMountPoint(oldContainerMntPoint) {
+			output, err := tryExec("zfs", "unmount", "-f", ctDataset)
+			if err != nil {
+				return fmt.Errorf("Failed to unmount ZFS filesystem: %s", output)
+			}
+		}
+
+		err = os.Remove(oldContainerMntPoint)
+		if err != nil {
+			return err
+		}
+
+		err = os.Remove(oldContainerMntPoint + ".zfs")
+		if err != nil {
+			return err
+		}
+
+		// Changing the mountpoint property should have actually created
+		// the path but in case it somehow didn't let's do it ourselves.
+		doesntMatter := false
+		newContainerMntPoint := getContainerMountPoint(defaultPoolName, ct)
+		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
+		if err != nil {
+			return err
+		}
+
+		// Set new mountpoint for the container's dataset it will be
+		// automatically mounted.
+		output, err := exec.Command(
+			"zfs",
+			"set",
+			fmt.Sprintf("mountpoint=%s", newContainerMntPoint),
+			ctDataset).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to set new ZFS mountpoint: %s.", output)
+		}
+
+		// Check if we need to account for snapshots for this container.
+		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		if err != nil {
+			return err
+		}
+
+		snapshotsPath := shared.VarPath("snapshots", ct)
+		for _, cs := range ctSnapshots {
+			// Insert storage volumes for snapshots into the
+			// database. Note that snapshots have already been moved
+			// and symlinked above. So no need to do any work here.
+			_, err := dbStoragePoolVolumeCreate(d.db, cs, storagePoolVolumeTypeContainer, poolID, volumeConfig)
+			if err != nil {
+				shared.LogWarnf("Could not insert a storage volume for snapshot \"%s\".", cs)
+				continue
+			}
+
+			// Create the new mountpoint for snapshots in the new
+			// storage api.
+			newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, cs)
+			err = os.MkdirAll(newSnapshotMntPoint, 0711)
+			if err != nil {
+				return err
+			}
+		}
+
+		os.RemoveAll(snapshotsPath)
+
+		// Create a symlink for this container's snapshots.
+		if len(ctSnapshots) != 0 {
+			newSnapshotsMntPoint := getSnapshotMountPoint(defaultPoolName, ct)
+			err := os.Symlink(newSnapshotsMntPoint, snapshotsPath)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	// Insert storage volumes for images into the database. Images don't
+	// move. The tarballs remain in their original location.
+	images := append(imgPublic, imgPrivate...)
+	for _, img := range images {
+		_, err := dbStoragePoolVolumeCreate(d.db, img, storagePoolVolumeTypeImage, poolID, volumeConfig)
+		if err != nil {
+			shared.LogWarnf("Could not insert a storage volume for image \"%s\".", img)
+			continue
+		}
+
+		imageMntPoint := getImageMountPoint(defaultPoolName, img)
+		err = os.MkdirAll(imageMntPoint, 0700)
+		if err != nil {
+			return err
+		}
+
+		oldImageMntPoint := shared.VarPath("images", img+".zfs")
+		imageDataset := fmt.Sprintf("%s/images/%s", defaultPoolName, img)
+		if shared.PathExists(oldImageMntPoint) {
+			if shared.IsMountPoint(oldImageMntPoint) {
+				output, err := tryExec("zfs", "unmount", "-f", imageDataset)
+				if err != nil {
+					return fmt.Errorf("Failed to unmount ZFS filesystem: %s", output)
+				}
+			}
+
+			err = os.Remove(oldImageMntPoint)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Set new mountpoint for the container's dataset it will be
+		// automatically mounted.
+		output, err := exec.Command("zfs", "set", "mountpoint=none", imageDataset).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to set new ZFS mountpoint: %s.", output)
 		}
 	}
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -17,80 +17,595 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
 type storageBtrfs struct {
-	d *Daemon
-
 	storageShared
 }
 
-func (s *storageBtrfs) Init(config map[string]interface{}) (storage, error) {
-	s.sType = storageTypeBtrfs
-	s.sTypeName = storageTypeToString(s.sType)
-	if err := s.initShared(); err != nil {
-		return s, err
+// ${LXD_DIR}/storage-pools/<pool>/containers
+func (s *storageBtrfs) getContainerSubvolumePath(poolName string) string {
+	return shared.VarPath("storage-pools", poolName, "containers")
+}
+
+// ${LXD_DIR}/storage-pools/<pool>/snapshots
+func (s *storageBtrfs) getSnapshotSubvolumePath(poolName string, containerName string) string {
+	return shared.VarPath("storage-pools", poolName, "snapshots", containerName)
+}
+
+// ${LXD_DIR}/storage-pools/<pool>/images
+func (s *storageBtrfs) getImageSubvolumePath(poolName string) string {
+	return shared.VarPath("storage-pools", poolName, "images")
+}
+
+// ${LXD_DIR}/storage-pools/<pool>/custom
+func (s *storageBtrfs) getCustomSubvolumePath(poolName string) string {
+	return shared.VarPath("storage-pools", poolName, "custom")
+}
+
+// subvol=containers/<container_name>
+func (s *storageBtrfs) getContainerMntOptions(name string) string {
+	return fmt.Sprintf("subvol=containers/%s", name)
+}
+
+// subvol=snapshots/<snapshot_name>
+func (s *storageBtrfs) getSnapshotMntOptions(name string) string {
+	return fmt.Sprintf("subvol=snapshots/%s", name)
+}
+
+// subvol=images/<fingerprint>
+func (s *storageBtrfs) getImageMntOptions(imageFingerprint string) string {
+	return fmt.Sprintf("subvol=images/%s", imageFingerprint)
+}
+
+// subvol=custom/<custom_name>
+func (s *storageBtrfs) getCustomMntOptions() string {
+	return fmt.Sprintf("subvol=custom/%s", s.volume.Name)
+}
+
+func (s *storageBtrfs) StorageCoreInit() (*storageCore, error) {
+	sCore := storageCore{}
+	sCore.sType = storageTypeBtrfs
+	typeName, err := storageTypeToString(sCore.sType)
+	if err != nil {
+		return nil, err
 	}
+	sCore.sTypeName = typeName
 
 	out, err := exec.LookPath("btrfs")
 	if err != nil || len(out) == 0 {
-		return s, fmt.Errorf("The 'btrfs' tool isn't available")
+		return nil, fmt.Errorf("The 'btrfs' tool isn't available")
 	}
 
 	output, err := exec.Command("btrfs", "version").CombinedOutput()
 	if err != nil {
-		return s, fmt.Errorf("The 'btrfs' tool isn't working properly")
+		return nil, fmt.Errorf("The 'btrfs' tool isn't working properly")
 	}
 
-	count, err := fmt.Sscanf(strings.SplitN(string(output), " ", 2)[1], "v%s\n", &s.sTypeVersion)
+	count, err := fmt.Sscanf(strings.SplitN(string(output), " ", 2)[1], "v%s\n", &sCore.sTypeVersion)
 	if err != nil || count != 1 {
-		return s, fmt.Errorf("The 'btrfs' tool isn't working properly")
+		return nil, fmt.Errorf("The 'btrfs' tool isn't working properly")
+	}
+
+	err = sCore.initShared()
+	if err != nil {
+		return nil, err
+	}
+
+	s.storageCore = sCore
+
+	return &sCore, nil
+}
+
+func (s *storageBtrfs) StoragePoolInit(config map[string]interface{}) (storage, error) {
+	_, err := s.StorageCoreInit()
+	if err != nil {
+		return s, err
 	}
 
 	return s, nil
 }
 
-func (s *storageBtrfs) ContainerCreate(container container) error {
-	cPath := container.Path()
+func (s *storageBtrfs) StoragePoolCheck() error {
+	// FIXEM(brauner): Think of something smart or useful (And then think
+	// again if it is worth implementing it. :)).
+	return nil
+}
 
-	// MkdirAll the pardir of the BTRFS Subvolume.
-	if err := os.MkdirAll(filepath.Dir(cPath), 0755); err != nil {
-		return err
+func (s *storageBtrfs) StoragePoolCreate() error {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
 	}
 
-	// Create the BTRFS Subvolume
-	err := s.subvolCreate(cPath)
+	if !filepath.IsAbs(source) {
+		return fmt.Errorf("Only absolute paths are allowed for now.")
+	}
+
+	// Create the mountpoint for the storage pool.
+	isBlockDev := shared.IsBlockdevPath(source)
+	if !isBlockDev {
+		if s.d.BackingFs == "btrfs" {
+			// Deal with the case where the backing fs is a btrfs
+			// pool itself.
+			// FIXME(brauner): Figure out a way to let users create a
+			// loop file even if the backing fs is btrfs.
+			err := s.btrfsPoolVolumeCreate(source)
+			if err != nil {
+				return err
+			}
+			return nil
+		} else {
+			source = source + ".img"
+			s.pool.Config["source"] = source
+
+			// This is likely a loop file.
+			f, err := os.Create(source)
+			if err != nil {
+				return fmt.Errorf("Failed to open %s: %s", source, err)
+			}
+			defer f.Close()
+
+			err = f.Chmod(0600)
+			if err != nil {
+				return fmt.Errorf("Failed to chmod %s: %s", source, err)
+			}
+
+			size, err := strconv.ParseInt(s.pool.Config["size"], 10, 64)
+			if err != nil {
+				return err
+			}
+
+			err = f.Truncate(size)
+			if err != nil {
+				return fmt.Errorf("Failed to create sparse file %s: %s", source, err)
+			}
+		}
+	}
+
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+	err := os.MkdirAll(poolMntPoint, 0711)
 	if err != nil {
 		return err
 	}
 
-	if container.IsPrivileged() {
-		if err := os.Chmod(cPath, 0700); err != nil {
+	// Create a btrfs filesystem.
+	output, err := exec.Command(
+		"mkfs.btrfs",
+		"-L", s.pool.Name, source).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to create the BTRFS pool: %s", output)
+	}
+
+	var err1 error
+	var devUUID string
+	if isBlockDev && filepath.IsAbs(source) {
+		devUUID, _ = shared.LookupUUIDByBlockDevPath(source)
+		// The symlink might not have been created even with the delay
+		// we granted it above. So try to call btrfs filesystem show and
+		// parse it out. (I __hate__ this!)
+		if devUUID == "" {
+			shared.LogWarnf("Failed to detect UUID by looking at /dev/disk/by-uuid.")
+			devUUID, err1 = s.btrfsLookupFsUUID(source)
+			if err1 != nil {
+				shared.LogErrorf("Failed to detect UUID by parsing filesystem info.")
+				return err1
+			}
+		}
+		s.pool.Config["source"] = devUUID
+
+		// If the symlink in /dev/disk/by-uuid hasn't been created yet
+		// aka we only detected it by parsing btrfs filesystem show, we
+		// cannot call StoragePoolMount() since it will try to do the
+		// reverse operation. So instead we shamelessly mount using the
+		// block device path at the time of pool creation.
+		err1 = syscall.Mount(source, poolMntPoint, "btrfs", 0, "")
+	} else {
+		_, err1 = s.StoragePoolMount()
+	}
+	if err1 != nil {
+		return err1
+	}
+
+	// Create default subvolumes.
+	dummyDir := getContainerMountPoint(s.pool.Name, "")
+	err = s.btrfsPoolVolumeCreate(dummyDir)
+	if err != nil {
+		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
+	}
+
+	dummyDir = getSnapshotMountPoint(s.pool.Name, "")
+	err = s.btrfsPoolVolumeCreate(dummyDir)
+	if err != nil {
+		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
+	}
+
+	dummyDir = getImageMountPoint(s.pool.Name, "")
+	err = s.btrfsPoolVolumeCreate(dummyDir)
+	if err != nil {
+		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
+	}
+
+	dummyDir = getStoragePoolVolumeMountPoint(s.pool.Name, "")
+	err = s.btrfsPoolVolumeCreate(dummyDir)
+	if err != nil {
+		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
+	}
+
+	return nil
+}
+
+func (s *storageBtrfs) StoragePoolDelete() error {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	// Delete default subvolumes.
+	dummyDir := getContainerMountPoint(s.pool.Name, "")
+	s.btrfsPoolVolumeDelete(dummyDir)
+
+	dummyDir = getSnapshotMountPoint(s.pool.Name, "")
+	s.btrfsPoolVolumeDelete(dummyDir)
+
+	dummyDir = getImageMountPoint(s.pool.Name, "")
+	s.btrfsPoolVolumeDelete(dummyDir)
+
+	dummyDir = getStoragePoolVolumeMountPoint(s.pool.Name, "")
+	s.btrfsPoolVolumeDelete(dummyDir)
+
+	_, err := s.StoragePoolUmount()
+	if err != nil {
+		return err
+	}
+
+	// This is a UUID. Check whether we can find the block device.
+	if !filepath.IsAbs(source) {
+		// Try to lookup the disk device by UUID but don't fail. If we
+		// don't find one this might just mean we have been given the
+		// UUID of a subvolume.
+		byUUID := fmt.Sprintf("/dev/disk/by-uuid/%s", source)
+		diskPath, err := os.Readlink(byUUID)
+		msg := ""
+		if err == nil {
+			msg = fmt.Sprintf("Removing disk device %s with UUID: %s.", diskPath, source)
+			diskPath = fmt.Sprintf("/dev/%s", strings.Trim(diskPath, "../../"))
+		} else {
+			msg = fmt.Sprintf("Failed to lookup disk device with UUID: %s: %s.", source, err)
+		}
+		s.log.Debug(msg)
+	} else {
+		var err error
+		if s.d.BackingFs == "btrfs" {
+			err = s.btrfsPoolVolumeDelete(source)
+		} else {
+			// This is a loop file --> simply remove it.
+			err = os.Remove(source)
+		}
+		if err != nil {
 			return err
 		}
+	}
+
+	// Remove the mountpoint for the storage pool.
+	os.RemoveAll(getStoragePoolMountPoint(s.pool.Name))
+
+	return nil
+}
+
+func (s *storageBtrfs) StoragePoolMount() (bool, error) {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return false, fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+
+	// Check whether the mount poolMntPoint exits.
+	if !shared.PathExists(poolMntPoint) {
+		err := os.MkdirAll(poolMntPoint, 0711)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	if shared.IsMountPoint(poolMntPoint) {
+		return false, nil
+	}
+
+	poolMntOptions := "user_subvol_rm_allowed"
+	mountSource := source
+	if filepath.IsAbs(source) {
+		if !shared.IsBlockdevPath(source) && s.d.BackingFs != "btrfs" {
+			loopF, err := prepareLoopDev(source)
+			if err != nil {
+				return false, fmt.Errorf("Could not prepare loop device.")
+			}
+			mountSource = loopF.Name()
+			defer loopF.Close()
+		} else {
+			return false, nil
+		}
+	} else {
+		// Try to lookup the disk device by UUID but don't fail. If we
+		// don't find one this might just mean we have been given the
+		// UUID of a subvolume.
+		byUUID := fmt.Sprintf("/dev/disk/by-uuid/%s", source)
+		diskPath, err := os.Readlink(byUUID)
+		if err == nil {
+			mountSource = fmt.Sprintf("/dev/%s", strings.Trim(diskPath, "../../"))
+		} else {
+			// We have very likely been given a subvolume UUID. In
+			// this case we should simply assume that the user has
+			// mounted the parent of the subvolume or the subvolume
+			// itself. Otherwise this becomes a really messy
+			// detection task.
+			return false, nil
+		}
+
+	}
+
+	// This is a block device.
+	err := syscall.Mount(mountSource, poolMntPoint, "btrfs", 0, poolMntOptions)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+
+	if shared.IsMountPoint(poolMntPoint) {
+		err := syscall.Unmount(poolMntPoint, 0)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (s *storageBtrfs) StoragePoolUpdate(changedConfig []string) error {
+	return fmt.Errorf("Btrfs storage properties cannot be changed.")
+}
+
+func (s *storageBtrfs) GetStoragePoolWritable() api.StoragePoolPut {
+	return s.pool.Writable()
+}
+
+func (s *storageBtrfs) SetStoragePoolWritable(writable *api.StoragePoolPut) {
+	s.pool.StoragePoolPut = *writable
+}
+
+func (s *storageBtrfs) ContainerPoolGet() string {
+	return s.pool.Name
+}
+
+func (s *storageBtrfs) ContainerPoolIDGet() int64 {
+	return s.poolID
+}
+
+// Functions dealing with storage volumes.
+func (s *storageBtrfs) StoragePoolVolumeCreate() error {
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	// Create subvolume path on the storage pool.
+	customSubvolumePath := s.getCustomSubvolumePath(s.pool.Name)
+	if !shared.PathExists(customSubvolumePath) {
+		err := os.MkdirAll(customSubvolumePath, 0700)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create subvolume.
+	customSubvolumeName := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	err = s.btrfsPoolVolumeCreate(customSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *storageBtrfs) StoragePoolVolumeDelete() error {
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	// Delete subvolume.
+	customSubvolumeName := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	err = s.btrfsPoolVolumeDelete(customSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	// Delete the mountpoint.
+	if shared.PathExists(customSubvolumeName) {
+		err = os.Remove(customSubvolumeName)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (s *storageBtrfs) StoragePoolVolumeMount() (bool, error) {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return false, fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	// Check if the storage volume is already mounted.
+	customMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	if shared.IsMountPoint(customMntPoint) {
+		return false, nil
+	}
+
+	// Mount the storage volume on its mountpoint.
+	customMntOptions := ""
+	if !shared.IsBlockdevPath(source) {
+		// mount("/dev/loop<n>", "/path/to/target", "btrfs", 0, "subvol=subvol/name")
+		loopF, err := prepareLoopDev(source)
+		if err != nil {
+			return false, fmt.Errorf("Could not prepare loop device.")
+		}
+		loopDev := loopF.Name()
+		defer loopF.Close()
+
+		// Pass the btrfs subvolume name as mountoption.
+		customMntOptions = s.getCustomMntOptions()
+		err = syscall.Mount(loopDev, customMntPoint, "btrfs", 0, customMntOptions)
+		if err != nil {
+			return false, err
+		}
+	} else {
+		err := syscall.Mount(source, customMntPoint, "btrfs", 0, customMntOptions)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (s *storageBtrfs) StoragePoolVolumeUmount() (bool, error) {
+	customMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	if shared.IsMountPoint(customMntPoint) {
+		err := syscall.Unmount(customMntPoint, 0)
+		if err != nil {
+			return false, err
+		}
+	}
+
+	return true, nil
+}
+
+func (s *storageBtrfs) StoragePoolVolumeUpdate(changedConfig []string) error {
+	return fmt.Errorf("Btrfs storage properties cannot be changed.")
+}
+
+func (s *storageBtrfs) GetStoragePoolVolumeWritable() api.StorageVolumePut {
+	return s.volume.Writable()
+}
+
+func (s *storageBtrfs) SetStoragePoolVolumeWritable(writable *api.StorageVolumePut) {
+	s.volume.StorageVolumePut = *writable
+}
+
+// Functions dealing with container storage.
+func (s *storageBtrfs) ContainerCreate(container container) error {
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	// We can only create the btrfs subvolume under the mounted storage
+	// pool. The on-disk layout for containers on a btrfs storage pool will
+	// thus be
+	// ${LXD_DIR}/storage-pools/<pool>/containers/. The btrfs tool will
+	// complain if the intermediate path does not exist, so create it if it
+	// doesn't already.
+	containerSubvolumePath := s.getContainerSubvolumePath(s.pool.Name)
+	if !shared.PathExists(containerSubvolumePath) {
+		err := os.MkdirAll(containerSubvolumePath, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create empty subvolume for container.
+	containerSubvolumeName := getContainerMountPoint(s.pool.Name, container.Name())
+	err = s.btrfsPoolVolumeCreate(containerSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	// Create the mountpoint for the container at:
+	// ${LXD_DIR}/containers/<name>
+	err = createContainerMountpoint(containerSubvolumeName, container.Path(), container.IsPrivileged())
+	if err != nil {
+		return err
 	}
 
 	return container.TemplateApply("create")
 }
 
-func (s *storageBtrfs) ContainerCreateFromImage(
-	container container, imageFingerprint string) error {
+// And this function is why I started hating on btrfs...
+func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint string) error {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
 
-	imageSubvol := fmt.Sprintf(
-		"%s.btrfs",
-		shared.VarPath("images", imageFingerprint))
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
 
-	// Create the btrfs subvol of the image first if it doesn exists.
-	if !shared.PathExists(imageSubvol) {
-		if err := s.ImageCreate(imageFingerprint); err != nil {
+	// We can only create the btrfs subvolume under the mounted storage
+	// pool. The on-disk layout for containers on a btrfs storage pool will
+	// thus be
+	// ${LXD_DIR}/storage-pools/<pool>/containers/. The btrfs tool will
+	// complain if the intermediate path does not exist, so create it if it
+	// doesn't already.
+	containerSubvolumePath := s.getContainerSubvolumePath(s.pool.Name)
+	if !shared.PathExists(containerSubvolumePath) {
+		err := os.MkdirAll(containerSubvolumePath, 0711)
+		if err != nil {
 			return err
 		}
 	}
 
-	// Now make a snapshot of the image subvol
-	err := s.subvolsSnapshot(imageSubvol, container.Path(), false)
+	// Mountpoint of the image:
+	// ${LXD_DIR}/images/<fingerprint>
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	imageStoragePoolLockID := fmt.Sprintf("%s/%s", s.pool.Name, fingerprint)
+	imageCreationInPoolLock.Lock()
+	if waitChannel, ok := imageCreationInPool[imageStoragePoolLockID]; ok {
+		imageCreationInPoolLock.Unlock()
+		if _, ok := <-waitChannel; ok {
+			shared.LogWarnf("Value transmitted over image lock semaphore?")
+		}
+	} else {
+		imageCreationInPool[imageStoragePoolLockID] = make(chan bool)
+		var imgerr error
+		if !shared.PathExists(imageMntPoint) || !s.isBtrfsPoolVolume(imageMntPoint) {
+			imgerr = s.ImageCreate(fingerprint)
+		}
+		if waitChannel, ok := imageCreationInPool[imageStoragePoolLockID]; ok {
+			close(waitChannel)
+			delete(imageCreationInPool, imageStoragePoolLockID)
+		}
+		imageCreationInPoolLock.Unlock()
+		if imgerr != nil {
+			return imgerr
+		}
+	}
+
+	// Create a rw snapshot at
+	// ${LXD_DIR}/storage-pools/<pool>/containers/<name>
+	// from the mounted ro image snapshot mounted at
+	// ${LXD_DIR}/storage-pools/<pool>/images/<fingerprint>
+	containerSubvolumeName := getContainerMountPoint(s.pool.Name, container.Name())
+	err = s.btrfsPoolVolumesSnapshot(imageMntPoint, containerSubvolumeName, false)
+	if err != nil {
+		return err
+	}
+
+	// Create the mountpoint for the container at:
+	// ${LXD_DIR}/containers/<name>
+	err = createContainerMountpoint(containerSubvolumeName, container.Path(), container.IsPrivileged())
 	if err != nil {
 		return err
 	}
@@ -98,10 +613,6 @@ func (s *storageBtrfs) ContainerCreateFromImage(
 	if !container.IsPrivileged() {
 		if err = s.shiftRootfs(container); err != nil {
 			s.ContainerDelete(container)
-			return err
-		}
-	} else {
-		if err := os.Chmod(container.Path(), 0700); err != nil {
 			return err
 		}
 	}
@@ -114,21 +625,41 @@ func (s *storageBtrfs) ContainerCanRestore(container container, sourceContainer 
 }
 
 func (s *storageBtrfs) ContainerDelete(container container) error {
-	cPath := container.Path()
+	// The storage pool needs to be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
 
-	// First remove the subvol (if it was one).
-	if s.isSubvolume(cPath) {
-		if err := s.subvolsDelete(cPath); err != nil {
+	// Delete the subvolume.
+	containerSubvolumeName := getContainerMountPoint(s.pool.Name, container.Name())
+	err = s.btrfsPoolVolumeDelete(containerSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	// Delete the container's symlink to the subvolume.
+	err = deleteContainerMountpoint(containerSubvolumeName, container.Path(), s.GetStorageTypeName())
+	if err != nil {
+		return err
+	}
+
+	// Delete potential snapshot mountpoints.
+	snapshotMntPoint := getSnapshotMountPoint(s.pool.Name, container.Name())
+	if shared.PathExists(snapshotMntPoint) {
+		err := os.RemoveAll(snapshotMntPoint)
+		if err != nil {
 			return err
 		}
 	}
 
-	// Then the directory (if it still exists).
-	if shared.PathExists(cPath) {
-		err := os.RemoveAll(cPath)
+	// Delete potential symlink
+	// ${LXD_DIR}/snapshots/<container_name> -> ${POOL}/snapshots/<container_name>
+	snapshotSymlink := shared.VarPath("snapshots", container.Name())
+	if shared.PathExists(snapshotSymlink) {
+		err := os.Remove(snapshotSymlink)
 		if err != nil {
-			s.log.Error("ContainerDelete: failed", log.Ctx{"cPath": cPath, "err": err})
-			return fmt.Errorf("Error cleaning up %s: %s", cPath, err)
+			return err
 		}
 	}
 
@@ -136,36 +667,83 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 }
 
 func (s *storageBtrfs) ContainerCopy(container container, sourceContainer container) error {
-	subvol := sourceContainer.Path()
-	dpath := container.Path()
+	// The storage pool needs to be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
 
-	if s.isSubvolume(subvol) {
-		// Snapshot the sourcecontainer
-		err := s.subvolsSnapshot(subvol, dpath, false)
+	err = sourceContainer.StorageStart()
+	if err != nil {
+		return err
+	}
+	defer sourceContainer.StorageStop()
+
+	sourcePool := sourceContainer.Storage().ContainerPoolGet()
+	sourceContainerSubvolumeName := ""
+	if sourceContainer.IsSnapshot() {
+		sourceContainerSubvolumeName = getSnapshotMountPoint(sourcePool, sourceContainer.Name())
+	} else {
+		sourceContainerSubvolumeName = getContainerMountPoint(sourcePool, sourceContainer.Name())
+	}
+
+	targetContainerSubvolumeName := ""
+	if container.IsSnapshot() {
+		targetContainerSubvolumeName = getSnapshotMountPoint(s.pool.Name, container.Name())
+	} else {
+		targetContainerSubvolumeName = getContainerMountPoint(s.pool.Name, container.Name())
+	}
+	if s.ContainerPoolGet() == sourcePool {
+		// COMMNET(brauner): They are on the same storage pool which
+		// means they both use btrfs. So we can simply create a new
+		// snapshot of the source container. For this we only mount the
+		// btrfs storage pool and snapshot the subvolume names. No
+		// f*cking around with mounting the containers.
+		ourMount, err := s.StoragePoolMount()
 		if err != nil {
 			return err
+		}
+		if ourMount {
+			defer s.StoragePoolUmount()
+		}
+
+		err = s.btrfsPoolVolumesSnapshot(sourceContainerSubvolumeName, targetContainerSubvolumeName, false)
+		if err != nil {
+			return err
+		}
+
+		err = createContainerMountpoint(targetContainerSubvolumeName, container.Path(), container.IsPrivileged())
+		if err != nil {
+			return err
+		}
+
+		// Make sure that template apply finds the
+		// container mounted.
+		ourMount, err = s.ContainerMount(container.Name(), container.Path())
+		if err != nil {
+			return err
+		}
+		if ourMount {
+			defer s.ContainerUmount(container.Name(), container.Path())
 		}
 	} else {
-		// Create the BTRFS Container.
-		if err := s.ContainerCreate(container); err != nil {
+		// Create an empty btrfs storage volume.
+		err = s.ContainerCreate(container)
+		if err != nil {
 			return err
 		}
 
-		/*
-		 * Copy by using rsync
-		 */
-		output, err := storageRsyncCopy(
-			sourceContainer.Path(),
-			container.Path())
+		// Use rsync to fill the empty volume.
+		output, err := storageRsyncCopy(sourceContainerSubvolumeName, targetContainerSubvolumeName)
 		if err != nil {
 			s.ContainerDelete(container)
-
 			s.log.Error("ContainerCopy: rsync failed", log.Ctx{"output": string(output)})
 			return fmt.Errorf("rsync failed: %s", string(output))
 		}
 	}
 
-	if err := s.setUnprivUserAcl(sourceContainer, dpath); err != nil {
+	err = s.setUnprivUserAcl(sourceContainer, targetContainerSubvolumeName)
+	if err != nil {
 		s.ContainerDelete(container)
 		return err
 	}
@@ -173,25 +751,58 @@ func (s *storageBtrfs) ContainerCopy(container container, sourceContainer contai
 	return container.TemplateApply("copy")
 }
 
-func (s *storageBtrfs) ContainerStart(name string, path string) error {
-	return nil
+func (s *storageBtrfs) ContainerMount(name string, path string) (bool, error) {
+	// The storage pool must be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
 }
 
-func (s *storageBtrfs) ContainerStop(name string, path string) error {
-	return nil
+func (s *storageBtrfs) ContainerUmount(name string, path string) (bool, error) {
+	return true, nil
 }
 
 func (s *storageBtrfs) ContainerRename(container container, newName string) error {
-	oldName := container.Name()
-	oldPath := container.Path()
-	newPath := containerPath(newName, false)
-
-	if err := os.Rename(oldPath, newPath); err != nil {
+	// The storage pool must be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
 		return err
 	}
 
-	if shared.PathExists(shared.VarPath(fmt.Sprintf("snapshots/%s", oldName))) {
-		err := os.Rename(shared.VarPath(fmt.Sprintf("snapshots/%s", oldName)), shared.VarPath(fmt.Sprintf("snapshots/%s", newName)))
+	oldContainerSubvolumeName := getContainerMountPoint(s.pool.Name, container.Name())
+	newContainerSubvolumeName := getContainerMountPoint(s.pool.Name, newName)
+	err = os.Rename(oldContainerSubvolumeName, newContainerSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	newSymlink := shared.VarPath("containers", newName)
+	err = renameContainerMountpoint(oldContainerSubvolumeName, container.Path(), newContainerSubvolumeName, newSymlink)
+	if err != nil {
+		return err
+	}
+
+	oldSnapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, container.Name())
+	newSnapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, newName)
+	if shared.PathExists(oldSnapshotSubvolumeName) {
+		err = os.Rename(oldSnapshotSubvolumeName, newSnapshotSubvolumeName)
+		if err != nil {
+			return err
+		}
+	}
+
+	oldSnapshotSymlink := shared.VarPath("snapshots", container.Name())
+	newSnapshotSymlink := shared.VarPath("snapshots", newName)
+	if shared.PathExists(oldSnapshotSymlink) {
+		err := os.Remove(oldSnapshotSymlink)
+		if err != nil {
+			return err
+		}
+
+		err = os.Symlink(newSnapshotSubvolumeName, newSnapshotSymlink)
 		if err != nil {
 			return err
 		}
@@ -200,38 +811,59 @@ func (s *storageBtrfs) ContainerRename(container container, newName string) erro
 	return nil
 }
 
-func (s *storageBtrfs) ContainerRestore(
-	container container, sourceContainer container) error {
-
-	targetSubVol := container.Path()
-	sourceSubVol := sourceContainer.Path()
-	sourceBackupPath := container.Path() + ".back"
-
-	// Create a backup of the container
-	err := os.Rename(container.Path(), sourceBackupPath)
+func (s *storageBtrfs) ContainerRestore(container container, sourceContainer container) error {
+	// The storage pool must be mounted.
+	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
 	}
 
+	// Create a backup so we can revert.
+	targetContainerSubvolumeName := getContainerMountPoint(s.pool.Name, container.Name())
+	backupTargetContainerSubvolumeName := fmt.Sprintf("%s.back", targetContainerSubvolumeName)
+	err = os.Rename(targetContainerSubvolumeName, backupTargetContainerSubvolumeName)
+	if err != nil {
+		return err
+	}
+	undo := true
+	defer func() {
+		if undo {
+			os.Rename(backupTargetContainerSubvolumeName, targetContainerSubvolumeName)
+		}
+	}()
+
+	err = sourceContainer.StorageStart()
+	if err != nil {
+		return err
+	}
+	defer sourceContainer.StorageStop()
+
+	// Mount the source container.
+	srcContainerStorage := sourceContainer.Storage()
+	sourcePool := srcContainerStorage.ContainerPoolGet()
+	sourceContainerSubvolumeName := ""
+	if sourceContainer.IsSnapshot() {
+		sourceContainerSubvolumeName = getSnapshotMountPoint(sourcePool, sourceContainer.Name())
+	} else {
+		sourceContainerSubvolumeName = getContainerMountPoint(sourcePool, sourceContainer.Name())
+	}
+
 	var failure error
-	if s.isSubvolume(sourceSubVol) {
-		// Restore using btrfs snapshots.
-		err := s.subvolsSnapshot(sourceSubVol, targetSubVol, false)
+	if s.ContainerPoolGet() == sourcePool {
+		// They are on the same storage pool, so we can simply snapshot.
+		err := s.btrfsPoolVolumesSnapshot(sourceContainerSubvolumeName, targetContainerSubvolumeName, false)
 		if err != nil {
 			failure = err
 		}
 	} else {
-		// Restore using rsync but create a btrfs subvol.
-		if err := s.subvolCreate(targetSubVol); err == nil {
-			output, err := storageRsyncCopy(
-				sourceSubVol,
-				targetSubVol)
-
+		err := s.btrfsPoolVolumeCreate(targetContainerSubvolumeName)
+		if err == nil {
+			// Use rsync to fill the empty volume.  Sync by using
+			// the subvolume name.
+			output, err := storageRsyncCopy(sourceContainerSubvolumeName, targetContainerSubvolumeName)
 			if err != nil {
-				s.log.Error(
-					"ContainerRestore: rsync failed",
-					log.Ctx{"output": string(output)})
-
+				s.ContainerDelete(container)
+				s.log.Error("ContainerRestore: rsync failed", log.Ctx{"output": string(output)})
 				failure = err
 			}
 		} else {
@@ -240,20 +872,19 @@ func (s *storageBtrfs) ContainerRestore(
 	}
 
 	// Now allow unprivileged users to access its data.
-	if err := s.setUnprivUserAcl(sourceContainer, targetSubVol); err != nil {
+	err = s.setUnprivUserAcl(sourceContainer, targetContainerSubvolumeName)
+	if err != nil {
 		failure = err
 	}
 
-	if failure != nil {
-		// Restore original container
-		s.ContainerDelete(container)
-		os.Rename(sourceBackupPath, container.Path())
-	} else {
-		// Remove the backup, we made
-		if s.isSubvolume(sourceBackupPath) {
-			return s.subvolsDelete(sourceBackupPath)
+	if failure == nil {
+		undo = false
+
+		if s.ContainerPoolGet() == srcContainerStorage.ContainerPoolGet() {
+			// Remove the backup, we made
+			return s.btrfsPoolVolumesDelete(backupTargetContainerSubvolumeName)
 		}
-		os.RemoveAll(sourceBackupPath)
+		os.RemoveAll(backupTargetContainerSubvolumeName)
 	}
 
 	return failure
@@ -262,7 +893,7 @@ func (s *storageBtrfs) ContainerRestore(
 func (s *storageBtrfs) ContainerSetQuota(container container, size int64) error {
 	subvol := container.Path()
 
-	_, err := s.subvolQGroup(subvol)
+	_, err := s.btrfsPoolVolumeQGroup(subvol)
 	if err != nil {
 		return err
 	}
@@ -282,67 +913,94 @@ func (s *storageBtrfs) ContainerSetQuota(container container, size int64) error 
 }
 
 func (s *storageBtrfs) ContainerGetUsage(container container) (int64, error) {
-	return s.subvolQGroupUsage(container.Path())
+	return s.btrfsPoolVolumeQGroupUsage(container.Path())
 }
 
-func (s *storageBtrfs) ContainerSnapshotCreate(
-	snapshotContainer container, sourceContainer container) error {
-
-	subvol := sourceContainer.Path()
-	dpath := snapshotContainer.Path()
-
-	if s.isSubvolume(subvol) {
-		// Create a readonly snapshot of the source.
-		err := s.subvolsSnapshot(subvol, dpath, true)
-		if err != nil {
-			s.ContainerSnapshotDelete(snapshotContainer)
-			return err
-		}
-	} else {
-		/*
-		 * Copy by using rsync
-		 */
-		output, err := storageRsyncCopy(
-			subvol,
-			dpath)
-		if err != nil {
-			s.ContainerSnapshotDelete(snapshotContainer)
-
-			s.log.Error(
-				"ContainerSnapshotCreate: rsync failed",
-				log.Ctx{"output": string(output)})
-			return fmt.Errorf("rsync failed: %s", string(output))
-		}
-	}
-
-	return nil
-}
-func (s *storageBtrfs) ContainerSnapshotDelete(
-	snapshotContainer container) error {
-
-	err := s.ContainerDelete(snapshotContainer)
-	if err != nil {
-		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.Name(), err)
-	}
-
-	oldPathParent := filepath.Dir(snapshotContainer.Path())
-	if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
-		os.Remove(oldPathParent)
-	}
-	return nil
-}
-
-func (s *storageBtrfs) ContainerSnapshotStart(container container) error {
-	if shared.PathExists(container.Path() + ".ro") {
-		return fmt.Errorf("The snapshot is already mounted read-write.")
-	}
-
-	err := os.Rename(container.Path(), container.Path()+".ro")
+func (s *storageBtrfs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
 	}
 
-	err = s.subvolsSnapshot(container.Path()+".ro", container.Path(), false)
+	// We can only create the btrfs subvolume under the mounted storage
+	// pool. The on-disk layout for snapshots on a btrfs storage pool will
+	// thus be
+	// ${LXD_DIR}/storage-pools/<pool>/snapshots/. The btrfs tool will
+	// complain if the intermediate path does not exist, so create it if it
+	// doesn't already.
+	snapshotSubvolumePath := s.getSnapshotSubvolumePath(s.pool.Name, sourceContainer.Name())
+	if !shared.PathExists(snapshotSubvolumePath) {
+		err := os.MkdirAll(snapshotSubvolumePath, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", s.volume.Name)
+	snapshotMntPointSymlink := shared.VarPath("snapshots", sourceContainer.Name())
+	if !shared.PathExists(snapshotMntPointSymlink) {
+		err := createContainerMountpoint(snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, snapshotContainer.IsPrivileged())
+		if err != nil {
+			return err
+		}
+	}
+
+	srcContainerSubvolumeName := getContainerMountPoint(s.pool.Name, sourceContainer.Name())
+	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, snapshotContainer.Name())
+	err = s.btrfsPoolVolumesSnapshot(srcContainerSubvolumeName, snapshotSubvolumeName, true)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (s *storageBtrfs) ContainerSnapshotDelete(snapshotContainer container) error {
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, snapshotContainer.Name())
+	err = s.btrfsPoolVolumeDelete(snapshotSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	sourceSnapshotMntPoint := shared.VarPath("snapshots", snapshotContainer.Name())
+	os.Remove(sourceSnapshotMntPoint)
+	os.Remove(snapshotSubvolumeName)
+
+	sourceFields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
+	sourceName := sourceFields[0]
+	snapshotSubvolumePath := s.getSnapshotSubvolumePath(s.pool.Name, sourceName)
+	os.Remove(snapshotSubvolumePath)
+	if !shared.PathExists(snapshotSubvolumePath) {
+		snapshotMntPointSymlink := shared.VarPath("snapshots", sourceName)
+		os.Remove(snapshotMntPointSymlink)
+	}
+
+	return nil
+}
+
+func (s *storageBtrfs) ContainerSnapshotStart(container container) error {
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, container.Name())
+	roSnapshotSubvolumeName := fmt.Sprintf("%s.ro", snapshotSubvolumeName)
+	if shared.PathExists(roSnapshotSubvolumeName) {
+		return fmt.Errorf("The snapshot is already mounted read-write.")
+	}
+
+	err = os.Rename(snapshotSubvolumeName, roSnapshotSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	err = s.btrfsPoolVolumesSnapshot(roSnapshotSubvolumeName, snapshotSubvolumeName, false)
 	if err != nil {
 		return err
 	}
@@ -351,16 +1009,23 @@ func (s *storageBtrfs) ContainerSnapshotStart(container container) error {
 }
 
 func (s *storageBtrfs) ContainerSnapshotStop(container container) error {
-	if !shared.PathExists(container.Path() + ".ro") {
-		return fmt.Errorf("The snapshot isn't currently mounted read-write.")
-	}
-
-	err := s.subvolsDelete(container.Path())
+	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
 	}
 
-	err = os.Rename(container.Path()+".ro", container.Path())
+	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, container.Name())
+	roSnapshotSubvolumeName := fmt.Sprintf("%s.ro", snapshotSubvolumeName)
+	if !shared.PathExists(roSnapshotSubvolumeName) {
+		return fmt.Errorf("The snapshot isn't currently mounted read-write.")
+	}
+
+	err = s.btrfsPoolVolumesDelete(snapshotSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(roSnapshotSubvolumeName, snapshotSubvolumeName)
 	if err != nil {
 		return err
 	}
@@ -369,66 +1034,166 @@ func (s *storageBtrfs) ContainerSnapshotStop(container container) error {
 }
 
 // ContainerSnapshotRename renames a snapshot of a container.
-func (s *storageBtrfs) ContainerSnapshotRename(
-	snapshotContainer container, newName string) error {
-
-	oldPath := snapshotContainer.Path()
-	newPath := containerPath(newName, true)
-
-	// Create the new parent.
-	if !shared.PathExists(filepath.Dir(newPath)) {
-		os.MkdirAll(filepath.Dir(newPath), 0700)
+func (s *storageBtrfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+	// The storage pool must be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
 	}
 
-	// Now rename the snapshot.
-	if !s.isSubvolume(oldPath) {
-		if err := os.Rename(oldPath, newPath); err != nil {
-			return err
-		}
-	} else {
-		if err := s.subvolsSnapshot(oldPath, newPath, true); err != nil {
-			return err
-		}
-		if err := s.subvolsDelete(oldPath); err != nil {
-			return err
-		}
-	}
-
-	// Remove the old parent (on container rename) if its empty.
-	if ok, _ := shared.PathIsEmpty(filepath.Dir(oldPath)); ok {
-		os.Remove(filepath.Dir(oldPath))
+	// Unmount the snapshot if it is mounted otherwise we'll get EBUSY.
+	// Rename the subvolume on the storage pool.
+	oldSnapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, snapshotContainer.Name())
+	newSnapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, newName)
+	err = os.Rename(oldSnapshotSubvolumeName, newSnapshotSubvolumeName)
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
+// Needed for live migration where an empty snapshot needs to be created before
+// rsyncing into it.
 func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	dpath := snapshotContainer.Path()
-	return s.subvolCreate(dpath)
+	// Mount the storage pool.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	// Create the snapshot subvole path on the storage pool.
+	sourceFields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
+	sourceName := sourceFields[0]
+	snapshotSubvolumePath := s.getSnapshotSubvolumePath(s.pool.Name, sourceName)
+	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, snapshotContainer.Name())
+	if !shared.PathExists(snapshotSubvolumePath) {
+		err := os.MkdirAll(snapshotSubvolumePath, 0711)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = s.btrfsPoolVolumeCreate(snapshotSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", sourceName)
+	snapshotMntPointSymlink := shared.VarPath("snapshots", sourceName)
+	if !shared.PathExists(snapshotMntPointSymlink) {
+		err := createContainerMountpoint(snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, snapshotContainer.IsPrivileged())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *storageBtrfs) ImageCreate(fingerprint string) error {
+	// Create the subvolume.
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
+
+	err = s.createImageDbPoolVolume(fingerprint)
+	if err != nil {
+		return err
+	}
+
+	// We can only create the btrfs subvolume under the mounted storage
+	// pool. The on-disk layout for images on a btrfs storage pool will thus
+	// be
+	// ${LXD_DIR}/storage-pools/<pool>/images/. The btrfs tool will
+	// complain if the intermediate path does not exist, so create it if it
+	// doesn't already.
+	imageSubvolumePath := s.getImageSubvolumePath(s.pool.Name)
+	if !shared.PathExists(imageSubvolumePath) {
+		err := os.MkdirAll(imageSubvolumePath, 0700)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Create a temporary rw btrfs subvolume. From this rw subvolume we'll
+	// create a ro snapshot below. The path with which we do this is
+	// ${LXD_DIR}/storage-pools/<pool>/images/<fingerprint>@<pool>_tmp.
+	imageSubvolumeName := getImageMountPoint(s.pool.Name, fingerprint)
+	tmpImageSubvolumeName := fmt.Sprintf("%s_tmp", imageSubvolumeName)
+	err = s.btrfsPoolVolumeCreate(tmpImageSubvolumeName)
+	if err != nil {
+		return err
+	}
+	// Delete volume on error.
+	undo := true
+	defer func() {
+		if undo {
+			s.btrfsPoolVolumeDelete(tmpImageSubvolumeName)
+		}
+	}()
+
+	// Unpack the image in imageMntPoint.
 	imagePath := shared.VarPath("images", fingerprint)
-	subvol := fmt.Sprintf("%s.btrfs", imagePath)
-
-	if err := s.subvolCreate(subvol); err != nil {
+	err = unpackImage(s.d, imagePath, tmpImageSubvolumeName, storageTypeBtrfs)
+	if err != nil {
 		return err
 	}
 
-	if err := unpackImage(s.d, imagePath, subvol); err != nil {
-		s.subvolDelete(subvol)
+	// Now create a read-only snapshot of the subvolume.
+	// The path with which we do this is
+	// ${LXD_DIR}/storage-pools/<pool>/images/<fingerprint>.
+	err = s.btrfsPoolVolumeSnapshot(tmpImageSubvolumeName, imageSubvolumeName, true)
+	if err != nil {
 		return err
 	}
+
+	defer func() {
+		if undo {
+			s.btrfsPoolVolumeDelete(imageSubvolumeName)
+		}
+	}()
+
+	err = s.btrfsPoolVolumeDelete(tmpImageSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	undo = false
 
 	return nil
 }
 
 func (s *storageBtrfs) ImageDelete(fingerprint string) error {
-	imagePath := shared.VarPath("images", fingerprint)
-	subvol := fmt.Sprintf("%s.btrfs", imagePath)
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return err
+	}
 
-	if s.isSubvolume(subvol) {
-		if err := s.subvolsDelete(subvol); err != nil {
+	// Delete the btrfs subvolume. The path with which we
+	// do this is ${LXD_DIR}/storage-pools/<pool>/images/<fingerprint>.
+	imageSubvolumeName := getImageMountPoint(s.pool.Name, fingerprint)
+	err = s.btrfsPoolVolumeDelete(imageSubvolumeName)
+	if err != nil {
+		return err
+	}
+
+	err = s.deleteImageDbPoolVolume(fingerprint)
+	if err != nil {
+		return err
+	}
+
+	// Now delete the mountpoint for the image:
+	// ${LXD_DIR}/images/<fingerprint>.
+	if shared.PathExists(imageSubvolumeName) {
+		err := os.RemoveAll(imageSubvolumeName)
+		if err != nil {
 			return err
 		}
 	}
@@ -436,10 +1201,24 @@ func (s *storageBtrfs) ImageDelete(fingerprint string) error {
 	return nil
 }
 
-func (s *storageBtrfs) subvolCreate(subvol string) error {
+func (s *storageBtrfs) ImageMount(fingerprint string) (bool, error) {
+	// The storage pool must be mounted.
+	_, err := s.StoragePoolMount()
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *storageBtrfs) ImageUmount(fingerprint string) (bool, error) {
+	return true, nil
+}
+
+func (s *storageBtrfs) btrfsPoolVolumeCreate(subvol string) error {
 	parentDestPath := filepath.Dir(subvol)
 	if !shared.PathExists(parentDestPath) {
-		if err := os.MkdirAll(parentDestPath, 0700); err != nil {
+		if err := os.MkdirAll(parentDestPath, 0711); err != nil {
 			return err
 		}
 	}
@@ -464,7 +1243,7 @@ func (s *storageBtrfs) subvolCreate(subvol string) error {
 	return nil
 }
 
-func (s *storageBtrfs) subvolQGroup(subvol string) (string, error) {
+func (s *storageBtrfs) btrfsPoolVolumeQGroup(subvol string) (string, error) {
 	output, err := exec.Command(
 		"btrfs",
 		"qgroup",
@@ -498,7 +1277,7 @@ func (s *storageBtrfs) subvolQGroup(subvol string) (string, error) {
 	return qgroup, nil
 }
 
-func (s *storageBtrfs) subvolQGroupUsage(subvol string) (int64, error) {
+func (s *storageBtrfs) btrfsPoolVolumeQGroupUsage(subvol string) (int64, error) {
 	output, err := exec.Command(
 		"btrfs",
 		"qgroup",
@@ -532,9 +1311,9 @@ func (s *storageBtrfs) subvolQGroupUsage(subvol string) (int64, error) {
 	return -1, fmt.Errorf("Unable to find current qgroup usage")
 }
 
-func (s *storageBtrfs) subvolDelete(subvol string) error {
+func (s *storageBtrfs) btrfsPoolVolumeDelete(subvol string) error {
 	// Attempt (but don't fail on) to delete any qgroup on the subvolume
-	qgroup, err := s.subvolQGroup(subvol)
+	qgroup, err := s.btrfsPoolVolumeQGroup(subvol)
 	if err == nil {
 		output, err := exec.Command(
 			"btrfs",
@@ -568,12 +1347,12 @@ func (s *storageBtrfs) subvolDelete(subvol string) error {
 	return nil
 }
 
-// subvolsDelete is the recursive variant on subvolDelete,
+// btrfsPoolVolumesDelete is the recursive variant on btrfsPoolVolumeDelete,
 // it first deletes subvolumes of the subvolume and then the
 // subvolume itself.
-func (s *storageBtrfs) subvolsDelete(subvol string) error {
+func (s *storageBtrfs) btrfsPoolVolumesDelete(subvol string) error {
 	// Delete subsubvols.
-	subsubvols, err := s.getSubVolumes(subvol)
+	subsubvols, err := s.btrfsPoolVolumesGet(subvol)
 	if err != nil {
 		return err
 	}
@@ -585,13 +1364,13 @@ func (s *storageBtrfs) subvolsDelete(subvol string) error {
 				"subvol":    subvol,
 				"subsubvol": subsubvol})
 
-		if err := s.subvolDelete(path.Join(subvol, subsubvol)); err != nil {
+		if err := s.btrfsPoolVolumeDelete(path.Join(subvol, subsubvol)); err != nil {
 			return err
 		}
 	}
 
 	// Delete the subvol itself
-	if err := s.subvolDelete(subvol); err != nil {
+	if err := s.btrfsPoolVolumeDelete(subvol); err != nil {
 		return err
 	}
 
@@ -599,25 +1378,11 @@ func (s *storageBtrfs) subvolsDelete(subvol string) error {
 }
 
 /*
- * subvolSnapshot creates a snapshot of "source" to "dest"
+ * btrfsPoolVolumeSnapshot creates a snapshot of "source" to "dest"
  * the result will be readonly if "readonly" is True.
  */
-func (s *storageBtrfs) subvolSnapshot(
+func (s *storageBtrfs) btrfsPoolVolumeSnapshot(
 	source string, dest string, readonly bool) error {
-
-	parentDestPath := filepath.Dir(dest)
-	if !shared.PathExists(parentDestPath) {
-		if err := os.MkdirAll(parentDestPath, 0700); err != nil {
-			return err
-		}
-	}
-
-	if shared.PathExists(dest) {
-		if err := os.Remove(dest); err != nil {
-			return err
-		}
-	}
-
 	var output []byte
 	var err error
 	if readonly {
@@ -652,11 +1417,9 @@ func (s *storageBtrfs) subvolSnapshot(
 	return err
 }
 
-func (s *storageBtrfs) subvolsSnapshot(
-	source string, dest string, readonly bool) error {
-
+func (s *storageBtrfs) btrfsPoolVolumesSnapshot(source string, dest string, readonly bool) error {
 	// Get a list of subvolumes of the root
-	subsubvols, err := s.getSubVolumes(source)
+	subsubvols, err := s.btrfsPoolVolumesGet(source)
 	if err != nil {
 		return err
 	}
@@ -672,17 +1435,16 @@ func (s *storageBtrfs) subvolsSnapshot(
 	}
 
 	// First snapshot the root
-	if err := s.subvolSnapshot(source, dest, readonly); err != nil {
+	if err := s.btrfsPoolVolumeSnapshot(source, dest, readonly); err != nil {
 		return err
 	}
 
 	// Now snapshot all subvolumes of the root.
 	for _, subsubvol := range subsubvols {
-		if err := s.subvolSnapshot(
+		if err := s.btrfsPoolVolumeSnapshot(
 			path.Join(source, subsubvol),
 			path.Join(dest, subsubvol),
 			readonly); err != nil {
-
 			return err
 		}
 	}
@@ -691,10 +1453,10 @@ func (s *storageBtrfs) subvolsSnapshot(
 }
 
 /*
- * isSubvolume returns true if the given Path is a btrfs subvolume
+ * isBtrfsPoolVolume returns true if the given Path is a btrfs subvolume
  * else false.
  */
-func (s *storageBtrfs) isSubvolume(subvolPath string) bool {
+func (s *storageBtrfs) isBtrfsPoolVolume(subvolPath string) bool {
 	fs := syscall.Stat_t{}
 	err := syscall.Lstat(subvolPath, &fs)
 	if err != nil {
@@ -710,7 +1472,7 @@ func (s *storageBtrfs) isSubvolume(subvolPath string) bool {
 }
 
 // getSubVolumes returns a list of relative subvolume paths of "path".
-func (s *storageBtrfs) getSubVolumes(path string) ([]string, error) {
+func (s *storageBtrfs) btrfsPoolVolumesGet(path string) ([]string, error) {
 	result := []string{}
 
 	if !strings.HasSuffix(path, "/") {
@@ -735,7 +1497,7 @@ func (s *storageBtrfs) getSubVolumes(path string) ([]string, error) {
 		}
 
 		// Check if a btrfs subvolume
-		if s.isSubvolume(fpath) {
+		if s.isBtrfsPoolVolume(fpath) {
 			result = append(result, strings.TrimPrefix(fpath, path))
 		}
 
@@ -802,57 +1564,78 @@ func (s *btrfsMigrationSourceDriver) send(conn *websocket.Conn, btrfsPath string
 }
 
 func (s *btrfsMigrationSourceDriver) SendWhileRunning(conn *websocket.Conn, op *operation) error {
+	containerPool := s.container.Storage().ContainerPoolGet()
+	containerName := s.container.Name()
+	containersPath := getContainerMountPoint(containerPool, "")
+	sourceName := containerName
+
+	// Deal with sending a snapshot to create a container on another LXD
+	// instance.
 	if s.container.IsSnapshot() {
-		tmpPath := containerPath(fmt.Sprintf("%s/.migration-send-%s", s.container.Name(), uuid.NewRandom().String()), true)
-		err := os.MkdirAll(tmpPath, 0700)
+		sourceFields := strings.SplitN(containerName, shared.SnapshotDelimiter, 2)
+		sourceName = sourceFields[0]
+		snapshotsPath := getSnapshotMountPoint(containerPool, sourceName)
+		tmpContainerMntPoint, err := ioutil.TempDir(snapshotsPath, sourceName)
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tmpContainerMntPoint)
+
+		err = os.Chmod(tmpContainerMntPoint, 0700)
 		if err != nil {
 			return err
 		}
 
-		btrfsPath := fmt.Sprintf("%s/.root", tmpPath)
-		if err := s.btrfs.subvolSnapshot(s.container.Path(), btrfsPath, true); err != nil {
+		migrationSendSnapshot := fmt.Sprintf("%s/.migration-send", tmpContainerMntPoint)
+		snapshotMntPoint := getSnapshotMountPoint(containerPool, containerName)
+		if s.container.IsSnapshot() {
+		}
+		err = s.btrfs.btrfsPoolVolumeSnapshot(snapshotMntPoint, migrationSendSnapshot, true)
+		if err != nil {
 			return err
 		}
+		defer s.btrfs.btrfsPoolVolumeDelete(migrationSendSnapshot)
 
-		defer s.btrfs.subvolDelete(btrfsPath)
-
-		wrapper := StorageProgressReader(op, "fs_progress", s.container.Name())
-		return s.send(conn, btrfsPath, "", wrapper)
+		wrapper := StorageProgressReader(op, "fs_progress", containerName)
+		return s.send(conn, migrationSendSnapshot, "", wrapper)
 	}
 
 	for i, snap := range s.snapshots {
 		prev := ""
 		if i > 0 {
-			prev = s.snapshots[i-1].Path()
+			prev = getSnapshotMountPoint(containerPool, s.snapshots[i-1].Name())
 		}
 
+		snapMntPoint := getSnapshotMountPoint(containerPool, snap.Name())
 		wrapper := StorageProgressReader(op, "fs_progress", snap.Name())
-		if err := s.send(conn, snap.Path(), prev, wrapper); err != nil {
+		if err := s.send(conn, snapMntPoint, prev, wrapper); err != nil {
 			return err
 		}
 	}
 
-	/* We can't send running fses, so let's snapshot the fs and send
-	 * the snapshot.
-	 */
-	tmpPath := containerPath(fmt.Sprintf("%s/.migration-send-%s", s.container.Name(), uuid.NewRandom().String()), true)
-	err := os.MkdirAll(tmpPath, 0700)
+	tmpContainerMntPoint, err := ioutil.TempDir(containersPath, containerName)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpContainerMntPoint)
+
+	err = os.Chmod(tmpContainerMntPoint, 0700)
 	if err != nil {
 		return err
 	}
 
-	s.runningSnapName = fmt.Sprintf("%s/.root", tmpPath)
-	if err := s.btrfs.subvolSnapshot(s.container.Path(), s.runningSnapName, true); err != nil {
+	migrationSendSnapshot := fmt.Sprintf("%s/.migration-send", tmpContainerMntPoint)
+	containerMntPoint := getContainerMountPoint(containerPool, sourceName)
+	if s.container.IsSnapshot() {
+	}
+	err = s.btrfs.btrfsPoolVolumeSnapshot(containerMntPoint, migrationSendSnapshot, true)
+	if err != nil {
 		return err
 	}
+	defer s.btrfs.btrfsPoolVolumeDelete(migrationSendSnapshot)
 
-	btrfsParent := ""
-	if len(s.btrfsSnapshotNames) > 0 {
-		btrfsParent = s.btrfsSnapshotNames[len(s.btrfsSnapshotNames)-1]
-	}
-
-	wrapper := StorageProgressReader(op, "fs_progress", s.container.Name())
-	return s.send(conn, s.runningSnapName, btrfsParent, wrapper)
+	wrapper := StorageProgressReader(op, "fs_progress", containerName)
+	return s.send(conn, migrationSendSnapshot, "", wrapper)
 }
 
 func (s *btrfsMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn) error {
@@ -863,7 +1646,7 @@ func (s *btrfsMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn) e
 	}
 
 	s.stoppedSnapName = fmt.Sprintf("%s/.root", tmpPath)
-	if err := s.btrfs.subvolSnapshot(s.container.Path(), s.stoppedSnapName, true); err != nil {
+	if err := s.btrfs.btrfsPoolVolumeSnapshot(s.container.Path(), s.stoppedSnapName, true); err != nil {
 		return err
 	}
 
@@ -872,11 +1655,11 @@ func (s *btrfsMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn) e
 
 func (s *btrfsMigrationSourceDriver) Cleanup() {
 	if s.stoppedSnapName != "" {
-		s.btrfs.subvolDelete(s.stoppedSnapName)
+		s.btrfs.btrfsPoolVolumeDelete(s.stoppedSnapName)
 	}
 
 	if s.runningSnapName != "" {
-		s.btrfs.subvolDelete(s.runningSnapName)
+		s.btrfs.btrfsPoolVolumeDelete(s.runningSnapName)
 	}
 }
 
@@ -930,22 +1713,12 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 		return rsyncMigrationSink(live, container, snapshots, conn, srcIdmap, op)
 	}
 
-	cName := container.Name()
-
-	snapshotsPath := shared.VarPath(fmt.Sprintf("snapshots/%s", cName))
-	if !shared.PathExists(snapshotsPath) {
-		err := os.MkdirAll(shared.VarPath(fmt.Sprintf("snapshots/%s", cName)), 0700)
-		if err != nil {
-			return err
-		}
-	}
-
-	btrfsRecv := func(btrfsPath string, targetPath string, isSnapshot bool, writeWrapper func(io.WriteCloser) io.WriteCloser) error {
+	btrfsRecv := func(snapName string, btrfsPath string, targetPath string, isSnapshot bool, writeWrapper func(io.WriteCloser) io.WriteCloser) error {
 		args := []string{"receive", "-e", btrfsPath}
 		cmd := exec.Command("btrfs", args...)
 
 		// Remove the existing pre-created subvolume
-		err := s.subvolsDelete(targetPath)
+		err := s.btrfsPoolVolumesDelete(targetPath)
 		if err != nil {
 			return err
 		}
@@ -983,57 +1756,125 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 		}
 
 		if !isSnapshot {
-			cPath := containerPath(fmt.Sprintf("%s/.root", cName), true)
-
-			err := s.subvolSnapshot(cPath, targetPath, false)
-			if err != nil {
-				shared.LogError("problem with btrfs snapshot", log.Ctx{"err": err})
-				return err
-			}
-
-			err = s.subvolsDelete(cPath)
-			if err != nil {
-				shared.LogError("problem with btrfs delete", log.Ctx{"err": err})
-				return err
-			}
+			btrfsPath = fmt.Sprintf("%s/.migration-send", btrfsPath)
+			err = s.btrfsPoolVolumeSnapshot(btrfsPath, targetPath, false)
+		} else {
+			btrfsPath = fmt.Sprintf("%s/%s", btrfsPath, snapName)
+			err = s.btrfsPoolVolumeSnapshot(btrfsPath, targetPath, true)
 		}
+		if err != nil {
+			shared.LogError("problem with btrfs snapshot", log.Ctx{"err": err})
+			return err
+		}
+
+		err = s.btrfsPoolVolumesDelete(btrfsPath)
+		if err != nil {
+			shared.LogError("problem with btrfs delete", log.Ctx{"err": err})
+			return err
+		}
+
+		os.RemoveAll(btrfsPath)
 
 		return nil
 	}
 
-	for _, snap := range snapshots {
-		args := snapshotProtobufToContainerArgs(container.Name(), snap)
-		s, err := containerCreateEmptySnapshot(container.Daemon(), args)
+	containerPool := container.Storage().ContainerPoolGet()
+	containersPath := getSnapshotMountPoint(containerPool, container.Name())
+	if len(snapshots) > 0 {
+		err := os.MkdirAll(containersPath, 0700)
 		if err != nil {
 			return err
 		}
 
-		wrapper := StorageProgressWriter(op, "fs_progress", snap.GetName())
-		if err := btrfsRecv(containerPath(cName, true), s.Path(), true, wrapper); err != nil {
+		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", containerPool, "snapshots", container.Name())
+		snapshotMntPointSymlink := shared.VarPath("snapshots", container.Name())
+		if !shared.PathExists(snapshotMntPointSymlink) {
+			err := os.Symlink(snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	for _, snap := range snapshots {
+		args := snapshotProtobufToContainerArgs(container.Name(), snap)
+		// Unset the pool of the orginal container and let
+		// containerLXCCreate figure out on which pool to  send it.
+		// Later we might make this more flexible.
+		for k, v := range args.Devices {
+			if v["type"] == "disk" && v["path"] == "/" {
+				args.Devices[k]["pool"] = ""
+			}
+		}
+		containerMntPoint := getSnapshotMountPoint(containerPool, args.Name)
+		_, err := containerCreateEmptySnapshot(container.Daemon(), args)
+		if err != nil {
 			return err
 		}
+		tmpContainerMntPoint, err := ioutil.TempDir(containersPath, container.Name())
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tmpContainerMntPoint)
+
+		err = os.Chmod(tmpContainerMntPoint, 0700)
+		if err != nil {
+			return err
+		}
+
+		wrapper := StorageProgressWriter(op, "fs_progress", *snap.Name)
+		err = btrfsRecv(*snap.Name, tmpContainerMntPoint, containerMntPoint, true, wrapper)
+		if err != nil {
+			return err
+		}
+	}
+
+	containersMntPoint := getContainerMountPoint(s.pool.Name, "")
+	err := createContainerMountpoint(containersMntPoint, container.Path(), container.IsPrivileged())
+	if err != nil {
+		return err
 	}
 
 	/* finally, do the real container */
 	wrapper := StorageProgressWriter(op, "fs_progress", container.Name())
-	if err := btrfsRecv(containerPath(cName, true), container.Path(), false, wrapper); err != nil {
+	tmpContainerMntPoint, err := ioutil.TempDir(containersMntPoint, container.Name())
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpContainerMntPoint)
+
+	err = os.Chmod(tmpContainerMntPoint, 0700)
+	if err != nil {
 		return err
 	}
 
-	if live {
-		wrapper := StorageProgressWriter(op, "fs_progress", container.Name())
-		if err := btrfsRecv(containerPath(cName, true), container.Path(), false, wrapper); err != nil {
-			return err
-		}
-	}
-
-	// Cleanup
-	if ok, _ := shared.PathIsEmpty(snapshotsPath); ok {
-		err := os.Remove(snapshotsPath)
-		if err != nil {
-			return err
-		}
+	containerMntPoint := getContainerMountPoint(s.pool.Name, container.Name())
+	err = btrfsRecv("", tmpContainerMntPoint, containerMntPoint, false, wrapper)
+	if err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func (s *storageBtrfs) btrfsLookupFsUUID(fs string) (string, error) {
+	output, err := exec.Command(
+		"btrfs",
+		"filesystem",
+		"show",
+		"--raw",
+		fs).CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("Failed to detect UUID.")
+	}
+
+	outputString := string(output)
+	idx := strings.Index(outputString, "uuid: ")
+	outputString = outputString[idx+6:]
+	outputString = strings.TrimSpace(outputString)
+	idx = strings.Index(outputString, "\t")
+	outputString = outputString[:idx]
+	outputString = strings.Trim(outputString, "\n")
+
+	return outputString, nil
 }

--- a/lxd/storage_cgo.go
+++ b/lxd/storage_cgo.go
@@ -1,0 +1,175 @@
+// +build linux
+// +build cgo
+
+package main
+
+/*
+#define _GNU_SOURCE
+#define _FILE_OFFSET_BITS 64
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/loop.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#ifndef LO_FLAGS_AUTOCLEAR
+#define LO_FLAGS_AUTOCLEAR 4
+#endif
+
+static int get_unused_loop_dev_legacy(char *loop_name)
+{
+	struct dirent *dp;
+	struct loop_info64 lo64;
+	DIR *dir;
+	int dfd = -1, fd = -1, ret = -1;
+
+	dir = opendir("/dev");
+	if (!dir)
+		return -1;
+
+	while ((dp = readdir(dir))) {
+		if (!dp)
+			break;
+
+		if (strncmp(dp->d_name, "loop", 4) != 0)
+			continue;
+
+		dfd = dirfd(dir);
+		if (dfd < 0)
+			continue;
+
+		fd = openat(dfd, dp->d_name, O_RDWR);
+		if (fd < 0)
+			continue;
+
+		ret = ioctl(fd, LOOP_GET_STATUS64, &lo64);
+		if (ret < 0)
+
+			if (ioctl(fd, LOOP_GET_STATUS64, &lo64) == 0 ||
+			    errno != ENXIO) {
+				close(fd);
+				fd = -1;
+				continue;
+			}
+
+		ret = snprintf(loop_name, LO_NAME_SIZE, "/dev/%s", dp->d_name);
+		if (ret < 0 || ret >= LO_NAME_SIZE) {
+			close(fd);
+			fd = -1;
+			continue;
+		}
+
+		break;
+	}
+
+	closedir(dir);
+
+	if (fd < 0)
+		return -1;
+
+	return fd;
+}
+
+static int get_unused_loop_dev(char *name_loop)
+{
+	int loop_nr, ret;
+	int fd_ctl = -1, fd_tmp = -1;
+
+	fd_ctl = open("/dev/loop-control", O_RDWR | O_CLOEXEC);
+	if (fd_ctl < 0)
+		return -ENODEV;
+
+	loop_nr = ioctl(fd_ctl, LOOP_CTL_GET_FREE);
+	if (loop_nr < 0)
+		goto on_error;
+
+	ret = snprintf(name_loop, LO_NAME_SIZE, "/dev/loop%d", loop_nr);
+	if (ret < 0 || ret >= LO_NAME_SIZE)
+		goto on_error;
+
+	fd_tmp = open(name_loop, O_RDWR | O_CLOEXEC);
+	if (fd_tmp < 0)
+		goto on_error;
+
+on_error:
+	close(fd_ctl);
+	return fd_tmp;
+}
+
+int prepare_loop_dev(const char *source, char *loop_dev)
+{
+	int ret;
+	struct loop_info64 lo64;
+	int fd_img = -1, fret = -1, fd_loop = -1;
+
+	fd_loop = get_unused_loop_dev(loop_dev);
+	if (fd_loop < 0) {
+		if (fd_loop == -ENODEV)
+			fd_loop = get_unused_loop_dev_legacy(loop_dev);
+		else
+			goto on_error;
+	}
+
+	fd_img = open(source, O_RDWR | O_CLOEXEC);
+	if (fd_img < 0)
+		goto on_error;
+
+	ret = ioctl(fd_loop, LOOP_SET_FD, fd_img);
+	if (ret < 0)
+		goto on_error;
+
+	memset(&lo64, 0, sizeof(lo64));
+	lo64.lo_flags = LO_FLAGS_AUTOCLEAR;
+
+	ret = ioctl(fd_loop, LOOP_SET_STATUS64, &lo64);
+	if (ret < 0)
+		goto on_error;
+
+	fret = 0;
+
+on_error:
+	if (fd_img >= 0)
+		close(fd_img);
+
+	if (fret < 0 && fd_loop >= 0) {
+		close(fd_loop);
+		fd_loop = -1;
+	}
+
+	return fd_loop;
+}
+*/
+import "C"
+
+import (
+	"fmt"
+	"os"
+	"unsafe"
+)
+
+// prepareLoopDev() detects and sets up a loop device for source. It returns an
+// open file descriptor to the free loop device and the path of the free loop
+// device. It's the callers responsibility to close the open file descriptor.
+func prepareLoopDev(source string) (*os.File, error) {
+	cLoopDev := C.malloc(C.size_t(C.LO_NAME_SIZE))
+	if cLoopDev == nil {
+		return nil, fmt.Errorf("Failed to allocate memory in C.")
+	}
+	defer C.free(cLoopDev)
+
+	cSource := C.CString(source)
+	defer C.free(unsafe.Pointer(cSource))
+	loopFd := int(C.prepare_loop_dev(cSource, (*C.char)(cLoopDev)))
+	if loopFd < 0 {
+		return nil, fmt.Errorf("Failed to prepare loop device.")
+	}
+
+	return os.NewFile(uintptr(loopFd), C.GoString((*C.char)(cLoopDev))), nil
+}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,19 +12,10 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 
 	log "gopkg.in/inconshreveable/log15.v2"
 )
-
-func storageLVMCheckVolumeGroup(vgName string) error {
-	output, err := exec.Command("vgdisplay", "-s", vgName).CombinedOutput()
-	if err != nil {
-		shared.LogDebug("vgdisplay failed to find vg", log.Ctx{"output": string(output)})
-		return fmt.Errorf("LVM volume group '%s' not found", vgName)
-	}
-
-	return nil
-}
 
 func storageLVMThinpoolExists(vgName string, poolName string) (bool, error) {
 	output, err := exec.Command("vgs", "--noheadings", "-o", "lv_attr", fmt.Sprintf("%s/%s", vgName, poolName)).Output()
@@ -88,7 +78,7 @@ func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 	return results, nil
 }
 
-func storageLVMValidateThinPoolName(d *Daemon, key string, value string) error {
+func storageLVMValidateThinPoolName(d *Daemon, vgName string, value string) error {
 	users, err := storageLVMGetThinPoolUsers(d)
 	if err != nil {
 		return fmt.Errorf("Error checking if a pool is already in use: %v", err)
@@ -98,39 +88,18 @@ func storageLVMValidateThinPoolName(d *Daemon, key string, value string) error {
 		return fmt.Errorf("Can not change LVM config. Images or containers are still using LVs: %v", users)
 	}
 
-	vgname := daemonConfig["storage.lvm_vg_name"].Get()
 	if value != "" {
-		if vgname == "" {
+		if vgName == "" {
 			return fmt.Errorf("Can not set lvm_thinpool_name without lvm_vg_name set.")
 		}
 
-		poolExists, err := storageLVMThinpoolExists(vgname, value)
+		poolExists, err := storageLVMThinpoolExists(vgName, value)
 		if err != nil {
-			return fmt.Errorf("Error checking for thin pool '%s' in '%s': %v", value, vgname, err)
+			return fmt.Errorf("Error checking for thin pool '%s' in '%s': %v", value, vgName, err)
 		}
 
 		if !poolExists {
-			return fmt.Errorf("Pool '%s' does not exist in Volume Group '%s'", value, vgname)
-		}
-	}
-
-	return nil
-}
-
-func storageLVMValidateVolumeGroupName(d *Daemon, key string, value string) error {
-	users, err := storageLVMGetThinPoolUsers(d)
-	if err != nil {
-		return fmt.Errorf("Error checking if a pool is already in use: %v", err)
-	}
-
-	if len(users) > 0 {
-		return fmt.Errorf("Can not change LVM config. Images or containers are still using LVs: %v", users)
-	}
-
-	if value != "" {
-		err = storageLVMCheckVolumeGroup(value)
-		if err != nil {
-			return err
+			return fmt.Errorf("Pool '%s' does not exist in Volume Group '%s'", value, vgName)
 		}
 	}
 
@@ -155,18 +124,30 @@ func containerNameToLVName(containerName string) string {
 }
 
 type storageLvm struct {
-	d      *Daemon
-	vgName string
-
 	storageShared
 }
 
-func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
-	s.sType = storageTypeLvm
-	s.sTypeName = storageTypeToString(s.sType)
-	if err := s.initShared(); err != nil {
-		return s, err
+func getLvmDevPath(lvmPool string, volumeType string, lvmVolume string) string {
+	return fmt.Sprintf("/dev/%s/%s_%s", lvmPool, volumeType, lvmVolume)
+}
+
+func getPrefixedLvName(volumeType string, lvmVolume string) string {
+	return fmt.Sprintf("%s_%s", volumeType, lvmVolume)
+}
+
+func getTmpSnapshotName(snap string) string {
+	return fmt.Sprintf("%s_tmp", snap)
+}
+
+// Only initialize the minimal information we need about a given storage type.
+func (s *storageLvm) StorageCoreInit() (*storageCore, error) {
+	sCore := storageCore{}
+	sCore.sType = storageTypeLvm
+	typeName, err := storageTypeToString(sCore.sType)
+	if err != nil {
+		return nil, err
 	}
+	sCore.sTypeName = typeName
 
 	output, err := exec.Command("lvm", "version").CombinedOutput()
 	if err != nil {
@@ -174,33 +155,39 @@ func (s *storageLvm) Init(config map[string]interface{}) (storage, error) {
 	}
 	lines := strings.Split(string(output), "\n")
 
-	s.sTypeVersion = ""
+	sCore.sTypeVersion = ""
 	for idx, line := range lines {
 		fields := strings.SplitAfterN(line, ":", 2)
 		if len(fields) < 2 {
 			continue
 		}
 		if idx > 0 {
-			s.sTypeVersion += " / "
+			sCore.sTypeVersion += " / "
 		}
-		s.sTypeVersion += strings.TrimSpace(fields[1])
+		sCore.sTypeVersion += strings.TrimSpace(fields[1])
 	}
 
-	if config["vgName"] == nil {
-		vgName := daemonConfig["storage.lvm_vg_name"].Get()
-		if vgName == "" {
-			return s, fmt.Errorf("LVM isn't enabled")
-		}
+	err = sCore.initShared()
+	if err != nil {
+		return nil, err
+	}
 
-		if err := storageLVMCheckVolumeGroup(vgName); err != nil {
-			return s, err
-		}
-		s.vgName = vgName
-	} else {
-		s.vgName = config["vgName"].(string)
+	s.storageCore = sCore
+
+	return &sCore, nil
+}
+
+func (s *storageLvm) StoragePoolInit(config map[string]interface{}) (storage, error) {
+	_, err := s.StorageCoreInit()
+	if err != nil {
+		return s, err
 	}
 
 	return s, nil
+}
+
+func (s *storageLvm) StoragePoolCheck() error {
+	return nil
 }
 
 func versionSplit(versionString string) (int, int, int, error) {
@@ -245,31 +232,70 @@ func (s *storageLvm) lvmVersionIsAtLeast(versionString string) (bool, error) {
 
 }
 
-func (s *storageLvm) ContainerCreate(container container) error {
-	containerName := containerNameToLVName(container.Name())
-	lvpath, err := s.createThinLV(containerName)
+func (s *storageLvm) StoragePoolCreate() error {
+	tryUndo := true
+
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	// Create the mountpoint for the storage pool.
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+	err := os.MkdirAll(poolMntPoint, 0711)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if tryUndo {
+			os.Remove(poolMntPoint)
+		}
+	}()
 
-	if err := os.MkdirAll(container.Path(), 0755); err != nil {
-		return err
+	if !shared.IsBlockdevPath(source) {
+		return fmt.Errorf("Loop backed lvm storage volumes are currently not supported.")
 	}
 
-	var mode os.FileMode
-	if container.IsPrivileged() {
-		mode = 0700
-	} else {
-		mode = 0755
-	}
-
-	err = os.Chmod(container.Path(), mode)
+	// Create a lvm physical volume.
+	output, err := exec.Command("pvcreate", source).CombinedOutput()
 	if err != nil {
-		return err
+		return fmt.Errorf("Failed to create the physical volume for the lvm storage pool: %s.", output)
+	}
+	defer func() {
+		if tryUndo {
+			exec.Command("pvremove", source).Run()
+		}
+	}()
+
+	// Create a volume group on the physical volume.
+	output, err = exec.Command("vgcreate", s.pool.Name, source).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to create the volume group for the lvm storage pool: %s.", output)
 	}
 
-	dst := fmt.Sprintf("%s.lv", container.Path())
-	err = os.Symlink(lvpath, dst)
+	s.pool.Config["source"] = s.pool.Name
+
+	// Deregister cleanup.
+	tryUndo = false
+
+	return nil
+}
+
+func (s *storageLvm) StoragePoolDelete() error {
+	source := s.pool.Config["source"]
+	if source == "" {
+		return fmt.Errorf("No \"source\" property found for the storage pool.")
+	}
+
+	// Remove the volume group.
+	output, err := exec.Command("vgremove", "-f", s.pool.Name).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("Failed to destroy the volume group for the lvm storage pool: %s.", output)
+	}
+
+	// Delete the mountpoint for the storage pool.
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+	err = os.RemoveAll(poolMntPoint)
 	if err != nil {
 		return err
 	}
@@ -277,93 +303,337 @@ func (s *storageLvm) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageLvm) ContainerCreateFromImage(
-	container container, imageFingerprint string) error {
+func (s *storageLvm) StoragePoolMount() (bool, error) {
+	return true, nil
+}
 
-	imageLVFilename := shared.VarPath(
-		"images", fmt.Sprintf("%s.lv", imageFingerprint))
+func (s *storageLvm) StoragePoolUmount() (bool, error) {
+	return true, nil
+}
 
-	if !shared.PathExists(imageLVFilename) {
-		if err := s.ImageCreate(imageFingerprint); err != nil {
+func (s *storageLvm) StoragePoolVolumeCreate() error {
+	tryUndo := true
+
+	vgName := s.pool.Name
+	thinPoolName := s.volume.Config["lvm.thinpool_name"]
+	lvFsType := s.volume.Config["block.filesystem"]
+	lvSize := s.volume.Config["size"]
+
+	volumeType, err := storagePoolVolumeTypeNameToApiEndpoint(s.volume.Type)
+	if err != nil {
+		return err
+	}
+
+	err = s.createThinLV(vgName, thinPoolName, s.volume.Name, lvFsType, lvSize, volumeType)
+	if err != nil {
+		s.log.Error("LVMCreateThinLV", log.Ctx{"err": err})
+		return fmt.Errorf("Error Creating LVM LV for new image: %v", err)
+	}
+	defer func() {
+		if tryUndo {
+			s.StoragePoolVolumeDelete()
+		}
+	}()
+
+	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	err = os.MkdirAll(customPoolVolumeMntPoint, 0711)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.StoragePoolVolumeMount()
+	if err != nil {
+		return err
+	}
+
+	tryUndo = false
+
+	return nil
+}
+
+func (s *storageLvm) StoragePoolVolumeDelete() error {
+	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	_, err := s.StoragePoolVolumeUmount()
+	if err != nil {
+		return err
+	}
+
+	volumeType, err := storagePoolVolumeTypeNameToApiEndpoint(s.volume.Type)
+	if err != nil {
+		return err
+	}
+
+	err = s.removeLV(s.pool.Name, volumeType, s.volume.Name)
+	if err != nil {
+		return err
+	}
+
+	if shared.PathExists(customPoolVolumeMntPoint) {
+		err := os.Remove(customPoolVolumeMntPoint)
+		if err != nil {
 			return err
 		}
 	}
 
-	containerName := containerNameToLVName(container.Name())
+	return nil
+}
 
-	lvpath, err := s.createSnapshotLV(containerName, imageFingerprint, false)
+func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
+	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	if shared.IsMountPoint(customPoolVolumeMntPoint) {
+		return false, nil
+	}
+
+	lvFsType := s.volume.Config["block.filesystem"]
+	volumeType, err := storagePoolVolumeTypeNameToApiEndpoint(s.volume.Type)
+	if err != nil {
+		return false, err
+	}
+
+	lvmVolumePath := getLvmDevPath(s.pool.Name, volumeType, s.volume.Name)
+	mountOptions := s.volume.Config["block.mount_options"]
+	err = tryMount(lvmVolumePath, customPoolVolumeMntPoint, lvFsType, 0, mountOptions)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
+	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
+	if !shared.IsMountPoint(customPoolVolumeMntPoint) {
+		return false, nil
+	}
+
+	err := tryUnmount(customPoolVolumeMntPoint, 0)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *storageLvm) GetStoragePoolWritable() api.StoragePoolPut {
+	return s.pool.Writable()
+}
+
+func (s *storageLvm) GetStoragePoolVolumeWritable() api.StorageVolumePut {
+	return s.volume.Writable()
+}
+
+func (s *storageLvm) SetStoragePoolWritable(writable *api.StoragePoolPut) {
+	s.pool.StoragePoolPut = *writable
+}
+
+func (s *storageLvm) SetStoragePoolVolumeWritable(writable *api.StorageVolumePut) {
+	s.volume.StorageVolumePut = *writable
+}
+
+func (s *storageLvm) ContainerPoolGet() string {
+	return s.pool.Name
+}
+
+func (s *storageLvm) ContainerPoolIDGet() int64 {
+	return s.poolID
+}
+
+func (s *storageLvm) StoragePoolUpdate(changedConfig []string) error {
+	if shared.StringInSlice("size", changedConfig) {
+		return fmt.Errorf("The \"size\" property cannot be changed.")
+	}
+
+	if shared.StringInSlice("source", changedConfig) {
+		return fmt.Errorf("The \"source\" property cannot be changed.")
+	}
+
+	if shared.StringInSlice("volume.zfs.use_refquota", changedConfig) {
+		return fmt.Errorf("The \"volume.zfs.use_refquota\" property cannot be changed.")
+	}
+
+	if shared.StringInSlice("volume.zfs.remove_snapshots", changedConfig) {
+		return fmt.Errorf("The \"volume.zfs.remove_snapshots\" property cannot be changed.")
+	}
+
+	if shared.StringInSlice("zfs.pool_name", changedConfig) {
+		return fmt.Errorf("The \"zfs.pool_name\" property cannot be changed.")
+	}
+
+	if shared.StringInSlice("volume.block.mount_options", changedConfig) {
+		// noop
+	}
+
+	if shared.StringInSlice("volume.block.filesystem", changedConfig) {
+		// noop
+	}
+
+	if shared.StringInSlice("volume.size", changedConfig) {
+		// noop
+	}
+
+	if shared.StringInSlice("volume.lvm.thinpool_name", changedConfig) {
+		return fmt.Errorf("The \"volume.lvm.thinpool_name\" property cannot be changed.")
+	}
+
+	return nil
+}
+
+func (s *storageLvm) StoragePoolVolumeUpdate(changedConfig []string) error {
+	if shared.StringInSlice("block.mount_options", changedConfig) && len(changedConfig) == 1 {
+		// noop
+	} else {
+		return fmt.Errorf("The properties \"%v\" cannot be changed.", changedConfig)
+	}
+
+	return nil
+}
+
+func (s *storageLvm) ContainerCreate(container container) error {
+	tryUndo := true
+
+	containerName := container.Name()
+	containerLvmName := containerNameToLVName(containerName)
+	thinPoolName := s.volume.Config["lvm.thinpool_name"]
+	lvFsType := s.volume.Config["block.filesystem"]
+	lvSize := s.volume.Config["size"]
+
+	err := s.createThinLV(s.pool.Name, thinPoolName, containerLvmName, lvFsType, lvSize, storagePoolVolumeApiEndpointContainers)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if tryUndo {
+			s.ContainerDelete(container)
+		}
+	}()
 
-	destPath := container.Path()
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return fmt.Errorf("Error creating container directory: %v", err)
+	if container.IsSnapshot() {
+		containerMntPoint := getSnapshotMountPoint(s.pool.Name, containerName)
+		fields := strings.SplitN(containerName, shared.SnapshotDelimiter, 2)
+		sourceName := fields[0]
+		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", sourceName)
+		snapshotMntPointSymlink := shared.VarPath("snapshots", sourceName)
+		err := os.MkdirAll(containerMntPoint, 0755)
+		if err != nil {
+			return err
+		}
+		err = createSnapshotMountpoint(containerMntPoint, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
+		if err != nil {
+			return err
+		}
+	} else {
+		containerMntPoint := getContainerMountPoint(s.pool.Name, containerName)
+		containerPath := container.Path()
+		err := os.MkdirAll(containerMntPoint, 0755)
+		if err != nil {
+			return err
+		}
+		err = createContainerMountpoint(containerMntPoint, containerPath, container.IsPrivileged())
+		if err != nil {
+			return err
+		}
 	}
 
-	err = os.Chmod(destPath, 0700)
+	tryUndo = false
+
+	return nil
+}
+
+func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string) error {
+	tryUndo := true
+
+	// Check if the image already exists.
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	imageLvmDevPath := getLvmDevPath(s.pool.Name, storagePoolVolumeApiEndpointImages, fingerprint)
+
+	imageStoragePoolLockID := fmt.Sprintf("%s/%s", s.pool.Name, fingerprint)
+	imageCreationInPoolLock.Lock()
+	if waitChannel, ok := imageCreationInPool[imageStoragePoolLockID]; ok {
+		imageCreationInPoolLock.Unlock()
+		if _, ok := <-waitChannel; ok {
+			shared.LogWarnf("Value transmitted over image lock semaphore?")
+		}
+	} else {
+		imageCreationInPool[imageStoragePoolLockID] = make(chan bool)
+		var imgerr error
+		if !shared.PathExists(imageMntPoint) || !shared.PathExists(imageLvmDevPath) {
+			imgerr = s.ImageCreate(fingerprint)
+		}
+		if waitChannel, ok := imageCreationInPool[imageStoragePoolLockID]; ok {
+			close(waitChannel)
+			delete(imageCreationInPool, imageStoragePoolLockID)
+		}
+		imageCreationInPoolLock.Unlock()
+		if imgerr != nil {
+			return imgerr
+		}
+	}
+
+	containerName := container.Name()
+	containerLvmName := containerNameToLVName(containerName)
+	containerLvSnapshotPath, err := s.createSnapshotLV(s.pool.Name, fingerprint, storagePoolVolumeApiEndpointImages, containerLvmName, storagePoolVolumeApiEndpointContainers, false)
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if tryUndo {
+			s.ContainerDelete(container)
+		}
+	}()
 
-	dst := shared.VarPath("containers", fmt.Sprintf("%s.lv", container.Name()))
-	err = os.Symlink(lvpath, dst)
+	containerMntPoint := getContainerMountPoint(s.pool.Name, containerName)
+	containerPath := container.Path()
+	err = os.MkdirAll(containerMntPoint, 0755)
+	if err != nil {
+		return err
+	}
+	err = createContainerMountpoint(containerMntPoint, containerPath, container.IsPrivileged())
 	if err != nil {
 		return err
 	}
 
 	// Generate a new xfs's UUID
-	fstype := daemonConfig["storage.lvm_fstype"].Get()
-	if fstype == "xfs" {
-		err := xfsGenerateNewUUID(lvpath)
+	lvFsType := s.volume.Config["block.filesystem"]
+	if lvFsType == "xfs" {
+		err := xfsGenerateNewUUID(containerLvSnapshotPath)
 		if err != nil {
-			s.ContainerDelete(container)
 			return err
 		}
 	}
 
-	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
-	err = tryMount(lvpath, destPath, fstype, 0, mountOptions)
+	ourMount, err := s.ContainerMount(containerName, containerPath)
 	if err != nil {
-		s.ContainerDelete(container)
-		return fmt.Errorf("Error mounting snapshot LV: %v", err)
+		return err
+	}
+	if ourMount {
+		defer s.ContainerUmount(containerName, containerPath)
 	}
 
-	var mode os.FileMode
 	if container.IsPrivileged() {
-		mode = 0700
+		err = os.Chmod(containerMntPoint, 0700)
 	} else {
-		mode = 0755
+		err = os.Chmod(containerMntPoint, 0755)
 	}
-
-	err = os.Chmod(destPath, mode)
 	if err != nil {
 		return err
 	}
 
 	if !container.IsPrivileged() {
-		if err = s.shiftRootfs(container); err != nil {
-			err2 := tryUnmount(destPath, 0)
-			if err2 != nil {
-				return fmt.Errorf("Error in umount: '%s' while cleaning up after error in shiftRootfs: '%s'", err2, err)
-			}
-			s.ContainerDelete(container)
-			return fmt.Errorf("Error in shiftRootfs: %v", err)
+		err := s.shiftRootfs(container)
+		if err != nil {
+			return err
 		}
 	}
 
 	err = container.TemplateApply("create")
 	if err != nil {
-		s.log.Error("Error in create template during ContainerCreateFromImage, continuing to unmount",
-			log.Ctx{"err": err})
+		s.log.Error("Error in create template during ContainerCreateFromImage, continuing to unmount", log.Ctx{"err": err})
+		return err
 	}
 
-	umounterr := tryUnmount(destPath, 0)
-	if umounterr != nil {
-		return fmt.Errorf("Error unmounting '%s' after shiftRootfs: %v", destPath, umounterr)
-	}
+	tryUndo = false
 
-	return err
+	return nil
 }
 
 func (s *storageLvm) ContainerCanRestore(container container, sourceContainer container) error {
@@ -371,107 +641,177 @@ func (s *storageLvm) ContainerCanRestore(container container, sourceContainer co
 }
 
 func (s *storageLvm) ContainerDelete(container container) error {
-	lvName := containerNameToLVName(container.Name())
-	if err := s.removeLV(lvName); err != nil {
+	containerName := container.Name()
+	containerLvmName := containerNameToLVName(containerName)
+	containerMntPoint := ""
+
+	if container.IsSnapshot() {
+		containerMntPoint = getSnapshotMountPoint(s.pool.Name, containerName)
+	} else {
+		containerMntPoint = getContainerMountPoint(s.pool.Name, containerName)
+	}
+
+	// Make sure that the container is really unmounted at this point.
+	// Otherwise we will fail.
+	if shared.IsMountPoint(containerMntPoint) {
+		err := tryUnmount(containerMntPoint, 0)
+		if err != nil {
+			return fmt.Errorf("failed to unmount container path '%s': %s", containerMntPoint, err)
+		}
+	}
+
+	err := s.removeLV(s.pool.Name, storagePoolVolumeApiEndpointContainers, containerLvmName)
+	if err != nil {
 		return err
 	}
 
-	lvLinkPath := fmt.Sprintf("%s.lv", container.Path())
-	if err := os.Remove(lvLinkPath); err != nil {
-		return err
+	if container.IsSnapshot() {
+		fields := strings.SplitN(containerName, shared.SnapshotDelimiter, 2)
+		sourceName := fields[0]
+		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", sourceName)
+		snapshotMntPointSymlink := shared.VarPath("snapshots", sourceName)
+		err = deleteSnapshotMountpoint(containerMntPoint, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
+	} else {
+		err = tryUnmount(containerMntPoint, 0)
+		err = deleteContainerMountpoint(containerMntPoint, container.Path(), s.GetStorageTypeName())
 	}
-
-	cPath := container.Path()
-	if err := os.RemoveAll(cPath); err != nil {
-		s.log.Error("ContainerDelete: failed to remove path", log.Ctx{"cPath": cPath, "err": err})
-		return fmt.Errorf("Cleaning up %s: %s", cPath, err)
+	if err != nil {
+		return err
 	}
 
 	return nil
 }
 
 func (s *storageLvm) ContainerCopy(container container, sourceContainer container) error {
-	if s.isLVMContainer(sourceContainer) {
-		if err := s.createSnapshotContainer(container, sourceContainer, false); err != nil {
+	tryUndo := true
+
+	err := sourceContainer.StorageStart()
+	if err != nil {
+		return err
+	}
+	defer sourceContainer.StorageStop()
+
+	if sourceContainer.Storage().GetStorageType() == storageTypeLvm {
+		err := s.createSnapshotContainer(container, sourceContainer, false)
+		if err != nil {
 			s.log.Error("Error creating snapshot LV for copy", log.Ctx{"err": err})
 			return err
 		}
 	} else {
-		s.log.Info("Copy from Non-LVM container", log.Ctx{"container": container.Name(),
-			"sourceContainer": sourceContainer.Name()})
-		if err := s.ContainerCreate(container); err != nil {
+		sourceContainerName := sourceContainer.Name()
+		targetContainerName := container.Name()
+		s.log.Info("Copy from Non-LVM container", log.Ctx{"container": targetContainerName, "sourceContainer": sourceContainerName})
+		err := s.ContainerCreate(container)
+		if err != nil {
 			s.log.Error("Error creating empty container", log.Ctx{"err": err})
 			return err
 		}
+		defer func() {
+			if tryUndo {
+				s.ContainerDelete(container)
+			}
+		}()
 
-		if err := s.ContainerStart(container.Name(), container.Path()); err != nil {
-			s.log.Error("Error starting/mounting container", log.Ctx{"err": err, "container": container.Name()})
-			s.ContainerDelete(container)
+		targetContainerPath := container.Path()
+		ourSourceMount, err := s.ContainerMount(targetContainerName, targetContainerPath)
+		if err != nil {
+			s.log.Error("Error starting/mounting container", log.Ctx{"err": err, "container": targetContainerName})
 			return err
 		}
+		if ourSourceMount {
+			defer s.ContainerUmount(targetContainerName, targetContainerPath)
+		}
 
-		output, err := storageRsyncCopy(
-			sourceContainer.Path(),
-			container.Path())
+		sourceContainerPath := sourceContainer.Path()
+		ourTargetMount, err := sourceContainer.Storage().ContainerMount(sourceContainerName, sourceContainerPath)
+		if err != nil {
+			return err
+		}
+		if ourTargetMount {
+			sourceContainer.Storage().ContainerUmount(sourceContainerName, sourceContainerPath)
+		}
+
+		sourcePool := sourceContainer.Storage().ContainerPoolGet()
+		sourceContainerMntPoint := getContainerMountPoint(sourcePool, sourceContainerName)
+		targetContainerMntPoint := getContainerMountPoint(s.pool.Name, targetContainerName)
+		output, err := storageRsyncCopy(sourceContainerMntPoint, targetContainerMntPoint)
 		if err != nil {
 			s.log.Error("ContainerCopy: rsync failed", log.Ctx{"output": string(output)})
 			s.ContainerDelete(container)
 			return fmt.Errorf("rsync failed: %s", string(output))
 		}
+	}
 
-		if err := s.ContainerStop(container.Name(), container.Path()); err != nil {
-			return err
+	err = container.TemplateApply("copy")
+	if err != nil {
+		return err
+	}
+
+	tryUndo = false
+
+	return nil
+}
+
+func (s *storageLvm) ContainerMount(name string, path string) (bool, error) {
+	containerLvmName := containerNameToLVName(name)
+	lvFsType := s.volume.Config["block.filesystem"]
+	containerLvmPath := getLvmDevPath(s.pool.Name, storagePoolVolumeApiEndpointContainers, containerLvmName)
+	mountOptions := s.volume.Config["block.mount_options"]
+	containerMntPoint := getContainerMountPoint(s.pool.Name, name)
+
+	if shared.IsMountPoint(containerMntPoint) {
+		return false, nil
+	}
+
+	err := tryMount(containerLvmPath, containerMntPoint, lvFsType, 0, mountOptions)
+	if err != nil {
+		return false, fmt.Errorf("Error mounting snapshot LV path='%s': %s", path, err)
+	}
+
+	return true, nil
+}
+
+func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
+	containerMntPoint := getContainerMountPoint(s.pool.Name, name)
+
+	if !shared.IsMountPoint(containerMntPoint) {
+		return false, nil
+	}
+
+	err := tryUnmount(containerMntPoint, 0)
+	if err != nil {
+		return false, fmt.Errorf("failed to unmount container path '%s': %s", path, err)
+	}
+
+	return true, nil
+}
+
+func (s *storageLvm) ContainerRename(container container, newContainerName string) error {
+	tryUndo := true
+
+	oldName := container.Name()
+	oldLvmName := containerNameToLVName(oldName)
+	newLvmName := containerNameToLVName(newContainerName)
+
+	_, err := s.ContainerUmount(oldName, container.Path())
+	if err != nil {
+		return err
+	}
+
+	output, err := s.renameLV(oldLvmName, newLvmName, storagePoolVolumeApiEndpointContainers)
+	if err != nil {
+		s.log.Error("Failed to rename a container LV", log.Ctx{"oldName": oldLvmName, "newName": newLvmName, "err": err, "output": string(output)})
+		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'", oldLvmName, newLvmName, err)
+	}
+	defer func() {
+		if tryUndo {
+			s.renameLV(newLvmName, oldLvmName, storagePoolVolumeApiEndpointContainers)
 		}
-	}
-	return container.TemplateApply("copy")
-}
+	}()
 
-func (s *storageLvm) ContainerStart(name string, path string) error {
-	lvName := containerNameToLVName(name)
-	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvName)
-	fstype := daemonConfig["storage.lvm_fstype"].Get()
-
-	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
-	err := tryMount(lvpath, path, fstype, 0, mountOptions)
-	if err != nil {
-		return fmt.Errorf(
-			"Error mounting snapshot LV path='%s': %v",
-			path,
-			err)
-	}
-
-	return nil
-}
-
-func (s *storageLvm) ContainerStop(name string, path string) error {
-	err := tryUnmount(path, 0)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to unmount container path '%s'.\nError: %v",
-			path,
-			err)
-	}
-
-	return nil
-}
-
-func (s *storageLvm) ContainerRename(
-	container container, newContainerName string) error {
-
-	oldName := containerNameToLVName(container.Name())
-	newName := containerNameToLVName(newContainerName)
-	output, err := s.renameLV(oldName, newName)
-	if err != nil {
-		s.log.Error("Failed to rename a container LV",
-			log.Ctx{"oldName": oldName,
-				"newName": newName,
-				"err":     err,
-				"output":  string(output)})
-
-		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'", oldName, newName, err)
-	}
-
-	// Rename the snapshots
+	// MAYBE(FIXME(brauner)): Register another cleanup function that tries to
+	// rename alreday renamed snapshots back to their old name when the
+	// rename fails.
 	if !container.IsSnapshot() {
 		snaps, err := container.Snapshots()
 		if err != nil {
@@ -480,60 +820,82 @@ func (s *storageLvm) ContainerRename(
 
 		for _, snap := range snaps {
 			baseSnapName := filepath.Base(snap.Name())
-			newSnapshotName := newName + shared.SnapshotDelimiter + baseSnapName
+			newSnapshotName := newContainerName + shared.SnapshotDelimiter + baseSnapName
 			err := s.ContainerRename(snap, newSnapshotName)
 			if err != nil {
 				return err
 			}
+		}
 
-			oldPathParent := filepath.Dir(snap.Path())
-			if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
-				os.Remove(oldPathParent)
+		oldContainerMntPoint := getContainerMountPoint(s.pool.Name, oldName)
+		oldContainerMntPointSymlink := container.Path()
+		newContainerMntPoint := getContainerMountPoint(s.pool.Name, newContainerName)
+		newContainerMntPointSymlink := shared.VarPath("containers", newContainerName)
+		err = renameContainerMountpoint(oldContainerMntPoint, oldContainerMntPointSymlink, newContainerMntPoint, newContainerMntPointSymlink)
+		if err != nil {
+			return err
+		}
+
+		oldSnapshotPath := getSnapshotMountPoint(s.pool.Name, oldName)
+		newSnapshotPath := getSnapshotMountPoint(s.pool.Name, newContainerName)
+		if shared.PathExists(oldSnapshotPath) {
+			err = os.Rename(oldSnapshotPath, newSnapshotPath)
+			if err != nil {
+				return err
+			}
+		}
+
+		oldSnapshotSymlink := shared.VarPath("snapshots", oldName)
+		newSnapshotSymlink := shared.VarPath("snapshots", newContainerName)
+		if shared.PathExists(oldSnapshotSymlink) {
+			err := os.Remove(oldSnapshotSymlink)
+			if err != nil {
+				return err
+			}
+
+			err = os.Symlink(newSnapshotPath, newSnapshotSymlink)
+			if err != nil {
+				return err
 			}
 		}
 	}
 
-	// Create a new symlink
-	newSymPath := fmt.Sprintf("%s.lv", containerPath(newContainerName, container.IsSnapshot()))
-
-	err = os.MkdirAll(filepath.Dir(containerPath(newContainerName, container.IsSnapshot())), 0700)
-	if err != nil {
-		return err
-	}
-
-	err = os.Symlink(fmt.Sprintf("/dev/%s/%s", s.vgName, newName), newSymPath)
-	if err != nil {
-		return err
-	}
-
-	// Remove the old symlink
-	oldSymPath := fmt.Sprintf("%s.lv", container.Path())
-	err = os.Remove(oldSymPath)
-	if err != nil {
-		return err
-	}
-
-	// Rename the directory
-	err = os.Rename(container.Path(), containerPath(newContainerName, container.IsSnapshot()))
-	if err != nil {
-		return err
-	}
+	tryUndo = false
 
 	return nil
-
 }
 
-func (s *storageLvm) ContainerRestore(
-	container container, sourceContainer container) error {
-	srcName := containerNameToLVName(sourceContainer.Name())
-	destName := containerNameToLVName(container.Name())
-
-	err := s.removeLV(destName)
+func (s *storageLvm) ContainerRestore(container container, sourceContainer container) error {
+	err := sourceContainer.StorageStart()
 	if err != nil {
-		return fmt.Errorf("Error removing LV about to be restored over: %v", err)
+		return err
+	}
+	defer sourceContainer.StorageStop()
+
+	if s.pool.Name != sourceContainer.Storage().ContainerPoolGet() {
+		return fmt.Errorf("Containers must be on the same pool to be restored.")
 	}
 
-	_, err = s.createSnapshotLV(destName, srcName, false)
+	srcName := sourceContainer.Name()
+	srcLvName := containerNameToLVName(srcName)
+	if sourceContainer.IsSnapshot() {
+		srcLvName = getTmpSnapshotName(srcLvName)
+	}
+
+	destName := container.Name()
+	destLvName := containerNameToLVName(destName)
+
+	_, err = container.Storage().ContainerUmount(container.Name(), container.Path())
+	if err != nil {
+		return err
+	}
+
+	err = s.removeLV(s.pool.Name, storagePoolVolumeApiEndpointContainers, destName)
+	if err != nil {
+		s.log.Error(fmt.Sprintf("Failed to remove \"%s\": %s.", destName, err))
+	}
+
+	_, err = s.createSnapshotLV(s.pool.Name, srcLvName, storagePoolVolumeApiEndpointContainers, destLvName, storagePoolVolumeApiEndpointContainers, false)
 	if err != nil {
 		return fmt.Errorf("Error creating snapshot LV: %v", err)
 	}
@@ -549,154 +911,154 @@ func (s *storageLvm) ContainerGetUsage(container container) (int64, error) {
 	return -1, fmt.Errorf("The LVM container backend doesn't support quotas.")
 }
 
-func (s *storageLvm) ContainerSnapshotCreate(
-	snapshotContainer container, sourceContainer container) error {
+func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
 	return s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
 }
 
-func (s *storageLvm) createSnapshotContainer(
-	snapshotContainer container, sourceContainer container, readonly bool) error {
+func (s *storageLvm) createSnapshotContainer(snapshotContainer container, sourceContainer container, readonly bool) error {
+	tryUndo := true
 
-	srcName := containerNameToLVName(sourceContainer.Name())
-	destName := containerNameToLVName(snapshotContainer.Name())
-	shared.LogDebug(
-		"Creating snapshot",
-		log.Ctx{"srcName": srcName, "destName": destName})
+	sourceContainerName := sourceContainer.Name()
+	targetContainerName := snapshotContainer.Name()
+	sourceContainerLvmName := containerNameToLVName(sourceContainerName)
+	targetContainerLvmName := containerNameToLVName(targetContainerName)
+	shared.LogDebug("Creating snapshot", log.Ctx{"srcName": sourceContainerName, "destName": targetContainerName})
 
-	lvpath, err := s.createSnapshotLV(destName, srcName, readonly)
+	_, err := s.createSnapshotLV(s.pool.Name, sourceContainerLvmName, storagePoolVolumeApiEndpointContainers, targetContainerLvmName, storagePoolVolumeApiEndpointContainers, readonly)
 	if err != nil {
-		return fmt.Errorf("Error creating snapshot LV: %v", err)
+		return fmt.Errorf("Error creating snapshot LV: %s", err)
 	}
+	defer func() {
+		if tryUndo {
+			s.ContainerCreate(snapshotContainer)
+		}
+	}()
 
-	destPath := snapshotContainer.Path()
-	if err := os.MkdirAll(destPath, 0755); err != nil {
-		return fmt.Errorf("Error creating container directory: %v", err)
-	}
-
-	var mode os.FileMode
-	if snapshotContainer.IsPrivileged() {
-		mode = 0700
+	targetContainerMntPoint := ""
+	targetContainerPath := snapshotContainer.Path()
+	targetIsSnapshot := snapshotContainer.IsSnapshot()
+	if targetIsSnapshot {
+		targetContainerMntPoint = getSnapshotMountPoint(s.pool.Name, targetContainerName)
+		sourceFields := strings.SplitN(sourceContainerName, shared.SnapshotDelimiter, 2)
+		sourceName := sourceFields[0]
+		sourcePool := sourceContainer.Storage().ContainerPoolGet()
+		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", sourcePool, "snapshots", sourceName)
+		snapshotMntPointSymlink := shared.VarPath("snapshots", sourceName)
+		err = createSnapshotMountpoint(targetContainerMntPoint, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
 	} else {
-		mode = 0755
+		targetContainerMntPoint = getContainerMountPoint(s.pool.Name, targetContainerName)
+		err = createContainerMountpoint(targetContainerMntPoint, targetContainerPath, snapshotContainer.IsPrivileged())
 	}
-
-	err = os.Chmod(destPath, mode)
 	if err != nil {
 		return err
 	}
 
-	dest := fmt.Sprintf("%s.lv", snapshotContainer.Path())
-	err = os.Symlink(lvpath, dest)
-	if err != nil {
-		return err
-	}
+	tryUndo = false
 
 	return nil
 }
 
-func (s *storageLvm) ContainerSnapshotDelete(
-	snapshotContainer container) error {
-
+func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer container) error {
 	err := s.ContainerDelete(snapshotContainer)
 	if err != nil {
 		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.Name(), err)
 	}
 
-	oldPathParent := filepath.Dir(snapshotContainer.Path())
-	if ok, _ := shared.PathIsEmpty(oldPathParent); ok {
-		os.Remove(oldPathParent)
-	}
 	return nil
 }
 
-func (s *storageLvm) ContainerSnapshotRename(
-	snapshotContainer container, newContainerName string) error {
-	oldName := containerNameToLVName(snapshotContainer.Name())
-	newName := containerNameToLVName(newContainerName)
-	oldPath := snapshotContainer.Path()
-	oldSymPath := fmt.Sprintf("%s.lv", oldPath)
-	newPath := containerPath(newContainerName, true)
-	newSymPath := fmt.Sprintf("%s.lv", newPath)
+func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newContainerName string) error {
+	tryUndo := true
 
-	// Rename the LV
-	output, err := s.renameLV(oldName, newName)
+	oldName := snapshotContainer.Name()
+	oldLvmName := containerNameToLVName(oldName)
+	newLvmName := containerNameToLVName(newContainerName)
+
+	output, err := s.renameLV(oldLvmName, newLvmName, storagePoolVolumeApiEndpointContainers)
 	if err != nil {
-		s.log.Error("Failed to rename a snapshot LV",
-			log.Ctx{"oldName": oldName, "newName": newName, "err": err, "output": string(output)})
-		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'", oldName, newName, err)
+		s.log.Error("Failed to rename a snapshot LV", log.Ctx{"oldName": oldLvmName, "newName": newLvmName, "err": err, "output": string(output)})
+		return fmt.Errorf("Failed to rename a container LV, oldName='%s', newName='%s', err='%s'", oldLvmName, newLvmName, err)
+	}
+	defer func() {
+		if tryUndo {
+			s.renameLV(newLvmName, oldLvmName, storagePoolVolumeApiEndpointContainers)
+		}
+	}()
+
+	oldSnapshotMntPoint := getSnapshotMountPoint(s.pool.Name, oldName)
+	newSnapshotMntPoint := getSnapshotMountPoint(s.pool.Name, newContainerName)
+	err = os.Rename(oldSnapshotMntPoint, newSnapshotMntPoint)
+	if err != nil {
+		return err
 	}
 
-	// Delete the symlink
-	err = os.Remove(oldSymPath)
-	if err != nil {
-		return fmt.Errorf("Failed to remove old symlink: %s", err)
-	}
-
-	// Create the symlink
-	err = os.Symlink(fmt.Sprintf("/dev/%s/%s", s.vgName, newName), newSymPath)
-	if err != nil {
-		return fmt.Errorf("Failed to create symlink: %s", err)
-	}
-
-	// Rename the mount point
-	err = os.Rename(oldPath, newPath)
-	if err != nil {
-		return fmt.Errorf("Failed to rename mountpoint: %s", err)
-	}
+	tryUndo = false
 
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotStart(container container) error {
-	srcName := containerNameToLVName(container.Name())
-	destName := containerNameToLVName(container.Name() + "/rw")
+	tryUndo := true
 
-	shared.LogDebug(
-		"Creating snapshot",
-		log.Ctx{"srcName": srcName, "destName": destName})
+	sourceName := container.Name()
+	targetName := sourceName
+	sourceLvmName := containerNameToLVName(sourceName)
+	targetLvmName := containerNameToLVName(targetName)
 
-	lvpath, err := s.createSnapshotLV(destName, srcName, false)
+	tmpTargetLvmName := getTmpSnapshotName(targetLvmName)
+
+	shared.LogDebug("Creating snapshot", log.Ctx{"srcName": sourceLvmName, "destName": targetLvmName})
+
+	lvpath, err := s.createSnapshotLV(s.pool.Name, sourceLvmName, storagePoolVolumeApiEndpointContainers, tmpTargetLvmName, storagePoolVolumeApiEndpointContainers, false)
 	if err != nil {
-		return fmt.Errorf("Error creating snapshot LV: %v", err)
+		return fmt.Errorf("Error creating snapshot LV: %s", err)
 	}
-
-	destPath := container.Path()
-	if !shared.PathExists(destPath) {
-		if err := os.MkdirAll(destPath, 0755); err != nil {
-			return fmt.Errorf("Error creating container directory: %v", err)
+	defer func() {
+		if tryUndo {
+			s.removeLV(s.pool.Name, storagePoolVolumeApiEndpointContainers, tmpTargetLvmName)
 		}
-	}
+	}()
+
+	lvFsType := s.volume.Config["block.filesystem"]
+	containerLvmPath := getLvmDevPath(s.pool.Name, storagePoolVolumeApiEndpointContainers, tmpTargetLvmName)
+	mountOptions := s.volume.Config["block.mount_options"]
+	containerMntPoint := getSnapshotMountPoint(s.pool.Name, sourceName)
 
 	// Generate a new xfs's UUID
-	fstype := daemonConfig["storage.lvm_fstype"].Get()
-	if fstype == "xfs" {
+	if lvFsType == "xfs" {
 		err := xfsGenerateNewUUID(lvpath)
 		if err != nil {
-			s.ContainerDelete(container)
 			return err
 		}
 	}
 
-	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
-	err = tryMount(lvpath, container.Path(), fstype, 0, mountOptions)
-	if err != nil {
-		return fmt.Errorf(
-			"Error mounting snapshot LV path='%s': %v",
-			container.Path(),
-			err)
+	if !shared.IsMountPoint(containerMntPoint) {
+		err = tryMount(containerLvmPath, containerMntPoint, lvFsType, 0, mountOptions)
+		if err != nil {
+			return fmt.Errorf("Error mounting snapshot LV path='%s': %s", containerMntPoint, err)
+		}
 	}
+
+	tryUndo = false
 
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotStop(container container) error {
-	err := s.ContainerStop(container.Name(), container.Path())
-	if err != nil {
-		return err
+	name := container.Name()
+	snapshotMntPoint := getSnapshotMountPoint(s.pool.Name, name)
+
+	if shared.IsMountPoint(snapshotMntPoint) {
+		err := tryUnmount(snapshotMntPoint, 0)
+		if err != nil {
+			return err
+		}
 	}
 
-	lvName := containerNameToLVName(container.Name() + "/rw")
-	if err := s.removeLV(lvName); err != nil {
+	lvName := containerNameToLVName(name)
+	tmpLvName := getTmpSnapshotName(lvName)
+	err := s.removeLV(s.pool.Name, storagePoolVolumeApiEndpointContainers, tmpLvName)
+	if err != nil {
 		return err
 	}
 
@@ -708,259 +1070,275 @@ func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 }
 
 func (s *storageLvm) ImageCreate(fingerprint string) error {
-	finalName := shared.VarPath("images", fingerprint)
+	tryUndo := true
 
-	lvpath, err := s.createThinLV(fingerprint)
+	vgName := s.pool.Name
+	thinPoolName := s.volume.Config["lvm.thinpool_name"]
+	lvFsType := s.volume.Config["block.filesystem"]
+	lvSize := s.volume.Config["size"]
+
+	err := s.createImageDbPoolVolume(fingerprint)
+	if err != nil {
+		return err
+	}
+
+	err = s.createThinLV(vgName, thinPoolName, fingerprint, lvFsType, lvSize, storagePoolVolumeApiEndpointImages)
 	if err != nil {
 		s.log.Error("LVMCreateThinLV", log.Ctx{"err": err})
 		return fmt.Errorf("Error Creating LVM LV for new image: %v", err)
 	}
-
-	dst := shared.VarPath("images", fmt.Sprintf("%s.lv", fingerprint))
-	err = os.Symlink(lvpath, dst)
-	if err != nil {
-		return err
-	}
-
-	tempLVMountPoint, err := ioutil.TempDir(shared.VarPath("images"), "tmp_lv_mnt")
-	if err != nil {
-		return err
-	}
 	defer func() {
-		if err := os.RemoveAll(tempLVMountPoint); err != nil {
-			s.log.Error("Deleting temporary LVM mount point", log.Ctx{"err": err})
+		if tryUndo {
+			s.ImageDelete(fingerprint)
 		}
 	}()
 
-	fstype := daemonConfig["storage.lvm_fstype"].Get()
-	mountOptions := daemonConfig["storage.lvm_mount_options"].Get()
-	err = tryMount(lvpath, tempLVMountPoint, fstype, 0, mountOptions)
-	if err != nil {
-		shared.LogInfof("Error mounting image LV for unpacking: %v", err)
-		return fmt.Errorf("Error mounting image LV: %v", err)
-	}
-
-	unpackErr := unpackImage(s.d, finalName, tempLVMountPoint)
-
-	err = tryUnmount(tempLVMountPoint, 0)
-	if err != nil {
-		s.log.Warn("could not unmount LV. Will not remove",
-			log.Ctx{"lvpath": lvpath, "mountpoint": tempLVMountPoint, "err": err})
-		if unpackErr == nil {
+	// Create image mountpoint.
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	if !shared.PathExists(imageMntPoint) {
+		err := os.MkdirAll(imageMntPoint, 0700)
+		if err != nil {
 			return err
 		}
-
-		return fmt.Errorf(
-			"Error unmounting '%s' during cleanup of error %v",
-			tempLVMountPoint, unpackErr)
 	}
 
-	if unpackErr != nil {
-		s.removeLV(fingerprint)
-		return unpackErr
+	_, err = s.ImageMount(fingerprint)
+	if err != nil {
+		return err
 	}
+
+	imagePath := shared.VarPath("images", fingerprint)
+	err = unpackImage(s.d, imagePath, imageMntPoint, storageTypeLvm)
+	if err != nil {
+		return err
+	}
+
+	s.ImageUmount(fingerprint)
+
+	tryUndo = false
 
 	return nil
 }
 
 func (s *storageLvm) ImageDelete(fingerprint string) error {
-	err := s.removeLV(fingerprint)
+	_, err := s.ImageUmount(fingerprint)
 	if err != nil {
 		return err
 	}
 
-	lvsymlink := fmt.Sprintf(
-		"%s.lv", shared.VarPath("images", fingerprint))
-	err = os.Remove(lvsymlink)
+	err = s.removeLV(s.pool.Name, storagePoolVolumeApiEndpointImages, fingerprint)
 	if err != nil {
-		return fmt.Errorf(
-			"Failed to remove symlink to deleted image LV: '%s': %v", lvsymlink, err)
+		return err
+	}
+
+	err = s.deleteImageDbPoolVolume(fingerprint)
+	if err != nil {
+		return err
+	}
+
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	if shared.PathExists(imageMntPoint) {
+		err := os.Remove(imageMntPoint)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil
 }
 
-func (s *storageLvm) createDefaultThinPool() (string, error) {
-	thinPoolName := daemonConfig["storage.lvm_thinpool_name"].Get()
-	isRecent, err := s.lvmVersionIsAtLeast("2.02.99")
+func (s *storageLvm) ImageMount(fingerprint string) (bool, error) {
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	if shared.IsMountPoint(imageMntPoint) {
+		return false, nil
+	}
+
+	// Shouldn't happen.
+	lvmFstype := s.volume.Config["block.filesystem"]
+	if lvmFstype == "" {
+		return false, fmt.Errorf("No filesystem type specified.")
+	}
+
+	lvmVolumePath := getLvmDevPath(s.pool.Name, storagePoolVolumeApiEndpointImages, fingerprint)
+	lvmMountOptions := s.volume.Config["block.mount_options"]
+	// Shouldn't be necessary since it should be validated in the config
+	// checks.
+	if lvmFstype == "ext4" && lvmMountOptions == "" {
+		lvmMountOptions = "discard"
+	}
+
+	err := tryMount(lvmVolumePath, imageMntPoint, lvmFstype, 0, lvmMountOptions)
 	if err != nil {
-		return "", fmt.Errorf("Error checking LVM version: %v", err)
+		shared.LogInfof("Error mounting image LV for unpacking: %s", err)
+		return false, fmt.Errorf("Error mounting image LV: %v", err)
 	}
 
-	// Create the thin pool
-	var output []byte
-	if isRecent {
-		output, err = tryExec(
-			"lvcreate",
-			"--poolmetadatasize", "1G",
-			"-l", "100%FREE",
-			"--thinpool",
-			fmt.Sprintf("%s/%s", s.vgName, thinPoolName))
-	} else {
-		output, err = tryExec(
-			"lvcreate",
-			"--poolmetadatasize", "1G",
-			"-L", "1G",
-			"--thinpool",
-			fmt.Sprintf("%s/%s", s.vgName, thinPoolName))
-	}
-
-	if err != nil {
-		s.log.Error(
-			"Could not create thin pool",
-			log.Ctx{
-				"name":   thinPoolName,
-				"err":    err,
-				"output": string(output)})
-
-		return "", fmt.Errorf(
-			"Could not create LVM thin pool named %s", thinPoolName)
-	}
-
-	if !isRecent {
-		// Grow it to the maximum VG size (two step process required by old LVM)
-		output, err = tryExec(
-			"lvextend",
-			"--alloc", "anywhere",
-			"-l", "100%FREE",
-			fmt.Sprintf("%s/%s", s.vgName, thinPoolName))
-
-		if err != nil {
-			s.log.Error(
-				"Could not grow thin pool",
-				log.Ctx{
-					"name":   thinPoolName,
-					"err":    err,
-					"output": string(output)})
-
-			return "", fmt.Errorf(
-				"Could not grow LVM thin pool named %s", thinPoolName)
-		}
-	}
-
-	return thinPoolName, nil
+	return true, nil
 }
 
-func (s *storageLvm) createThinLV(lvname string) (string, error) {
-	var err error
+func (s *storageLvm) ImageUmount(fingerprint string) (bool, error) {
+	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
+	if !shared.IsMountPoint(imageMntPoint) {
+		return false, nil
+	}
 
-	vgname := daemonConfig["storage.lvm_vg_name"].Get()
-	poolname := daemonConfig["storage.lvm_thinpool_name"].Get()
-	exists, err := storageLVMThinpoolExists(vgname, poolname)
+	err := tryUnmount(imageMntPoint, 0)
 	if err != nil {
-		return "", err
+		return false, err
+	}
+
+	return true, nil
+}
+
+func (s *storageLvm) createThinLV(vgName string, thinPoolName string, lvName string, lvFsType string, lvSize string, volumeType string) error {
+	exists, err := storageLVMThinpoolExists(vgName, thinPoolName)
+	if err != nil {
+		return err
 	}
 
 	if !exists {
-		poolname, err = s.createDefaultThinPool()
+		err := s.createDefaultThinPool(vgName, thinPoolName, lvName, lvFsType)
 		if err != nil {
-			return "", fmt.Errorf("Error creating LVM thin pool: %v", err)
+			return err
 		}
 
-		err = storageLVMValidateThinPoolName(s.d, "", poolname)
+		err = storageLVMValidateThinPoolName(s.d, vgName, thinPoolName)
 		if err != nil {
 			s.log.Error("Setting thin pool name", log.Ctx{"err": err})
-			return "", fmt.Errorf("Error setting LVM thin pool config: %v", err)
+			return fmt.Errorf("Error setting LVM thin pool config: %v", err)
 		}
 	}
 
-	lvSize := daemonConfig["storage.lvm_volume_size"].Get()
-
+	lvmThinPoolPath := fmt.Sprintf("%s/%s", vgName, thinPoolName)
+	lvmPoolVolumeName := getPrefixedLvName(volumeType, lvName)
 	output, err := tryExec(
 		"lvcreate",
 		"--thin",
-		"-n", lvname,
-		"--virtualsize", lvSize,
-		fmt.Sprintf("%s/%s", s.vgName, poolname))
+		"-n", lvmPoolVolumeName,
+		"--virtualsize", lvSize+"B", lvmThinPoolPath)
 	if err != nil {
-		s.log.Error("Could not create LV", log.Ctx{"lvname": lvname, "output": string(output)})
-		return "", fmt.Errorf("Could not create thin LV named %s", lvname)
+		s.log.Error("Could not create LV", log.Ctx{"lvname": lvmPoolVolumeName, "output": string(output)})
+		return fmt.Errorf("Could not create thin LV named %s", lvmPoolVolumeName)
 	}
 
-	lvpath := fmt.Sprintf("/dev/%s/%s", s.vgName, lvname)
-
-	fstype := daemonConfig["storage.lvm_fstype"].Get()
-	switch fstype {
+	fsPath := getLvmDevPath(vgName, volumeType, lvName)
+	switch lvFsType {
 	case "xfs":
-		output, err = tryExec(
-			"mkfs.xfs",
-			lvpath)
+		output, err = tryExec("mkfs.xfs", fsPath)
 	default:
 		// default = ext4
 		output, err = tryExec(
 			"mkfs.ext4",
 			"-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0",
-			lvpath)
+			fsPath)
 	}
 
 	if err != nil {
 		s.log.Error("Filesystem creation failed", log.Ctx{"output": string(output)})
-		return "", fmt.Errorf("Error making filesystem on image LV: %v", err)
-	}
-
-	return lvpath, nil
-}
-
-func (s *storageLvm) removeLV(lvname string) error {
-	var err error
-	var output []byte
-
-	output, err = tryExec(
-		"lvremove", "-f", fmt.Sprintf("%s/%s", s.vgName, lvname))
-
-	if err != nil {
-		s.log.Error("Could not remove LV", log.Ctx{"lvname": lvname, "output": string(output)})
-		return fmt.Errorf("Could not remove LV named %s", lvname)
+		return fmt.Errorf("Error making filesystem on image LV: %v", err)
 	}
 
 	return nil
 }
 
-func (s *storageLvm) createSnapshotLV(lvname string, origlvname string, readonly bool) (string, error) {
-	s.log.Debug("in createSnapshotLV:", log.Ctx{"lvname": lvname, "dev string": fmt.Sprintf("/dev/%s/%s", s.vgName, origlvname)})
+func (s *storageLvm) createDefaultThinPool(vgName string, thinPoolName string, lvName string, lvFsType string) error {
+	isRecent, err := s.lvmVersionIsAtLeast("2.02.99")
+	if err != nil {
+		return fmt.Errorf("Error checking LVM version: %s", err)
+	}
+
+	// Create the thin pool
+	lvmThinPool := fmt.Sprintf("%s/%s", vgName, thinPoolName)
+	var output []byte
+	if isRecent {
+		output, err = tryExec(
+			"lvcreate",
+			"--poolmetadatasize", "1G",
+			"-l", "100%FREE",
+			"--thinpool", lvmThinPool)
+	} else {
+		output, err = tryExec(
+			"lvcreate",
+			"--poolmetadatasize", "1G",
+			"-L", "1G",
+			"--thinpool", lvmThinPool)
+	}
+
+	if err != nil {
+		s.log.Error("Could not create thin pool", log.Ctx{"name": thinPoolName, "err": err, "output": string(output)})
+		return fmt.Errorf("Could not create LVM thin pool named %s", thinPoolName)
+	}
+
+	if !isRecent {
+		// Grow it to the maximum VG size (two step process required by old LVM)
+		output, err = tryExec("lvextend", "--alloc", "anywhere", "-l", "100%FREE", lvmThinPool)
+
+		if err != nil {
+			s.log.Error("Could not grow thin pool", log.Ctx{"name": thinPoolName, "err": err, "output": string(output)})
+			return fmt.Errorf("Could not grow LVM thin pool named %s", thinPoolName)
+		}
+	}
+
+	return nil
+}
+
+func (s *storageLvm) removeLV(vgName string, volumeType string, lvName string) error {
+	lvmVolumePath := getLvmDevPath(vgName, volumeType, lvName)
+	output, err := tryExec("lvremove", "-f", lvmVolumePath)
+
+	if err != nil {
+		s.log.Error("Could not remove LV", log.Ctx{"lvname": lvName, "output": string(output)})
+		return fmt.Errorf("Could not remove LV named %s", lvName)
+	}
+
+	return nil
+}
+
+func (s *storageLvm) createSnapshotLV(vgName string, origLvName string, origVolumeType string, lvName string, volumeType string, readonly bool) (string, error) {
+	sourceLvmVolumePath := getLvmDevPath(vgName, origVolumeType, origLvName)
+	s.log.Debug("in createSnapshotLV:", log.Ctx{"lvname": lvName, "dev string": sourceLvmVolumePath})
 	isRecent, err := s.lvmVersionIsAtLeast("2.02.99")
 	if err != nil {
 		return "", fmt.Errorf("Error checking LVM version: %v", err)
 	}
+
+	lvmPoolVolumeName := getPrefixedLvName(volumeType, lvName)
 	var output []byte
 	if isRecent {
 		output, err = tryExec(
 			"lvcreate",
 			"-kn",
-			"-n", lvname,
-			"-s", fmt.Sprintf("/dev/%s/%s", s.vgName, origlvname))
+			"-n", lvmPoolVolumeName,
+			"-s", sourceLvmVolumePath)
 	} else {
 		output, err = tryExec(
 			"lvcreate",
-			"-n", lvname,
-			"-s", fmt.Sprintf("/dev/%s/%s", s.vgName, origlvname))
+			"-n", lvmPoolVolumeName,
+			"-s", sourceLvmVolumePath)
 	}
 	if err != nil {
-		s.log.Error("Could not create LV snapshot", log.Ctx{"lvname": lvname, "origlvname": origlvname, "output": string(output)})
-		return "", fmt.Errorf("Could not create snapshot LV named %s", lvname)
+		s.log.Error("Could not create LV snapshot", log.Ctx{"lvname": lvName, "origlvname": origLvName, "output": string(output)})
+		return "", fmt.Errorf("Could not create snapshot LV named %s", lvName)
 	}
 
-	snapshotFullName := fmt.Sprintf("/dev/%s/%s", s.vgName, lvname)
-
+	targetLvmVolumePath := getLvmDevPath(vgName, volumeType, lvName)
 	if readonly {
-		output, err = tryExec("lvchange", "-ay", "-pr", snapshotFullName)
+		output, err = tryExec("lvchange", "-ay", "-pr", targetLvmVolumePath)
 	} else {
-		output, err = tryExec("lvchange", "-ay", snapshotFullName)
+		output, err = tryExec("lvchange", "-ay", targetLvmVolumePath)
 	}
 
 	if err != nil {
-		return "", fmt.Errorf("Could not activate new snapshot '%s': %v\noutput:%s", lvname, err, string(output))
+		return "", fmt.Errorf("Could not activate new snapshot '%s': %v\noutput:%s", lvName, err, string(output))
 	}
 
-	return snapshotFullName, nil
+	return targetLvmVolumePath, nil
 }
 
-func (s *storageLvm) isLVMContainer(container container) bool {
-	return shared.PathExists(fmt.Sprintf("%s.lv", container.Path()))
-}
-
-func (s *storageLvm) renameLV(oldName string, newName string) (string, error) {
-	output, err := tryExec("lvrename", s.vgName, oldName, newName)
+func (s *storageLvm) renameLV(oldName string, newName string, volumeType string) (string, error) {
+	oldLvmName := getPrefixedLvName(volumeType, oldName)
+	newLvmName := getPrefixedLvName(volumeType, newName)
+	output, err := tryExec("lvrename", s.pool.Name, oldLvmName, newLvmName)
 	return string(output), err
 }
 

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -6,35 +6,107 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/shared"
-
-	log "gopkg.in/inconshreveable/log15.v2"
+	"github.com/lxc/lxd/shared/api"
 )
 
 type storageMock struct {
-	d     *Daemon
-	sType storageType
-	log   log.Logger
-
 	storageShared
 }
 
-func (s *storageMock) Init(config map[string]interface{}) (storage, error) {
-	s.sType = storageTypeMock
-	s.sTypeName = storageTypeToString(storageTypeMock)
+func (s *storageMock) StorageCoreInit() (*storageCore, error) {
+	sCore := storageCore{}
+	sCore.sType = storageTypeMock
+	typeName, err := storageTypeToString(sCore.sType)
+	if err != nil {
+		return nil, err
+	}
+	sCore.sTypeName = typeName
 
-	if err := s.initShared(); err != nil {
+	err = sCore.initShared()
+	if err != nil {
+		return nil, err
+	}
+
+	s.storageCore = sCore
+
+	return &sCore, nil
+}
+
+func (s *storageMock) StoragePoolInit(config map[string]interface{}) (storage, error) {
+	_, err := s.StorageCoreInit()
+	if err != nil {
 		return s, err
 	}
 
 	return s, nil
 }
 
-func (s *storageMock) GetStorageType() storageType {
-	return s.sType
+func (s *storageMock) StoragePoolCheck() error {
+	return nil
 }
 
-func (s *storageMock) GetStorageTypeName() string {
-	return s.sTypeName
+func (s *storageMock) StoragePoolCreate() error {
+	return nil
+}
+
+func (s *storageMock) StoragePoolDelete() error {
+	return nil
+}
+
+func (s *storageMock) StoragePoolMount() (bool, error) {
+	return true, nil
+}
+
+func (s *storageMock) StoragePoolUmount() (bool, error) {
+	return true, nil
+}
+
+func (s *storageMock) GetStoragePoolWritable() api.StoragePoolPut {
+	return s.pool.StoragePoolPut
+}
+
+func (s *storageMock) GetStoragePoolVolumeWritable() api.StorageVolumePut {
+	return api.StorageVolumePut{}
+}
+
+func (s *storageMock) SetStoragePoolWritable(writable *api.StoragePoolPut) {
+	s.pool.StoragePoolPut = *writable
+}
+
+func (s *storageMock) SetStoragePoolVolumeWritable(writable *api.StorageVolumePut) {
+	s.volume.StorageVolumePut = *writable
+}
+
+func (s *storageMock) ContainerPoolGet() string {
+	return s.pool.Name
+}
+
+func (s *storageMock) ContainerPoolIDGet() int64 {
+	return s.poolID
+}
+
+func (s *storageMock) StoragePoolVolumeCreate() error {
+	return nil
+}
+
+func (s *storageMock) StoragePoolVolumeDelete() error {
+	return nil
+}
+
+func (s *storageMock) StoragePoolVolumeMount() (bool, error) {
+	return true, nil
+}
+
+func (s *storageMock) StoragePoolVolumeUmount() (bool, error) {
+	return true, nil
+}
+
+func (s *storageMock) StoragePoolVolumeUpdate(changedConfig []string) error {
+	return nil
+}
+
+func (s *storageMock) StoragePoolUpdate(changedConfig []string) error {
+	return nil
 }
 
 func (s *storageMock) ContainerCreate(container container) error {
@@ -61,12 +133,12 @@ func (s *storageMock) ContainerCopy(
 	return nil
 }
 
-func (s *storageMock) ContainerStart(name string, path string) error {
-	return nil
+func (s *storageMock) ContainerMount(name string, path string) (bool, error) {
+	return true, nil
 }
 
-func (s *storageMock) ContainerStop(name string, path string) error {
-	return nil
+func (s *storageMock) ContainerUmount(name string, path string) (bool, error) {
+	return true, nil
 }
 
 func (s *storageMock) ContainerRename(
@@ -127,6 +199,14 @@ func (s *storageMock) ImageCreate(fingerprint string) error {
 
 func (s *storageMock) ImageDelete(fingerprint string) error {
 	return nil
+}
+
+func (s *storageMock) ImageMount(fingerprint string) (bool, error) {
+	return true, nil
+}
+
+func (s *storageMock) ImageUmount(fingerprint string) (bool, error) {
+	return true, nil
 }
 
 func (s *storageMock) MigrationType() MigrationFSType {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -1,0 +1,346 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
+)
+
+// /1.0/storage-pools
+// List all storage pools.
+func storagePoolsGet(d *Daemon, r *http.Request) Response {
+	recursionStr := r.FormValue("recursion")
+	recursion, err := strconv.Atoi(recursionStr)
+	if err != nil {
+		recursion = 0
+	}
+
+	pools, err := dbStoragePools(d.db)
+	if err != nil && err != NoSuchObjectError {
+		return InternalError(err)
+	}
+
+	resultString := []string{}
+	resultMap := []api.StoragePool{}
+	for _, pool := range pools {
+		if recursion == 0 {
+			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s", version.APIVersion, pool))
+		} else {
+			plID, pl, err := dbStoragePoolGet(d.db, pool)
+			if err != nil {
+				continue
+			}
+
+			// Get all users of the storage pool.
+			poolUsedBy, err := storagePoolUsedByGet(d.db, plID, pool)
+			if err != nil && err != NoSuchObjectError {
+				return SmartError(err)
+			}
+			pl.UsedBy = poolUsedBy
+
+			resultMap = append(resultMap, *pl)
+		}
+	}
+
+	if recursion == 0 {
+		return SyncResponse(true, resultString)
+	}
+
+	return SyncResponse(true, resultMap)
+}
+
+// /1.0/storage-pools
+// Create a storage pool.
+func storagePoolsPost(d *Daemon, r *http.Request) Response {
+	req := api.StoragePool{}
+
+	// Parse the request.
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Sanity checks.
+	if req.Name == "" {
+		return BadRequest(fmt.Errorf("No name provided"))
+	}
+
+	if req.Driver == "" {
+		return BadRequest(fmt.Errorf("No driver provided"))
+	}
+
+	// Check if the storage pool name is valid.
+	err = storageValidName(req.Name)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Check that the storage pool does not already exist.
+	_, err = dbStoragePoolGetID(d.db, req.Name)
+	if err != nil {
+		if err != NoSuchObjectError {
+			return InternalError(err)
+		}
+	}
+
+	// Make sure that we don't pass a nil to the next function.
+	if req.Config == nil {
+		req.Config = map[string]string{}
+	}
+
+	// Validate the requested storage pool configuration.
+	err = storagePoolValidateConfig(req.Name, req.Driver, req.Config)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Create the database entry for the storage pool.
+	_, err = dbStoragePoolCreate(d.db, req.Name, req.Driver, req.Config)
+	if err != nil {
+		return InternalError(fmt.Errorf("Error inserting %s into database: %s", req.Name, err))
+	}
+
+	// Define a function which reverts everything.  Defer this function
+	// so that it doesn't need to be explicitly called in every failing
+	// return path. Track whether or not we want to undo the changes
+	// using a closure.
+	tryUndo := true
+	defer func() {
+		if tryUndo {
+			dbStoragePoolDelete(d.db, req.Name)
+		}
+	}()
+
+	s, err := storagePoolInit(d, req.Name)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = s.StoragePoolCreate()
+	if err != nil {
+		return InternalError(err)
+	}
+	defer func() {
+		if tryUndo {
+			s.StoragePoolDelete()
+		}
+	}()
+
+	// In case the storage pool config was changed during the pool creation,
+	// we need to update the database to reflect this change. This can e.g.
+	// happen, when we create a loop file image. This means we append ".img"
+	// to the path the user gave us and update the config in the storage
+	// callback. So diff the config here to see if something like this has
+	// happened.
+	postCreateConfig := s.GetStoragePoolWritable().Config
+	configDiff, _ := storageConfigDiff(req.Config, postCreateConfig)
+	if len(configDiff) > 0 {
+		// Create the database entry for the storage pool.
+		err = dbStoragePoolUpdate(d.db, req.Name, postCreateConfig)
+		if err != nil {
+			return InternalError(fmt.Errorf("Error inserting %s into database: %s", req.Name, err))
+		}
+	}
+
+	// Success, update the closure to mark that the changes should be kept.
+	tryUndo = false
+
+	return SyncResponseLocation(true, nil, fmt.Sprintf("/%s/storage-pools/%s", version.APIVersion, req.Name))
+}
+
+var storagePoolsCmd = Command{name: "storage-pools", get: storagePoolsGet, post: storagePoolsPost}
+
+// /1.0/storage-pools/{name}
+// Get a single storage pool.
+func storagePoolGet(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	// Get the existing storage pool.
+	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get all users of the storage pool.
+	poolUsedBy, err := storagePoolUsedByGet(d.db, poolID, poolName)
+	if err != nil && err != NoSuchObjectError {
+		return SmartError(err)
+	}
+	pool.UsedBy = poolUsedBy
+
+	etag := []interface{}{pool.Name, pool.UsedBy, pool.Config}
+
+	return SyncResponseETag(true, &pool, etag)
+}
+
+// /1.0/storage-pools/{name}
+// Replace pool properties.
+func storagePoolPut(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	// Get the existing storage pool.
+	_, dbInfo, err := dbStoragePoolGet(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Validate the ETag
+	etag := []interface{}{dbInfo.Name, dbInfo.UsedBy, dbInfo.Config}
+
+	err = etagCheck(r, etag)
+	if err != nil {
+		return PreconditionFailed(err)
+	}
+
+	req := api.StoragePool{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return BadRequest(err)
+	}
+
+	// Validate the configuration
+	err = storagePoolValidateConfig(poolName, req.Driver, req.Config)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	err = storagePoolUpdate(d, poolName, req.Config)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return EmptySyncResponse
+}
+
+// /1.0/storage-pools/{name}
+// Change pool properties.
+func storagePoolPatch(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	// Get the existing network
+	_, dbInfo, err := dbStoragePoolGet(d.db, poolName)
+	if dbInfo != nil {
+		return SmartError(err)
+	}
+
+	// Validate the ETag
+	etag := []interface{}{dbInfo.Name, dbInfo.UsedBy, dbInfo.Config}
+
+	err = etagCheck(r, etag)
+	if err != nil {
+		return PreconditionFailed(err)
+	}
+
+	req := api.StoragePool{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return BadRequest(err)
+	}
+
+	// Config stacking
+	if req.Config == nil {
+		req.Config = map[string]string{}
+	}
+
+	for k, v := range dbInfo.Config {
+		_, ok := req.Config[k]
+		if !ok {
+			req.Config[k] = v
+		}
+	}
+
+	// Validate the configuration
+	err = storagePoolValidateConfig(poolName, req.Driver, req.Config)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	err = storagePoolUpdate(d, poolName, req.Config)
+	if err != nil {
+		return InternalError(fmt.Errorf("Failed to update the storage pool configuration."))
+	}
+
+	return EmptySyncResponse
+}
+
+// /1.0/storage-pools/{name}
+// Delete storage pool.
+func storagePoolDelete(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return NotFound
+	}
+
+	// Check if the storage pool has any volumes associated with it, if so
+	// error out.
+	volumeCount, err := dbStoragePoolVolumesGetNames(d.db, poolID)
+	if volumeCount > 0 {
+		return BadRequest(fmt.Errorf("Storage pool \"%s\" has volumes attached to it.", poolName))
+	}
+
+	s, err := storagePoolInit(d, poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = s.StoragePoolDelete()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = dbStoragePoolDelete(d.db, poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	// In case we deleted the default storage pool, try to update the
+	// default profile.
+	defaultID, defaultProfile, err := dbProfileGet(d.db, "default")
+	if err != nil {
+		return EmptySyncResponse
+	}
+	for k, v := range defaultProfile.Devices {
+		if v["type"] == "disk" && v["path"] == "/" {
+			if v["pool"] == poolName {
+				defaultProfile.Devices[k]["pool"] = ""
+
+				tx, err := dbBegin(d.db)
+				if err != nil {
+					return EmptySyncResponse
+				}
+
+				err = dbProfileConfigClear(tx, defaultID)
+				if err != nil {
+					tx.Rollback()
+					return EmptySyncResponse
+				}
+
+				err = dbProfileConfigAdd(tx, defaultID, defaultProfile.Config)
+				if err != nil {
+					tx.Rollback()
+					return EmptySyncResponse
+				}
+
+				err = dbDevicesAdd(tx, "profile", defaultID, defaultProfile.Devices)
+				if err != nil {
+					tx.Rollback()
+					return EmptySyncResponse
+				}
+
+				err = txCommit(tx)
+				if err != nil {
+					return EmptySyncResponse
+				}
+			}
+		}
+	}
+
+	return EmptySyncResponse
+}
+
+var storagePoolCmd = Command{name: "storage-pools/{name}", get: storagePoolGet, put: storagePoolPut, patch: storagePoolPatch, delete: storagePoolDelete}

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/lxc/lxd/shared"
+)
+
+var storagePoolConfigKeys = map[string]func(value string) error{
+	"source": shared.IsAny,
+	"size": func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		_, err := shared.ParseByteSizeString(value)
+		return err
+	},
+	"volume.block.mount_options": shared.IsAny,
+	"volume.block.filesystem": func(value string) error {
+		return shared.IsOneOf(value, []string{"ext4", "xfs"})
+	},
+	"volume.size": func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		_, err := shared.ParseByteSizeString(value)
+		return err
+	},
+	"volume.zfs.use_refquota":     shared.IsBool,
+	"volume.zfs.remove_snapshots": shared.IsBool,
+	"volume.lvm.thinpool_name":    shared.IsAny,
+	"zfs.pool_name":               shared.IsAny,
+}
+
+func storagePoolValidateConfig(name string, driver string, config map[string]string) error {
+	err := func(value string) error {
+		return shared.IsOneOf(value, supportedStorageTypes)
+	}(driver)
+	if err != nil {
+		return err
+	}
+
+	if config["source"] == "" {
+		if driver == "dir" {
+			config["source"] = filepath.Join(shared.VarPath("storage-pools"), name)
+		} else {
+			config["source"] = filepath.Join(shared.VarPath("disks"), name)
+		}
+	}
+
+	for key, val := range config {
+		// User keys are not validated.
+		if strings.HasPrefix(key, "user.") {
+			continue
+		}
+
+		// Validate storage pool config keys.
+		validator, ok := storagePoolConfigKeys[key]
+		if !ok {
+			return fmt.Errorf("Invalid storage pool configuration key: %s", key)
+		}
+
+		err := validator(val)
+		if err != nil {
+			return err
+		}
+
+		if driver != "zfs" || driver == "dir" {
+			if config["volume.zfs.use_refquota"] != "" {
+				return fmt.Errorf("The key volume.zfs.use_refquota cannot be used with non zfs storage pools.")
+			}
+
+			if config["volume.zfs.remove_snapshots"] != "" {
+				return fmt.Errorf("The key volume.zfs.remove_snapshots cannot be used with non zfs storage pools.")
+			}
+
+			if config["zfs.pool_name"] != "" {
+				return fmt.Errorf("The key zfs.pool_name cannot be used with non zfs storage pools.")
+			}
+		}
+
+		if driver == "dir" {
+			if config["size"] != "" {
+				return fmt.Errorf("The key size cannot be used with dir storage pools.")
+			}
+
+			if config["volume.block.mount_options"] != "" {
+				return fmt.Errorf("The key volume.block.mount_options cannot be used with dir storage pools.")
+			}
+
+			if config["volume.block.filesystem"] != "" {
+				return fmt.Errorf("The key volume.block.filesystem cannot be used with dir storage pools.")
+			}
+
+			if config["volume.size"] != "" {
+				return fmt.Errorf("The key volume.size cannot be used with dir storage pools.")
+			}
+		}
+	}
+
+	err = storagePoolFillDefault(name, driver, config)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func storagePoolFillDefault(name string, driver string, config map[string]string) error {
+	if driver != "dir" {
+		var size uint64
+		if config["size"] == "" {
+			st := syscall.Statfs_t{}
+			err := syscall.Statfs(shared.VarPath(), &st)
+			if err != nil {
+				return fmt.Errorf("couldn't statfs %s: %s", shared.VarPath(), err)
+			}
+
+			/* choose 15 GB < x < 100GB, where x is 20% of the disk size */
+			gb := uint64(1024 * 1024 * 1024)
+			size = uint64(st.Frsize) * st.Blocks / 5
+			if (size / gb) > 100 {
+				size = 100 * gb
+			}
+			if (size / gb) < 15 {
+				size = 15 * gb
+			}
+		} else {
+			sz, err := shared.ParseByteSizeString(config["size"])
+			if err != nil {
+				return err
+			}
+			size = uint64(sz)
+		}
+		config["size"] = strconv.FormatUint(uint64(size), 10)
+	}
+
+	if driver == "zfs" {
+		if val, ok := config["zfs.pool_name"]; !ok || val == "" {
+			config["zfs.pool_name"] = name
+		}
+	}
+
+	if driver == "lvm" {
+		if config["volume.lvm.thinpool_name"] == "" {
+			config["volume.lvm.thinpool_name"] = "LXDThinpool"
+		}
+
+		if config["volume.block.filesystem"] == "" {
+			config["volume.block.filesystem"] = "ext4"
+		}
+
+		if config["volume.block.mount_options"] == "" {
+			config["volume.block.mount_options"] = "discard"
+		}
+	}
+
+	if config["volume.size"] == "" {
+		if driver == "lvm" {
+			sz, err := shared.ParseByteSizeString("10GB")
+			if err != nil {
+				return err
+			}
+			size := uint64(sz)
+			config["volume.size"] = strconv.FormatUint(uint64(size), 10)
+		} else {
+			config["volume.size"] = "0"
+		}
+	}
+
+	return nil
+}

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/version"
+)
+
+func storagePoolUpdate(d *Daemon, name string, newConfig map[string]string) error {
+	s, err := storagePoolInit(d, name)
+	if err != nil {
+		return err
+	}
+
+	oldWritable := s.GetStoragePoolWritable()
+	newWritable := oldWritable
+
+	// Backup the current state
+	oldConfig := map[string]string{}
+	err = shared.DeepCopy(&oldWritable.Config, &oldConfig)
+	if err != nil {
+		return err
+	}
+
+	// Define a function which reverts everything.  Defer this function
+	// so that it doesn't need to be explicitly called in every failing
+	// return path. Track whether or not we want to undo the changes
+	// using a closure.
+	undoChanges := true
+	defer func() {
+		if undoChanges {
+			s.SetStoragePoolWritable(&oldWritable)
+		}
+	}()
+
+	changedConfig, userOnly := storageConfigDiff(oldConfig, newConfig)
+	// Skip on no change
+	if len(changedConfig) == 0 {
+		return nil
+	}
+
+	// Update the storage pool
+	if !userOnly {
+		if shared.StringInSlice("driver", changedConfig) {
+			return fmt.Errorf("The \"driver\" property of a storage pool cannot be changed.")
+		}
+
+		err = s.StoragePoolUpdate(changedConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	newWritable.Config = newConfig
+
+	// Apply the new configuration
+	s.SetStoragePoolWritable(&newWritable)
+
+	// Update the database
+	err = dbStoragePoolUpdate(d.db, name, newConfig)
+	if err != nil {
+		return err
+	}
+
+	// Success, update the closure to mark that the changes should be kept.
+	undoChanges = false
+
+	return nil
+}
+
+// /1.0/containers/alp1
+// /1.0/containers/alp1/snapshots/snap0
+// /1.0/images/cedce20b5b236f1071134beba7a5fd2aa923fda49eea4c66454dd559a5d6e906
+// /1.0/storage-pools/pool1/volumes/custom/vol1
+func storagePoolUsedByGet(db *sql.DB, poolID int64, poolName string) ([]string, error) {
+	poolVolumes, err := dbStoragePoolVolumesGet(db, poolID)
+	if err != nil {
+		return []string{}, err
+	}
+
+	poolUsedBy := make([]string, len(poolVolumes))
+
+	for i := 0; i < len(poolVolumes); i++ {
+		apiEndpoint, _ := storagePoolVolumeTypeNameToApiEndpoint(poolVolumes[i].Type)
+		switch apiEndpoint {
+		case storagePoolVolumeApiEndpointContainers:
+			if strings.Index(poolVolumes[i].Name, shared.SnapshotDelimiter) > 0 {
+				fields := strings.SplitN(poolVolumes[i].Name, shared.SnapshotDelimiter, 2)
+				poolUsedBy[i] = fmt.Sprintf("/%s/containers/%s/snapshots/%s", version.APIVersion, fields[0], fields[1])
+			} else {
+				poolUsedBy[i] = fmt.Sprintf("/%s/containers/%s", version.APIVersion, poolVolumes[i].Name)
+			}
+		case storagePoolVolumeApiEndpointImages:
+			poolUsedBy[i] = fmt.Sprintf("/%s/images/%s", version.APIVersion, poolVolumes[i].Name)
+		case storagePoolVolumeApiEndpointCustom:
+			// noop
+		default:
+			shared.LogWarnf("Invalid storage type for storage volume \"%s\".", poolVolumes[i].Name)
+		}
+	}
+
+	return poolUsedBy, err
+}

--- a/lxd/storage_utils.go
+++ b/lxd/storage_utils.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func storageValidName(value string) error {
+	return nil
+}
+
+func storageConfigDiff(oldConfig map[string]string, newConfig map[string]string) ([]string, bool) {
+	changedConfig := []string{}
+	userOnly := true
+	for key := range oldConfig {
+		if oldConfig[key] != newConfig[key] {
+			if !strings.HasPrefix(key, "user.") {
+				userOnly = false
+			}
+
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	for key := range newConfig {
+		if oldConfig[key] != newConfig[key] {
+			if !strings.HasPrefix(key, "user.") {
+				userOnly = false
+			}
+
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	// Skip on no change
+	if len(changedConfig) == 0 {
+		return nil, false
+	}
+
+	return changedConfig, userOnly
+}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -1,0 +1,461 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/gorilla/mux"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
+)
+
+// /1.0/storage-pools/{name}/volumes
+// List all storage volumes attached to a given storage pool.
+func storagePoolVolumesGet(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	recursionStr := r.FormValue("recursion")
+	recursion, err := strconv.Atoi(recursionStr)
+	if err != nil {
+		recursion = 0
+	}
+
+	// Retrieve ID of the storage pool (and check if the storage pool
+	// exists).
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get all volumes currently attached to the storage pool by ID of the
+	// pool.
+	volumes, err := dbStoragePoolVolumesGet(d.db, poolID)
+	if err != nil && err != NoSuchObjectError {
+		return SmartError(err)
+	}
+
+	resultString := []string{}
+	for _, volume := range volumes {
+		apiEndpoint, err := storagePoolVolumeTypeNameToApiEndpoint(volume.Type)
+		if err != nil {
+			return InternalError(err)
+		}
+
+		if recursion == 0 {
+			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, apiEndpoint, volume.Name))
+		} else {
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volume.Name)
+			if err != nil {
+				return InternalError(err)
+			}
+			volume.UsedBy = volumeUsedBy
+		}
+	}
+
+	if recursion == 0 {
+		return SyncResponse(true, resultString)
+	}
+
+	return SyncResponse(true, volumes)
+}
+
+var storagePoolVolumesCmd = Command{name: "storage-pools/{name}/volumes", get: storagePoolVolumesGet}
+
+// /1.0/storage-pools/{name}/volumes/{type}
+// List all storage volumes of a given volume type for a given storage pool.
+func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
+	// Get the name of the pool the storage volume is supposed to be
+	// attached to.
+	poolName := mux.Vars(r)["name"]
+
+	recursionStr := r.FormValue("recursion")
+	recursion, err := strconv.Atoi(recursionStr)
+	if err != nil {
+		recursion = 0
+	}
+
+	// Get the name of the volume type.
+	volumeTypeName := mux.Vars(r)["type"]
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(volumeTypeName)
+	if err != nil {
+		return BadRequest(err)
+	}
+	// Check that the storage volume type is valid.
+	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
+		return BadRequest(fmt.Errorf("Invalid storage volume type %s.", volumeTypeName))
+	}
+
+	// Retrieve ID of the storage pool (and check if the storage pool
+	// exists).
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get the names of all storage volumes of a given volume type currently
+	// attached to the storage pool.
+	volumes, err := dbStoragePoolVolumesGetType(d.db, volumeType, poolID)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	resultString := []string{}
+	resultMap := []*api.StorageVolume{}
+	for _, volume := range volumes {
+		if recursion == 0 {
+			apiEndpoint, err := storagePoolVolumeTypeToApiEndpoint(volumeType)
+			if err != nil {
+				return InternalError(err)
+			}
+			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, apiEndpoint, volume))
+		} else {
+			_, vol, err := dbStoragePoolVolumeGetType(d.db, volume, volumeType, poolID)
+			if err != nil {
+				continue
+			}
+
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d, vol.Name)
+			if err != nil {
+				return InternalError(err)
+			}
+			vol.UsedBy = volumeUsedBy
+
+			resultMap = append(resultMap, vol)
+		}
+	}
+
+	if recursion == 0 {
+		return SyncResponse(true, resultString)
+	}
+
+	return SyncResponse(true, resultMap)
+}
+
+// /1.0/storage-pools/{name}/volumes/{type}
+// Create a storage volume of a given volume type in a given storage pool.
+func storagePoolVolumesTypePost(d *Daemon, r *http.Request) Response {
+	req := api.StorageVolume{}
+
+	// Parse the request.
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Sanity checks.
+	if req.Name == "" {
+		return BadRequest(fmt.Errorf("No name provided"))
+	}
+
+	// Check that the name of the new storage volume is valid. (For example.
+	// zfs pools cannot contain "/" in their names.)
+	err = storageValidName(req.Name)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Check that the user gave use a storage volume type for the storage
+	// volume we are about to create.
+	if req.Type == "" {
+		return BadRequest(fmt.Errorf("You must provide a storage volume type of the storage volume."))
+	}
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(req.Type)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// We currently only allow to create storage volumes of type
+	// storagePoolVolumeTypeCustom. So check, that nothing else was
+	// requested.
+	if volumeType != storagePoolVolumeTypeCustom {
+		return BadRequest(fmt.Errorf("Currently not allowed to create storage volumes of type %s.", req.Type))
+	}
+
+	// Check if the user gave us a valid pool name in which the new storage
+	// volume is supposed to be created.
+	poolName := mux.Vars(r)["name"]
+
+	// Load storage pool the volume will be attached to.
+	poolID, poolStruct, err := dbStoragePoolGet(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Check that a storage volume of the same storage volume type does not
+	// already exist.
+	volumeID, _ := dbStoragePoolVolumeGetTypeID(d.db, req.Name, volumeType, poolID)
+	if volumeID > 0 {
+		return BadRequest(fmt.Errorf("A storage volume of type %s does already exist.", req.Type))
+	}
+
+	// Make sure that we don't pass a nil to the next function.
+	if req.Config == nil {
+		req.Config = map[string]string{}
+	}
+
+	// Validate the requested storage volume configuration.
+	err = storageVolumeValidateConfig(poolName, req.Config, poolStruct)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	// Create the database entry for the storage volume.
+	_, err = dbStoragePoolVolumeCreate(d.db, req.Name, volumeType, poolID, req.Config)
+	if err != nil {
+		return InternalError(fmt.Errorf("Error inserting %s of type %s into database: %s", poolName, req.Type, err))
+	}
+
+	s, err := storagePoolVolumeInit(d, poolName, req.Name, volumeType)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	// Create storage volume.
+	err = s.StoragePoolVolumeCreate()
+	if err != nil {
+		dbStoragePoolVolumeDelete(d.db, req.Name, volumeType, poolID)
+		return InternalError(err)
+	}
+
+	apiEndpoint, err := storagePoolVolumeTypeToApiEndpoint(volumeType)
+	if err != nil {
+		return InternalError(err)
+	}
+	return SyncResponseLocation(true, nil, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s", version.APIVersion, poolName, apiEndpoint))
+}
+
+var storagePoolVolumesTypeCmd = Command{name: "storage-pools/{name}/volumes/{type}", get: storagePoolVolumesTypeGet, post: storagePoolVolumesTypePost}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+// Get storage volume of a given volume type on a given storage pool.
+func storagePoolVolumeTypeGet(d *Daemon, r *http.Request) Response {
+	// Get the name of the storage volume.
+	volumeName := mux.Vars(r)["name"]
+
+	// Get the name of the storage pool the volume is supposed to be
+	// attached to.
+	poolName := mux.Vars(r)["pool"]
+
+	// Get the name of the volume type.
+	volumeTypeName := mux.Vars(r)["type"]
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(volumeTypeName)
+	if err != nil {
+		return BadRequest(err)
+	}
+	// Check that the storage volume type is valid.
+	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
+		return BadRequest(fmt.Errorf("Invalid storage volume type %s.", volumeTypeName))
+	}
+
+	// Get the ID of the storage pool the storage volume is supposed to be
+	// attached to.
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	// Get the storage volume.
+	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volume.Name)
+	if err != nil {
+		return InternalError(err)
+	}
+	volume.UsedBy = volumeUsedBy
+
+	etag := []interface{}{volume.Name, volume.Type, volume.UsedBy, volume.Config}
+
+	return SyncResponseETag(true, volume, etag)
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func storagePoolVolumeTypePut(d *Daemon, r *http.Request) Response {
+	// Get the name of the storage volume.
+	volumeName := mux.Vars(r)["name"]
+
+	// Get the name of the storage pool the volume is supposed to be
+	// attached to.
+	poolName := mux.Vars(r)["pool"]
+
+	// Get the name of the volume type.
+	volumeTypeName := mux.Vars(r)["type"]
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(volumeTypeName)
+	if err != nil {
+		return BadRequest(err)
+	}
+	// Check that the storage volume type is valid.
+	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
+		return BadRequest(fmt.Errorf("Invalid storage volume type %s.", volumeTypeName))
+	}
+
+	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get the existing storage volume.
+	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Validate the ETag
+	etag := []interface{}{volume.Name, volume.Type, volume.UsedBy, volume.Config}
+
+	err = etagCheck(r, etag)
+	if err != nil {
+		return PreconditionFailed(err)
+	}
+
+	req := api.StorageVolume{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return BadRequest(err)
+	}
+
+	// Validate the configuration
+	err = storageVolumeValidateConfig(req.Name, req.Config, pool)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	err = storagePoolVolumeUpdate(d, poolName, req.Name, volumeType, req.Config)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return EmptySyncResponse
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func storagePoolVolumeTypePatch(d *Daemon, r *http.Request) Response {
+	// Get the name of the storage volume.
+	volumeName := mux.Vars(r)["name"]
+
+	// Get the name of the storage pool the volume is supposed to be
+	// attached to.
+	poolName := mux.Vars(r)["pool"]
+
+	// Get the name of the volume type.
+	volumeTypeName := mux.Vars(r)["type"]
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(volumeTypeName)
+	if err != nil {
+		return BadRequest(err)
+	}
+	// Check that the storage volume type is valid.
+	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
+		return BadRequest(fmt.Errorf("Invalid storage volume type %s.", volumeTypeName))
+	}
+
+	// Get the ID of the storage pool the storage volume is supposed to be
+	// attached to.
+	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get the existing storage volume.
+	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Validate the ETag
+	etag := []interface{}{volume.Name, volume.Type, volume.UsedBy, volume.Config}
+
+	err = etagCheck(r, etag)
+	if err != nil {
+		return PreconditionFailed(err)
+	}
+
+	req := api.StorageVolume{}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return BadRequest(err)
+	}
+
+	if req.Config == nil {
+		req.Config = map[string]string{}
+	}
+
+	for k, v := range volume.Config {
+		_, ok := req.Config[k]
+		if !ok {
+			req.Config[k] = v
+		}
+	}
+
+	// Validate the configuration
+	err = storageVolumeValidateConfig(volumeName, req.Config, pool)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	err = storagePoolVolumeUpdate(d, poolName, req.Name, volumeType, req.Config)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return EmptySyncResponse
+}
+
+// /1.0/storage-pools/{pool}/volumes/{type}/{name}
+func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
+	// Get the name of the storage volume.
+	volumeName := mux.Vars(r)["name"]
+
+	// Get the name of the storage pool the volume is supposed to be
+	// attached to.
+	poolName := mux.Vars(r)["pool"]
+
+	// Get the name of the volume type.
+	volumeTypeName := mux.Vars(r)["type"]
+
+	// Convert the volume type name to our internal integer representation.
+	volumeType, err := storagePoolVolumeTypeNameToType(volumeTypeName)
+	if err != nil {
+		return BadRequest(err)
+	}
+	// Check that the storage volume type is valid.
+	if !shared.IntInSlice(volumeType, supportedVolumeTypes) {
+		return BadRequest(fmt.Errorf("Invalid storage volume type %s.", volumeTypeName))
+	}
+
+	s, err := storagePoolVolumeInit(d, poolName, volumeName, volumeType)
+	if err != nil {
+		return NotFound
+	}
+
+	err = s.StoragePoolVolumeDelete()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = dbStoragePoolVolumeDelete(d.db, volumeName, volumeType, poolID)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return EmptySyncResponse
+}
+
+var storagePoolVolumeTypeCmd = Command{name: "storage-pools/{pool}/volumes/{type}/{name}", get: storagePoolVolumeTypeGet, put: storagePoolVolumeTypePut, patch: storagePoolVolumeTypePatch, delete: storagePoolVolumeTypeDelete}

--- a/lxd/storage_volumes_config.go
+++ b/lxd/storage_volumes_config.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+var storageVolumeConfigKeys = map[string]func(value string) error{
+	"block.mount_options": shared.IsAny,
+	"block.filesystem": func(value string) error {
+		return shared.IsOneOf(value, []string{"ext4", "xfs"})
+	},
+	"size": func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		_, err := shared.ParseByteSizeString(value)
+		return err
+	},
+	"zfs.use_refquota":     shared.IsBool,
+	"zfs.remove_snapshots": shared.IsBool,
+}
+
+func storageVolumeValidateConfig(name string, config map[string]string, parentPool *api.StoragePool) error {
+	for key, val := range config {
+		// User keys are not validated.
+		if strings.HasPrefix(key, "user.") {
+			continue
+		}
+
+		// Validate storage volume config keys.
+		validator, ok := storageVolumeConfigKeys[key]
+		if !ok {
+			return fmt.Errorf("Invalid storage volume configuration key: %s", key)
+		}
+
+		err := validator(val)
+		if err != nil {
+			return err
+		}
+
+		if parentPool.Driver != "zfs" || parentPool.Driver == "dir" {
+			if config["zfs.use_refquota"] != "" {
+				return fmt.Errorf("The key volume.zfs.use_refquota cannot be used with non zfs storage volumes.")
+			}
+
+			if config["zfs.remove_snapshots"] != "" {
+				return fmt.Errorf("The key volume.zfs.remove_snapshots cannot be used with non zfs storage volumes.")
+			}
+		}
+
+		if parentPool.Driver == "dir" {
+			if config["block.mount_options"] != "" {
+				return fmt.Errorf("The key block.mount_options cannot be used with dir storage volumes.")
+			}
+
+			if config["block.filesystem"] != "" {
+				return fmt.Errorf("The key block.filesystem cannot be used with dir storage volumes.")
+			}
+
+			if config["size"] != "" {
+				return fmt.Errorf("The key size cannot be used with dir storage volumes.")
+			}
+		}
+
+		if parentPool.Driver == "lvm" {
+			if config["block.filesystem"] == "" {
+				config["block.filesystem"] = parentPool.Config["volume.block.filesystem"]
+			}
+
+			if config["block.mount_options"] == "" {
+				config["block.mount_options"] = parentPool.Config["volume.block.mount_options"]
+			}
+		}
+	}
+
+	err := storageVolumeFillDefault(name, config, parentPool)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func storageVolumeFillDefault(name string, config map[string]string, parentPool *api.StoragePool) error {
+	if parentPool.Driver == "dir" {
+		config["size"] = "0"
+	} else if parentPool.Driver == "lvm" {
+		if config["size"] == "0" || config["size"] == "" {
+			config["size"] = parentPool.Config["volume.size"]
+		}
+
+		if config["size"] == "0" || config["size"] == "" {
+			sz, err := shared.ParseByteSizeString("10GB")
+			if err != nil {
+				return err
+			}
+			size := uint64(sz)
+			config["size"] = strconv.FormatUint(uint64(size), 10)
+		}
+	} else {
+		if config["size"] == "" {
+			config["size"] = parentPool.Config["volume.size"]
+		}
+
+		if config["size"] == "" {
+			config["size"] = "0"
+		}
+	}
+
+	if parentPool.Driver == "lvm" {
+		if config["block.filesystem"] == "" {
+			config["block.filesystem"] = "ext4"
+		}
+
+		if config["block.mount_options"] == "" && config["block.filesystem"] == "ext4" {
+			config["block.mount_options"] = "discard"
+		}
+
+		if config["lvm.thinpool_name"] == "" {
+			config["lvm.thinpool_name"] = parentPool.Config["volume.lvm.thinpool_name"]
+			if config["lvm.thinpool_name"] == "" {
+				config["lvm.thinpool_name"] = "LXDThinPool"
+			}
+		}
+	}
+
+	return nil
+}

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -1,0 +1,206 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/version"
+)
+
+const (
+	storagePoolVolumeTypeContainer = iota
+	storagePoolVolumeTypeImage
+	storagePoolVolumeTypeCustom
+)
+
+// Leave the string type in here! This guarantees that go treats this is as a
+// typed string constant. Removing it causes go to treat these as untyped string
+// constants which is not what we want.
+const (
+	storagePoolVolumeTypeNameContainer string = "container"
+	storagePoolVolumeTypeNameImage     string = "image"
+	storagePoolVolumeTypeNameCustom    string = "custom"
+)
+
+// Leave the string type in here! This guarantees that go treats this is as a
+// typed string constant. Removing it causes go to treat these as untyped string
+// constants which is not what we want.
+const (
+	storagePoolVolumeApiEndpointContainers string = "containers"
+	storagePoolVolumeApiEndpointImages     string = "images"
+	storagePoolVolumeApiEndpointCustom     string = "custom"
+)
+
+var supportedVolumeTypes = []int{storagePoolVolumeTypeContainer, storagePoolVolumeTypeImage, storagePoolVolumeTypeCustom}
+
+func storagePoolVolumeTypeNameToType(volumeTypeName string) (int, error) {
+	switch volumeTypeName {
+	case storagePoolVolumeTypeNameContainer:
+		return storagePoolVolumeTypeContainer, nil
+	case storagePoolVolumeTypeNameImage:
+		return storagePoolVolumeTypeImage, nil
+	case storagePoolVolumeTypeNameCustom:
+		return storagePoolVolumeTypeCustom, nil
+	}
+
+	return -1, fmt.Errorf("Invalid storage volume type name.")
+}
+
+func storagePoolVolumeTypeNameToApiEndpoint(volumeTypeName string) (string, error) {
+	switch volumeTypeName {
+	case storagePoolVolumeTypeNameContainer:
+		return storagePoolVolumeApiEndpointContainers, nil
+	case storagePoolVolumeTypeNameImage:
+		return storagePoolVolumeApiEndpointImages, nil
+	case storagePoolVolumeTypeNameCustom:
+		return storagePoolVolumeApiEndpointCustom, nil
+	}
+
+	return "", fmt.Errorf("Invalid storage volume type name.")
+}
+
+func storagePoolVolumeTypeToName(volumeType int) (string, error) {
+	switch volumeType {
+	case storagePoolVolumeTypeContainer:
+		return storagePoolVolumeTypeNameContainer, nil
+	case storagePoolVolumeTypeImage:
+		return storagePoolVolumeTypeNameImage, nil
+	case storagePoolVolumeTypeCustom:
+		return storagePoolVolumeTypeNameCustom, nil
+	}
+
+	return "", fmt.Errorf("Invalid storage volume type.")
+}
+
+func storagePoolVolumeTypeToApiEndpoint(volumeType int) (string, error) {
+	switch volumeType {
+	case storagePoolVolumeTypeContainer:
+		return storagePoolVolumeApiEndpointContainers, nil
+	case storagePoolVolumeTypeImage:
+		return storagePoolVolumeApiEndpointImages, nil
+	case storagePoolVolumeTypeCustom:
+		return storagePoolVolumeApiEndpointCustom, nil
+	}
+
+	return "", fmt.Errorf("Invalid storage volume type.")
+}
+
+func storagePoolVolumeUpdate(d *Daemon, poolName string, volumeName string, volumeType int, newConfig map[string]string) error {
+	s, err := storagePoolVolumeInit(d, poolName, volumeName, volumeType)
+	if err != nil {
+		return err
+	}
+
+	oldWritable := s.GetStoragePoolVolumeWritable()
+	newWritable := oldWritable
+
+	// Backup the current state
+	oldConfig := map[string]string{}
+	err = shared.DeepCopy(&oldWritable.Config, &oldConfig)
+	if err != nil {
+		return err
+	}
+
+	// Define a function which reverts everything.  Defer this function
+	// so that it doesn't need to be explicitly called in every failing
+	// return path. Track whether or not we want to undo the changes
+	// using a closure.
+	undoChanges := true
+	defer func() {
+		if undoChanges {
+			s.SetStoragePoolVolumeWritable(&oldWritable)
+		}
+	}()
+
+	// Diff the configurations
+	changedConfig := []string{}
+	userOnly := true
+	for key := range oldConfig {
+		if oldConfig[key] != newConfig[key] {
+			if !strings.HasPrefix(key, "user.") {
+				userOnly = false
+			}
+
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	for key := range newConfig {
+		if oldConfig[key] != newConfig[key] {
+			if !strings.HasPrefix(key, "user.") {
+				userOnly = false
+			}
+
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	// Skip on no change
+	if len(changedConfig) == 0 {
+		return nil
+	}
+
+	// Update the storage pool
+	if !userOnly {
+		err = s.StoragePoolVolumeUpdate(changedConfig)
+		if err != nil {
+			return err
+		}
+	}
+
+	newWritable.Config = newConfig
+
+	// Apply the new configuration
+	s.SetStoragePoolVolumeWritable(&newWritable)
+
+	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	if err != nil {
+		return err
+	}
+
+	// Update the database
+	err = dbStoragePoolVolumeUpdate(d.db, volumeName, volumeType, poolID, newConfig)
+	if err != nil {
+		return err
+	}
+
+	// Success, update the closure to mark that the changes should be kept.
+	undoChanges = false
+
+	return nil
+}
+
+func storagePoolVolumeUsedByGet(d *Daemon, volumeName string) ([]string, error) {
+	// Look for containers using the interface
+	cts, err := dbContainersList(d.db, cTypeRegular)
+	if err != nil {
+		return []string{}, err
+	}
+
+	volumeUsedBy := []string{}
+	for _, ct := range cts {
+		// We're not accessing any storage here.
+		c, err := containerLoadByName(d, ct)
+		if err != nil {
+			return []string{}, err
+		}
+
+		for _, d := range c.LocalDevices() {
+			if d["type"] != "disk" {
+				continue
+			}
+
+			containerAsVolume := fmt.Sprintf("%s/%s", storagePoolVolumeApiEndpointContainers, volumeName)
+			if (d["source"] == volumeName) || (d["source"] == containerAsVolume) {
+				volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/containers/%s", version.APIVersion, ct))
+			}
+		}
+	}
+
+	return volumeUsedBy, nil
+}

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-01-24 18:22-0500\n"
+        "POT-Creation-Date: 2017-02-14 01:13+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -30,6 +30,35 @@ msgstr  ""
 
 #: lxc/info.go:194
 msgid   "  Network usage:"
+msgstr  ""
+
+#: lxc/storage.go:33
+msgid   "### This is a yaml representation of a storage pool.\n"
+        "### Any line starting with a '# will be ignored.\n"
+        "###\n"
+        "### A storage pool consists of a set of configuration items.\n"
+        "###\n"
+        "### An example would look like:\n"
+        "### name: default\n"
+        "### driver: zfs\n"
+        "### used_by: []\n"
+        "### config:\n"
+        "###   size: \"61203283968\"\n"
+        "###   source: /home/chb/mnt/lxd_test/default.img\n"
+        "###   zfs.pool_name: default"
+msgstr  ""
+
+#: lxc/storage.go:50
+msgid   "### This is a yaml representation of a storage volume.\n"
+        "### Any line starting with a '# will be ignored.\n"
+        "###\n"
+        "### A storage volume consists of a set of configuration items.\n"
+        "###\n"
+        "### name: vol1\n"
+        "### type: custom\n"
+        "### used_by: []\n"
+        "### config:\n"
+        "###   size: \"61203283968\""
 msgstr  ""
 
 #: lxc/config.go:37
@@ -121,7 +150,7 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -168,7 +197,7 @@ msgstr  ""
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -182,7 +211,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
 
-#: lxc/network.go:390 lxc/profile.go:424
+#: lxc/network.go:390 lxc/profile.go:424 lxc/storage.go:522
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
@@ -208,15 +237,15 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: lxc/list.go:122 lxc/list.go:123
+#: lxc/list.go:123 lxc/list.go:124
 msgid   "Columns"
 msgstr  ""
 
-#: lxc/copy.go:32 lxc/copy.go:33 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:32 lxc/copy.go:33 lxc/init.go:137 lxc/init.go:138
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:535 lxc/config.go:600 lxc/image.go:737 lxc/network.go:346 lxc/profile.go:218
+#: lxc/config.go:535 lxc/config.go:600 lxc/image.go:737 lxc/network.go:346 lxc/profile.go:218 lxc/storage.go:478 lxc/storage.go:824
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -229,7 +258,7 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:141 lxc/copy.go:242 lxc/init.go:230
+#: lxc/copy.go:141 lxc/copy.go:242 lxc/init.go:246
 #, c-format
 msgid   "Container name is: %s"
 msgstr  ""
@@ -288,17 +317,21 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:181 lxc/launch.go:127
+#: lxc/init.go:184 lxc/launch.go:139
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:179
+#: lxc/init.go:182
 msgid   "Creating the container"
 msgstr  ""
 
 #: lxc/image.go:644 lxc/image.go:685
 msgid   "DESCRIPTION"
+msgstr  ""
+
+#: lxc/storage.go:551
+msgid   "DRIVER"
 msgstr  ""
 
 #: lxc/publish.go:38
@@ -323,7 +356,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/list.go:574
+#: lxc/list.go:576
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -347,7 +380,7 @@ msgstr  ""
 msgid   "Environment:"
 msgstr  ""
 
-#: lxc/copy.go:36 lxc/copy.go:37 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:36 lxc/copy.go:37 lxc/init.go:141 lxc/init.go:142
 msgid   "Ephemeral container"
 msgstr  ""
 
@@ -376,7 +409,7 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/list.go:125
+#: lxc/list.go:126
 msgid   "Fast mode (same as --columns=nsacPt"
 msgstr  ""
 
@@ -397,7 +430,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:169 lxc/list.go:124
+#: lxc/image.go:169 lxc/list.go:125
 msgid   "Format"
 msgstr  ""
 
@@ -411,11 +444,11 @@ msgid   "Help page for the LXD client.\n"
         "lxc help [--all]"
 msgstr  ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:426
+#: lxc/list.go:427
 msgid   "IPV6"
 msgstr  ""
 
@@ -449,10 +482,10 @@ msgstr  ""
 msgid   "Importing the image: %s"
 msgstr  ""
 
-#: lxc/init.go:74
+#: lxc/init.go:75
 msgid   "Initialize a container from a particular image.\n"
         "\n"
-        "lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>]\n"
+        "lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]\n"
         "\n"
         "Initializes a container using the specified image and name.\n"
         "\n"
@@ -494,7 +527,7 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:429
+#: lxc/list.go:430
 msgid   "LAST USED AT"
 msgstr  ""
 
@@ -514,7 +547,7 @@ msgstr  ""
 #: lxc/launch.go:23
 msgid   "Launch a container from a particular image.\n"
         "\n"
-        "lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>]\n"
+        "lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]\n"
         "\n"
         "Launches a container using the specified image and name.\n"
         "\n"
@@ -560,6 +593,7 @@ msgid   "Lists the containers.\n"
         "* 4 - IPv4 address\n"
         "* 6 - IPv6 address\n"
         "* a - architecture\n"
+        "* b - storage pool\n"
         "* c - creation date\n"
         "* l - last used date\n"
         "* n - name\n"
@@ -733,6 +767,40 @@ msgid   "Manage remote LXD servers.\n"
         "lxc remote get-default                                                      Print the default remote."
 msgstr  ""
 
+#: lxc/storage.go:64
+msgid   "Manage storage.\n"
+        "\n"
+        "lxc storage list [<remote>:]                           List available storage pools.\n"
+        "lxc storage show [<remote>:]<pool>                     Show details of a storage pool.\n"
+        "lxc storage create [<remote>:]<pool> [key=value]...    Create a storage pool.\n"
+        "lxc storage get [<remote>:]<pool> <key>                Get storage pool configuration.\n"
+        "lxc storage set [<remote>:]<pool> <key> <value>        Set storage pool configuration.\n"
+        "lxc storage unset [<remote>:]<pool> <key>              Unset storage pool configuration.\n"
+        "lxc storage delete [<remote>:]<pool>                   Delete a storage pool.\n"
+        "lxc storage edit [<remote>:]<pool>\n"
+        "    Edit storage pool, either by launching external editor or reading STDIN.\n"
+        "    Example: lxc storage edit [<remote>:]<pool> # launch editor\n"
+        "             cat pool.yaml | lxc storage edit [<remote>:]<pool> # read from pool.yaml\n"
+        "\n"
+        "lxc storage volume list [<remote>:]<pool>                              List available storage volumes on a storage pool.\n"
+        "lxc storage volume show [<remote>:]<pool> <volume>			Show details of a storage volume on a storage pool.\n"
+        "lxc storage volume create [<remote>:]<pool> <volume> [key=value]...    Create a storage volume on a storage pool.\n"
+        "lxc storage volume get [<remote>:]<pool> <volume> <key>                Get storage volume configuration on a storage pool.\n"
+        "lxc storage volume set [<remote>:]<pool> <volume> <key> <value>        Set storage volume configuration on a storage pool.\n"
+        "lxc storage volume unset [<remote>:]<pool> <volume> <key>              Unset storage volume configuration on a storage pool.\n"
+        "lxc storage volume delete [<remote>:]<pool> <volume>                   Delete a storage volume on a storage pool.\n"
+        "lxc storage volume edit [<remote>:]<pool> <volume>\n"
+        "    Edit storage pool, either by launching external editor or reading STDIN.\n"
+        "    Example: lxc storage volume edit [<remote>:]<pool> <volume> # launch editor\n"
+        "             cat pool.yaml | lxc storage volume edit [<remote>:]<pool> <volume> # read from pool.yaml\n"
+        "\n"
+        "lxc storage volume attach [<remote>:]<pool> <volume> <container> [device name] <path>\n"
+        "lxc storage volume attach-profile [<remote:>]<pool> <volume> <profile> [device name] <path>\n"
+        "\n"
+        "lxc storage volume detach [<remote>:]<pool> <volume> <container> [device name]\n"
+        "lxc storage volume detach-profile [<remote:>]<pool> <volume> <profile> [device name]\n"
+msgstr  ""
+
 #: lxc/image.go:96
 msgid   "Manipulate container images.\n"
         "\n"
@@ -827,7 +895,7 @@ msgid   "Monitor activity on the LXD server.\n"
         "    lxc monitor --type=logging"
 msgstr  ""
 
-#: lxc/network.go:216 lxc/network.go:265
+#: lxc/network.go:216 lxc/network.go:265 lxc/storage.go:309 lxc/storage.go:405
 msgid   "More than one device matches, specify the device name."
 msgstr  ""
 
@@ -852,7 +920,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:430 lxc/network.go:426 lxc/profile.go:451 lxc/remote.go:380
+#: lxc/list.go:431 lxc/network.go:426 lxc/profile.go:451 lxc/remote.go:380 lxc/storage.go:550 lxc/storage.go:640 lxc/storage.go:673
 msgid   "NAME"
 msgstr  ""
 
@@ -875,7 +943,7 @@ msgstr  ""
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid   "Network name"
 msgstr  ""
 
@@ -889,6 +957,10 @@ msgstr  ""
 
 #: lxc/network.go:225 lxc/network.go:274
 msgid   "No device found for this network"
+msgstr  ""
+
+#: lxc/storage.go:318 lxc/storage.go:414
+msgid   "No device found for this storage volume."
 msgstr  ""
 
 #: lxc/config.go:308
@@ -920,15 +992,15 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:576
+#: lxc/list.go:578
 msgid   "PERSISTENT"
 msgstr  ""
 
-#: lxc/list.go:431
+#: lxc/list.go:432
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:432
+#: lxc/list.go:433
 msgid   "PROFILES"
 msgstr  ""
 
@@ -965,7 +1037,7 @@ msgstr  ""
 msgid   "Pid: %d"
 msgstr  ""
 
-#: lxc/network.go:347 lxc/profile.go:219
+#: lxc/network.go:347 lxc/profile.go:219 lxc/storage.go:479 lxc/storage.go:825
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
@@ -1020,7 +1092,7 @@ msgstr  ""
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/copy.go:34 lxc/copy.go:35 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:34 lxc/copy.go:35 lxc/init.go:139 lxc/init.go:140
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
@@ -1095,7 +1167,7 @@ msgid   "Restore a container's state to a previous snapshot.\n"
         "    lxc restore u1 snap0"
 msgstr  ""
 
-#: lxc/init.go:240
+#: lxc/init.go:256
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -1104,16 +1176,24 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/list.go:434
+#: lxc/storage.go:552
+msgid   "SOURCE"
+msgstr  ""
+
+#: lxc/list.go:435
 msgid   "STATE"
 msgstr  ""
 
 #: lxc/remote.go:384
 msgid   "STATIC"
+msgstr  ""
+
+#: lxc/list.go:437
+msgid   "STORAGE POOL"
 msgstr  ""
 
 #: lxc/remote.go:225
@@ -1169,7 +1249,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/launch.go:136
+#: lxc/launch.go:148
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -1187,6 +1267,30 @@ msgstr  ""
 msgid   "Stopping container failed!"
 msgstr  ""
 
+#: lxc/storage.go:379
+#, c-format
+msgid   "Storage pool %s created"
+msgstr  ""
+
+#: lxc/storage.go:429
+#, c-format
+msgid   "Storage pool %s deleted"
+msgstr  ""
+
+#: lxc/init.go:145 lxc/init.go:146
+msgid   "Storage pool name"
+msgstr  ""
+
+#: lxc/storage.go:696
+#, c-format
+msgid   "Storage volume %s created"
+msgstr  ""
+
+#: lxc/storage.go:705
+#, c-format
+msgid   "Storage volume %s deleted"
+msgstr  ""
+
 #: lxc/action.go:46
 msgid   "Store the container state (only for stop)"
 msgstr  ""
@@ -1199,7 +1303,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/list.go:435 lxc/network.go:427
+#: lxc/list.go:436 lxc/network.go:427 lxc/storage.go:641 lxc/storage.go:674
 msgid   "TYPE"
 msgstr  ""
 
@@ -1211,7 +1315,7 @@ msgstr  ""
 msgid   "The container is currently running. Use --force to have it stopped and restarted."
 msgstr  ""
 
-#: lxc/init.go:313
+#: lxc/init.go:329
 msgid   "The container you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -1219,7 +1323,7 @@ msgstr  ""
 msgid   "The device doesn't exist"
 msgstr  ""
 
-#: lxc/init.go:297
+#: lxc/init.go:313
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
@@ -1228,7 +1332,7 @@ msgstr  ""
 msgid   "The opposite of `lxc pause` is `lxc start`."
 msgstr  ""
 
-#: lxc/network.go:230 lxc/network.go:279
+#: lxc/network.go:230 lxc/network.go:279 lxc/storage.go:323 lxc/storage.go:419
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -1248,11 +1352,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:315
+#: lxc/init.go:331
 msgid   "To attach a network to a container, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:314
+#: lxc/init.go:330
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -1265,7 +1369,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/action.go:100 lxc/launch.go:149
+#: lxc/action.go:100 lxc/launch.go:161
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -1286,7 +1390,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:429 lxc/profile.go:452
+#: lxc/network.go:429 lxc/profile.go:452 lxc/storage.go:553 lxc/storage.go:642 lxc/storage.go:675
 msgid   "USED BY"
 msgstr  ""
 
@@ -1328,7 +1432,7 @@ msgstr  ""
 msgid   "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr  ""
 
-#: lxc/launch.go:120
+#: lxc/launch.go:132
 msgid   "bad number of things scanned from image, container or snapshot"
 msgstr  ""
 
@@ -1356,7 +1460,7 @@ msgstr  ""
 msgid   "default"
 msgstr  ""
 
-#: lxc/copy.go:132 lxc/copy.go:137 lxc/copy.go:233 lxc/copy.go:238 lxc/init.go:220 lxc/init.go:225 lxc/launch.go:104 lxc/launch.go:109
+#: lxc/copy.go:132 lxc/copy.go:137 lxc/copy.go:233 lxc/copy.go:238 lxc/init.go:236 lxc/init.go:241 lxc/launch.go:116 lxc/launch.go:121
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
@@ -1378,7 +1482,7 @@ msgstr  ""
 msgid   "error: unknown command: %s"
 msgstr  ""
 
-#: lxc/launch.go:124
+#: lxc/launch.go:136
 msgid   "got bad version"
 msgstr  ""
 
@@ -1394,7 +1498,7 @@ msgstr  ""
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:304 lxc/main.go:308
+#: lxc/main.go:305 lxc/main.go:309
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -1436,11 +1540,11 @@ msgstr  ""
 msgid   "taken at %s"
 msgstr  ""
 
-#: lxc/exec.go:186
+#: lxc/exec.go:189
 msgid   "unreachable return reached"
 msgstr  ""
 
-#: lxc/main.go:236
+#: lxc/main.go:237
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/shared/api/storage.go
+++ b/shared/api/storage.go
@@ -1,0 +1,49 @@
+package api
+
+// StoragePool represents the fields of a LXD storage pool.
+//
+// API extension: storage
+type StoragePool struct {
+	StoragePoolPut `yaml:",inline"`
+
+	Name   string   `json:"name" yaml:"name"`
+	Driver string   `json:"driver" yaml:"driver"`
+	UsedBy []string `json:"used_by" yaml:"used_by"`
+}
+
+// StoragePoolPut represents the modifiable fields of a LXD storage pool.
+//
+// API extension: storage
+type StoragePoolPut struct {
+	Config map[string]string `json:"config" yaml:"config"`
+}
+
+// StorageVolume represents the fields of a LXD storage volume.
+//
+// API extension: storage
+type StorageVolume struct {
+	StorageVolumePut `yaml:",inline"`
+
+	Type   string   `json:"type" yaml:"type"`
+	UsedBy []string `json:"used_by" yaml:"used_by"`
+}
+
+// StorageVolumePut represents the modifiable fields of a LXD storage volume.
+//
+// API extension: storage
+type StorageVolumePut struct {
+	Name   string            `json:"name" yaml:"name"`
+	Config map[string]string `json:"config" yaml:"config"`
+}
+
+// Writable converts a full StoragePool struct into a StoragePoolPut struct
+// (filters read-only fields).
+func (storagePool *StoragePool) Writable() StoragePoolPut {
+	return storagePool.StoragePoolPut
+}
+
+// Writable converts a full StorageVolume struct into a StorageVolumePut struct
+// (filters read-only fields).
+func (storageVolume *StorageVolume) Writable() StorageVolumePut {
+	return storageVolume.StorageVolumePut
+}

--- a/shared/util.go
+++ b/shared/util.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"os/exec"
@@ -651,15 +652,14 @@ func ParseByteSizeString(input string) (int64, error) {
 	}
 
 	if unicode.IsNumber(rune(input[len(input)-1])) {
-		// COMMENT(brauner): No suffix --> bytes.
+		// No suffix --> bytes.
 		suffixLen = 0
 	} else if (len(input) >= 2) && (input[len(input)-1] == 'B') && unicode.IsNumber(rune(input[len(input)-2])) {
-		// COMMENT(brauner): "B" suffix --> bytes.
+		// "B" suffix --> bytes.
 		suffixLen = 1
 	} else if strings.HasSuffix(input, " bytes") {
-		// COMMENT(brauner): Backward compatible behaviour in case we
-		// talk to a LXD that still uses GetByteSizeString() that
-		// returns "n bytes".
+		// Backward compatible behaviour in case we talk to a LXD that
+		// still uses GetByteSizeString() that returns "n bytes".
 		suffixLen = 6
 	} else if (len(input) < 3) && (suffixLen == 2) {
 		return -1, fmt.Errorf("Invalid value: %s", input)
@@ -679,7 +679,7 @@ func ParseByteSizeString(input string) (int64, error) {
 		return -1, fmt.Errorf("Invalid value: %d", valueInt)
 	}
 
-	// COMMENT(brauner): The value is already in bytes.
+	// The value is already in bytes.
 	if suffixLen != 2 {
 		return valueInt, nil
 	}
@@ -801,4 +801,12 @@ func TimeIsSet(ts time.Time) bool {
 	}
 
 	return true
+}
+
+func Round(x float64) int64 {
+	if x < 0 {
+		return int64(math.Ceil(x - 0.5))
+	}
+
+	return int64(math.Floor(x + 0.5))
 }

--- a/test/backends/btrfs.sh
+++ b/test/backends/btrfs.sh
@@ -12,10 +12,6 @@ btrfs_setup() {
     echo "Couldn't find the btrfs binary"; false
   fi
 
-  truncate -s 100G "${TEST_DIR}/$(basename "${LXD_DIR}").btrfs"
-  mkfs.btrfs "${TEST_DIR}/$(basename "${LXD_DIR}").btrfs"
-
-  mount -o loop "${TEST_DIR}/$(basename "${LXD_DIR}").btrfs" "${LXD_DIR}"
 }
 
 btrfs_configure() {
@@ -23,6 +19,9 @@ btrfs_configure() {
   local LXD_DIR
 
   LXD_DIR=$1
+
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" btrfs size=100GB
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 
   echo "==> Configuring btrfs backend in ${LXD_DIR}"
 }
@@ -34,7 +33,4 @@ btrfs_teardown() {
   LXD_DIR=$1
 
   echo "==> Tearing down btrfs backend in ${LXD_DIR}"
-
-  umount -l "${LXD_DIR}"
-  rm -f "${TEST_DIR}/$(basename "${LXD_DIR}").btrfs"
 }

--- a/test/backends/dir.sh
+++ b/test/backends/dir.sh
@@ -21,6 +21,9 @@ dir_configure() {
   LXD_DIR=$1
 
   echo "==> Configuring directory backend in ${LXD_DIR}"
+
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" dir
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 }
 
 dir_teardown() {

--- a/test/backends/lvm.sh
+++ b/test/backends/lvm.sh
@@ -21,7 +21,6 @@ lvm_setup() {
   echo "${pvloopdev}" > "${TEST_DIR}/$(basename "${LXD_DIR}").lvm.vg"
 
   pvcreate "${pvloopdev}"
-  vgcreate "lxdtest-$(basename "${LXD_DIR}")" "${pvloopdev}"
 }
 
 lvm_configure() {
@@ -32,8 +31,8 @@ lvm_configure() {
 
   echo "==> Configuring lvm backend in ${LXD_DIR}"
 
-  lxc config set storage.lvm_volume_size "10Mib"
-  lxc config set storage.lvm_vg_name "lxdtest-$(basename "${LXD_DIR}")"
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" lvm source="$(cat "${TEST_DIR}/$(basename "${LXD_DIR}").lvm.vg")" volume.size=10MB
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 }
 
 lvm_teardown() {
@@ -47,7 +46,6 @@ lvm_teardown() {
   SUCCESS=0
   # shellcheck disable=SC2034
   for i in $(seq 10); do
-    vgremove -f "lxdtest-$(basename "${LXD_DIR}")" >/dev/null 2>&1 || true
     pvremove -f "$(cat "${TEST_DIR}/$(basename "${LXD_DIR}").lvm.vg")" >/dev/null 2>&1 || true
     if losetup -d "$(cat "${TEST_DIR}/$(basename "${LXD_DIR}").lvm.vg")"; then
       SUCCESS=1

--- a/test/backends/zfs.sh
+++ b/test/backends/zfs.sh
@@ -11,11 +11,6 @@ zfs_setup() {
   if ! which zfs >/dev/null 2>&1; then
     echo "Couldn't find zfs binary"; false
   fi
-
-  truncate -s 100G "${LXD_DIR}/zfspool"
-  # prefix lxdtest- here, as zfs pools must start with a letter, but tempdir
-  # won't necessarily generate one that does.
-  zpool create "lxdtest-$(basename "${LXD_DIR}")" "${LXD_DIR}/zfspool" -m none
 }
 
 zfs_configure() {
@@ -26,11 +21,8 @@ zfs_configure() {
 
   echo "==> Configuring ZFS backend in ${LXD_DIR}"
 
-  lxc config set storage.zfs_pool_name "lxdtest-$(basename "${LXD_DIR}")"
-
-  # Avoid a zfs bug in "-p" handling during concurent create
-  zfs create -p -o mountpoint=none "lxdtest-$(basename "${LXD_DIR}")/containers"
-  zfs create -p -o mountpoint=none "lxdtest-$(basename "${LXD_DIR}")/images"
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" zfs size=100GB
+  lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 }
 
 zfs_teardown() {
@@ -40,23 +32,4 @@ zfs_teardown() {
   LXD_DIR=$1
 
   echo "==> Tearing down ZFS backend in ${LXD_DIR}"
-
-  # Wait up to 5s for zpool destroy to succeed
-  SUCCESS=0
-
-  # shellcheck disable=SC2034
-  for i in $(seq 10); do
-    zpool destroy -f "lxdtest-$(basename "${LXD_DIR}")" >/dev/null 2>&1 || true
-    if ! zpool list -o name -H | grep -q "^lxdtest-$(basename "${LXD_DIR}")"; then
-      SUCCESS=1
-      break
-    fi
-
-    sleep 0.5
-  done
-
-  if [ "${SUCCESS}" = "0" ]; then
-    echo "Failed to destroy the zpool"
-    false
-  fi
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -68,6 +68,9 @@ spawn_lxd() {
   lxddir=${1}
   shift
 
+  storage=${1}
+  shift
+
   # Copy pre generated Certs
   cp deps/server.crt "${lxddir}"
   cp deps/server.key "${lxddir}"
@@ -109,8 +112,10 @@ spawn_lxd() {
     LXD_DIR="${lxddir}" lxc network attach-profile lxdbr0 default eth0
   fi
 
-  echo "==> Configuring storage backend"
-  "$LXD_BACKEND"_configure "${lxddir}"
+  if [ "${storage}" = true ]; then
+    echo "==> Configuring storage backend"
+    "$LXD_BACKEND"_configure "${lxddir}"
+  fi
 }
 
 lxc() {
@@ -247,6 +252,11 @@ kill_lxd() {
       lxc profile delete "${profile}" --force-local || true
     done
 
+    echo "==> Deleting all storage pools"
+    for storage in $(lxc storage list --force-local | tail -n+3 | grep "^| " | cut -d' ' -f2); do
+      lxc storage delete "${storage}" --force-local || true
+    done
+
     echo "==> Checking for locked DB tables"
     for table in $(echo .tables | sqlite3 "${daemon_dir}/lxd.db"); do
       echo "SELECT * FROM ${table};" | sqlite3 "${daemon_dir}/lxd.db" >/dev/null
@@ -299,6 +309,10 @@ kill_lxd() {
     check_empty_table "${daemon_dir}/lxd.db" "profiles_config"
     check_empty_table "${daemon_dir}/lxd.db" "profiles_devices"
     check_empty_table "${daemon_dir}/lxd.db" "profiles_devices_config"
+    check_empty_table "${daemon_dir}/lxd.db" "storage_pools"
+    check_empty_table "${daemon_dir}/lxd.db" "storage_pools_config"
+    check_empty_table "${daemon_dir}/lxd.db" "storage_volumes"
+    check_empty_table "${daemon_dir}/lxd.db" "storage_volumes_config"
   fi
 
   # teardown storage
@@ -410,14 +424,14 @@ export LXD_CONF
 LXD_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
 export LXD_DIR
 chmod +x "${LXD_DIR}"
-spawn_lxd "${LXD_DIR}"
+spawn_lxd "${LXD_DIR}" true
 LXD_ADDR=$(cat "${LXD_DIR}/lxd.addr")
 export LXD_ADDR
 
 # Setup the second LXD
 LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
 chmod +x "${LXD2_DIR}"
-spawn_lxd "${LXD2_DIR}"
+spawn_lxd "${LXD2_DIR}" true
 LXD2_ADDR=$(cat "${LXD2_DIR}/lxd.addr")
 export LXD2_ADDR
 
@@ -464,5 +478,6 @@ run_test test_migration "migration"
 run_test test_fdleak "fd leak"
 run_test test_cpu_profiling "CPU profiling"
 run_test test_mem_profiling "memory profiling"
+run_test test_storage "storage"
 
 TEST_RESULT=success

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -218,7 +218,7 @@ test_basic_usage() {
   # Test activateifneeded/shutdown
   LXD_ACTIVATION_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_ACTIVATION_DIR}"
-  spawn_lxd "${LXD_ACTIVATION_DIR}"
+  spawn_lxd "${LXD_ACTIVATION_DIR}" true
   (
     set -e
     # shellcheck disable=SC2030
@@ -369,7 +369,7 @@ test_basic_usage() {
   # make sure that privileged containers are not world-readable
   lxc profile create unconfined
   lxc profile set unconfined security.privileged true
-  lxc init testimage foo2 -p unconfined
+  lxc init testimage foo2 -p unconfined -s "lxdtest-$(basename "${LXD_DIR}")"
   [ "$(stat -L -c "%a" "${LXD_DIR}/containers/foo2")" = "700" ]
   lxc delete foo2
   lxc profile delete unconfined

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -100,7 +100,7 @@ test_mount_order() {
 test_config_profiles() {
   ensure_import_testimage
 
-  lxc init testimage foo
+  lxc init testimage foo -s "lxdtest-$(basename "${LXD_DIR}")"
   lxc profile list | grep default
 
   # let's check that 'lxc config profile' still works while it's deprecated
@@ -207,7 +207,7 @@ test_config_profiles() {
 
   lxc delete foo
 
-  lxc init testimage foo
+  lxc init testimage foo -s "lxdtest-$(basename "${LXD_DIR}")"
   lxc profile assign foo onenic,unconfined
   lxc start foo
 

--- a/test/suites/database_update.sh
+++ b/test/suites/database_update.sh
@@ -8,15 +8,15 @@ test_database_update(){
   sqlite3 "${MIGRATE_DB}" > /dev/null < deps/schema1.sql
 
   # Start an LXD demon in the tmp directory. This should start the updates.
-  spawn_lxd "${LXD_MIGRATE_DIR}"
+  spawn_lxd "${LXD_MIGRATE_DIR}" true
 
   # Assert there are enough tables.
-  expected_tables=19
+  expected_tables=23
   tables=$(sqlite3 "${MIGRATE_DB}" ".dump" | grep -c "CREATE TABLE")
   [ "${tables}" -eq "${expected_tables}" ] || { echo "FAIL: Wrong number of tables after database migration. Found: ${tables}, expected ${expected_tables}"; false; }
 
-  # There should be 13 "ON DELETE CASCADE" occurrences
-  expected_cascades=12
+  # There should be 15 "ON DELETE CASCADE" occurrences
+  expected_cascades=15
   cascades=$(sqlite3 "${MIGRATE_DB}" ".dump" | grep -c "ON DELETE CASCADE")
   [ "${cascades}" -eq "${expected_cascades}" ] || { echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys. Found: ${cascades}, exected: ${expected_cascades}"; false; }
 }

--- a/test/suites/fdleak.sh
+++ b/test/suites/fdleak.sh
@@ -3,7 +3,7 @@
 test_fdleak() {
   LXD_FDLEAK_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_FDLEAK_DIR}"
-  spawn_lxd "${LXD_FDLEAK_DIR}"
+  spawn_lxd "${LXD_FDLEAK_DIR}" true
   pid=$(cat "${LXD_FDLEAK_DIR}/lxd.pid")
 
   beforefds=$(/bin/ls "/proc/${pid}/fd" | wc -l)

--- a/test/suites/pki.sh
+++ b/test/suites/pki.sh
@@ -26,7 +26,7 @@ test_pki() {
   cat "${TEST_DIR}/pki/keys/127.0.0.1.crt" "${TEST_DIR}/pki/keys/ca.crt" > "${LXD5_DIR}/server.crt"
   cp "${TEST_DIR}/pki/keys/127.0.0.1.key" "${LXD5_DIR}/server.key"
   cp "${TEST_DIR}/pki/keys/ca.crt" "${LXD5_DIR}/server.ca"
-  spawn_lxd "${LXD5_DIR}"
+  spawn_lxd "${LXD5_DIR}" true
   LXD5_ADDR=$(cat "${LXD5_DIR}/lxd.addr")
 
   # Setup the client

--- a/test/suites/profiling.sh
+++ b/test/suites/profiling.sh
@@ -3,7 +3,7 @@
 test_cpu_profiling() {
   LXD3_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD3_DIR}"
-  spawn_lxd "${LXD3_DIR}" --cpuprofile "${LXD3_DIR}/cpu.out"
+  spawn_lxd "${LXD3_DIR}" false --cpuprofile "${LXD3_DIR}/cpu.out"
   lxdpid=$(cat "${LXD3_DIR}/lxd.pid")
   kill -TERM "${lxdpid}"
   wait "${lxdpid}" || true
@@ -21,7 +21,7 @@ test_cpu_profiling() {
 test_mem_profiling() {
   LXD4_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD4_DIR}"
-  spawn_lxd "${LXD4_DIR}" --memprofile "${LXD4_DIR}/mem"
+  spawn_lxd "${LXD4_DIR}" false --memprofile "${LXD4_DIR}/mem"
   lxdpid=$(cat "${LXD4_DIR}/lxd.pid")
 
   if [ -e "${LXD4_DIR}/mem" ]; then

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -8,19 +8,17 @@ test_security() {
   if [ "${LXD_BACKEND}" = "zfs" ]; then
     LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_INIT_DIR}"
-    spawn_lxd "${LXD_INIT_DIR}"
+    spawn_lxd "${LXD_INIT_DIR}" false
 
     ZFS_POOL="lxdtest-$(basename "${LXD_DIR}")-init"
     LXD_DIR=${LXD_INIT_DIR} lxd init --storage-backend zfs --storage-create-loop 1 --storage-pool "${ZFS_POOL}" --auto
 
-    PERM=$(stat -c %a "${LXD_INIT_DIR}/zfs.img")
+    PERM=$(stat -c %a "${LXD_INIT_DIR}/disks/${ZFS_POOL}.img")
     if [ "${PERM}" != "600" ]; then
       echo "Bad zfs.img permissions: ${PERM}"
-      zpool destroy "${ZFS_POOL}"
       false
     fi
 
-    zpool destroy "${ZFS_POOL}"
     kill_lxd "${LXD_INIT_DIR}"
   fi
 

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -2,7 +2,7 @@
 
 test_server_config() {
   LXD_SERVERCONFIG_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  spawn_lxd "${LXD_SERVERCONFIG_DIR}"
+  spawn_lxd "${LXD_SERVERCONFIG_DIR}" true
 
   lxc config set core.trust_password 123456
 

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+
+configure_lvm_loop_device() {
+  lv_loop_file=$(mktemp -p "${TEST_DIR}" XXXX.lvm)
+  truncate -s 4G "${lv_loop_file}"
+  pvloopdev=$(losetup --show -f "${lv_loop_file}")
+  if [ ! -e "${pvloopdev}" ]; then
+    echo "failed to setup loop"
+    false
+  fi
+
+  pvcreate "${pvloopdev}"
+
+  # The following code enables to return a value from a shell function by
+  # calling the function as: fun VAR1
+
+  # shellcheck disable=2039
+  local  __tmp1="${1}"
+  # shellcheck disable=2039
+  local  res1="${lv_loop_file}"
+  if [ "${__tmp1}" ]; then
+      eval "${__tmp1}='${res1}'"
+  fi
+
+  # shellcheck disable=2039
+  local  __tmp2="${2}"
+  # shellcheck disable=2039
+  local  res2="${pvloopdev}"
+  if [ "${__tmp2}" ]; then
+      eval "${__tmp2}='${res2}'"
+  fi
+}
+
+deconfigure_lvm_loop_device() {
+  lv_loop_file="${1}"
+  loopdev="${2}"
+
+  SUCCESS=0
+  # shellcheck disable=SC2034
+  for i in $(seq 10); do
+    pvremove -f "${loopdev}" > /dev/null 2>&1 || true
+    if losetup -d "${loopdev}"; then
+      SUCCESS=1
+      break
+    fi
+
+    sleep 0.5
+  done
+
+  if [ "${SUCCESS}" = "0" ]; then
+    echo "Failed to tear down loop device."
+    false
+  fi
+
+  rm -f "${lv_loop_file}"
+}
+
+configure_loop_device() {
+  lv_loop_file=$(mktemp -p "${TEST_DIR}" XXXX.img)
+  truncate -s 10G "${lv_loop_file}"
+  pvloopdev=$(losetup --show -f "${lv_loop_file}")
+  if [ ! -e "${pvloopdev}" ]; then
+    echo "failed to setup loop"
+    false
+  fi
+
+  # The following code enables to return a value from a shell function by
+  # calling the function as: fun VAR1
+
+  # shellcheck disable=2039
+  local  __tmp1="${1}"
+  # shellcheck disable=2039
+  local  res1="${lv_loop_file}"
+  if [ "${__tmp1}" ]; then
+      eval "${__tmp1}='${res1}'"
+  fi
+
+  # shellcheck disable=2039
+  local  __tmp2="${2}"
+  # shellcheck disable=2039
+  local  res2="${pvloopdev}"
+  if [ "${__tmp2}" ]; then
+      eval "${__tmp2}='${res2}'"
+  fi
+}
+
+deconfigure_loop_device() {
+  lv_loop_file="${1}"
+  loopdev="${2}"
+
+  SUCCESS=0
+  # shellcheck disable=SC2034
+  for i in $(seq 10); do
+    if losetup -d "${loopdev}"; then
+      SUCCESS=1
+      break
+    fi
+
+    sleep 0.5
+  done
+
+  if [ "${SUCCESS}" = "0" ]; then
+    echo "Failed to tear down loop device"
+    false
+  fi
+
+  rm -f "${lv_loop_file}"
+}
+
+test_storage() {
+  LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
+  chmod +x "${LXD_STORAGE_DIR}"
+  spawn_lxd "${LXD_STORAGE_DIR}" false
+  (
+    set -e
+    # shellcheck disable=2030
+    LXD_DIR="${LXD_STORAGE_DIR}"
+
+    # Only create zfs pools on 64 bit arches. I think getconf LONG_BIT should
+    # even work when running a 32bit userspace on a 64 bit kernel.
+    ARCH=$(getconf LONG_BIT)
+    BACKEND=btrfs
+    if [ "${ARCH}" = "64" ]; then
+	    BACKEND=zfs
+    fi
+
+    # Create loop file zfs pool.
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" "${BACKEND}"
+
+    # Create device backed zfs pool
+    configure_loop_device loop_file_1 loop_device_1
+    # shellcheck disable=SC2154
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" "${BACKEND}" source="${loop_device_1}"
+
+    # Create loop file btrfs pool.
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool3" btrfs
+
+    # Create device backed btrfs pool.
+    configure_loop_device loop_file_2 loop_device_2
+    # shellcheck disable=SC2154
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool4" btrfs source="${loop_device_2}"
+
+    # Create dir pool.
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool5" dir
+
+    # Create lvm pool.
+    configure_lvm_loop_device loop_file_3 loop_device_3
+    # shellcheck disable=SC2154
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool6" lvm source="${loop_device_3}"
+
+    # Set default storage pool for image import.
+    lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")-pool1"
+
+    # Import image into default storage pool.
+    ensure_import_testimage
+
+    # Muck around with some containers on various pools.
+    lxc init testimage c1pool1 -s "lxdtest-$(basename "${LXD_DIR}")-pool1"
+    lxc list -c b c1pool1 | grep "lxdtest-$(basename "${LXD_DIR}")-pool1"
+    lxc init testimage c2pool2 -s "lxdtest-$(basename "${LXD_DIR}")-pool2"
+    lxc list -c b c2pool2 | grep "lxdtest-$(basename "${LXD_DIR}")-pool2"
+
+    lxc launch testimage c3pool1 -s "lxdtest-$(basename "${LXD_DIR}")-pool1"
+    lxc list -c b c3pool1 | grep "lxdtest-$(basename "${LXD_DIR}")-pool1"
+    lxc launch testimage c4pool2 -s "lxdtest-$(basename "${LXD_DIR}")-pool2"
+    lxc list -c b c4pool2 | grep "lxdtest-$(basename "${LXD_DIR}")-pool2"
+
+    lxc init testimage c5pool3 -s "lxdtest-$(basename "${LXD_DIR}")-pool3"
+    lxc list -c b c5pool3 | grep "lxdtest-$(basename "${LXD_DIR}")-pool3"
+    lxc init testimage c6pool4 -s "lxdtest-$(basename "${LXD_DIR}")-pool4"
+    lxc list -c b c6pool4 | grep "lxdtest-$(basename "${LXD_DIR}")-pool4"
+
+    lxc launch testimage c7pool3 -s "lxdtest-$(basename "${LXD_DIR}")-pool3"
+    lxc list -c b c7pool3 | grep "lxdtest-$(basename "${LXD_DIR}")-pool3"
+    lxc launch testimage c8pool4 -s "lxdtest-$(basename "${LXD_DIR}")-pool4"
+    lxc list -c b c8pool4 | grep "lxdtest-$(basename "${LXD_DIR}")-pool4"
+
+    lxc init testimage c9pool5 -s "lxdtest-$(basename "${LXD_DIR}")-pool5"
+    lxc list -c b c9pool5 | grep "lxdtest-$(basename "${LXD_DIR}")-pool5"
+    lxc init testimage c10pool6 -s "lxdtest-$(basename "${LXD_DIR}")-pool6"
+    lxc list -c b c10pool6 | grep "lxdtest-$(basename "${LXD_DIR}")-pool6"
+
+    lxc launch testimage c11pool5 -s "lxdtest-$(basename "${LXD_DIR}")-pool5"
+    lxc list -c b c11pool5 | grep "lxdtest-$(basename "${LXD_DIR}")-pool5"
+    lxc launch testimage c12pool6 -s "lxdtest-$(basename "${LXD_DIR}")-pool6"
+    lxc list -c b c12pool6 | grep "lxdtest-$(basename "${LXD_DIR}")-pool6"
+
+    lxc delete -f c1pool1
+    lxc delete -f c2pool2
+
+    lxc delete -f c3pool1
+    lxc delete -f c4pool2
+
+    lxc delete -f c5pool3
+    lxc delete -f c6pool4
+
+    lxc delete -f c7pool3
+    lxc delete -f c8pool4
+
+    lxc delete -f c9pool5
+    lxc delete -f c10pool6
+
+    lxc delete -f c11pool5
+    lxc delete -f c12pool6
+
+    lxc image delete testimage
+
+    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool2"
+    # shellcheck disable=SC2154
+    deconfigure_loop_device "${loop_file_1}" "${loop_device_1}"
+
+    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool4"
+    # shellcheck disable=SC2154
+    deconfigure_loop_device "${loop_file_2}" "${loop_device_2}"
+
+    lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool6"
+    # shellcheck disable=SC2154
+    deconfigure_lvm_loop_device "${loop_file_3}" "${loop_device_3}"
+  )
+
+  # shellcheck disable=SC2031
+  LXD_DIR="${LXD_DIR}"
+  kill_lxd "${LXD_STORAGE_DIR}"
+}


### PR DESCRIPTION
The plan is to implement support for multiple storage pools and basic volume
management. For this first pass we’re focusing on just exposing our existing
storage options over the API. This can be further expanded later to include
additional backends for network storage and the like, but for now we’ll keep
things simple.

### REST API
A new /1.0/storage-pools endpoint will be implemented.
This will allow for the creation of storage pools through the REST API, some
amount of configuration on them and allocating volumes from those pools to be
attached inside existing containers. This will be a self-contained API addition
which will not break backward compatibility.

#### API additions

* /1.0/storage-pools
  * GET: list pools
  * POST: create a new pool
* /1.0/storage-pools/{pool_name}
   * GET: list pool properties
   * POST: rename pool
   * PUT: replace pool properties
   * PATCH: change pool properties
   * DELETE: remove pool

* /1.0/storage-pools/{pool_name}/volumes
   * GET: list volumes

* /1.0/storage-pools/{pool_name}/volumes/{volume_type}
   * GET: list volumes of {volume_type}
   * POST: create a new volume of {volume_type}

* /1.0/storage-pools/{pool_name}/volumes/{volume_type}/{volume_name}
   * GET: list volume properties
   * POST: rename volume (or migrate it)
   * PUT: replace volume properties
   * PATCH: change volume properties
   * DELETE: remove volume

* /1.0/images
   * POST: grow a field to target a specific storage pool

### Command Line
A new set of "lxc storage" subcommands will be added. The subcommands will be
similar to those for container, daemon, network, or profile configuration. The
commands will allow the user to create, list, modify or delete storage pools and
volumes.

Loop backed pool using default size

    ubuntu@xenial:~$ lxc storage create ssd zfs

Loop backed pool stored somewhere else and with custom size

	ubuntu@xenial:~$ lxc storage create ssd zfs source=/srv/ssd.img size=20GB

Device backed pool

	ubuntu@xenial:~$ lxc storage create ssd zfs source=/dev/sdc


### Default Setup
On a clean install, LXD will come with no storage defined. As a result,
containers will fail creation until such time as at least one storage pool has
been defined. “lxd init” will guide the user through the creation of their
initial storage pool.

### Upgrade
On upgrade from an older version of LXD, a new storage pool will automatically
be defined from the existing single-pool setup. Everything else is entirely
backward compatible at the API and CLI level. The only difference is that the
newly installed LXD will not have a pool defined, requiring the user to create
one by hand or go through “lxd init” to define one. After that, everything will
work identically.

### Daemon (set as a global daemon property)
- images.default_storage_pool (string, default=””, What pool to for images use when not specified)
- storage.default_pool (string, default="", What pool to use when non is specified)

### Storage pool properties
- driver (string, default=””, Name of storage driver (zfs, dir, …))
- source (string, default=””, Path to block device or loop file or filesystem entry or zfs dataset)
- size (int, default=0, Size of the pool in bytes (suffixes supported) (loop based pools and zfs))
- user.* (string, default=””, Free for all key/value storage for user provided properties)
- volume.block.mount_options (string, default=”discard”, Mount options for block devices)
- volume.block.filesystem (string, default=”ext4”, Filesystem to use for new volumes)
- volume.size (int, default=0, Default volume size)
- volume.zfs.use_refquota (bool, default=false, Use refquota instead of quota for space)
- volume.zfs.remove_snapshots (bool, default=false, Remove snapshots as needed)
- volume.lvm.thinpool_name (string, default="LXDPool", default thin where images and containers are created)
- zfs.pool_name (string, default=””, Name of the ZPOOL, defaults to same as storage pool)

General keys are top-level. Driver specific keys are namespaced by driver name.
Volume keys apply to any volume created in the pool unless the value is
overridden on a per-volume basis.
Container (set as property of the disk):
- pool (string, default=””, Name of the storage pool to allocate from, used for root device)
Disk type entries in the containers config file will gain an additional property
"pool" that will show to which storage pool this disk device belongs to:

```
	devices:
	  root:
	    path: /
	    type: disk
```
will be expanded to

```
	devices:
	  root:
	    path: /
	    pool: <pool name>
	    type: disk
```

### Storage volume properties
- block.mount_options (string, default=”discard”, Mount options for block devices)
- block.filesystem (string, default=”ext4”, Filesystem to use for this volume)
- size (int, default=0, Volume size in bytes (suffixes supported))
- user.* (string, default=””, Free for all key/value storage for user provided properties)
- zfs.use_refquota (bool, default=false, Use refquota instead of quota for space)
- zfs.remove_snapshots (bool, default=false, Remove snapshots as needed)

### Some implementation details
#### Image handling
Images will be stored on the same pool as the container that caused them to be
downloaded. If an image was imported directly (not as part of container
creation), then the first available pool will be used (unless told otherwise by
the user).

For pools which require the image to be present in order to create a container
from it, the image will be transparently imported so it can be cloned.

#### Volume and pool properties
Properties which existed prior to this work and are currently stored as daemon
configuration options will become the default value for those same volume or
pool properties, unless overridden by the user at the pool or volume level.

#### Default pool structure
- all container volumes are located under the volume "containers" of the pool
- all image volumes are located under the volume "images" of the pool
- all additional volumes are located under the volume "custom" of the pool
Hence, a standard pool layout would be:

	- pool1
	  - pool1/containers
	    - pool1/containers/c1
	    - pool1/containers/c2
	    - pool1/containers/c3
	  - pool1/snapshots
	    - pool1/snapshots/c1
	    - pool1/snapshots/c2
	    - pool1/snapshots/c3
	  - pool1/images
	    - pool1/images/img1
	    - pool1/images/img2
	    - pool1/images/img3
	  - pool1/custom
	    - pool1/custom/vol1
	    - pool1/custom/vol2
	    - pool1/custom/vol3

#### New `LXD` directory layout

```
${LXD_DIR}/storage-pools
${LXD_DIR}/storage-pools/disks/<loop_image_name>.img
${LXD_DIR}/storage-pools/{pool_name}
${LXD_DIR}/storage-pools/{pool_name}/containers
${LXD_DIR}/storage-pools/{pool_name}/containers/{container_name}
${LXD_DIR}/storage-pools/{pool_name}/snapshots
${LXD_DIR}/storage-pools/{pool_name}/snapshots/{snapshot_name}
${LXD_DIR}/storage-pools/{pool_name}/images
${LXD_DIR}/storage-pools/{pool_name}/images/{fingerprint}
${LXD_DIR}/storage-pools/{pool_name}/custom
${LXD_DIR}/storage-pools/{pool_name}/custom/{volume_name}
```

For all storage types that require storage pools or storage volumes to be mounted these directories will serve as respective mountpoints.

#### Changes to current `LXD` directory layout

- All entries in 

```
${LXD_DIR}/containers/
```
will be symbolic links to the respective mountpoint of the container's storage volume. For example:

```
${LXD_DIR}/containers/c1 -> ${LXD_DIR}/storage-pools/{pool_name}/containers/c1
```

- All entries in

```
${LXD_DIR}/snapshots
```
will be symbolic links to the parent container's storage volume. For example:

```
${LXD_DIR}/snapshots/c1 -> ${LXD_DIR}/storage-pools/{pool_name}/snapshots/c1
```

where the individual snapshots will reside in:

```
${LXD_DIR}/storage-pools/{pool_name}/snapshots/c1/snap0
${LXD_DIR}/storage-pools/{pool_name}/snapshots/c1/snap1

```