### PR TITLE
db: actually enable foreign keys per connection

### DIFF
--- a/lxd/db.go
+++ b/lxd/db.go
@@ -181,6 +181,15 @@ CREATE TABLE IF NOT EXISTS schema (
     UNIQUE (version)
 );`
 
+func enableForeignKeys(conn *sqlite3.SQLiteConn) error {
+	_, err := conn.Exec("PRAGMA foreign_keys=ON;", nil)
+	return err
+}
+
+func init() {
+	sql.Register("sqlite3_with_fk", &sqlite3.SQLiteDriver{ConnectHook: enableForeignKeys})
+}
+
 // Create the initial (current) schema for a given SQLite DB connection.
 func createDb(db *sql.DB) (err error) {
 	latestVersion := dbGetSchema(db)
@@ -240,7 +249,7 @@ func initializeDbObject(d *Daemon, path string) (err error) {
 	openPath = fmt.Sprintf("%s?_busy_timeout=%d&_txlock=exclusive", path, timeout*1000)
 
 	// Open the database. If the file doesn't exist it is created.
-	d.db, err = sql.Open("sqlite3", openPath)
+	d.db, err = sql.Open("sqlite3_with_fk", openPath)
 	if err != nil {
 		return err
 	}
@@ -250,9 +259,6 @@ func initializeDbObject(d *Daemon, path string) (err error) {
 	if err != nil {
 		return fmt.Errorf("Error creating database: %s", err)
 	}
-
-	// Run PRAGMA statements now since they are *per-connection*.
-	d.db.Exec("PRAGMA foreign_keys=ON;") // This allows us to use ON DELETE CASCADE
 
 	// Apply any update
 	err = dbUpdatesApplyAll(d)

--- a/lxd/db_images.go
+++ b/lxd/db_images.go
@@ -248,9 +248,6 @@ func dbImageDelete(db *sql.DB, id int) error {
 		return err
 	}
 
-	_, _ = tx.Exec("DELETE FROM images_aliases WHERE image_id=?", id)
-	_, _ = tx.Exec("DELETE FROM images_properties WHERE image_id=?", id)
-	_, _ = tx.Exec("DELETE FROM images_source WHERE image_id=?", id)
 	_, _ = tx.Exec("DELETE FROM images WHERE id=?", id)
 
 	if err := txCommit(tx); err != nil {


### PR DESCRIPTION
According to: https://www.sqlite.org/pragma.html#pragma_foreign_keys (and
the comments in the code deleted by this patch); the foreign keys pragma
needs to be set per connection to a sqlite database. The problem here is
that the golang sql driver hides the fact that there might be more than one
connection, and they're pooled, so only the first connection would have
foreign keys enabled. This means that e.g. the constraints aren't enforced
on other connections that were automatically created by the sql driver.

This patch installs our own sql driver and uses that, which uses the
sqlite3 hook interface to always enable foreign keys on every connection
that's created, so we don't have this problem any more.

Signed-off-by: Tycho Andersen <tycho.andersen@canonical.com>