### PR TITLE
Forward user-agent and other headers on redirect

### DIFF
--- a/client.go
+++ b/client.go
@@ -278,6 +278,15 @@ func NewClientFromInfo(info ConnectInfo) (*Client, error) {
 		},
 	}
 	c.Name = info.Name
+
+	// Setup redirect policy
+	c.Http.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// Replicate the headers
+		req.Header = via[len(via)-1].Header
+
+		return nil
+	}
+
 	var err error
 	if strings.HasPrefix(info.RemoteConfig.Addr, "unix:") {
 		err = connectViaUnix(c, &info.RemoteConfig)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -137,6 +137,14 @@ func (d *Daemon) httpClient(certificate string) (*http.Client, error) {
 		Transport: tr,
 	}
 
+	// Setup redirect policy
+	myhttp.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// Replicate the headers
+		req.Header = via[len(via)-1].Header
+
+		return nil
+	}
+
 	return &myhttp, nil
 }
 


### PR DESCRIPTION
We don't use sensitive headers so don't need to be concerned about
crossing domain boundaries. So simply always copy all headers to
subsequent requests in the redirect chain.

Closes #2805

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>