### PR TITLE
storage: simplify backend

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -70,10 +70,9 @@ func (s *storageBtrfs) StorageCoreInit() (*storageCore, error) {
 		return nil, fmt.Errorf("The 'btrfs' tool isn't working properly")
 	}
 
-	shared.LogInfof("Initializing a BTRFS driver.")
-
 	s.storageCore = sCore
 
+	shared.LogInfof("Initializing a BTRFS driver.")
 	return &sCore, nil
 }
 
@@ -89,10 +88,13 @@ func (s *storageBtrfs) StoragePoolInit(config map[string]interface{}) (storage, 
 func (s *storageBtrfs) StoragePoolCheck() error {
 	// FIXEM(brauner): Think of something smart or useful (And then think
 	// again if it is worth implementing it. :)).
+	shared.LogInfof("Checking BTRFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolCreate() error {
+	shared.LogInfof("Creating BTRFS storage pool \"%s\".", s.pool.Name)
+
 	isBlockDev := false
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -223,10 +225,13 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
 	}
 
+	shared.LogInfof("Created BTRFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolDelete() error {
+	shared.LogInfof("Deleting BTRFS storage pool \"%s\".", s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -281,10 +286,13 @@ func (s *storageBtrfs) StoragePoolDelete() error {
 	// Remove the mountpoint for the storage pool.
 	os.RemoveAll(getStoragePoolMountPoint(s.pool.Name))
 
+	shared.LogInfof("Deleted BTRFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolMount() (bool, error) {
+	shared.LogInfof("Mounting BTRFS storage pool \"%s\".", s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return false, fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -367,10 +375,13 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 		return false, err
 	}
 
+	shared.LogInfof("Mounted BTRFS storage pool \"%s\".", s.pool.Name)
 	return true, nil
 }
 
 func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
+	shared.LogInfof("Unmounting BTRFS storage pool \"%s\".", s.pool.Name)
+
 	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
 
 	poolUmountLockID := getPoolUmountLockID(s.pool.Name)
@@ -406,6 +417,7 @@ func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
 		}
 	}
 
+	shared.LogInfof("Unmounted BTRFS storage pool \"%s\".", s.pool.Name)
 	return true, nil
 }
 
@@ -431,6 +443,8 @@ func (s *storageBtrfs) ContainerPoolIDGet() int64 {
 
 // Functions dealing with storage volumes.
 func (s *storageBtrfs) StoragePoolVolumeCreate() error {
+	shared.LogInfof("Creating BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -452,10 +466,13 @@ func (s *storageBtrfs) StoragePoolVolumeCreate() error {
 		return err
 	}
 
+	shared.LogInfof("Created BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolVolumeDelete() error {
+	shared.LogInfof("Deleting BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -476,16 +493,20 @@ func (s *storageBtrfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	shared.LogInfof("Deleted BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolVolumeMount() (bool, error) {
+	shared.LogInfof("Mounting BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return false, err
 	}
 
+	shared.LogInfof("Mounted BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
@@ -512,6 +533,8 @@ func (s *storageBtrfs) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageBtrfs) ContainerCreate(container container) error {
+	shared.LogInfof("Creating empty BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -545,11 +568,14 @@ func (s *storageBtrfs) ContainerCreate(container container) error {
 		return err
 	}
 
+	shared.LogInfof("Created empty BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return container.TemplateApply("create")
 }
 
 // And this function is why I started hating on btrfs...
 func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint string) error {
+	shared.LogInfof("Creating BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -629,6 +655,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint
 		}
 	}
 
+	shared.LogInfof("Created BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return container.TemplateApply("create")
 }
 
@@ -637,6 +664,8 @@ func (s *storageBtrfs) ContainerCanRestore(container container, sourceContainer 
 }
 
 func (s *storageBtrfs) ContainerDelete(container container) error {
+	shared.LogInfof("Deleting BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// The storage pool needs to be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -675,10 +704,13 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 		}
 	}
 
+	shared.LogInfof("Deleted BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerCopy(container container, sourceContainer container) error {
+	shared.LogInfof("Copying BTRFS container storage %s -> %s.", sourceContainer.Name(), container.Name())
+
 	// The storage pool needs to be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -760,16 +792,20 @@ func (s *storageBtrfs) ContainerCopy(container container, sourceContainer contai
 		return err
 	}
 
+	shared.LogInfof("Copied BTRFS container storage %s -> %s.", sourceContainer.Name(), container.Name())
 	return container.TemplateApply("copy")
 }
 
 func (s *storageBtrfs) ContainerMount(name string, path string) (bool, error) {
+	shared.LogInfof("Mounting BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return false, err
 	}
 
+	shared.LogInfof("Mounted BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
@@ -778,6 +814,8 @@ func (s *storageBtrfs) ContainerUmount(name string, path string) (bool, error) {
 }
 
 func (s *storageBtrfs) ContainerRename(container container, newName string) error {
+	shared.LogInfof("Renaming BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -820,10 +858,13 @@ func (s *storageBtrfs) ContainerRename(container container, newName string) erro
 		}
 	}
 
+	shared.LogInfof("Renamed BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerRestore(container container, sourceContainer container) error {
+	shared.LogInfof("Restoring BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -899,10 +940,13 @@ func (s *storageBtrfs) ContainerRestore(container container, sourceContainer con
 		os.RemoveAll(backupTargetContainerSubvolumeName)
 	}
 
+	shared.LogInfof("Restored BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
 	return failure
 }
 
 func (s *storageBtrfs) ContainerSetQuota(container container, size int64) error {
+	shared.LogInfof("Setting BTRFS quota for container \"%s\".", container.Name())
+
 	subvol := container.Path()
 
 	_, err := btrfsSubVolumeQGroup(subvol)
@@ -921,6 +965,7 @@ func (s *storageBtrfs) ContainerSetQuota(container container, size int64) error 
 		return fmt.Errorf("Failed to set btrfs quota: %s", output)
 	}
 
+	shared.LogInfof("Set BTRFS quota for container \"%s\".", container.Name())
 	return nil
 }
 
@@ -929,6 +974,8 @@ func (s *storageBtrfs) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageBtrfs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+	shared.LogInfof("Creating BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -964,10 +1011,13 @@ func (s *storageBtrfs) ContainerSnapshotCreate(snapshotContainer container, sour
 		return err
 	}
 
+	shared.LogInfof("Created BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerSnapshotDelete(snapshotContainer container) error {
+	shared.LogInfof("Deleting BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -992,10 +1042,13 @@ func (s *storageBtrfs) ContainerSnapshotDelete(snapshotContainer container) erro
 		os.Remove(snapshotMntPointSymlink)
 	}
 
+	shared.LogInfof("Deleted BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerSnapshotStart(container container) error {
+	shared.LogInfof("Initializing BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -1017,10 +1070,13 @@ func (s *storageBtrfs) ContainerSnapshotStart(container container) error {
 		return err
 	}
 
+	shared.LogInfof("Initialized BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerSnapshotStop(container container) error {
+	shared.LogInfof("Stopping BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -1042,11 +1098,14 @@ func (s *storageBtrfs) ContainerSnapshotStop(container container) error {
 		return err
 	}
 
+	shared.LogInfof("Stopped BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 // ContainerSnapshotRename renames a snapshot of a container.
 func (s *storageBtrfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+	shared.LogInfof("Renaming BTRFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1062,12 +1121,15 @@ func (s *storageBtrfs) ContainerSnapshotRename(snapshotContainer container, newN
 		return err
 	}
 
+	shared.LogInfof("Renamed BTRFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 // Needed for live migration where an empty snapshot needs to be created before
 // rsyncing into it.
 func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+	shared.LogInfof("Creating empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// Mount the storage pool.
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1100,10 +1162,13 @@ func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container)
 		}
 	}
 
+	shared.LogInfof("Created empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ImageCreate(fingerprint string) error {
+	shared.LogInfof("Creating BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// Create the subvolume.
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -1179,10 +1244,13 @@ func (s *storageBtrfs) ImageCreate(fingerprint string) error {
 
 	undo = false
 
+	shared.LogInfof("Created BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ImageDelete(fingerprint string) error {
+	shared.LogInfof("Deleting BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -1210,16 +1278,20 @@ func (s *storageBtrfs) ImageDelete(fingerprint string) error {
 		}
 	}
 
+	shared.LogInfof("Deleted BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ImageMount(fingerprint string) (bool, error) {
+	shared.LogInfof("Mounting BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return false, err
 	}
 
+	shared.LogInfof("Mounted BTRFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 

--- a/lxd/storage_core.go
+++ b/lxd/storage_core.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+)
+
+type storageCoreInfo interface {
+	StorageCoreInit() (*storageCore, error)
+	GetStorageType() storageType
+	GetStorageTypeName() string
+	GetStorageTypeVersion() string
+}
+
+type storageCore struct {
+	sType        storageType
+	sTypeName    string
+	sTypeVersion string
+}
+
+func (sc *storageCore) GetStorageType() storageType {
+	return sc.sType
+}
+
+func (sc *storageCore) GetStorageTypeName() string {
+	return sc.sTypeName
+}
+
+func (sc *storageCore) GetStorageTypeVersion() string {
+	return sc.sTypeVersion
+}
+
+func storagePoolCoreInit(poolDriver string) (*storageCore, error) {
+	sType, err := storageStringToType(poolDriver)
+	if err != nil {
+		return nil, err
+	}
+
+	var s storage
+	switch sType {
+	case storageTypeBtrfs:
+		s = &storageBtrfs{}
+	case storageTypeZfs:
+		s = &storageZfs{}
+	case storageTypeLvm:
+		s = &storageLvm{}
+	case storageTypeDir:
+		s = &storageDir{}
+	case storageTypeMock:
+		s = &storageMock{}
+	default:
+		return nil, fmt.Errorf("Unknown storage pool driver \"%s\".", poolDriver)
+	}
+
+	return s.StorageCoreInit()
+}

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -28,10 +28,7 @@ func (s *storageDir) StorageCoreInit() (*storageCore, error) {
 	sCore.sTypeName = typeName
 	sCore.sTypeVersion = "1"
 
-	err = sCore.initShared()
-	if err != nil {
-		return nil, err
-	}
+	shared.LogInfof("Initializing a DIR driver.")
 
 	s.storageCore = sCore
 
@@ -507,11 +504,11 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 	if sourceContainer.IsRunning() {
 		// This is done to ensure consistency when snapshotting. But we
 		// probably shouldn't fail just because of that.
-		s.log.Debug("Trying to freeze and rsync again to ensure consistency.")
+		shared.LogDebugf("Trying to freeze and rsync again to ensure consistency.")
 
 		err := sourceContainer.Freeze()
 		if err != nil {
-			s.log.Warn("Trying to freeze and rsync again failed.")
+			shared.LogWarnf("Trying to freeze and rsync again failed.")
 			return nil
 		}
 

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -28,10 +28,9 @@ func (s *storageDir) StorageCoreInit() (*storageCore, error) {
 	sCore.sTypeName = typeName
 	sCore.sTypeVersion = "1"
 
-	shared.LogInfof("Initializing a DIR driver.")
-
 	s.storageCore = sCore
 
+	shared.LogInfof("Initializing a DIR driver.")
 	return &sCore, nil
 }
 
@@ -47,10 +46,13 @@ func (s *storageDir) StoragePoolInit(config map[string]interface{}) (storage, er
 
 // Initialize a full storage interface.
 func (s *storageDir) StoragePoolCheck() error {
+	shared.LogInfof("Checking DIR storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolCreate() error {
+	shared.LogInfof("Creating DIR storage pool \"%s\".", s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		source = filepath.Join(shared.VarPath("storage-pools"), s.pool.Name)
@@ -81,10 +83,13 @@ func (s *storageDir) StoragePoolCreate() error {
 
 	revert = false
 
+	shared.LogInfof("Created DIR storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolDelete() error {
+	shared.LogInfof("Deleting DIR storage pool \"%s\".", s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -110,6 +115,7 @@ func (s *storageDir) StoragePoolDelete() error {
 		}
 	}
 
+	shared.LogInfof("Deleted DIR storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
@@ -151,6 +157,8 @@ func (s *storageDir) StoragePoolUpdate(changedConfig []string) error {
 
 // Functions dealing with storage pools.
 func (s *storageDir) StoragePoolVolumeCreate() error {
+	shared.LogInfof("Creating DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -162,10 +170,13 @@ func (s *storageDir) StoragePoolVolumeCreate() error {
 		return err
 	}
 
+	shared.LogInfof("Created DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolVolumeDelete() error {
+	shared.LogInfof("Deleting DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -181,6 +192,7 @@ func (s *storageDir) StoragePoolVolumeDelete() error {
 		return err
 	}
 
+	shared.LogInfof("Deleted DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -203,6 +215,8 @@ func (s *storageDir) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageDir) ContainerCreate(container container) error {
+	shared.LogInfof("Creating empty DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -228,10 +242,13 @@ func (s *storageDir) ContainerCreate(container container) error {
 
 	revert = false
 
+	shared.LogInfof("Created empty DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerCreateFromImage(container container, imageFingerprint string) error {
+	shared.LogInfof("Creating DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -272,6 +289,7 @@ func (s *storageDir) ContainerCreateFromImage(container container, imageFingerpr
 
 	revert = false
 
+	shared.LogInfof("Created DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -280,6 +298,8 @@ func (s *storageDir) ContainerCanRestore(container container, sourceContainer co
 }
 
 func (s *storageDir) ContainerDelete(container container) error {
+	shared.LogInfof("Deleting DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -324,10 +344,13 @@ func (s *storageDir) ContainerDelete(container container) error {
 		}
 	}
 
+	shared.LogInfof("Deleted DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerCopy(container container, sourceContainer container) error {
+	shared.LogInfof("Copying DIR container storage %s -> %s.", sourceContainer.Name(), container.Name())
+
 	err := sourceContainer.StorageStart()
 	if err != nil {
 		return err
@@ -386,6 +409,7 @@ func (s *storageDir) ContainerCopy(container container, sourceContainer containe
 
 	revert = false
 
+	shared.LogInfof("Copied DIR container storage %s -> %s.", sourceContainer.Name(), container.Name())
 	return nil
 }
 
@@ -398,6 +422,8 @@ func (s *storageDir) ContainerUmount(name string, path string) (bool, error) {
 }
 
 func (s *storageDir) ContainerRename(container container, newName string) error {
+	shared.LogInfof("Renaming DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -441,10 +467,13 @@ func (s *storageDir) ContainerRename(container container, newName string) error 
 		}
 	}
 
+	shared.LogInfof("Renamed DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageDir) ContainerRestore(container container, sourceContainer container) error {
+	shared.LogInfof("Restoring DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+
 	targetPath := container.Path()
 	sourcePath := sourceContainer.Path()
 
@@ -459,6 +488,7 @@ func (s *storageDir) ContainerRestore(container container, sourceContainer conta
 		return err
 	}
 
+	shared.LogInfof("Restored DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
 	return nil
 }
 
@@ -471,6 +501,8 @@ func (s *storageDir) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+	shared.LogInfof("Creating DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// Create the path for the snapshot.
 	targetContainerName := snapshotContainer.Name()
 	targetContainerMntPoint := getSnapshotMountPoint(s.pool.Name, targetContainerName)
@@ -532,10 +564,13 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 		}
 	}
 
+	shared.LogInfof("Created DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+	shared.LogInfof("Creating empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	// Create the path for the snapshot.
 	targetContainerName := snapshotContainer.Name()
 	targetContainerMntPoint := getSnapshotMountPoint(s.pool.Name, targetContainerName)
@@ -567,10 +602,13 @@ func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 
 	revert = false
 
+	shared.LogInfof("Created empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error {
+	shared.LogInfof("Deleting DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -611,10 +649,13 @@ func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error 
 		}
 	}
 
+	shared.LogInfof("Deleted DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+	shared.LogInfof("Renaming DIR storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	// Rename the mountpoint for the snapshot:
 	// ${POOL}/snapshots/<old_snapshot_name> to ${POOL}/snapshots/<new_snapshot_name>
 	oldSnapshotMntPoint := getSnapshotMountPoint(s.pool.Name, snapshotContainer.Name())
@@ -624,6 +665,7 @@ func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newNam
 		return err
 	}
 
+	shared.LogInfof("Renamed DIR storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -259,10 +259,9 @@ func (s *storageLvm) StorageCoreInit() (*storageCore, error) {
 		sCore.sTypeVersion += strings.TrimSpace(fields[1])
 	}
 
-	shared.LogInfof("Initializing an LVM driver.")
-
 	s.storageCore = sCore
 
+	shared.LogInfof("Initializing an LVM driver.")
 	return &sCore, nil
 }
 
@@ -302,6 +301,7 @@ func (s *storageLvm) StoragePoolInit(config map[string]interface{}) (storage, er
 }
 
 func (s *storageLvm) StoragePoolCheck() error {
+	shared.LogInfof("Checking LVM storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
@@ -348,6 +348,7 @@ func (s *storageLvm) lvmVersionIsAtLeast(versionString string) (bool, error) {
 }
 
 func (s *storageLvm) StoragePoolCreate() error {
+	shared.LogInfof("Creating LVM storage pool \"%s\".", s.pool.Name)
 	tryUndo := true
 
 	// Create the mountpoint for the storage pool.
@@ -427,10 +428,13 @@ func (s *storageLvm) StoragePoolCreate() error {
 	// Deregister cleanup.
 	tryUndo = false
 
+	shared.LogInfof("Created LVM storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolDelete() error {
+	shared.LogInfof("Deleting LVM storage pool \"%s\".", s.pool.Name)
+
 	source := s.pool.Config["source"]
 	if source == "" {
 		return fmt.Errorf("No \"source\" property found for the storage pool.")
@@ -450,6 +454,7 @@ func (s *storageLvm) StoragePoolDelete() error {
 		return err
 	}
 
+	shared.LogInfof("Deleted LVM storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
@@ -462,6 +467,8 @@ func (s *storageLvm) StoragePoolUmount() (bool, error) {
 }
 
 func (s *storageLvm) StoragePoolVolumeCreate() error {
+	shared.LogInfof("Creating LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	tryUndo := true
 
 	poolName := s.getOnDiskPoolName()
@@ -501,10 +508,13 @@ func (s *storageLvm) StoragePoolVolumeCreate() error {
 
 	tryUndo = false
 
+	shared.LogInfof("Created LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolVolumeDelete() error {
+	shared.LogInfof("Deleting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 	_, err := s.StoragePoolVolumeUmount()
 	if err != nil {
@@ -529,10 +539,13 @@ func (s *storageLvm) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	shared.LogInfof("Deleted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
+	shared.LogInfof("Mounting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 	poolName := s.getOnDiskPoolName()
 	mountOptions := s.getLvmBlockMountOptions()
@@ -576,10 +589,13 @@ func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
 		return false, customerr
 	}
 
+	shared.LogInfof("Mounted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
+	shared.LogInfof("Unmounting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
 	customUmountLockID := getCustomUmountLockID(s.pool.Name, s.volume.Name)
@@ -615,6 +631,7 @@ func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
 		return false, customerr
 	}
 
+	shared.LogInfof("Unmounted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -643,6 +660,8 @@ func (s *storageLvm) ContainerPoolIDGet() int64 {
 }
 
 func (s *storageLvm) StoragePoolUpdate(changedConfig []string) error {
+	shared.LogInfof("Updating LVM storage pool \"%s\".", s.pool.Name)
+
 	if shared.StringInSlice("size", changedConfig) {
 		return fmt.Errorf("The \"size\" property cannot be changed.")
 	}
@@ -683,16 +702,20 @@ func (s *storageLvm) StoragePoolUpdate(changedConfig []string) error {
 		return fmt.Errorf("The \"lvm.vg_name\" property cannot be changed.")
 	}
 
+	shared.LogInfof("Updated LVM storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolVolumeUpdate(changedConfig []string) error {
+	shared.LogInfof("Updating LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	if shared.StringInSlice("block.mount_options", changedConfig) && len(changedConfig) == 1 {
 		// noop
 	} else {
 		return fmt.Errorf("The properties \"%v\" cannot be changed.", changedConfig)
 	}
 
+	shared.LogInfof("Updated LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -705,6 +728,8 @@ func (s *storageLvm) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageLvm) ContainerCreate(container container) error {
+	shared.LogInfof("Creating empty LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	tryUndo := true
 
 	containerName := container.Name()
@@ -756,10 +781,13 @@ func (s *storageLvm) ContainerCreate(container container) error {
 
 	tryUndo = false
 
+	shared.LogInfof("Created empty LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string) error {
+	shared.LogInfof("Creating LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	tryUndo := true
 
 	poolName := s.getOnDiskPoolName()
@@ -860,6 +888,7 @@ func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint s
 
 	tryUndo = false
 
+	shared.LogInfof("Created LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -868,6 +897,8 @@ func (s *storageLvm) ContainerCanRestore(container container, sourceContainer co
 }
 
 func (s *storageLvm) ContainerDelete(container container) error {
+	shared.LogInfof("Deleting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerName := container.Name()
 	containerLvmName := containerNameToLVName(containerName)
 	containerMntPoint := ""
@@ -909,10 +940,13 @@ func (s *storageLvm) ContainerDelete(container container) error {
 		}
 	}
 
+	shared.LogInfof("Deleted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerCopy(container container, sourceContainer container) error {
+	shared.LogInfof("Copying LVM container storage %s -> %s.", sourceContainer.Name(), container.Name())
+
 	tryUndo := true
 
 	err := sourceContainer.StorageStart()
@@ -979,10 +1013,13 @@ func (s *storageLvm) ContainerCopy(container container, sourceContainer containe
 
 	tryUndo = false
 
+	shared.LogInfof("Copied LVM container storage %s -> %s.", sourceContainer.Name(), container.Name())
 	return nil
 }
 
 func (s *storageLvm) ContainerMount(name string, path string) (bool, error) {
+	shared.LogInfof("Mounting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerLvmName := containerNameToLVName(name)
 	lvFsType := s.getLvmFilesystem()
 	poolName := s.getOnDiskPoolName()
@@ -1023,10 +1060,13 @@ func (s *storageLvm) ContainerMount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
+	shared.LogInfof("Mounted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
+	shared.LogInfof("Unmounting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerMntPoint := getContainerMountPoint(s.pool.Name, name)
 
 	containerUmountLockID := getContainerUmountLockID(s.pool.Name, name)
@@ -1062,10 +1102,13 @@ func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
+	shared.LogInfof("Unmounted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
 func (s *storageLvm) ContainerRename(container container, newContainerName string) error {
+	shared.LogInfof("Renaming LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+
 	tryUndo := true
 
 	oldName := container.Name()
@@ -1141,10 +1184,13 @@ func (s *storageLvm) ContainerRename(container container, newContainerName strin
 
 	tryUndo = false
 
+	shared.LogInfof("Renamed LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
 	return nil
 }
 
 func (s *storageLvm) ContainerRestore(container container, sourceContainer container) error {
+	shared.LogInfof("Restoring LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+
 	err := sourceContainer.StorageStart()
 	if err != nil {
 		return err
@@ -1180,6 +1226,7 @@ func (s *storageLvm) ContainerRestore(container container, sourceContainer conta
 		return fmt.Errorf("Error creating snapshot LV: %v", err)
 	}
 
+	shared.LogInfof("Restored LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
 	return nil
 }
 
@@ -1192,7 +1239,15 @@ func (s *storageLvm) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
-	return s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
+	shared.LogInfof("Creating LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
+	err := s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
+	if err != nil {
+		return err
+	}
+
+	shared.LogInfof("Created LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	return nil
 }
 
 func (s *storageLvm) createSnapshotContainer(snapshotContainer container, sourceContainer container, readonly bool) error {
@@ -1240,15 +1295,20 @@ func (s *storageLvm) createSnapshotContainer(snapshotContainer container, source
 }
 
 func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer container) error {
+	shared.LogInfof("Deleting LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	err := s.ContainerDelete(snapshotContainer)
 	if err != nil {
 		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.Name(), err)
 	}
 
+	shared.LogInfof("Deleted LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newContainerName string) error {
+	shared.LogInfof("Renaming LVM storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+
 	tryUndo := true
 
 	oldName := snapshotContainer.Name()
@@ -1275,10 +1335,13 @@ func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newCon
 
 	tryUndo = false
 
+	shared.LogInfof("Renamed LVM storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotStart(container container) error {
+	shared.LogInfof("Initializing LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	tryUndo := true
 
 	sourceName := container.Name()
@@ -1323,10 +1386,13 @@ func (s *storageLvm) ContainerSnapshotStart(container container) error {
 
 	tryUndo = false
 
+	shared.LogInfof("Initialized LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotStop(container container) error {
+	shared.LogInfof("Stopping LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	name := container.Name()
 	snapshotMntPoint := getSnapshotMountPoint(s.pool.Name, name)
 
@@ -1345,14 +1411,25 @@ func (s *storageLvm) ContainerSnapshotStop(container container) error {
 		return err
 	}
 
+	shared.LogInfof("Stopped LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	return s.ContainerCreate(snapshotContainer)
+	shared.LogInfof("Creating empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
+	err := s.ContainerCreate(snapshotContainer)
+	if err != nil {
+		return err
+	}
+
+	shared.LogInfof("Created empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	return nil
 }
 
 func (s *storageLvm) ImageCreate(fingerprint string) error {
+	shared.LogInfof("Creating LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	tryUndo := true
 
 	poolName := s.getOnDiskPoolName()
@@ -1403,10 +1480,13 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 
 	tryUndo = false
 
+	shared.LogInfof("Created LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ImageDelete(fingerprint string) error {
+	shared.LogInfof("Deleting LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	_, err := s.ImageUmount(fingerprint)
 	if err != nil {
 		return err
@@ -1431,10 +1511,13 @@ func (s *storageLvm) ImageDelete(fingerprint string) error {
 		}
 	}
 
+	shared.LogInfof("Deleted LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ImageMount(fingerprint string) (bool, error) {
+	shared.LogInfof("Mounting LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if shared.IsMountPoint(imageMntPoint) {
 		return false, nil
@@ -1456,10 +1539,13 @@ func (s *storageLvm) ImageMount(fingerprint string) (bool, error) {
 		return false, fmt.Errorf("Error mounting image LV: %v", err)
 	}
 
+	shared.LogInfof("Mounted LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageLvm) ImageUmount(fingerprint string) (bool, error) {
+	shared.LogInfof("Unmounting LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if !shared.IsMountPoint(imageMntPoint) {
 		return false, nil
@@ -1470,6 +1556,7 @@ func (s *storageLvm) ImageUmount(fingerprint string) (bool, error) {
 		return false, err
 	}
 
+	shared.LogInfof("Unmounted LVM storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/lxd/types"
+	"github.com/lxc/lxd/shared"
+)
+
+type MigrationStorageSourceDriver interface {
+	/* snapshots for this container, if any */
+	Snapshots() []container
+
+	/* send any bits of the container/snapshots that are possible while the
+	 * container is still running.
+	 */
+	SendWhileRunning(conn *websocket.Conn, op *operation) error
+
+	/* send the final bits (e.g. a final delta snapshot for zfs, btrfs, or
+	 * do a final rsync) of the fs after the container has been
+	 * checkpointed. This will only be called when a container is actually
+	 * being live migrated.
+	 */
+	SendAfterCheckpoint(conn *websocket.Conn) error
+
+	/* Called after either success or failure of a migration, can be used
+	 * to clean up any temporary snapshots, etc.
+	 */
+	Cleanup()
+}
+
+type rsyncStorageSourceDriver struct {
+	container container
+	snapshots []container
+}
+
+func (s rsyncStorageSourceDriver) Snapshots() []container {
+	return s.snapshots
+}
+
+func (s rsyncStorageSourceDriver) SendWhileRunning(conn *websocket.Conn, op *operation) error {
+	for _, send := range s.snapshots {
+		if err := send.StorageStart(); err != nil {
+			return err
+		}
+		defer send.StorageStop()
+
+		path := send.Path()
+		wrapper := StorageProgressReader(op, "fs_progress", send.Name())
+		if err := RsyncSend(shared.AddSlash(path), conn, wrapper); err != nil {
+			return err
+		}
+	}
+
+	wrapper := StorageProgressReader(op, "fs_progress", s.container.Name())
+	return RsyncSend(shared.AddSlash(s.container.Path()), conn, wrapper)
+}
+
+func (s rsyncStorageSourceDriver) SendAfterCheckpoint(conn *websocket.Conn) error {
+	/* resync anything that changed between our first send and the checkpoint */
+	return RsyncSend(shared.AddSlash(s.container.Path()), conn, nil)
+}
+
+func (s rsyncStorageSourceDriver) Cleanup() {
+	/* no-op */
+}
+
+func rsyncMigrationSource(container container) (MigrationStorageSourceDriver, error) {
+	snapshots, err := container.Snapshots()
+	if err != nil {
+		return nil, err
+	}
+
+	return rsyncStorageSourceDriver{container, snapshots}, nil
+}
+
+func snapshotProtobufToContainerArgs(containerName string, snap *Snapshot) containerArgs {
+	config := map[string]string{}
+
+	for _, ent := range snap.LocalConfig {
+		config[ent.GetKey()] = ent.GetValue()
+	}
+
+	devices := types.Devices{}
+	for _, ent := range snap.LocalDevices {
+		props := map[string]string{}
+		for _, prop := range ent.Config {
+			props[prop.GetKey()] = prop.GetValue()
+		}
+
+		devices[ent.GetName()] = props
+	}
+
+	name := containerName + shared.SnapshotDelimiter + snap.GetName()
+	return containerArgs{
+		Name:         name,
+		Ctype:        cTypeSnapshot,
+		Config:       config,
+		Profiles:     snap.Profiles,
+		Ephemeral:    snap.GetEphemeral(),
+		Devices:      devices,
+		Architecture: int(snap.GetArchitecture()),
+		Stateful:     snap.GetStateful(),
+	}
+}
+
+func rsyncMigrationSink(live bool, container container, snapshots []*Snapshot, conn *websocket.Conn, srcIdmap *shared.IdmapSet, op *operation) error {
+	if err := container.StorageStart(); err != nil {
+		return err
+	}
+	defer container.StorageStop()
+
+	isDirBackend := container.Storage().GetStorageType() == storageTypeDir
+	if isDirBackend {
+		for _, snap := range snapshots {
+			args := snapshotProtobufToContainerArgs(container.Name(), snap)
+			// Unset the pool of the orginal container and let
+			// containerLXCCreate figure out on which pool to  send
+			// it. Later we might make this more flexible.
+			for k, v := range args.Devices {
+				if v["type"] == "disk" && v["path"] == "/" {
+					args.Devices[k]["pool"] = ""
+				}
+			}
+			s, err := containerCreateEmptySnapshot(container.Daemon(), args)
+			if err != nil {
+				return err
+			}
+
+			wrapper := StorageProgressWriter(op, "fs_progress", s.Name())
+			if err := RsyncRecv(shared.AddSlash(s.Path()), conn, wrapper); err != nil {
+				return err
+			}
+
+			if err := ShiftIfNecessary(container, srcIdmap); err != nil {
+				return err
+			}
+		}
+
+		wrapper := StorageProgressWriter(op, "fs_progress", container.Name())
+		if err := RsyncRecv(shared.AddSlash(container.Path()), conn, wrapper); err != nil {
+			return err
+		}
+	} else {
+		for _, snap := range snapshots {
+			args := snapshotProtobufToContainerArgs(container.Name(), snap)
+			// Unset the pool of the orginal container and let
+			// containerLXCCreate figure out on which pool to  send
+			// it. Later we might make this more flexible.
+			for k, v := range args.Devices {
+				if v["type"] == "disk" && v["path"] == "/" {
+					args.Devices[k]["pool"] = ""
+				}
+			}
+			wrapper := StorageProgressWriter(op, "fs_progress", snap.GetName())
+			if err := RsyncRecv(shared.AddSlash(container.Path()), conn, wrapper); err != nil {
+				return err
+			}
+
+			if err := ShiftIfNecessary(container, srcIdmap); err != nil {
+				return err
+			}
+
+			_, err := containerCreateAsSnapshot(container.Daemon(), args, container)
+			if err != nil {
+				return err
+			}
+		}
+
+		wrapper := StorageProgressWriter(op, "fs_progress", container.Name())
+		if err := RsyncRecv(shared.AddSlash(container.Path()), conn, wrapper); err != nil {
+			return err
+		}
+	}
+
+	if live {
+		/* now receive the final sync */
+		wrapper := StorageProgressWriter(op, "fs_progress", container.Name())
+		if err := RsyncRecv(shared.AddSlash(container.Path()), conn, wrapper); err != nil {
+			return err
+		}
+	}
+
+	if err := ShiftIfNecessary(container, srcIdmap); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -22,10 +22,7 @@ func (s *storageMock) StorageCoreInit() (*storageCore, error) {
 	}
 	sCore.sTypeName = typeName
 
-	err = sCore.initShared()
-	if err != nil {
-		return nil, err
-	}
+	shared.LogInfof("Initializing a MOCK driver.")
 
 	s.storageCore = sCore
 

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -22,10 +22,9 @@ func (s *storageMock) StorageCoreInit() (*storageCore, error) {
 	}
 	sCore.sTypeName = typeName
 
-	shared.LogInfof("Initializing a MOCK driver.")
-
 	s.storageCore = sCore
 
+	shared.LogInfof("Initializing a MOCK driver.")
 	return &sCore, nil
 }
 
@@ -39,14 +38,19 @@ func (s *storageMock) StoragePoolInit(config map[string]interface{}) (storage, e
 }
 
 func (s *storageMock) StoragePoolCheck() error {
+	shared.LogInfof("Checking MOCK storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageMock) StoragePoolCreate() error {
+	shared.LogInfof("Creating MOCK storage pool \"%s\".", s.pool.Name)
+	shared.LogInfof("Created MOCK storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageMock) StoragePoolDelete() error {
+	shared.LogInfof("Deleting MOCK storage pool \"%s\".", s.pool.Name)
+	shared.LogInfof("Deleted MOCK storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
@@ -154,9 +158,7 @@ func (s *storageMock) ContainerRestore(
 	return nil
 }
 
-func (s *storageMock) ContainerSetQuota(
-	container container, size int64) error {
-
+func (s *storageMock) ContainerSetQuota(container container, size int64) error {
 	return nil
 }
 

--- a/lxd/storage_shared.go
+++ b/lxd/storage_shared.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+)
+
+type storageShared struct {
+	storageCore
+
+	d *Daemon
+
+	poolID int64
+	pool   *api.StoragePool
+
+	volume *api.StorageVolume
+}
+
+func (ss *storageShared) shiftRootfs(c container) error {
+	dpath := c.Path()
+	rpath := c.RootfsPath()
+
+	shared.LogDebugf("Shifting root filesystem \"%s\" for \"%s\".", rpath, c.Name())
+
+	idmapset := c.IdmapSet()
+
+	if idmapset == nil {
+		return fmt.Errorf("IdmapSet of container '%s' is nil", c.Name())
+	}
+
+	err := idmapset.ShiftRootfs(rpath)
+	if err != nil {
+		shared.LogDebugf("Shift of rootfs %s failed: %s", rpath, err)
+		return err
+	}
+
+	/* Set an acl so the container root can descend the container dir */
+	// TODO: i changed this so it calls ss.setUnprivUserAcl, which does
+	// the acl change only if the container is not privileged, think thats right.
+	return ss.setUnprivUserAcl(c, dpath)
+}
+
+func (ss *storageShared) setUnprivUserAcl(c container, destPath string) error {
+	idmapset := c.IdmapSet()
+
+	// Skip for privileged containers
+	if idmapset == nil {
+		return nil
+	}
+
+	// Make sure the map is valid. Skip if container uid 0 == host uid 0
+	uid, _ := idmapset.ShiftIntoNs(0, 0)
+	switch uid {
+	case -1:
+		return fmt.Errorf("Container doesn't have a uid 0 in its map")
+	case 0:
+		return nil
+	}
+
+	// Attempt to set a POSIX ACL first. Fallback to chmod if the fs doesn't support it.
+	acl := fmt.Sprintf("%d:rx", uid)
+	_, err := exec.Command("setfacl", "-m", acl, destPath).CombinedOutput()
+	if err != nil {
+		_, err := exec.Command("chmod", "+x", destPath).CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("Failed to chmod the container path: %s.", err)
+		}
+	}
+
+	return nil
+}
+
+func (ss *storageShared) createImageDbPoolVolume(fingerprint string) error {
+	// Fill in any default volume config.
+	volumeConfig := map[string]string{}
+	err := storageVolumeFillDefault(ss.pool.Name, volumeConfig, ss.pool)
+	if err != nil {
+		return err
+	}
+
+	// Create a db entry for the storage volume of the image.
+	_, err = dbStoragePoolVolumeCreate(ss.d.db, fingerprint, storagePoolVolumeTypeImage, ss.poolID, volumeConfig)
+	if err != nil {
+		// Try to delete the db entry on error.
+		dbStoragePoolVolumeDelete(ss.d.db, fingerprint, storagePoolVolumeTypeImage, ss.poolID)
+		return err
+	}
+
+	return nil
+}
+
+func (ss *storageShared) deleteImageDbPoolVolume(fingerprint string) error {
+	err := dbStoragePoolVolumeDelete(ss.d.db, fingerprint, storagePoolVolumeTypeImage, ss.poolID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -73,10 +73,9 @@ func (s *storageZfs) StorageCoreInit() (*storageCore, error) {
 		return nil, err
 	}
 
-	shared.LogInfof("Initializing a ZFS driver.")
-
 	s.storageCore = sCore
 
+	shared.LogInfof("Initializing a ZFS driver.")
 	return &sCore, nil
 }
 
@@ -98,10 +97,14 @@ func (s *storageZfs) StoragePoolInit(config map[string]interface{}) (storage, er
 func (s *storageZfs) StoragePoolCheck() error {
 	// Make noop for now until we figure out something useful to do for all
 	// supported use cases.
+
+	shared.LogInfof("Checking ZFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolCreate() error {
+	shared.LogInfof("Creating ZFS storage pool \"%s\".", s.pool.Name)
+
 	err := s.zfsPoolCreate()
 	if err != nil {
 		return err
@@ -122,10 +125,13 @@ func (s *storageZfs) StoragePoolCreate() error {
 
 	revert = false
 
+	shared.LogInfof("Created ZFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolDelete() error {
+	shared.LogInfof("Deleting ZFS storage pool \"%s\".", s.pool.Name)
+
 	err := s.zfsFilesystemEntityDelete()
 	if err != nil {
 		return err
@@ -139,6 +145,7 @@ func (s *storageZfs) StoragePoolDelete() error {
 		}
 	}
 
+	shared.LogInfof("Deleted ZFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
@@ -151,6 +158,8 @@ func (s *storageZfs) StoragePoolUmount() (bool, error) {
 }
 
 func (s *storageZfs) StoragePoolVolumeCreate() error {
+	shared.LogInfof("Creating ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
@@ -177,10 +186,13 @@ func (s *storageZfs) StoragePoolVolumeCreate() error {
 
 	revert = false
 
+	shared.LogInfof("Created ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolVolumeDelete() error {
+	shared.LogInfof("Deleting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
@@ -196,10 +208,13 @@ func (s *storageZfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	shared.LogInfof("Deleted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
+	shared.LogInfof("Mounting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
@@ -236,10 +251,13 @@ func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
 		return false, customerr
 	}
 
+	shared.LogInfof("Mounted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
+	shared.LogInfof("Unmounting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
@@ -276,6 +294,7 @@ func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
 		return false, customerr
 	}
 
+	shared.LogInfof("Unmounted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -304,6 +323,8 @@ func (s *storageZfs) ContainerPoolIDGet() int64 {
 }
 
 func (s *storageZfs) StoragePoolUpdate(changedConfig []string) error {
+	shared.LogInfof("Updating ZFS storage pool \"%s\".", s.pool.Name)
+
 	if shared.StringInSlice("size", changedConfig) {
 		return fmt.Errorf("The \"size\" property cannot be changed.")
 	}
@@ -336,10 +357,13 @@ func (s *storageZfs) StoragePoolUpdate(changedConfig []string) error {
 		return fmt.Errorf("The \"zfs.pool_name\" property cannot be changed.")
 	}
 
+	shared.LogInfof("Updated ZFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolVolumeUpdate(changedConfig []string) error {
+	shared.LogInfof("Updating ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	if shared.StringInSlice("block.mount_options", changedConfig) {
 		return fmt.Errorf("The \"block.mount_options\" property cannot be changed.")
 	}
@@ -352,11 +376,14 @@ func (s *storageZfs) StoragePoolVolumeUpdate(changedConfig []string) error {
 		return fmt.Errorf("The \"size\" property cannot be changed.")
 	}
 
+	shared.LogInfof("Updated ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 // Things we don't need to care about
 func (s *storageZfs) ContainerMount(name string, path string) (bool, error) {
+	shared.LogInfof("Mounting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("containers/%s", name)
 	containerPoolVolumeMntPoint := getContainerMountPoint(s.pool.Name, name)
 
@@ -393,10 +420,13 @@ func (s *storageZfs) ContainerMount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
+	shared.LogInfof("Mounted ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
+	shared.LogInfof("Unmounting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("containers/%s", name)
 	containerPoolVolumeMntPoint := getContainerMountPoint(s.pool.Name, name)
 
@@ -433,6 +463,7 @@ func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
+	shared.LogInfof("Unmounted ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -444,6 +475,8 @@ func (s *storageZfs) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageZfs) ContainerCreate(container container) error {
+	shared.LogInfof("Creating empty ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerPath := container.Path()
 	containerName := container.Name()
 	fs := fmt.Sprintf("containers/%s", containerName)
@@ -480,10 +513,13 @@ func (s *storageZfs) ContainerCreate(container container) error {
 
 	revert = false
 
+	shared.LogInfof("Created empty ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint string) error {
+	shared.LogInfof("Creating ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerPath := container.Path()
 	containerName := container.Name()
 	fs := fmt.Sprintf("containers/%s", containerName)
@@ -551,6 +587,7 @@ func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint s
 
 	revert = false
 
+	shared.LogInfof("Created ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -578,6 +615,8 @@ func (s *storageZfs) ContainerCanRestore(container container, sourceContainer co
 }
 
 func (s *storageZfs) ContainerDelete(container container) error {
+	shared.LogInfof("Deleting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	containerName := container.Name()
 	fs := fmt.Sprintf("containers/%s", containerName)
 	containerPoolVolumeMntPoint := getContainerMountPoint(s.pool.Name, containerName)
@@ -658,10 +697,13 @@ func (s *storageZfs) ContainerDelete(container container) error {
 		}
 	}
 
+	shared.LogInfof("Deleted ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerCopy(container container, sourceContainer container) error {
+	shared.LogInfof("Copying ZFS container storage %s -> %s.", sourceContainer.Name(), container.Name())
+
 	sourceContainerName := sourceContainer.Name()
 	sourceContainerPath := sourceContainer.Path()
 
@@ -758,10 +800,13 @@ func (s *storageZfs) ContainerCopy(container container, sourceContainer containe
 
 	revert = false
 
+	shared.LogInfof("Copied ZFS container storage %s -> %s.", sourceContainer.Name(), container.Name())
 	return nil
 }
 
 func (s *storageZfs) ContainerRename(container container, newName string) error {
+	shared.LogInfof("Renaming ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	oldName := container.Name()
 
 	// Unmount the dataset.
@@ -837,10 +882,13 @@ func (s *storageZfs) ContainerRename(container container, newName string) error 
 
 	revert = false
 
+	shared.LogInfof("Renamed ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageZfs) ContainerRestore(container container, sourceContainer container) error {
+	shared.LogInfof("Restoring ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+
 	// Remove any needed snapshot
 	snaps, err := container.Snapshots()
 	if err != nil {
@@ -868,10 +916,13 @@ func (s *storageZfs) ContainerRestore(container container, sourceContainer conta
 		return err
 	}
 
+	shared.LogInfof("Restored ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
 	return nil
 }
 
 func (s *storageZfs) ContainerSetQuota(container container, size int64) error {
+	shared.LogInfof("Setting ZFS quota for container \"%s\".", container.Name())
+
 	var err error
 
 	fs := fmt.Sprintf("containers/%s", container.Name())
@@ -899,6 +950,7 @@ func (s *storageZfs) ContainerSetQuota(container container, size int64) error {
 		return err
 	}
 
+	shared.LogInfof("Set ZFS quota for container \"%s\".", container.Name())
 	return nil
 }
 
@@ -934,6 +986,8 @@ func (s *storageZfs) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+	shared.LogInfof("Creating ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	snapshotContainerName := snapshotContainer.Name()
 	sourceContainerName := sourceContainer.Name()
 
@@ -973,10 +1027,13 @@ func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, source
 
 	revert = false
 
+	shared.LogInfof("Created ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error {
+	shared.LogInfof("Deleting ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
 	sourceContainerName := fields[0]
 	snapName := fmt.Sprintf("snapshot-%s", fields[1])
@@ -1047,10 +1104,13 @@ func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error 
 		}
 	}
 
+	shared.LogInfof("Deleted ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+	shared.LogInfof("Renaming ZFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+
 	oldName := snapshotContainer.Name()
 
 	oldFields := strings.SplitN(snapshotContainer.Name(), shared.SnapshotDelimiter, 2)
@@ -1109,10 +1169,13 @@ func (s *storageZfs) ContainerSnapshotRename(snapshotContainer container, newNam
 
 	revert = false
 
+	shared.LogInfof("Renamed ZFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotStart(container container) error {
+	shared.LogInfof("Initializing ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fields := strings.SplitN(container.Name(), shared.SnapshotDelimiter, 2)
 	if len(fields) < 2 {
 		return fmt.Errorf("Invalid snapshot name: %s", container.Name())
@@ -1130,10 +1193,13 @@ func (s *storageZfs) ContainerSnapshotStart(container container) error {
 		return err
 	}
 
+	shared.LogInfof("Initialized ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotStop(container container) error {
+	shared.LogInfof("Stopping ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fields := strings.SplitN(container.Name(), shared.SnapshotDelimiter, 2)
 	if len(fields) < 2 {
 		return fmt.Errorf("Invalid snapshot name: %s", container.Name())
@@ -1149,7 +1215,13 @@ func (s *storageZfs) ContainerSnapshotStop(container container) error {
 
 	/* zfs creates this directory on clone (start), so we need to clean it
 	 * up on stop */
-	return os.RemoveAll(container.Path())
+	shared.LogInfof("Stopped ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	err = os.RemoveAll(container.Path())
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
@@ -1165,6 +1237,8 @@ func (s *storageZfs) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 // - remove mountpoint property from zfs volume images/<fingerprint>
 // - create read-write snapshot from zfs volume images/<fingerprint>
 func (s *storageZfs) ImageCreate(fingerprint string) error {
+	shared.LogInfof("Creating ZFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	fs := fmt.Sprintf("images/%s", fingerprint)
 	revert := true
@@ -1283,10 +1357,13 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 
 	revert = false
 
+	shared.LogInfof("Created ZFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ImageDelete(fingerprint string) error {
+	shared.LogInfof("Deleting ZFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+
 	fs := fmt.Sprintf("images/%s", fingerprint)
 
 	if s.zfsFilesystemEntityExists(fs, true) {
@@ -1333,6 +1410,7 @@ func (s *storageZfs) ImageDelete(fingerprint string) error {
 		}
 	}
 
+	shared.LogInfof("Deleted ZFS storage volume for image \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }
 


### PR DESCRIPTION
I intended to do this right at the beginning but then focused on the crucial parts.
- rip out all the unnecessary log-wrapping stuff: We can achieve the same with simply logging directly in the functions like we e.g. do in `lxd/container_lxc.go`.
- move separate interfaces into separate files