### PR TITLE
patches: do not parse volume.size for lvm

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 
@@ -796,21 +795,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	poolConfig["lvm.vg_name"] = daemonConfig["storage.lvm_vg_name"].Get()
 
 	poolConfig["volume.size"] = daemonConfig["storage.lvm_volume_size"].Get()
-	if poolConfig["volume.size"] == "" {
-		// Get size of the volume group.
-		output, err := tryExec("vgs", "--nosuffix", "--units", "b", "--noheadings", "-o", "size", defaultPoolName)
-		if err != nil {
-			return err
-		}
-		tmp := string(output)
-		tmp = strings.TrimSpace(tmp)
-		szFloat, err := strconv.ParseFloat(tmp, 32)
-		if err != nil {
-			return err
-		}
-		szInt64 := shared.Round(szFloat)
-		poolConfig["volume.size"] = fmt.Sprintf("%dGB", szInt64)
-	} else {
+	if poolConfig["volume.size"] != "" {
 		// In case stuff like GiB is used which
 		// share.dParseByteSizeString() doesn't handle.
 		if strings.Contains(poolConfig["volume.size"], "i") {


### PR DESCRIPTION
It really doesn't make a lot of sense to look at the size of the volume group.
Simply set the default.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>