### PR TITLE
storage: bugfixes

### DIFF
--- a/lxd/db_storage_pools.go
+++ b/lxd/db_storage_pools.go
@@ -273,11 +273,11 @@ func dbStoragePoolVolumesGetNames(db *sql.DB, poolID int64) (int, error) {
 }
 
 // Get all storage volumes attached to a given storage pool.
-func dbStoragePoolVolumesGet(db *sql.DB, poolID int64) ([]*api.StorageVolume, error) {
+func dbStoragePoolVolumesGet(db *sql.DB, poolID int64, volumeTypes []int) ([]*api.StorageVolume, error) {
 	// Get all storage volumes of all types attached to a given storage
 	// pool.
 	result := []*api.StorageVolume{}
-	for _, volumeType := range supportedVolumeTypes {
+	for _, volumeType := range volumeTypes {
 		volumeNames, err := dbStoragePoolVolumesGetType(db, volumeType, poolID)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1812,7 +1812,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 		}
 
 		// Get all storage volumes on the storage pool.
-		volumes, err := dbStoragePoolVolumesGet(d.db, poolID)
+		volumes, err := dbStoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
 		if err != nil {
 			if err == NoSuchObjectError {
 				continue

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -496,10 +496,9 @@ func createContainerMountpoint(mountPoint string, mountPointSymlink string, priv
 			return err
 		}
 
-		err = os.Chmod(mountPoint, mode)
-	} else {
-		err = os.Chmod(mountPoint, mode)
 	}
+
+	err = os.Chmod(mountPoint, mode)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1730,9 +1730,9 @@ func (s *storageBtrfs) MigrationType() MigrationFSType {
 func (s *storageBtrfs) PreservesInodes() bool {
 	if runningInUserns {
 		return false
-	} else {
-		return true
 	}
+
+	return true
 }
 
 func (s *storageBtrfs) MigrationSource(c container) (MigrationStorageSourceDriver, error) {

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -39,7 +39,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) Response {
 
 			// Get all users of the storage pool.
 			poolUsedBy, err := storagePoolUsedByGet(d.db, plID, pool)
-			if err != nil && err != NoSuchObjectError {
+			if err != nil {
 				return SmartError(err)
 			}
 			pl.UsedBy = poolUsedBy

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/shared/api"
@@ -287,6 +288,15 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Storage pool \"%s\" has volumes attached to it.", poolName))
 	}
 
+	// Check if the storage pool is still referenced in any profiles.
+	profiles, err := profilesUsingPoolGetNames(d.db, poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+	if len(profiles) > 0 {
+		return BadRequest(fmt.Errorf("Storage pool \"%s\" has profiles using it:\n%s", poolName, strings.Join(profiles, "\n")))
+	}
+
 	s, err := storagePoolInit(d, poolName)
 	if err != nil {
 		return InternalError(err)
@@ -300,48 +310,6 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 	err = dbStoragePoolDelete(d.db, poolName)
 	if err != nil {
 		return InternalError(err)
-	}
-
-	// In case we deleted the default storage pool, try to update the
-	// default profile.
-	defaultID, defaultProfile, err := dbProfileGet(d.db, "default")
-	if err != nil {
-		return EmptySyncResponse
-	}
-	for k, v := range defaultProfile.Devices {
-		if v["type"] == "disk" && v["path"] == "/" {
-			if v["pool"] == poolName {
-				defaultProfile.Devices[k]["pool"] = ""
-
-				tx, err := dbBegin(d.db)
-				if err != nil {
-					return EmptySyncResponse
-				}
-
-				err = dbProfileConfigClear(tx, defaultID)
-				if err != nil {
-					tx.Rollback()
-					return EmptySyncResponse
-				}
-
-				err = dbProfileConfigAdd(tx, defaultID, defaultProfile.Config)
-				if err != nil {
-					tx.Rollback()
-					return EmptySyncResponse
-				}
-
-				err = dbDevicesAdd(tx, "profile", defaultID, defaultProfile.Devices)
-				if err != nil {
-					tx.Rollback()
-					return EmptySyncResponse
-				}
-
-				err = txCommit(tx)
-				if err != nil {
-					return EmptySyncResponse
-				}
-			}
-		}
 	}
 
 	return EmptySyncResponse

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -103,3 +103,27 @@ func storagePoolUsedByGet(db *sql.DB, poolID int64, poolName string) ([]string, 
 
 	return poolUsedBy, err
 }
+
+func profilesUsingPoolGetNames(db *sql.DB, poolName string) ([]string, error) {
+	usedBy := []string{}
+
+	profiles, err := dbProfiles(db)
+	if err != nil {
+		return usedBy, err
+	}
+
+	for _, pName := range profiles {
+		_, profile, err := dbProfileGet(db, pName)
+		if err != nil {
+			return usedBy, err
+		}
+
+		for _, v := range profile.Devices {
+			if v["pool"] == poolName {
+				usedBy = append(usedBy, pName)
+			}
+		}
+	}
+
+	return usedBy, nil
+}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -32,7 +32,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) Response {
 
 	// Get all volumes currently attached to the storage pool by ID of the
 	// pool.
-	volumes, err := dbStoragePoolVolumesGet(d.db, poolID)
+	volumes, err := dbStoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
 	if err != nil && err != NoSuchObjectError {
 		return SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -446,7 +446,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 	}
 
 	if len(volumeUsedBy) > 0 {
-		return BadRequest(fmt.Errorf("The storage volume is in use by containers."))
+		return BadRequest(fmt.Errorf("The storage volume is still in use by containers or profiles."))
 	}
 
 	s, err := storagePoolVolumeInit(d, poolName, volumeName, volumeType)

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"database/sql"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/lxc/lxd/shared"
@@ -183,6 +185,7 @@ func storagePoolVolumeUsedByGet(d *Daemon, volumeName string, volumeTypeName str
 	}
 
 	volumeUsedBy := []string{}
+	volumeNameWithType := fmt.Sprintf("%s/%s", volumeTypeName, volumeName)
 	for _, ct := range cts {
 		c, err := containerLoadByName(d, ct)
 		if err != nil {
@@ -194,25 +197,65 @@ func storagePoolVolumeUsedByGet(d *Daemon, volumeName string, volumeTypeName str
 				continue
 			}
 
-			apiEndpoint, err := storagePoolVolumeTypeNameToApiEndpoint(volumeTypeName)
-			if err != nil {
-				return []string{}, err
-			}
-
-			mustBeEqualTo := ""
-			switch apiEndpoint {
-			case storagePoolVolumeApiEndpointImages:
-				mustBeEqualTo = fmt.Sprintf("%s/%s", apiEndpoint, volumeName)
-			case storagePoolVolumeApiEndpointContainers:
-				mustBeEqualTo = fmt.Sprintf("%s/%s", apiEndpoint, volumeName)
-			default:
-				mustBeEqualTo = volumeName
-			}
-			if d["source"] == mustBeEqualTo {
+			// Make sure that we don't compare against stuff like
+			// "container////bla" but only against "container/bla".
+			cleanSource := filepath.Clean(d["source"])
+			if cleanSource == volumeName || cleanSource == volumeNameWithType {
 				volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/containers/%s", version.APIVersion, ct))
 			}
 		}
 	}
 
+	profiles, err := profilesUsingPoolVolumeGetNames(d.db, volumeName, volumeTypeName)
+	if err != nil {
+		return []string{}, err
+	}
+
+	if len(volumeUsedBy) == 0 && len(profiles) == 0 {
+		return []string{}, err
+	}
+
+	for _, pName := range profiles {
+		volumeUsedBy = append(volumeUsedBy, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, pName))
+	}
+
 	return volumeUsedBy, nil
+}
+
+func profilesUsingPoolVolumeGetNames(db *sql.DB, volumeName string, volumeType string) ([]string, error) {
+	usedBy := []string{}
+
+	profiles, err := dbProfiles(db)
+	if err != nil {
+		return usedBy, err
+	}
+
+	for _, pName := range profiles {
+		_, profile, err := dbProfileGet(db, pName)
+		if err != nil {
+			return usedBy, err
+		}
+
+		volumeNameWithType := fmt.Sprintf("%s/%s", volumeType, volumeName)
+		for _, v := range profile.Devices {
+			if v["type"] != "disk" {
+				continue
+			}
+
+			// Can't be a storage volume.
+			if filepath.IsAbs(v["source"]) {
+				continue
+			}
+
+			// Make sure that we don't compare against stuff
+			// like "container////bla" but only against
+			// "container/bla".
+			cleanSource := filepath.Clean(v["source"])
+			if cleanSource == volumeName || cleanSource == volumeNameWithType {
+				usedBy = append(usedBy, pName)
+			}
+		}
+	}
+
+	return usedBy, nil
 }


### PR DESCRIPTION
So this may be somewhat debatable. One could make a reasonable argument that we simply leave the profile devices that have a pool property set alone and simply let users figure this out. However, I feel that this might be a problem. Consider the case where a user has a profile that has a disk device entry like:

```
sensitive-device:
  path: /opt
  source: sensitive-vol1
  pool: pool1
```

and the user deletes the volume and the pool but we leave the properties set in the device. Now the user creates a new pool of the same name and a new volume of the same name that contains sensitive data and creates a container on the profile that still contains this device. This could potentially be a problem. So wipe the pool property on pool delete. For disk devices outside of LXD's storage management abilities (host paths etc.) we can't do this. But for pools and volumes we created we should probably do this. 