### PR TITLE
storage_cgo: make flag argument configurable

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -338,7 +338,10 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 	mountSource := source
 	if filepath.IsAbs(source) {
 		if !shared.IsBlockdevPath(source) && s.d.BackingFs != "btrfs" {
-			loopF, err := prepareLoopDev(source)
+			// Since we mount the loop device LO_FLAGS_AUTOCLEAR is
+			// fine since the loop device will be kept around for as
+			// long as the mount exists.
+			loopF, err := prepareLoopDev(source, LO_FLAGS_AUTOCLEAR)
 			if err != nil {
 				return false, fmt.Errorf("Could not prepare loop device.")
 			}


### PR DESCRIPTION
For loop-backed btrfs pools we actually mount the loop device and so it's fine
to use LO_FLAGS_AUTOCLEAR since the loop device is guaranteed to be kept around
for as long as the mount exists. When we implement lvm loop-backed pools
however, we do not mount the loop device so we need to make sure that it is not
deconfigured automatically when we close all handles to it.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>