### PR TITLE
lvm: use lvmized container name

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1553,9 +1553,9 @@ func (s *storageLvm) ContainerRestore(container container, sourceContainer conta
 	}
 
 	poolName := s.getOnDiskPoolName()
-	err = s.removeLV(poolName, storagePoolVolumeApiEndpointContainers, destName)
+	err = s.removeLV(poolName, storagePoolVolumeApiEndpointContainers, destLvName)
 	if err != nil {
-		shared.LogErrorf(fmt.Sprintf("Failed to remove \"%s\": %s.", destName, err))
+		shared.LogErrorf(fmt.Sprintf("Failed to remove \"%s\": %s.", destLvName, err))
 	}
 
 	_, err = s.createSnapshotLV(poolName, srcLvName, storagePoolVolumeApiEndpointContainers, destLvName, storagePoolVolumeApiEndpointContainers, false)

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -570,10 +570,12 @@ func (s *storageLvm) StoragePoolDelete() error {
 		return err
 	}
 	if s.loopInfo != nil {
-		err := setAutoclearOnLoopDev(int(s.loopInfo.Fd()))
-		if err != nil {
-			shared.LogWarnf("Failed to set LO_FLAGS_AUTOCLEAR on loop device: %s. Manual cleanup needed.", err)
-		}
+		defer func() {
+			err := setAutoclearOnLoopDev(int(s.loopInfo.Fd()))
+			if err != nil {
+				shared.LogWarnf("Failed to set LO_FLAGS_AUTOCLEAR on loop device: %s. Manual cleanup needed.", err)
+			}
+		}()
 		defer s.loopInfo.Close()
 	}
 

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -654,19 +654,6 @@ func (s *storageLvm) StoragePoolMount() (bool, error) {
 			return false, fmt.Errorf("Could not prepare loop device: %s", err)
 		}
 		s.loopInfo = loopF
-
-		// Force rescan, since LVM is not working nicely with loop
-		// devices.
-		output, err := tryExec("pvscan")
-		if err != nil {
-			shared.LogWarnf("pvscan failed: %s.", string(output))
-		}
-
-		// See comment above.
-		output, err = tryExec("vgscan")
-		if err != nil {
-			shared.LogWarnf("vgscan failed: %s.", string(output))
-		}
 	}
 
 	return true, nil

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -409,7 +409,7 @@ test_basic_usage() {
   REBOOTED="false"
 
   # shellcheck disable=SC2034
-  for i in $(seq 10); do
+  for i in $(seq 20); do
     NEW_INIT=$(lxc info foo | grep ^Pid || true)
 
     if [ -n "${NEW_INIT}" ] && [ "${OLD_INIT}" != "${NEW_INIT}" ]; then

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -154,6 +154,18 @@ test_snap_restore() {
   lxc stop --force bar
 
   lxc delete bar
+
+  # Test if container's with hyphen's in their names are treated correctly.
+  if [ "${LXD_BACKEND}" = "lvm" ]; then
+	  lxc launch testimage a-b
+	  lxc snapshot a-b base
+	  lxc restore a-b base
+
+	  lxc snapshot a-b c-d
+	  lxc restore a-b c-d
+
+	  lxc delete -f a-b
+  fi
 }
 
 restore_and_compare_fs() {


### PR DESCRIPTION
LVM has some very specific naming requirements for logical volumes. We have a
specific function that turns a container name into a valid logical volume name.
The only thing left to do is to actual use that valid logical volume name...

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>