### PR TITLE
util: check for err in {UUID, BlockDev} lookup

### DIFF
--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -701,6 +701,10 @@ var ObjectFound = fmt.Errorf("Found requested object.")
 func LookupUUIDByBlockDevPath(diskDevice string) (string, error) {
 	uuid := ""
 	readUUID := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if (info.Mode() & os.ModeSymlink) == os.ModeSymlink {
 			link, err := os.Readlink(path)
 			if err != nil {
@@ -737,6 +741,10 @@ func LookupUUIDByBlockDevPath(diskDevice string) (string, error) {
 func LookupBlockDevByUUID(uuid string) (string, error) {
 	detectedPath := ""
 	readPath := func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
 		if (info.Mode() & os.ModeSymlink) == os.ModeSymlink {
 			link, err := os.Readlink(path)
 			if err != nil {


### PR DESCRIPTION
From the golang help for filepath.Walk:
"If there was a problem walking to the file or directory named by path, the
incoming error will describe the problem and the function can decide how to
handle that error (and Walk will not descend into that directory)."

It seems that we should really be checking for an error that is passed in
through type WalkFunc:

```
+ /lxd/build/tmp.TDmNlEAzM1/go/bin/lxc storage create lxdtest-TtKYYWxz2-pool4 btrfs source=/dev/loop30 --verbose
INFO[03-02|06:36:21] Creating BTRFS storage pool "lxdtest-TtKYYWxz2-pool4".
2017/03/02 06:36:22 http: panic serving @: runtime error: invalid memory address or nil pointer dereference
goroutine 326 [running]:
net/http.(*conn).serve.func1(0xc8202c2380)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/net/http/server.go:1389 +0xc1
panic(0xbd2da0, 0xc820010150)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/runtime/panic.go:443 +0x4e9
github.com/lxc/lxd/shared.LookupUUIDByBlockDevPath.func1(0xc8202b1900, 0x36, 0x0, 0x0, 0x7f7080816d68, 0xc820289320, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/shared/util_linux.go:704 +0x63
path/filepath.walk(0xd09bd0, 0x11, 0x7f7080816c78, 0xc820086270, 0xc8202de7c0, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/path/filepath/path.go:370 +0x415
path/filepath.Walk(0xd09bd0, 0x11, 0xc8202de7c0, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/path/filepath/path.go:396 +0xe1
github.com/lxc/lxd/shared.LookupUUIDByBlockDevPath(0xc8202c4c90, 0xb, 0x0, 0x0, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/shared/util_linux.go:724 +0xed
main.(*storageBtrfs).StoragePoolCreate(0xc8201c0460, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/lxd/storage_btrfs.go:166 +0x102c
main.storagePoolsPost(0xc820124120, 0xc8201de000, 0x0, 0x0)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/lxd/storage_pools.go:129 +0x93d
main.(*Daemon).createCmd.func1(0x7f70807ce268, 0xc8201360d0, 0xc8201de000)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/lxd/daemon.go:323 +0x768
net/http.HandlerFunc.ServeHTTP(0xc8202a1e50, 0x7f70807ce268, 0xc8201360d0, 0xc8201de000)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/net/http/server.go:1618 +0x3a
github.com/gorilla/mux.(*Router).ServeHTTP(0xc8202a0050, 0x7f70807ce268, 0xc8201360d0, 0xc8201de000)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/gorilla/mux/mux.go:114 +0x2a8
main.(*lxdHttpServer).ServeHTTP(0xc82032e330, 0x7f70807ce268, 0xc8201360d0, 0xc8201de000)
	/lxd/build/tmp.TDmNlEAzM1/go/src/github.com/lxc/lxd/lxd/daemon.go:1432 +0x4ad
net/http.serverHandler.ServeHTTP(0xc82031e580, 0x7f70807ce268, 0xc8201360d0, 0xc8201de000)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/net/http/server.go:2081 +0x19e
net/http.(*conn).serve(0xc8202c2380)
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/net/http/server.go:1472 +0xf2e
created by net/http.(*Server).Serve
	/lxd/build/tmp.TDmNlEAzM1/go/golang/src/net/http/server.go:2137 +0x44e
error: Post http://unix.socket/1.0/storage-pools: EOF
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>