### PR TITLE
storage: call StoragePoolCheck() if pool exists

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -307,12 +307,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 
 		storagePool = rootDiskDevice["pool"]
 
-		ps, err := storagePoolInit(d, storagePool)
-		if err != nil {
-			return InternalError(err)
-		}
-
-		err = ps.StoragePoolCheck()
+		ps, err := storagePoolInit(d, storagePool, true)
 		if err != nil {
 			return InternalError(err)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -368,15 +368,10 @@ func (d *Daemon) SetupStorageDriver() error {
 
 	for _, pool := range pools {
 		shared.LogDebugf("Initializing and checking storage pool \"%s\".", pool)
-		ps, err := storagePoolInit(d, pool)
+		_, err := storagePoolInit(d, pool, true)
 		if err != nil {
 			shared.LogErrorf("Error initializing storage pool \"%s\": %s. Correct functionality of the storage pool cannot be guaranteed.", pool, err)
 			continue
-		}
-
-		err = ps.StoragePoolCheck()
-		if err != nil {
-			shared.LogErrorf("Error checking storage pool \"%s\": %s. Correct functionality of the storage pool cannot be guaranteed.", pool, err)
 		}
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -636,7 +636,7 @@ func imageCreateInPool(d *Daemon, info *api.Image, storagePool string) error {
 	}
 
 	// Initialize a new storage interface.
-	s, err := storagePoolInit(d, storagePool)
+	s, err := storagePoolInit(d, storagePool, true)
 	if err != nil {
 		return err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -316,7 +316,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		}
 		poolID = tmp
 
-		s, err := storagePoolInit(d, defaultPoolName)
+		s, err := storagePoolInit(d, defaultPoolName, false)
 		if err != nil {
 			return err
 		}
@@ -575,7 +575,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		}
 		poolID = tmp
 
-		s, err := storagePoolInit(d, defaultPoolName)
+		s, err := storagePoolInit(d, defaultPoolName, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -222,6 +222,11 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 		return fmt.Errorf("Could not create btrfs subvolume: %s", dummyDir)
 	}
 
+	err = s.StoragePoolCheck()
+	if err != nil {
+		return err
+	}
+
 	shared.LogInfof("Created BTRFS storage pool \"%s\".", s.pool.Name)
 	return nil
 }

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -78,6 +78,11 @@ func (s *storageDir) StoragePoolCreate() error {
 		}
 	}
 
+	err = s.StoragePoolCheck()
+	if err != nil {
+		return err
+	}
+
 	revert = false
 
 	shared.LogInfof("Created DIR storage pool \"%s\".", s.pool.Name)

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/gorilla/websocket"
@@ -14,6 +15,22 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
+
+// lvmLoopDeviceCache is a hashmap that allows loop-backed LVM pools to store
+// the name of the associated loop device that is currently associated with the
+// loop file for the storage pool. This allows to avoid having to parse
+// "/sys/block" everytime in case we find that the file is still associated with
+// the loop device in question.
+var lvmLoopDeviceCache = map[string]string{}
+
+// lvmLoopDeviceCacheLock is used to access lvmLoopDeviceCache.
+var lvmLoopDeviceCacheLock sync.Mutex
+
+// The following function is used to construct a simple hashmap key that is
+// unique per pool.
+func getLvmPoolLoopDeviceLockID(poolName string) string {
+	return fmt.Sprintf("loop/pool/%s", poolName)
+}
 
 func storageVGActivate(lvmVolumePath string) error {
 	output, err := tryExec("vgchange", "-ay", lvmVolumePath)
@@ -651,11 +668,37 @@ func (s *storageLvm) StoragePoolMount() (bool, error) {
 	defer removeLockFromMap()
 
 	if filepath.IsAbs(source) && !shared.IsBlockdevPath(source) {
-		loopF, err := prepareLoopDev(source, 0)
-		if err != nil {
-			return false, fmt.Errorf("Could not prepare loop device: %s", err)
+		var loopErr error
+		var loopF *os.File
+		poolLoopDeviceLockID := getLvmPoolLoopDeviceLockID(s.pool.Name)
+
+		lvmLoopDeviceCacheLock.Lock()
+		loopDevice, ok := lvmLoopDeviceCache[poolLoopDeviceLockID]
+		if ok {
+			loopF, loopErr = loopDeviceHasBackingFile(loopDevice, source)
+			if loopErr == nil {
+				loopErr = unsetAutoclearOnLoopDev(int(loopF.Fd()))
+			}
+
+			if loopErr == nil {
+				s.loopInfo = loopF
+				lvmLoopDeviceCacheLock.Unlock()
+				return true, nil
+			}
+
+			// Something went wrong, so delete entry from cache.
+			delete(lvmLoopDeviceCache, poolLoopDeviceLockID)
 		}
+
+		// Try to prepare new loop device.
+		loopF, loopErr = prepareLoopDev(source, 0)
+		if loopErr != nil {
+			lvmLoopDeviceCacheLock.Unlock()
+			return false, fmt.Errorf("Could not prepare loop device: %s", loopErr)
+		}
+		lvmLoopDeviceCache[poolLoopDeviceLockID] = loopF.Name()
 		s.loopInfo = loopF
+		lvmLoopDeviceCacheLock.Unlock()
 	}
 
 	return true, nil

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -121,7 +121,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) Response {
 		}
 	}()
 
-	s, err := storagePoolInit(d, req.Name)
+	s, err := storagePoolInit(d, req.Name, false)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -297,7 +297,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Storage pool \"%s\" has profiles using it:\n%s", poolName, strings.Join(profiles, "\n")))
 	}
 
-	s, err := storagePoolInit(d, poolName)
+	s, err := storagePoolInit(d, poolName, true)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -10,7 +10,7 @@ import (
 )
 
 func storagePoolUpdate(d *Daemon, name string, newConfig map[string]string) error {
-	s, err := storagePoolInit(d, name)
+	s, err := storagePoolInit(d, name, true)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -120,6 +120,11 @@ func (s *storageZfs) StoragePoolCreate() error {
 		return err
 	}
 
+	err = s.StoragePoolCheck()
+	if err != nil {
+		return err
+	}
+
 	revert = false
 
 	shared.LogInfof("Created ZFS storage pool \"%s\".", s.pool.Name)


### PR DESCRIPTION
The operations performed in StoragePoolCheck() are only operations that are
necessary to guarantee correct functionality of the storage pool. So call them
in storagePoolInit(). To support this, storagePoolInit() gains the boolean
argument "poolExistsOnDisk" which is used to indicate whether the pool has
already been created on disk.
The only exception is in the case of calling StoragePoolCreate(). In this case
StoragePoolCheck() needs to be called explicitly, to make sure that things are
alright after creation.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>