### PR TITLE
Add note about restricting access to kernel ring buffer

### DIFF
--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -38,6 +38,7 @@ fs.inotify.max\_queued\_events  | 1048576   | 16384   | This specifies an upper 
 fs.inotify.max\_user\_instances | 1048576   | 128     | This specifies an upper limit on the number of inotify instances that can be created per real user ID. [1]
 fs.inotify.max\_user\_watches   | 1048576   | 8192    | This specifies an upper limit on the number of watches that can be created per real user ID. [1]
 vm.max\_map\_count              | 262144    | 65530   | This file contains the maximum number of memory map areas a process may have. Memory map areas are used as a side-effect of calling malloc, directly by mmap and mprotect, and also when loading shared libraries.
+kernel.dmesg\_restrict          | 1         | 0       | This denies container access to the messages in the kernel ring buffer. Please note that this also will deny access to non-root users on the host system.
 
 
 Then, reboot the server.


### PR DESCRIPTION
By default the Linux kernel grants access to the kernel ring buffer
(dmesg) to all users. Consequently containers do have access to this
data. The kernel ring buffer might contain sensitive information.

Fixes #1397