### PR TITLE
improve backup handling

### DIFF
--- a/doc/backup.md
+++ b/doc/backup.md
@@ -1,0 +1,29 @@
+# LXD Backup Strategies
+
+To backup a LXD instance different strategies are available.
+
+## Full backup
+This requires that the whole `/var/lib/lxd` folder will be backuped up.
+Additionally, it is necessary to backup all storage pools as well.
+In order to restore the LXD instance the old `/var/lib/lxd` folder needs to be
+removed and replaced with the `/var/lib/lxd` snapshot. All storage pools
+need to be restored as well.
+
+## Secondary LXD
+This requires a second LXD instance to be setup and reachable from the LXD
+instance that is to be backed up. Then, all containers can be copied to the
+secondary LXD instance for backup.
+
+## Container backup and restore
+Additionally, LXD maintains a `backup.yaml` file in the containers storage
+volume. This file contains all necessary information to recover a given
+container. The tool `lxd import` is designed to process this file and to
+restore containers from it.
+This recovery mechanism is mostly meant for emergency recoveries and will try
+to re-create container and storage database entries from a backup of the
+storage pool configuration. This requires that the corresponding storage volume
+for the container exists and is accessible. For example, if the container's
+storage volume got unmounted the user is required to remount it manually.
+Note that if any existing database entry is found then `lxd import` will refuse
+to restore the container unless the `--force` flag is passed which will cause
+LXD to delete and replace any currently existing db entries.

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -136,9 +136,9 @@ func internalImport(d *Daemon, r *http.Request) Response {
 	}
 
 	if len(containerMntPoints) > 1 {
-		return BadRequest(fmt.Errorf("The container \"%\" seems to exist on another storage pool.", name))
+		return BadRequest(fmt.Errorf("The container \"%s\" seems to exist on another storage pool.", name))
 	} else if len(containerMntPoints) != 1 {
-		return BadRequest(fmt.Errorf("The container \"%\" does not seem to exist on any storage pool.", name))
+		return BadRequest(fmt.Errorf("The container \"%s\" does not seem to exist on any storage pool.", name))
 	}
 
 	containerMntPoint := containerMntPoints[0]
@@ -148,7 +148,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 	}
 
 	if isEmpty {
-		return BadRequest(fmt.Errorf("The container's directory \"%\" appears to be empty. Please ensure that the container's storage volume is mounted.", containerMntPoint))
+		return BadRequest(fmt.Errorf("The container's directory \"%s\" appears to be empty. Please ensure that the container's storage volume is mounted.", containerMntPoint))
 	}
 
 	sf, err := slurpBackupFile(shared.VarPath("containers", name, "backup.yaml"))

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"database/sql"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 
@@ -11,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -107,40 +111,66 @@ func slurpBackupFile(path string) (*backupFile, error) {
 		return nil, err
 	}
 
-	sf := backupFile{}
+	backup := backupFile{}
 
-	if err := yaml.Unmarshal(data, &sf); err != nil {
+	if err := yaml.Unmarshal(data, &backup); err != nil {
 		return nil, err
 	}
 
-	return &sf, nil
+	return &backup, nil
+}
+
+type internalImportPost struct {
+	Name  string `json:"name" yaml:"name"`
+	Force bool   `json:"force" yaml:"force"`
 }
 
 func internalImport(d *Daemon, r *http.Request) Response {
-	name := r.FormValue("target")
-	if name == "" {
-		return BadRequest(fmt.Errorf("target is required"))
+	req := &internalImportPost{}
+	// Parse the request.
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return BadRequest(err)
 	}
 
-	storagePoolNames, err := dbStoragePools(d.db)
+	if req.Name == "" {
+		return BadRequest(fmt.Errorf("The name of the container is required."))
+	}
+
+	storagePoolsPath := shared.VarPath("storage-pools")
+	storagePoolsDir, err := os.Open(storagePoolsPath)
 	if err != nil {
 		return InternalError(err)
 	}
 
+	// Get a list of all storage pools.
+	storagePoolNames, err := storagePoolsDir.Readdirnames(-1)
+	if err != nil {
+		storagePoolsDir.Close()
+		return InternalError(err)
+	}
+	storagePoolsDir.Close()
+
+	// Detect the container's mountpoint.
 	containerMntPoints := []string{}
+	containerPoolName := ""
 	for _, poolName := range storagePoolNames {
-		containerMntPoint := getContainerMountPoint(poolName, name)
+		containerMntPoint := getContainerMountPoint(poolName, req.Name)
 		if shared.PathExists(containerMntPoint) {
 			containerMntPoints = append(containerMntPoints, containerMntPoint)
+			containerPoolName = poolName
 		}
 	}
 
+	// Sanity checks.
 	if len(containerMntPoints) > 1 {
-		return BadRequest(fmt.Errorf("The container \"%s\" seems to exist on another storage pool.", name))
+		return BadRequest(fmt.Errorf("The container \"%s\" seems to exist on another storage pool.", req.Name))
 	} else if len(containerMntPoints) != 1 {
-		return BadRequest(fmt.Errorf("The container \"%s\" does not seem to exist on any storage pool.", name))
+		return BadRequest(fmt.Errorf("The container \"%s\" does not seem to exist on any storage pool.", req.Name))
 	}
 
+	// User needs to make sure that we can access the directory where
+	// backup.yaml lives.
 	containerMntPoint := containerMntPoints[0]
 	isEmpty, err := shared.PathIsEmpty(containerMntPoint)
 	if err != nil {
@@ -151,40 +181,250 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("The container's directory \"%s\" appears to be empty. Please ensure that the container's storage volume is mounted.", containerMntPoint))
 	}
 
-	sf, err := slurpBackupFile(shared.VarPath("containers", name, "backup.yaml"))
+	// Read in the backup.yaml file.
+	backup, err := slurpBackupFile(shared.VarPath("containers", req.Name, "backup.yaml"))
 	if err != nil {
 		return SmartError(err)
 	}
 
-	baseImage := sf.Container.Config["volatile.base_image"]
-	for k := range sf.Container.Config {
-		if strings.HasPrefix(k, "volatile") {
-			delete(sf.Container.Config, k)
+	// Try to retrieve the storage pool the container supposedly lives on.
+	var poolErr error
+	poolID, pool, poolErr := dbStoragePoolGet(d.db, containerPoolName)
+	if poolErr != nil {
+		if poolErr != NoSuchObjectError {
+			return SmartError(poolErr)
 		}
 	}
 
-	arch, err := osarch.ArchitectureId(sf.Container.Architecture)
+	if backup.Pool == nil {
+		// We don't know what kind of storage type the pool is.
+		return BadRequest(fmt.Errorf("No storage pool struct in the backup file found. The storage pool needs to be recovered manually."))
+	}
+
+	if poolErr == NoSuchObjectError {
+		// Create the storage pool db entry if it doesn't exist.
+		err := storagePoolDBCreate(d, containerPoolName, backup.Pool.Driver, backup.Pool.Config)
+		if err != nil {
+			return InternalError(err)
+		}
+
+		poolID, err = dbStoragePoolGetID(d.db, containerPoolName)
+		if err != nil {
+			return InternalError(err)
+		}
+	} else {
+		if backup.Pool.Name != containerPoolName {
+			return BadRequest(fmt.Errorf("The storage pool \"%s\" the container was detected on does not match the storage pool \"%s\" specified in the backup file.", backup.Pool.Name, containerPoolName))
+		}
+
+		if backup.Pool.Driver != pool.Driver {
+			return BadRequest(fmt.Errorf("The storage pool's \"%s\" driver \"%s\" conflicts with the driver \"%s\" recorded in the container's backup file.", containerPoolName, pool.Driver, backup.Pool.Driver))
+		}
+	}
+
+	// Check if a storage volume entry for the container already exists.
+	_, volume, ctVolErr := dbStoragePoolVolumeGetType(d.db, req.Name, storagePoolVolumeTypeContainer, poolID)
+	if ctVolErr != nil {
+		if ctVolErr != NoSuchObjectError {
+			return InternalError(ctVolErr)
+		}
+	}
+	// If a storage volume entry exists only proceed if force was specified.
+	if ctVolErr == nil && !req.Force {
+		return BadRequest(fmt.Errorf("Storage volume for container \"%s\" already exists in the database. Set \"force\" to overwrite.", req.Name))
+	}
+
+	// Check if an entry for the container already exists in the db.
+	_, containerErr := dbContainerId(d.db, req.Name)
+	if containerErr != nil {
+		if containerErr != sql.ErrNoRows {
+			return InternalError(containerErr)
+		}
+	}
+	// If a db entry exists only proceed if force was specified.
+	if containerErr == nil && !req.Force {
+		return BadRequest(fmt.Errorf("Entry for container \"%s\" already exists in the database. Set \"force\" to overwrite.", req.Name))
+	}
+
+	// Detect discrepancy between snapshots recorded in "backup.yaml" and
+	// those actually existing on disk.
+	snapshotsPath := getSnapshotMountPoint(containerPoolName, req.Name)
+	snapshotsDir, err := os.Open(snapshotsPath)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	// Get a list of all snapshots that exist on disk.
+	snapshotNames, err := snapshotsDir.Readdirnames(-1)
+	if err != nil {
+		snapshotsDir.Close()
+		return InternalError(err)
+	}
+	snapshotsDir.Close()
+
+	onDiskSnapshots := map[string]*api.ContainerSnapshot{}
+	for _, snapName := range snapshotNames {
+		fullSnapName := fmt.Sprintf("%s/%s", req.Name, snapName)
+		snapshotMntPoint := getSnapshotMountPoint(containerPoolName, fullSnapName)
+		if shared.PathExists(snapshotMntPoint) {
+			onDiskSnapshots[fullSnapName] = nil
+		}
+	}
+
+	// Pre-check snapshots to ensure that nothings gets messed up because
+	// "force" is missing.
+	for _, snap := range backup.Snapshots {
+		// Kick out any snapshots that do not exist on-disk anymore.
+		_, ok := onDiskSnapshots[snap.Name]
+		if !ok {
+			shared.LogWarnf("The snapshot \"%s\" for container \"%s\" does not exist on disk anymore. Skipping...", snap.Name, req.Name)
+			continue
+		}
+
+		onDiskSnapshots[snap.Name] = snap
+
+		// Check if an entry for the snapshot already exists in the db.
+		_, snapErr := dbContainerId(d.db, snap.Name)
+		if snapErr != nil {
+			if snapErr != sql.ErrNoRows {
+				return InternalError(snapErr)
+			}
+		}
+
+		// If a db entry exists only proceed if force was specified.
+		if snapErr == nil && !req.Force {
+			return BadRequest(fmt.Errorf("Entry for snapshot \"%s\" already exists in the database. Set \"force\" to overwrite.", snap.Name))
+		}
+
+		// Check if a storage volume entry for the snapshot already exists.
+		_, _, snapVolErr := dbStoragePoolVolumeGetType(d.db, snap.Name, storagePoolVolumeTypeContainer, poolID)
+		if snapVolErr != nil {
+			if snapVolErr != NoSuchObjectError {
+				return InternalError(snapVolErr)
+			}
+		}
+
+		// If a storage volume entry exists only proceed if force was specified.
+		if snapVolErr == nil && !req.Force {
+			return BadRequest(fmt.Errorf("Storage volume for snapshot \"%s\" already exists in the database. Set \"force\" to overwrite.", snap.Name))
+		}
+	}
+
+	if backup.Volume == nil {
+		return BadRequest(fmt.Errorf("No storage volume struct in the backup file found. The storage volume needs to be recovered manually."))
+	}
+
+	if ctVolErr == nil {
+		if volume.Name != backup.Volume.Name {
+			return BadRequest(fmt.Errorf("The name \"%s\" of the storage volume is not identical to the container's name \"%s\".", volume.Name, req.Name))
+		}
+
+		if volume.Type != backup.Volume.Type {
+			return BadRequest(fmt.Errorf("The type \"%s\" of the storage volume is not identical to the container's type \"%s\".", volume.Type, backup.Volume.Type))
+		}
+
+		// Remove the storage volume db entry for the container since
+		// force was specified.
+		err := dbStoragePoolVolumeDelete(d.db, req.Name, storagePoolVolumeTypeContainer, poolID)
+		if err != nil {
+			return SmartError(err)
+		}
+	}
+
+	if containerErr == nil {
+		// Remove the storage volume db entry for the container since
+		// force was specified.
+		err := dbContainerRemove(d.db, req.Name)
+		if err != nil {
+			return InternalError(err)
+		}
+	}
+
+	baseImage := backup.Container.Config["volatile.base_image"]
+	for k := range backup.Container.Config {
+		if strings.HasPrefix(k, "volatile") {
+			delete(backup.Container.Config, k)
+		}
+	}
+
+	arch, err := osarch.ArchitectureId(backup.Container.Architecture)
 	if err != nil {
 		return SmartError(err)
 	}
 	_, err = containerCreateInternal(d, containerArgs{
 		Architecture: arch,
 		BaseImage:    baseImage,
-		Config:       sf.Container.Config,
-		CreationDate: sf.Container.CreatedAt,
-		LastUsedDate: sf.Container.LastUsedAt,
+		Config:       backup.Container.Config,
+		CreationDate: backup.Container.CreatedAt,
+		LastUsedDate: backup.Container.LastUsedAt,
 		Ctype:        cTypeRegular,
-		Devices:      sf.Container.Devices,
-		Ephemeral:    sf.Container.Ephemeral,
-		Name:         sf.Container.Name,
-		Profiles:     sf.Container.Profiles,
-		Stateful:     sf.Container.Stateful,
+		Devices:      backup.Container.Devices,
+		Ephemeral:    backup.Container.Ephemeral,
+		Name:         backup.Container.Name,
+		Profiles:     backup.Container.Profiles,
+		Stateful:     backup.Container.Stateful,
 	})
 	if err != nil {
 		return SmartError(err)
 	}
 
-	for _, snap := range sf.Snapshots {
+	for snapName, snap := range onDiskSnapshots {
+		// Check if an entry for the snapshot already exists in the db.
+		_, snapErr := dbContainerId(d.db, snapName)
+		if snapErr != nil {
+			if snapErr != sql.ErrNoRows {
+				return InternalError(snapErr)
+			}
+		}
+
+		// If a db entry exists only proceed if force was specified.
+		if snapErr == nil && !req.Force {
+			return BadRequest(fmt.Errorf("Entry for snapshot \"%s\" already exists in the database. Set \"force\" to overwrite.", snapName))
+		}
+
+		// Check if a storage volume entry for the snapshot already exists.
+		_, _, csVolErr := dbStoragePoolVolumeGetType(d.db, snapName, storagePoolVolumeTypeContainer, poolID)
+		if csVolErr != nil {
+			if csVolErr != NoSuchObjectError {
+				return InternalError(csVolErr)
+			}
+		}
+
+		// If a storage volume entry exists only proceed if force was specified.
+		if csVolErr == nil && !req.Force {
+			return BadRequest(fmt.Errorf("Storage volume for snapshot \"%s\" already exists in the database. Set \"force\" to overwrite.", snapName))
+		}
+
+		if snapErr == nil {
+			err := dbContainerRemove(d.db, snapName)
+			if err != nil {
+				return InternalError(err)
+			}
+		}
+
+		if csVolErr == nil {
+			err := dbStoragePoolVolumeDelete(d.db, snapName, storagePoolVolumeTypeContainer, poolID)
+			if err != nil {
+				return SmartError(err)
+			}
+		}
+
+		// Snapshot exists on disk but does not have an entry in the
+		// "backup.yaml" file. Recreate it by copying the parent
+		// container's settings.
+		if snap == nil {
+			shared.LogWarnf("The snapshot \"%s\" for the container \"%s\" exists on disk but not in the backup file. Restoring with parent container's settings.", snapName, req.Name)
+			snap = &api.ContainerSnapshot{}
+			snap.Config = backup.Container.Config
+			snap.CreationDate = backup.Container.CreatedAt
+			snap.LastUsedDate = backup.Container.LastUsedAt
+			snap.Devices = backup.Container.Devices
+			snap.Ephemeral = backup.Container.Ephemeral
+			snap.Profiles = backup.Container.Profiles
+			snap.Stateful = backup.Container.Stateful
+			snap.Architecture = backup.Container.Architecture
+		}
+
 		baseImage := snap.Config["volatile.base_image"]
 		for k := range snap.Config {
 			if strings.HasPrefix(k, "volatile") {
@@ -206,7 +446,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 			Ctype:        cTypeSnapshot,
 			Devices:      snap.Devices,
 			Ephemeral:    snap.Ephemeral,
-			Name:         snap.Name,
+			Name:         snapName,
 			Profiles:     snap.Profiles,
 			Stateful:     snap.Stateful,
 		})

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1553,7 +1553,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	if !reflect.DeepEqual(idmap, lastIdmap) {
 		shared.LogDebugf("Container idmap changed, remapping")
 
-		err := c.StorageStart()
+		ourStart, err := c.StorageStart()
 		if err != nil {
 			return "", err
 		}
@@ -1561,7 +1561,9 @@ func (c *containerLXC) startCommon() (string, error) {
 		if lastIdmap != nil {
 			err = lastIdmap.UnshiftRootfs(c.RootfsPath())
 			if err != nil {
-				c.StorageStop()
+				if ourStart {
+					c.StorageStop()
+				}
 				return "", err
 			}
 		}
@@ -1569,7 +1571,9 @@ func (c *containerLXC) startCommon() (string, error) {
 		if idmap != nil {
 			err = idmap.ShiftRootfs(c.RootfsPath())
 			if err != nil {
-				c.StorageStop()
+				if ourStart {
+					c.StorageStop()
+				}
 				return "", err
 			}
 		}
@@ -1597,9 +1601,11 @@ func (c *containerLXC) startCommon() (string, error) {
 			return "", err
 		}
 
-		err = c.StorageStop()
-		if err != nil {
-			return "", err
+		if ourStart {
+			_, err = c.StorageStop()
+			if err != nil {
+				return "", err
+			}
 		}
 	}
 
@@ -1842,7 +1848,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	}
 
 	// Storage is guaranteed to be mountable now.
-	err = c.StorageStart()
+	ourStart, err := c.StorageStart()
 	if err != nil {
 		return "", err
 	}
@@ -1858,11 +1864,13 @@ func (c *containerLXC) startCommon() (string, error) {
 	// Update the backup.yaml file
 	err = writeBackupFile(c)
 	if err != nil {
-		c.StorageStop()
+		if ourStart {
+			c.StorageStop()
+		}
 		return "", err
 	}
 
-	err = c.StorageStop()
+	_, err = c.StorageStop()
 	if err != nil {
 		return "", err
 	}
@@ -1898,7 +1906,7 @@ func (c *containerLXC) Start(stateful bool) error {
 	}
 
 	// Ensure that the container storage volume is mounted.
-	err = c.StorageStart()
+	_, err = c.StorageStart()
 	if err != nil {
 		return err
 	}
@@ -2008,7 +2016,7 @@ func (c *containerLXC) OnStart() error {
 	c.fromHook = true
 
 	// Start the storage for this container
-	err := c.StorageStart()
+	ourStart, err := c.StorageStart()
 	if err != nil {
 		return err
 	}
@@ -2016,7 +2024,9 @@ func (c *containerLXC) OnStart() error {
 	// Load the container AppArmor profile
 	err = AALoadProfile(c)
 	if err != nil {
-		c.StorageStop()
+		if ourStart {
+			c.StorageStop()
+		}
 		return err
 	}
 
@@ -2027,7 +2037,9 @@ func (c *containerLXC) OnStart() error {
 		err = c.templateApplyNow(c.localConfig[key])
 		if err != nil {
 			AADestroy(c)
-			c.StorageStop()
+			if ourStart {
+				c.StorageStop()
+			}
 			return err
 		}
 
@@ -2035,7 +2047,9 @@ func (c *containerLXC) OnStart() error {
 		err := dbContainerConfigRemove(c.daemon.db, c.id, key)
 		if err != nil {
 			AADestroy(c)
-			c.StorageStop()
+			if ourStart {
+				c.StorageStop()
+			}
 			return err
 		}
 	}
@@ -2043,7 +2057,9 @@ func (c *containerLXC) OnStart() error {
 	err = c.templateApplyNow("start")
 	if err != nil {
 		AADestroy(c)
-		c.StorageStop()
+		if ourStart {
+			c.StorageStop()
+		}
 		return err
 	}
 
@@ -2250,7 +2266,7 @@ func (c *containerLXC) OnStop(target string) error {
 	c.fromHook = true
 
 	// Stop the storage for this container
-	err := c.StorageStop()
+	_, err := c.StorageStop()
 	if err != nil {
 		if op != nil {
 			op.Done(err)
@@ -3802,8 +3818,11 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 	 * yet before container creation; this is okay, because at the end of
 	 * container creation we write the backup file, so let's not worry about
 	 * ENOENT. */
-	if err := writeBackupFile(c); err != nil && !os.IsNotExist(err) {
-		return err
+	if c.storage.ContainerStorageReady(c.Name()) {
+		err := writeBackupFile(c)
+		if err != nil && !os.IsNotExist(err) {
+			return err
+		}
 	}
 
 	// Update network leases
@@ -3838,12 +3857,14 @@ func (c *containerLXC) Export(w io.Writer, properties map[string]string) error {
 	shared.LogInfo("Exporting container", ctxMap)
 
 	// Start the storage
-	err := c.StorageStart()
+	ourStart, err := c.StorageStart()
 	if err != nil {
 		shared.LogError("Failed exporting container", ctxMap)
 		return err
 	}
-	defer c.StorageStop()
+	if ourStart {
+		defer c.StorageStop()
+	}
 
 	// Unshift the container
 	idmap, err := c.LastIdmapSet()
@@ -4146,19 +4167,21 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 				return err
 			}
 
-			err = c.StorageStart()
+			ourStart, err := c.StorageStart()
 			if err != nil {
 				return err
 			}
 
 			err = idmapset.ShiftRootfs(stateDir)
-			err2 := c.StorageStop()
-			if err != nil {
-				return err
-			}
+			if ourStart {
+				_, err2 := c.StorageStop()
+				if err != nil {
+					return err
+				}
 
-			if err2 != nil {
-				return err2
+				if err2 != nil {
+					return err2
+				}
 			}
 		}
 
@@ -4388,8 +4411,10 @@ func (c *containerLXC) templateApplyNow(trigger string) error {
 
 func (c *containerLXC) FileExists(path string) error {
 	// Setup container storage if needed
+	var ourStart bool
+	var err error
 	if !c.IsRunning() {
-		err := c.StorageStart()
+		ourStart, err = c.StorageStart()
 		if err != nil {
 			return err
 		}
@@ -4405,8 +4430,8 @@ func (c *containerLXC) FileExists(path string) error {
 	)
 
 	// Tear down container storage if needed
-	if !c.IsRunning() {
-		err := c.StorageStop()
+	if !c.IsRunning() && ourStart {
+		_, err := c.StorageStop()
 		if err != nil {
 			return err
 		}
@@ -4431,9 +4456,11 @@ func (c *containerLXC) FileExists(path string) error {
 }
 
 func (c *containerLXC) FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error) {
+	var ourStart bool
+	var err error
 	// Setup container storage if needed
 	if !c.IsRunning() {
-		err := c.StorageStart()
+		ourStart, err = c.StorageStart()
 		if err != nil {
 			return -1, -1, 0, "", nil, err
 		}
@@ -4450,8 +4477,8 @@ func (c *containerLXC) FilePull(srcpath string, dstpath string) (int64, int64, o
 	)
 
 	// Tear down container storage if needed
-	if !c.IsRunning() {
-		err := c.StorageStop()
+	if !c.IsRunning() && ourStart {
+		_, err := c.StorageStop()
 		if err != nil {
 			return -1, -1, 0, "", nil, err
 		}
@@ -4567,9 +4594,11 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int64, gid i
 		}
 	}
 
+	var ourStart bool
+	var err error
 	// Setup container storage if needed
 	if !c.IsRunning() {
-		err := c.StorageStart()
+		ourStart, err = c.StorageStart()
 		if err != nil {
 			return err
 		}
@@ -4593,8 +4622,8 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int64, gid i
 	)
 
 	// Tear down container storage if needed
-	if !c.IsRunning() {
-		err := c.StorageStop()
+	if !c.IsRunning() && ourStart {
+		_, err := c.StorageStop()
 		if err != nil {
 			return err
 		}
@@ -4631,10 +4660,12 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int64, gid i
 
 func (c *containerLXC) FileRemove(path string) error {
 	var errStr string
+	var ourStart bool
+	var err error
 
 	// Setup container storage if needed
 	if !c.IsRunning() {
-		err := c.StorageStart()
+		ourStart, err = c.StorageStart()
 		if err != nil {
 			return err
 		}
@@ -4650,8 +4681,8 @@ func (c *containerLXC) FileRemove(path string) error {
 	)
 
 	// Tear down container storage if needed
-	if !c.IsRunning() {
-		err := c.StorageStop()
+	if !c.IsRunning() && ourStart {
+		_, err := c.StorageStop()
 		if err != nil {
 			return err
 		}
@@ -5023,40 +5054,38 @@ func (c *containerLXC) Storage() storage {
 	return c.storage
 }
 
-func (c *containerLXC) StorageStart() error {
+func (c *containerLXC) StorageStart() (bool, error) {
 	// Initialize storage interface for the container.
 	err := c.initStorage()
 	if err != nil {
-		return err
+		return false, err
 	}
 
+	isOurOperation := false
 	if c.IsSnapshot() {
-		return c.storage.ContainerSnapshotStart(c)
+		isOurOperation, err = c.storage.ContainerSnapshotStart(c)
+	} else {
+		isOurOperation, err = c.storage.ContainerMount(c.Name(), c.Path())
 	}
 
-	_, err = c.storage.ContainerMount(c.Name(), c.Path())
-	if err != nil {
-		return err
-	}
-	return nil
+	return isOurOperation, err
 }
 
-func (c *containerLXC) StorageStop() error {
+func (c *containerLXC) StorageStop() (bool, error) {
 	// Initialize storage interface for the container.
 	err := c.initStorage()
 	if err != nil {
-		return err
+		return false, err
 	}
 
+	isOurOperation := false
 	if c.IsSnapshot() {
-		return c.storage.ContainerSnapshotStop(c)
+		isOurOperation, err = c.storage.ContainerSnapshotStop(c)
+	} else {
+		isOurOperation, err = c.storage.ContainerUmount(c.Name(), c.Path())
 	}
 
-	_, err = c.storage.ContainerUmount(c.Name(), c.Path())
-	if err != nil {
-		return err
-	}
-	return err
+	return isOurOperation, err
 }
 
 // Mount handling

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2916,6 +2916,7 @@ func (c *containerLXC) ConfigKeySet(key string, value string) error {
 type backupFile struct {
 	Container *api.Container           `yaml:"container"`
 	Snapshots []*api.ContainerSnapshot `yaml:"snapshots"`
+	Pool      *api.StoragePool         `yaml:"pool"`
 }
 
 func writeBackupFile(c container) error {
@@ -2956,9 +2957,20 @@ func writeBackupFile(c container) error {
 		sis = append(sis, si.(*api.ContainerSnapshot))
 	}
 
+	poolName, err := c.StoragePool()
+	if err != nil {
+		return err
+	}
+
+	_, pool, err := dbStoragePoolGet(c.Daemon().db, poolName)
+	if err != nil {
+		return err
+	}
+
 	data, err := yaml.Marshal(&backupFile{
 		Container: ci.(*api.Container),
 		Snapshots: sis,
+		Pool:      pool,
 	})
 	if err != nil {
 		return err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2917,6 +2917,7 @@ type backupFile struct {
 	Container *api.Container           `yaml:"container"`
 	Snapshots []*api.ContainerSnapshot `yaml:"snapshots"`
 	Pool      *api.StoragePool         `yaml:"pool"`
+	Volume    *api.StorageVolume       `yaml:"volume"`
 }
 
 func writeBackupFile(c container) error {
@@ -2962,7 +2963,13 @@ func writeBackupFile(c container) error {
 		return err
 	}
 
-	_, pool, err := dbStoragePoolGet(c.Daemon().db, poolName)
+	db := c.Daemon().db
+	poolID, pool, err := dbStoragePoolGet(c.Daemon().db, poolName)
+	if err != nil {
+		return err
+	}
+
+	_, volume, err := dbStoragePoolVolumeGetType(db, c.Name(), storagePoolVolumeTypeContainer, poolID)
 	if err != nil {
 		return err
 	}
@@ -2971,6 +2978,7 @@ func writeBackupFile(c container) error {
 		Container: ci.(*api.Container),
 		Snapshots: sis,
 		Pool:      pool,
+		Volume:    volume,
 	})
 	if err != nil {
 		return err

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -107,20 +107,11 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	// Check whether the container will be mounted exclusively by us or if
-	// it already was by someone else. In the latter case don't unmount it.
-	storagePool, err := c.StoragePool()
-	if err != nil {
-		return SmartError(err)
-	}
-
-	containerPoolVolumeMntPoint := getContainerMountPoint(storagePool, name)
-	mountedBefore := shared.IsMountPoint(containerPoolVolumeMntPoint)
-	err = c.StorageStart()
+	ourStart, err := c.StorageStart()
 	if err != nil {
 		return InternalError(err)
 	}
-	if !mountedBefore || c.IsSnapshot() {
+	if ourStart {
 		defer c.StorageStop()
 	}
 

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -119,7 +119,7 @@ func (suite *lxdTestSuite) TestContainer_LoadFromDB() {
 	c2, err := containerLoadByName(suite.d, "testFoo")
 	c2.IsRunning()
 	suite.Req.Nil(err)
-	err = c2.StorageStart()
+	_, err = c2.StorageStart()
 	suite.Req.Nil(err)
 
 	suite.Exactly(

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -32,6 +32,7 @@ var argTimeout = gnuflag.Int("timeout", -1, "")
 var argTrustPassword = gnuflag.String("trust-password", "", "")
 var argVerbose = gnuflag.Bool("verbose", false, "")
 var argVersion = gnuflag.Bool("version", false, "")
+var argForce = gnuflag.Bool("force", false, "")
 
 // Global variables
 var debug bool
@@ -74,7 +75,7 @@ func run() error {
 		fmt.Printf("        Perform a clean shutdown of LXD and all running containers\n")
 		fmt.Printf("    waitready [--timeout=15]\n")
 		fmt.Printf("        Wait until LXD is ready to handle requests\n")
-		fmt.Printf("    import <container name>\n")
+		fmt.Printf("    import <container name> [--force]\n")
 		fmt.Printf("        Import a pre-existing container from storage\n")
 
 		fmt.Printf("\n\nCommon options:\n")

--- a/lxd/main_import.go
+++ b/lxd/main_import.go
@@ -1,27 +1,44 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"net/http"
 
 	"github.com/lxc/lxd"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/version"
 )
 
 func cmdImport(args []string) error {
 	name := args[1]
+	b := shared.Jmap{
+		"name":  name,
+		"force": *argForce,
+	}
+
+	buf := bytes.Buffer{}
+	err := json.NewEncoder(&buf).Encode(b)
+	if err != nil {
+		return err
+	}
 
 	c, err := lxd.NewClient(&lxd.DefaultConfig, "local")
 	if err != nil {
 		return err
 	}
 
-	url := fmt.Sprintf("%s/internal/containers?target=%s", c.BaseURL, name)
+	url := fmt.Sprintf("%s/internal/containers", c.BaseURL)
 
-	req, err := http.NewRequest("POST", url, nil)
+	req, err := http.NewRequest("POST", url, &buf)
 	if err != nil {
 		return err
 	}
+
+	req.Header.Set("User-Agent", version.UserAgent)
+	req.Header.Set("Content-Type", "application/json")
 
 	raw, err := c.Http.Do(req)
 	_, err = lxd.HoistResponse(raw, api.SyncResponse)

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -296,11 +296,13 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 
 	// Storage needs to start unconditionally now, since we need to
 	// initialize a new storage interface.
-	err := s.container.StorageStart()
+	ourStart, err := s.container.StorageStart()
 	if err != nil {
 		return err
 	}
-	defer s.container.StorageStop()
+	if ourStart {
+		defer s.container.StorageStop()
+	}
 
 	idmaps := make([]*IDMapType, 0)
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -235,8 +235,8 @@ type storage interface {
 	ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error
 	ContainerSnapshotDelete(snapshotContainer container) error
 	ContainerSnapshotRename(snapshotContainer container, newName string) error
-	ContainerSnapshotStart(container container) error
-	ContainerSnapshotStop(container container) error
+	ContainerSnapshotStart(container container) (bool, error)
+	ContainerSnapshotStop(container container) (bool, error)
 
 	// For use in migrating snapshots.
 	ContainerSnapshotCreateEmpty(snapshotContainer container) error

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -357,9 +357,12 @@ func (s *storageDir) ContainerDelete(container container) error {
 func (s *storageDir) ContainerCopy(container container, sourceContainer container) error {
 	shared.LogDebugf("Copying DIR container storage %s -> %s.", sourceContainer.Name(), container.Name())
 
-	err := sourceContainer.StorageStart()
+	ourStart, err := sourceContainer.StorageStart()
 	if err != nil {
 		return err
+	}
+	if ourStart {
+		defer sourceContainer.StorageStop()
 	}
 
 	// Deal with the source container.
@@ -526,9 +529,12 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 		return nil
 	}
 
-	err = sourceContainer.StorageStart()
+	ourStart, err := sourceContainer.StorageStart()
 	if err != nil {
 		return err
+	}
+	if ourStart {
+		defer sourceContainer.StorageStop()
 	}
 
 	_, sourcePool := sourceContainer.Storage().GetContainerPoolInfo()
@@ -675,12 +681,12 @@ func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newNam
 	return nil
 }
 
-func (s *storageDir) ContainerSnapshotStart(container container) error {
-	return nil
+func (s *storageDir) ContainerSnapshotStart(container container) (bool, error) {
+	return true, nil
 }
 
-func (s *storageDir) ContainerSnapshotStop(container container) error {
-	return nil
+func (s *storageDir) ContainerSnapshotStop(container container) (bool, error) {
+	return true, nil
 }
 
 func (s *storageDir) ImageCreate(fingerprint string) error {

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -177,12 +177,12 @@ func (s *storageMock) ContainerSnapshotRename(
 	return nil
 }
 
-func (s *storageMock) ContainerSnapshotStart(container container) error {
-	return nil
+func (s *storageMock) ContainerSnapshotStart(container container) (bool, error) {
+	return true, nil
 }
 
-func (s *storageMock) ContainerSnapshotStop(container container) error {
-	return nil
+func (s *storageMock) ContainerSnapshotStop(container container) (bool, error) {
+	return true, nil
 }
 
 func (s *storageMock) ContainerSnapshotCreateEmpty(snapshotContainer container) error {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1008,9 +1008,9 @@ func (s *storageZfs) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
-	shared.LogDebugf("Creating ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
-
 	snapshotContainerName := snapshotContainer.Name()
+	shared.LogDebugf("Creating ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", snapshotContainerName, s.pool.Name)
+
 	sourceContainerName := sourceContainer.Name()
 
 	fields := strings.SplitN(snapshotContainerName, shared.SnapshotDelimiter, 2)
@@ -1038,7 +1038,7 @@ func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, source
 		}
 	}
 
-	snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", s.volume.Name)
+	snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "snapshots", sourceContainer.Name())
 	snapshotMntPointSymlink := shared.VarPath("snapshots", sourceContainerName)
 	if !shared.PathExists(snapshotMntPointSymlink) {
 		err := os.Symlink(snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
@@ -1049,7 +1049,7 @@ func (s *storageZfs) ContainerSnapshotCreate(snapshotContainer container, source
 
 	revert = false
 
-	shared.LogDebugf("Created ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	shared.LogDebugf("Created ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", snapshotContainerName, s.pool.Name)
 	return nil
 }
 
@@ -1235,14 +1235,7 @@ func (s *storageZfs) ContainerSnapshotStop(container container) (bool, error) {
 		return false, err
 	}
 
-	/* zfs creates this directory on clone (start), so we need to clean it
-	 * up on stop */
 	shared.LogDebugf("Stopped ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
-	err = os.RemoveAll(container.Path())
-	if err != nil {
-		return false, err
-	}
-
 	return true, nil
 }
 

--- a/test/main.sh
+++ b/test/main.sh
@@ -536,5 +536,6 @@ run_test test_mem_profiling "memory profiling"
 run_test test_storage "storage"
 run_test test_lxd_autoinit "lxd init auto"
 run_test test_storage_profiles "storage profiles"
+run_test test_container_import "container import"
 
 TEST_RESULT=success

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+test_container_import() {
+  ensure_import_testimage
+
+  lxc init testimage ctImport
+  lxc snapshot ctImport
+  lxc start ctImport
+  ! lxd import ctImport
+  lxd import ctImport --force
+  lxc info ctImport | grep snap0
+  lxc delete --force ctImport
+
+  lxc init testimage ctImport
+  lxc snapshot ctImport
+  lxc start ctImport
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+  ! lxd import ctImport
+  lxd import ctImport --force
+  lxc info ctImport | grep snap0
+  lxc delete --force ctImport
+
+  lxc init testimage ctImport
+  lxc snapshot ctImport
+  lxc start ctImport
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+  ! lxd import ctImport
+  lxd import ctImport --force
+  lxc info ctImport | grep snap0
+  lxc delete --force ctImport
+
+  lxc init testimage ctImport
+  lxc snapshot ctImport
+  lxc start ctImport
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
+  ! lxd import ctImport
+  lxd import ctImport --force
+  lxc info ctImport | grep snap0
+  lxc delete --force ctImport
+
+  lxc init testimage ctImport
+  lxc snapshot ctImport
+  lxc start ctImport
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
+  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+  lxd import ctImport
+  lxd import ctImport --force
+  lxc info ctImport | grep snap0
+  lxc delete --force ctImport
+
+  # Test whether a snapshot that exists on disk but not in the "backup.yaml"
+  # file is correctly restored. This can be done by not starting the parent
+  # container which avoids that the backup file is written out.
+  if [ "${LXD_BACKEND}" = "dir" ]; then
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+    ! lxd import ctImport
+    lxd import ctImport --force
+    lxc info ctImport | grep snap0
+    lxc delete --force ctImport
+  fi
+}

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -21,18 +21,6 @@ test_migration() {
   lxc_remote move l1:nonlive l2:
   lxc_remote config show l2:nonlive/snap0 | grep user.tester | grep foo
 
-  # test `lxd import`
-  if [ "${LXD_BACKEND}" = "zfs" ]; then
-    lxc_remote init testimage backup
-    lxc_remote snapshot backup
-    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='backup'"
-    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='backup/snap0'"
-    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='backup'"
-    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='backup/snap0'"
-    lxd import backup
-    lxc_remote info backup | grep snap0
-  fi
-
   # FIXME: make this backend agnostic
   if [ "${LXD_BACKEND}" != "lvm" ]; then
     [ -d "${LXD2_DIR}/containers/nonlive/rootfs" ]


### PR DESCRIPTION
This way we can have Storage{Start,Stop}() indicate whether the operation that
is taking place has been initialized by us and if so we can make an informed
decision about stopping it or not. This should e.g. avoid unnecessary
{u,m}ounts and also should improve writing out the Backup.yaml file.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>