### PR TITLE
doc: fix broken table

### DIFF
--- a/doc/production-setup.md
+++ b/doc/production-setup.md
@@ -22,12 +22,12 @@ using containers that require tens of thousands of file operations.
 
 Domain  | Type  | Item    | Value     | Default   | Description
 :-----  | :---  | :----   | :-------- | :-------- | :----------
-*       | soft  | nofile  | 1048576   | unset     | maximum number of open files
-*       | hard  | nofile  | 1048576   | unset     | maximum number of open files
+\*      | soft  | nofile  | 1048576   | unset     | maximum number of open files
+\*      | hard  | nofile  | 1048576   | unset     | maximum number of open files
 root    | soft  | nofile  | 1048576   | unset     | maximum number of open files
 root    | hard  | nofile  | 1048576   | unset     | maximum number of open files
-*       | soft  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
-*       | hard  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
+\*      | soft  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
+\*      | hard  | memlock | unlimited | unset     | maximum locked-in-memory address space (KB)
 
 
 ## /etc/sysctl.conf


### PR DESCRIPTION
Table is broken in `doc/production-setup.md`.
Escaped charactor `*`.

## Before
![image](https://cloud.githubusercontent.com/assets/591247/24196765/5d1f1c64-0f42-11e7-9bc7-e1a69df1aff1.png)

## After
![image](https://cloud.githubusercontent.com/assets/591247/24196799/73b3ad14-0f42-11e7-9307-7bd47d21dfb6.png)
