### PR TITLE
migration: fix stateful restore

### DIFF
--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -114,7 +114,8 @@ func containerSnapRestore(d *Daemon, name string, snap string) error {
 		}
 	}
 
-	if err := c.Restore(source); err != nil {
+	err = c.Restore(source)
+	if err != nil {
 		return err
 	}
 


### PR DESCRIPTION
With the new storage api work done {m,um}ounting containers is done on demand
so we need to ensure that storage is available at the right time. In the
restore case, when the container is running it is stopped which will also
unmounted the storage volume for e.g. the zfs backend. So let's make sure that
it is mounted again right after.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>