### PR TITLE
test: improve import tests

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -118,6 +118,28 @@ spawn_lxd() {
   fi
 }
 
+respawn_lxd() {
+  set +x
+  # LXD_DIR is local here because since $(lxc) is actually a function, it
+  # overwrites the environment and we would lose LXD_DIR's value otherwise.
+
+  # shellcheck disable=2039
+  local LXD_DIR
+
+  lxddir=${1}
+  shift
+
+  echo "==> Spawning lxd in ${lxddir}"
+  # shellcheck disable=SC2086
+  LXD_DIR="${lxddir}" lxd --logfile "${lxddir}/lxd.log" ${DEBUG-} "$@" 2>&1 &
+  LXD_PID=$!
+  echo "${LXD_PID}" > "${lxddir}/lxd.pid"
+  echo "==> Spawned LXD (PID is ${LXD_PID})"
+
+  echo "==> Confirming lxd is responsive"
+  LXD_DIR="${lxddir}" lxd waitready --timeout=300
+}
+
 lxc() {
   LXC_LOCAL=1
   lxc_remote "$@"
@@ -324,6 +346,22 @@ kill_lxd() {
 
   # Remove the daemon from the list
   sed "\|^${daemon_dir}|d" -i "${TEST_DIR}/daemons"
+}
+
+shutdown_lxd() {
+  # LXD_DIR is local here because since $(lxc) is actually a function, it
+  # overwrites the environment and we would lose LXD_DIR's value otherwise.
+
+  # shellcheck disable=2039
+  local LXD_DIR
+
+  daemon_dir=${1}
+  LXD_DIR=${daemon_dir}
+  daemon_pid=$(cat "${daemon_dir}/lxd.pid")
+  echo "==> Killing LXD at ${daemon_dir}"
+
+  # Kill the daemon
+  lxd shutdown || kill -9 "${daemon_pid}" 2>/dev/null || true
 }
 
 cleanup() {

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -3,65 +3,82 @@
 test_container_import() {
   ensure_import_testimage
 
-  lxc init testimage ctImport
-  lxc snapshot ctImport
-  lxc start ctImport
-  ! lxd import ctImport
-  lxd import ctImport --force
-  lxc info ctImport | grep snap0
-  lxc delete --force ctImport
-
-  lxc init testimage ctImport
-  lxc snapshot ctImport
-  lxc start ctImport
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
-  ! lxd import ctImport
-  lxd import ctImport --force
-  lxc info ctImport | grep snap0
-  lxc delete --force ctImport
-
-  lxc init testimage ctImport
-  lxc snapshot ctImport
-  lxc start ctImport
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
-  ! lxd import ctImport
-  lxd import ctImport --force
-  lxc info ctImport | grep snap0
-  lxc delete --force ctImport
-
-  lxc init testimage ctImport
-  lxc snapshot ctImport
-  lxc start ctImport
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
-  ! lxd import ctImport
-  lxd import ctImport --force
-  lxc info ctImport | grep snap0
-  lxc delete --force ctImport
-
-  lxc init testimage ctImport
-  lxc snapshot ctImport
-  lxc start ctImport
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
-  sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
-  lxd import ctImport
-  lxd import ctImport --force
-  lxc info ctImport | grep snap0
-  lxc delete --force ctImport
-
-  # Test whether a snapshot that exists on disk but not in the "backup.yaml"
-  # file is correctly restored. This can be done by not starting the parent
-  # container which avoids that the backup file is written out.
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  LXD_IMPORT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_IMPORT_DIR}"
+  spawn_lxd "${LXD_IMPORT_DIR}" true
+  (
     lxc init testimage ctImport
     lxc snapshot ctImport
-    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+    lxc start ctImport
     ! lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
     lxc delete --force ctImport
-  fi
+
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    lxc start ctImport
+    shutdown_lxd "${LXD_IMPORT_DIR}"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+    respawn_lxd "${LXD_IMPORT_DIR}"
+    ! lxd import ctImport
+    lxd import ctImport --force
+    lxc info ctImport | grep snap0
+    lxc delete --force ctImport
+
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    lxc start ctImport
+    shutdown_lxd "${LXD_IMPORT_DIR}"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+    respawn_lxd "${LXD_IMPORT_DIR}"
+    ! lxd import ctImport
+    lxd import ctImport --force
+    lxc info ctImport | grep snap0
+    lxc delete --force ctImport
+
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    lxc start ctImport
+    shutdown_lxd "${LXD_IMPORT_DIR}"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
+    respawn_lxd "${LXD_IMPORT_DIR}"
+    ! lxd import ctImport
+    lxd import ctImport --force
+    lxc info ctImport | grep snap0
+    lxc delete --force ctImport
+
+    lxc init testimage ctImport
+    lxc snapshot ctImport
+    lxc start ctImport
+    shutdown_lxd "${LXD_IMPORT_DIR}"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM containers WHERE name='ctImport/snap0'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport'"
+    sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+    respawn_lxd "${LXD_IMPORT_DIR}"
+    lxd import ctImport
+    lxd import ctImport --force
+    lxc info ctImport | grep snap0
+    lxc delete --force ctImport
+
+    # Test whether a snapshot that exists on disk but not in the "backup.yaml"
+    # file is correctly restored. This can be done by not starting the parent
+    # container which avoids that the backup file is written out.
+    if [ "${LXD_BACKEND}" = "dir" ]; then
+      lxc init testimage ctImport
+      lxc snapshot ctImport
+      shutdown_lxd "${LXD_IMPORT_DIR}"
+      sqlite3 "${LXD_DIR}/lxd.db" "DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
+      respawn_lxd "${LXD_IMPORT_DIR}"
+      ! lxd import ctImport
+      lxd import ctImport --force
+      lxc info ctImport | grep snap0
+      lxc delete --force ctImport
+    fi
+  )
+  # shellcheck disable=SC2031
+  kill_lxd "${LXD_IMPORT_DIR}"
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -237,17 +237,13 @@ test_basic_usage() {
 
     lxc start autostart --force-local
     PID=$(lxc info autostart --force-local | grep ^Pid | awk '{print $2}')
-    lxd shutdown
+    shutdown_lxd "${LXD_DIR}"
     [ -d "/proc/${PID}" ] && false
 
     lxd activateifneeded --debug 2>&1 | grep -q "Daemon has auto-started containers, activating..."
 
-    # shellcheck disable=SC2086
-    lxd --logfile "${LXD_DIR}/lxd.log" ${DEBUG-} "$@" 2>&1 &
-    LXD_PID=$!
-    echo "${LXD_PID}" > "${LXD_DIR}/lxd.pid"
-    echo "${LXD_DIR}" >> "${TEST_DIR}/daemons"
-    lxd waitready --timeout=300
+    # shellcheck disable=SC2031
+    respawn_lxd "${LXD_DIR}"
 
     lxc list --force-local autostart | grep -q RUNNING
 


### PR DESCRIPTION
- Add respawn_lxd() and shutdown_lxd() to allow stopping and restarting an
  already running LXD daemon in the test-suite.
- Stop the daemon before calling sqlite3 to avoid db locked errors in the
  test-suite.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>