### PR TITLE
Added soft memory limit even when hard is selected

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3502,6 +3502,12 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 							return err
 						}
 					}
+					// Set soft limit to value 10% less than hard limit
+					err = c.CGroupSet("memory.soft_limit_in_bytes", memory*0.9)
+					if err != nil {
+						revertMemory()
+						return err
+					}
 				}
 
 				// Configure the swappiness

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1032,6 +1032,11 @@ func (c *containerLXC) initLXC() error {
 						return err
 					}
 				}
+				// Set soft limit to value 10% less than hard limit
+				err = lxcSetConfigItem(cc, "lxc.cgroup.memory.soft_limit_in_bytes", fmt.Sprintf("%d", valueInt*0.9))
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1033,7 +1033,7 @@ func (c *containerLXC) initLXC() error {
 					}
 				}
 				// Set soft limit to value 10% less than hard limit
-				err = lxcSetConfigItem(cc, "lxc.cgroup.memory.soft_limit_in_bytes", fmt.Sprintf("%d", valueInt*0.9))
+				err = lxcSetConfigItem(cc, "lxc.cgroup.memory.soft_limit_in_bytes", fmt.Sprintf("%.0f", float64(valueInt)*0.9))
 				if err != nil {
 					return err
 				}
@@ -3507,8 +3507,15 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 							return err
 						}
 					}
+
 					// Set soft limit to value 10% less than hard limit
-					err = c.CGroupSet("memory.soft_limit_in_bytes", memory*0.9)
+					valueInt, err := strconv.ParseInt(memory, 10, 64)
+					if err != nil {
+						revertMemory()
+						return err
+					}
+
+					err = c.CGroupSet("memory.soft_limit_in_bytes", fmt.Sprintf("%.0f", float64(valueInt)*0.9))
 					if err != nil {
 						revertMemory()
 						return err


### PR DESCRIPTION
When hard memory limit is set, OOM is called even if buffers/cache can be released to free memory. To avoid this, soft limit can be enabled in addition to hard. I propose to set soft limit at 90% of hard limit value. It's mentioned in cgroup documentation:
https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
> NOTE2: It is recommended to set the soft limit always below the hard limit, otherwise the hard limit will take precedence. 

Signed-off-by: Lukasz Matczak <lukasz.matczak@cba.pl>