### PR TITLE
build: add debug logging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,12 @@ update:
 	go get -t -v -d -u ./...
 	@echo "Dependencies updated"
 
+.PHONY: debug
+debug:
+	go get -t -v -d ./...
+	go install -v $(TAGS) -tags logdebug $(DEBUG) ./...
+	@echo "LXD built successfully"
+
 # This only needs to be done when migrate.proto is actually changed; since we
 # commit the .pb.go in the tree and it's not expected to change very often,
 # it's not a default build step.

--- a/shared/log_debug.go
+++ b/shared/log_debug.go
@@ -1,4 +1,4 @@
-// +build !logdebug
+// +build logdebug
 
 package shared
 
@@ -32,30 +32,40 @@ func init() {
 // General wrappers around Logger interface functions.
 func LogDebug(msg string, ctx interface{}) {
 	if Log != nil {
+		pc, fn, line, _ := runtime.Caller(1)
+		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
 		Log.Debug(msg, ctx)
 	}
 }
 
 func LogInfo(msg string, ctx interface{}) {
 	if Log != nil {
+		pc, fn, line, _ := runtime.Caller(1)
+		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
 		Log.Info(msg, ctx)
 	}
 }
 
 func LogWarn(msg string, ctx interface{}) {
 	if Log != nil {
+		pc, fn, line, _ := runtime.Caller(1)
+		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
 		Log.Warn(msg, ctx)
 	}
 }
 
 func LogError(msg string, ctx interface{}) {
 	if Log != nil {
+		pc, fn, line, _ := runtime.Caller(1)
+		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
 		Log.Error(msg, ctx)
 	}
 }
 
 func LogCrit(msg string, ctx interface{}) {
 	if Log != nil {
+		pc, fn, line, _ := runtime.Caller(1)
+		msg := fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
 		Log.Crit(msg, ctx)
 	}
 }
@@ -64,31 +74,46 @@ func LogCrit(msg string, ctx interface{}) {
 // by running it through fmt.Sprintf().
 func LogInfof(format string, args ...interface{}) {
 	if Log != nil {
-		Log.Info(fmt.Sprintf(format, args...))
+		msg := fmt.Sprintf(format, args...)
+		pc, fn, line, _ := runtime.Caller(1)
+		msg = fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
+		Log.Info(msg)
 	}
 }
 
 func LogDebugf(format string, args ...interface{}) {
 	if Log != nil {
-		Log.Debug(fmt.Sprintf(format, args...))
+		msg := fmt.Sprintf(format, args...)
+		pc, fn, line, _ := runtime.Caller(1)
+		msg = fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
+		Log.Debug(msg)
 	}
 }
 
 func LogWarnf(format string, args ...interface{}) {
 	if Log != nil {
-		Log.Warn(fmt.Sprintf(format, args...))
+		msg := fmt.Sprintf(format, args...)
+		pc, fn, line, _ := runtime.Caller(1)
+		msg = fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
+		Log.Warn(msg)
 	}
 }
 
 func LogErrorf(format string, args ...interface{}) {
 	if Log != nil {
-		Log.Error(fmt.Sprintf(format, args...))
+		msg := fmt.Sprintf(format, args...)
+		pc, fn, line, _ := runtime.Caller(1)
+		msg = fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
+		Log.Error(msg)
 	}
 }
 
 func LogCritf(format string, args ...interface{}) {
 	if Log != nil {
-		Log.Crit(fmt.Sprintf(format, args...))
+		msg := fmt.Sprintf(format, args...)
+		pc, fn, line, _ := runtime.Caller(1)
+		msg = fmt.Sprintf("%s: %d: %s: %s", fn, line, runtime.FuncForPC(pc).Name(), msg)
+		Log.Crit(msg)
 	}
 }
 


### PR DESCRIPTION
This allows to build LXD with debug logging enabled which prints the file name,
line number, and function name in all log output. This is mostly meant for
development purposes.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>

Normal LXD output:
```
INFO[03-24|01:49:08] LXD 2.12 is startingin normal mode      path=/home/chb/mnt/l2
WARN[03-24|01:49:08] CGroup memory swap accounting is disabled, swap limits will beignored.
INFO[03-24|01:49:08] Kernel uid/gid map:
INFO[03-24|01:49:08]  - u 0 0 4294967295
INFO[03-24|01:49:08]  - g 0 0 4294967295
INFO[03-24|01:49:08] Configured LXD uid/gid map:
INFO[03-24|01:49:08]  - u 0 100000 65536
INFO[03-24|01:49:08]  - g 0 100000 65536
DBUG[03-24|01:49:08] Initializing and checking storage pool "pool1".
DBUG[03-24|01:49:08] Initializing a BTRFSdriver.
DBUG[03-24|01:49:08] Checking BTRFS storage pool "pool1".
INFO[03-24|01:49:08] Expiring log files
INFO[03-24|01:49:08] Done expiring log files
INFO[03-24|01:49:08] Starting /dev/lxd handler
DBUG[03-24|01:49:08] Looking for existingcertificates        cert=/home/chb/mnt/l2/server.crt key=/home/chb/mnt/l2/server.key
INFO[03-24|01:49:08] LXD isn't socket activated
INFO[03-24|01:49:08] REST API daemon:
INFO[03-24|01:49:08]  - binding Unix socket                   socket=/home/chb/mnt/l2/unix.socket
INFO[03-24|01:49:08]  - binding TCP socket                    socket=127.0.0.1:8443
INFO[03-24|01:49:08] Pruning expired images
INFO[03-24|01:49:08] Done pruning expiredimages
INFO[03-24|01:49:08] Updating images
DBUG[03-24|01:49:08] Processing image                    alias=ubuntu/xenial fp=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185 protocol=simplestreams server=https://images.linuxcontainers.org
DBUG[03-24|01:49:10] Image already exists in the db           image=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185
DBUG[03-24|01:49:10] Image already exists on storage pool "pool1".
DBUG[03-24|01:49:10] Already up to date                       fp=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185
DBUG[03-24|01:49:10] Processing image                         alias=alpine/edge fp=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967 protocol=simplestreams server=https://images.linuxcontainers.org
DBUG[03-24|01:49:10] Using SimpleStreams cache entry          expiry=2017-03-24T02:49:10+0100 server=https://images.linuxcontainers.org
DBUG[03-24|01:49:10] Image already exists in the db           image=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967
DBUG[03-24|01:49:10] Image already exists on storage pool "pool1".
DBUG[03-24|01:49:10] Already up to date                       fp=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967
INFO[03-24|01:49:10] Done updating images
```

`make debug` LXD output:

```
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 606:main.(*Daemon).Init: LXD 2.12 is starting in normal mode path=/home/chb/mnt/l2
WARN[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 741:main.(*Daemon).Init: CGroup memory swap accounting is disabled, swap limits will beignored.
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 826:main.(*Daemon).Init: Kernel uid/gid map:
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 828:main.(*Daemon).Init:  - u 0 0 4294967295
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 828:main.(*Daemon).Init:  - g 0 0 4294967295
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 837:main.(*Daemon).Init: Configured LXD uid/gid map:
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 846:main.(*Daemon).Init:  - u 0 100000 65536
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 846:main.(*Daemon).Init:  - g 0 100000 65536
DBUG[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 389:main.(*Daemon).SetupStorageDriver: Initializing and checking storage pool "pool1".
DBUG[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/storage_btrfs.go: 72: main.(*storageBtrfs).StorageCoreInit: Initializing a BTRFS driver.
DBUG[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/storage_btrfs.go: 88: main.(*storageBtrfs).StoragePoolCheck: Checking BTRFS storage pool "pool1".
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 901:main.(*Daemon).Init.func2: Expiring log files
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 908:main.(*Daemon).Init.func2: Done expiring log files
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 932:main.(*Daemon).Init: Starting /dev/lxd handler
DBUG[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 218:main.readMyCert: Looking for existing certificates cert=/home/chb/mnt/l2/server.crtkey=/home/chb/mnt/l2/server.key
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 1027: main.(*Daemon).Init: LXD isn't socket activated
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 1099: main.(*Daemon).Init: REST API daemon:
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 1101: main.(*Daemon).Init:  - binding Unix socket socket=/home/chb/mnt/l2/unix.socket
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon.go: 1106: main.(*Daemon).Init:  - binding TCP socket socket=127.0.0.1:8443
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 979:main.pruneExpiredImages: Pruning expired images
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 866:main.autoUpdateImages: Updating images
DBUG[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 908:main.autoUpdateImages: Processing image alias=ubuntu/xenial fp=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185 protocol=simplestreams server=https://images.linuxcontainers.org
INFO[03-24|01:50:54] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 1041: main.pruneExpiredImages: Done pruning expired images
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon_images.go: 191: main.(*Daemon).ImageDownload: Image already exists in the db image=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon_images.go: 214: main.(*Daemon).ImageDownload: Image already exists on storage pool "pool1".
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 915: main.autoUpdateImages: Already up to date fp=6f14c1f6763f2c5fb338d808ee85fec6edfeb0a927126aefbfd331c887816185
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 908: main.autoUpdateImages: Processing image alias=alpine/edge fp=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967 protocol=simplestreams server=https://images.linuxcontainers.org
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon_images.go: 154: main.(*Daemon).ImageDownload: Using SimpleStreams cache entry expiry=2017-03-24T02:51:01+0100 server=https://images.linuxcontainers.org
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon_images.go: 191: main.(*Daemon).ImageDownload: Image already exists in the db image=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/daemon_images.go: 214: main.(*Daemon).ImageDownload: Image already exists on storage pool "pool1".
DBUG[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 915: main.autoUpdateImages: Already up to date fp=fc0e8c67c8809f6d78cb982c5dfa163f63e2cbaefb39210906d970198cfb0967
INFO[03-24|01:51:01] /home/chb/source/go/src/github.com/lxc/lxd/lxd/images.go: 975: main.autoUpdateImages: Done updating images
```