### PR TITLE
Fix unix device removal (bad cgroup.deny entry)

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5464,8 +5464,10 @@ func (c *containerLXC) removeUnixDevice(m types.Device) error {
 	}
 
 	dType := ""
-	if m["type"] != "" {
-		dType = m["type"]
+	if m["type"] == "unix-char" {
+		dType = "c"
+	} else if m["type"] == "unix-block" {
+		dType = "b"
 	}
 
 	if dType == "" || dMajor < 0 || dMinor < 0 {


### PR DESCRIPTION
This got fixed in the insert function a little while back, but the
matching code in the remove function was missed.

Closes #3107

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>