### PR TITLE
storage: ensure the container directory has the right permission

### DIFF
--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -36,10 +36,15 @@ func (s *storageDir) ContainerCreate(container container) error {
 		return fmt.Errorf("Error creating containers directory")
 	}
 
+	var mode os.FileMode
 	if container.IsPrivileged() {
-		if err := os.Chmod(cPath, 0700); err != nil {
-			return err
-		}
+		mode = 0700
+	} else {
+		mode = 0755
+	}
+
+	if err := os.Chmod(cPath, mode); err != nil {
+		return err
 	}
 
 	return container.TemplateApply("create")
@@ -53,10 +58,15 @@ func (s *storageDir) ContainerCreateFromImage(
 		return fmt.Errorf("Error creating rootfs directory")
 	}
 
+	var mode os.FileMode
 	if container.IsPrivileged() {
-		if err := os.Chmod(container.Path(), 0700); err != nil {
-			return err
-		}
+		mode = 0700
+	} else {
+		mode = 0755
+	}
+
+	if err := os.Chmod(container.Path(), mode); err != nil {
+		return err
 	}
 
 	imagePath := shared.VarPath("images", imageFingerprint)


### PR DESCRIPTION
When the container directory was created by other application(such as nova-lxd), the
container directory maybe has the wrong perrmissions, so chmod 755 to ensure the directory has the right permission

Signed-off-by: codejuan <xh@decbug.com>