### PR TITLE
Fix handling of devices with minor>255

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5350,7 +5350,8 @@ func (c *containerLXC) createUnixDevice(m types.Device) ([]string, error) {
 
 	// Create the new entry
 	if !runningInUserns {
-		if err := syscall.Mknod(devPath, uint32(mode), minor|(major<<8)); err != nil {
+		encoded_device_number := (minor & 0xff) | (major << 8) | ((minor & ^0xff) << 12)
+		if err := syscall.Mknod(devPath, uint32(mode), encoded_device_number); err != nil {
 			return nil, fmt.Errorf("Failed to create device %s for %s: %s", devPath, m["path"], err)
 		}
 


### PR DESCRIPTION
Device minor numbers are 12-bit, and the kernel expects combined major-minor device IDs to be passed as a 32-bit integer with the following components, from MSB to LSB:

 * 12 zero bits
 * the 4 upper bits of the minor number
 * all 8 bits of the major number
 * the 8 lower bits of the minor number

Currently LXD writes `(major | minor >> 8)` in the bits where the kernel expects to find the major number.