### PR TITLE
Properly invalidate the idmap cache

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -316,6 +316,9 @@ func containerLXCCreate(d *Daemon, args containerArgs) (container, error) {
 		return nil, err
 	}
 
+	// Invalid idmap cache
+	c.idmapset = nil
+
 	// Set last_state to the map we have on disk
 	if c.localConfig["volatile.last_state.idmap"] == "" {
 		err = c.ConfigKeySet("volatile.last_state.idmap", jsonIdmap)
@@ -3281,6 +3284,9 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 		}
 		c.localConfig["volatile.idmap.next"] = jsonIdmap
 		c.localConfig["volatile.idmap.base"] = fmt.Sprintf("%v", base)
+
+		// Invalid idmap cache
+		c.idmapset = nil
 	}
 
 	// Retrieve old root disk devices.


### PR DESCRIPTION
Without this we'd run the risk of changing idmap values and then doing
an action like a publish with an incorect map.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>