### PR TITLE
Select random storage backend for the second LXD instance in tests.

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -12,7 +12,7 @@ To run only the integration tests, run from the test directory:
 
 Name                            | Default                   | Description
 :--                             | :---                      | :----------
-LXD\_BACKEND                    | dir                       | What backend to test against (btrfs, dir, lvm or zfs)
+LXD\_BACKEND                    | dir                       | What backend to test against (btrfs, dir, lvm, zfs, or random)
 LXD\_CONCURRENT                 | 0                         | Run concurency tests, very CPU intensive
 LXD\_DEBUG                      | 0                         | Run lxd, lxc and the shell in debug mode (very verbose)
 LXD\_INSPECT                    | 0                         | Don't teardown the test environment on failure

--- a/test/backends/btrfs.sh
+++ b/test/backends/btrfs.sh
@@ -7,11 +7,6 @@ btrfs_setup() {
   LXD_DIR=$1
 
   echo "==> Setting up btrfs backend in ${LXD_DIR}"
-
-  if ! which btrfs >/dev/null 2>&1; then
-    echo "Couldn't find the btrfs binary"; false
-  fi
-
 }
 
 btrfs_configure() {

--- a/test/backends/lvm.sh
+++ b/test/backends/lvm.sh
@@ -7,10 +7,6 @@ lvm_setup() {
   LXD_DIR=$1
 
   echo "==> Setting up lvm backend in ${LXD_DIR}"
-
-  if ! which lvm >/dev/null 2>&1; then
-    echo "Couldn't find the lvm binary"; false
-  fi
 }
 
 lvm_configure() {

--- a/test/backends/zfs.sh
+++ b/test/backends/zfs.sh
@@ -7,10 +7,6 @@ zfs_setup() {
   LXD_DIR=$1
 
   echo "==> Setting up ZFS backend in ${LXD_DIR}"
-
-  if ! which zfs >/dev/null 2>&1; then
-    echo "Couldn't find zfs binary"; false
-  fi
 }
 
 zfs_configure() {

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -89,7 +89,7 @@ test_container_import() {
     # Test whether a snapshot that exists on disk but not in the "backup.yaml"
     # file is correctly restored. This can be done by not starting the parent
     # container which avoids that the backup file is written out.
-    if [ "${LXD_BACKEND}" = "dir" ]; then
+    if [ "$(storage_backend "$LXD_DIR")" = "dir" ]; then
       lxc init testimage ctImport
       lxc snapshot ctImport
       shutdown_lxd "${LXD_IMPORT_DIR}"

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -1,6 +1,10 @@
 #!/bin/sh
 
 test_basic_usage() {
+  # shellcheck disable=2039
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
@@ -133,9 +137,9 @@ test_basic_usage() {
   # the container's filesystem. That's ok though: the logic we're trying to
   # test here is independent of storage backend, so running it for just one
   # backend (or all non-lvm backends) is enough.
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
+  if [ "$lxd_backend" = "lvm" ]; then
     lxc init testimage nometadata
-    rm "${LXD_DIR}/containers/nometadata/metadata.yaml"
+    rm -f "${LXD_DIR}/containers/nometadata/metadata.yaml"
     lxc publish nometadata --alias=nometadata-image
     lxc image delete nometadata-image
     lxc delete nometadata
@@ -316,7 +320,7 @@ test_basic_usage() {
   rm "${LXD_DIR}/out"
 
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     content=$(cat "${LXD_DIR}/containers/foo/rootfs/tmp/foo")
     [ "${content}" = "foo" ]
   fi

--- a/test/suites/database_update.sh
+++ b/test/suites/database_update.sh
@@ -19,4 +19,6 @@ test_database_update(){
   expected_cascades=15
   cascades=$(sqlite3 "${MIGRATE_DB}" ".dump" | grep -c "ON DELETE CASCADE")
   [ "${cascades}" -eq "${expected_cascades}" ] || { echo "FAIL: Wrong number of ON DELETE CASCADE foreign keys. Found: ${cascades}, exected: ${expected_cascades}"; false; }
+
+  kill_lxd "$LXD_MIGRATE_DIR"
 }

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -84,7 +84,7 @@ test_filemanip() {
 
   lxc delete filemanip -f
 
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" != "lvm" ]; then
     lxc launch testimage idmap -c "raw.idmap=\"both 0 0\""
     [ "$(stat -c %u "${LXD_DIR}/containers/idmap/rootfs")" = "0" ]
     lxc delete idmap --force

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
 
 test_image_expiry() {
+  # shellcheck disable=2039
+  local LXD2_DIR LXD2_ADDR
+  LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD2_DIR}"
+  spawn_lxd "${LXD2_DIR}" true
+  LXD2_ADDR=$(cat "${LXD2_DIR}/lxd.addr")
+
   ensure_import_testimage
 
   if ! lxc_remote remote list | grep -q l1; then
+    # shellcheck disable=2153
     lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
   fi
   if ! lxc_remote remote list | grep -q l2; then
@@ -28,4 +36,7 @@ test_image_expiry() {
   lxc_remote remote set-default l2
   lxc_remote config set images.remote_cache_expiry 10
   lxc_remote remote set-default local
+
+  lxc_remote remote remove l2
+  kill_lxd "$LXD2_DIR"
 }

--- a/test/suites/init.sh
+++ b/test/suites/init.sh
@@ -8,7 +8,7 @@ test_lxd_autoinit() {
   # naming. This can cause naming conflicts when multiple test-suites are run on
   # a single runner.
 
-  if [ "${LXD_BACKEND}" = "zfs" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" = "zfs" ]; then
     # lxd init --auto --storage-backend zfs --storage-pool <name>
     LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_INIT_DIR}"

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -1,37 +1,63 @@
 #!/bin/sh
 
 test_migration() {
+  # setup a second LXD
+  # shellcheck disable=2039
+  local LXD2_DIR LXD2_ADDR lxd_backend
+  # shellcheck disable=2153
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
+  LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD2_DIR}"
+  spawn_lxd "${LXD2_DIR}" true
+  LXD2_ADDR=$(cat "${LXD2_DIR}/lxd.addr")
+
   # workaround for kernel/criu
   umount /sys/kernel/debug >/dev/null 2>&1 || true
 
   if ! lxc_remote remote list | grep -q l1; then
+    # shellcheck disable=2153
     lxc_remote remote add l1 "${LXD_ADDR}" --accept-certificate --password foo
   fi
   if ! lxc_remote remote list | grep -q l2; then
     lxc_remote remote add l2 "${LXD2_ADDR}" --accept-certificate --password foo
   fi
 
-  migration
+  migration "$LXD2_DIR"
 
-  if [ "${LXD_BACKEND}" = "lvm" ]; then
+  if [ "${lxd_backend}" = "lvm" ]; then
     # Test that non-thinpool lvm backends work fine with migration.
-    lxc_remote storage create l1:"lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration" lvm lvm.use_thinpool=false volume.size=25MB
-    lxc_remote profile device set l1:default root pool "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration"
 
-    lxc_remote storage create l2:"lxdtest-$(basename "${LXD2_DIR}")-non-thinpool-lvm-migration" lvm lvm.use_thinpool=false volume.size=25MB
-    lxc_remote profile device set l2:default root pool "lxdtest-$(basename "${LXD2_DIR}")-non-thinpool-lvm-migration"
+    # shellcheck disable=2039
+    local storage_pool1 storage_pool2
+    # shellcheck disable=2153
+    storage_pool1="lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration"
+    storage_pool2="lxdtest-$(basename "${LXD2_DIR}")-non-thinpool-lvm-migration"
+    lxc_remote storage create l1:"$storage_pool1" lvm lvm.use_thinpool=false volume.size=25MB
+    lxc_remote profile device set l1:default root pool "$storage_pool1"
 
-    migration
+    lxc_remote storage create l2:"$storage_pool2" lvm lvm.use_thinpool=false volume.size=25MB
+    lxc_remote profile device set l2:default root pool "$storage_pool2"
+
+    migration "$LXD2_DIR"
 
     lxc_remote profile device set l1:default root pool "lxdtest-$(basename "${LXD_DIR}")"
     lxc_remote profile device set l2:default root pool "lxdtest-$(basename "${LXD2_DIR}")"
 
-    lxc_remote storage delete l1:"lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-migration"
-    lxc_remote storage delete l2:"lxdtest-$(basename "${LXD2_DIR}")-non-thinpool-lvm-migration"
+    lxc_remote storage delete l1:"$storage_pool1"
+    lxc_remote storage delete l2:"$storage_pool2"
   fi
+
+  lxc_remote remote remove l2
+  kill_lxd "$LXD2_DIR"
 }
 
 migration() {
+  # shellcheck disable=2039
+  local lxd2_dir lxd_backend lxd2_backend
+  lxd2_dir="$1"
+  lxd_backend=$(storage_backend "$LXD_DIR")
+  lxd2_backend=$(storage_backend "$lxd2_dir")
   ensure_import_testimage
 
   lxc_remote init testimage nonlive
@@ -43,14 +69,14 @@ migration() {
   lxc_remote config show l2:nonlive/snap0 | grep user.tester | grep foo
 
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
-    [ -d "${LXD2_DIR}/containers/nonlive/rootfs" ]
+  if [ "$lxd2_backend" != "lvm" ]; then
+    [ -d "${lxd2_dir}/containers/nonlive/rootfs" ]
   fi
 
   [ ! -d "${LXD_DIR}/containers/nonlive" ]
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
-    [ -d "${LXD2_DIR}/snapshots/nonlive/snap0/rootfs/bin" ]
+  if [ "$lxd2_backend" = "dir" ]; then
+    [ -d "${lxd2_dir}/snapshots/nonlive/snap0/rootfs/bin" ]
   fi
 
   lxc_remote copy l2:nonlive l1:nonlive2
@@ -59,19 +85,19 @@ migration() {
   lxc_remote start l2:nonlive
   [ -d "${LXD_DIR}/containers/nonlive2" ]
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
-    [ -d "${LXD2_DIR}/containers/nonlive/rootfs/bin" ]
+  if [ "$lxd2_backend" != "lvm" ]; then
+    [ -d "${lxd2_dir}/containers/nonlive/rootfs/bin" ]
   fi
 
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/nonlive2/snap0/rootfs/bin" ]
   fi
 
   lxc_remote copy l1:nonlive2/snap0 l2:nonlive3
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
-    [ -d "${LXD2_DIR}/containers/nonlive3/rootfs/bin" ]
+  if [ "$lxd2_backend" != "lvm" ]; then
+    [ -d "${lxd2_dir}/containers/nonlive3/rootfs/bin" ]
   fi
   lxc_remote delete l2:nonlive3 --force
 
@@ -146,7 +172,7 @@ migration() {
   [ "$(lxc info udssr | grep -c snap)" -eq 2 ]
   lxc delete udssr
 
-  if [ "${LXD_BACKEND}" = "zfs" ]; then
+  if [ "$lxd_backend" = "zfs" ]; then
     # Test container only copies when zfs.clone_copy is set to false.
     lxc storage set "lxdtest-$(basename "${LXD_DIR}")" zfs.clone_copy false
     lxc init testimage cccp

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 test_remote_url() {
+  # shellcheck disable=2153
   for url in "${LXD_ADDR}" "https://${LXD_ADDR}"; do
     lxc_remote remote add test "${url}" --accept-certificate --password foo
     lxc_remote finger test:
@@ -10,6 +11,7 @@ test_remote_url() {
     lxc_remote remote remove test
   done
 
+  # shellcheck disable=2153
   urls="${LXD_DIR}/unix.socket unix:${LXD_DIR}/unix.socket unix://${LXD_DIR}/unix.socket"
   if [ -z "${LXD_OFFLINE:-}" ]; then
     urls="images.linuxcontainers.org https://images.linuxcontainers.org ${urls}"
@@ -69,6 +71,13 @@ test_remote_admin() {
 }
 
 test_remote_usage() {
+  # shellcheck disable=2039
+  local LXD2_DIR LXD2_ADDR
+  LXD2_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD2_DIR}"
+  spawn_lxd "${LXD2_DIR}" true
+  LXD2_ADDR=$(cat "${LXD2_DIR}/lxd.addr")
+
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
@@ -148,4 +157,6 @@ test_remote_usage() {
 
   mv "${LXD_CONF}/client.crt.bak" "${LXD_CONF}/client.crt"
   mv "${LXD_CONF}/client.key.bak" "${LXD_CONF}/client.key"
+
+  kill_lxd "$LXD2_DIR"
 }

--- a/test/suites/security.sh
+++ b/test/suites/security.sh
@@ -5,7 +5,7 @@ test_security() {
   ensure_has_localhost_remote "${LXD_ADDR}"
 
   # CVE-2016-1581
-  if [ "${LXD_BACKEND}" = "zfs" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" = "zfs" ]; then
     LXD_INIT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
     chmod +x "${LXD_INIT_DIR}"
     spawn_lxd "${LXD_INIT_DIR}" false

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -3,7 +3,7 @@
 test_snapshots() {
   snapshots
 
-  if [ "${LXD_BACKEND}" = "lvm" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" = "lvm" ]; then
     # Test that non-thinpool lvm backends work fine with snaphots.
     lxc storage create "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots" lvm lvm.use_thinpool=false volume.size=25MB
     lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snapshots"
@@ -17,6 +17,10 @@ test_snapshots() {
 }
 
 snapshots() {
+  # shellcheck disable=2039
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
@@ -24,58 +28,58 @@ snapshots() {
 
   lxc snapshot foo
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/foo/snap0" ]
   fi
 
   lxc snapshot foo
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/foo/snap1" ]
   fi
 
   lxc snapshot foo tester
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/foo/tester" ]
   fi
 
   lxc copy foo/tester foosnap1
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" != "lvm" ]; then
+  if [ "$lxd_backend" != "lvm" ]; then
     [ -d "${LXD_DIR}/containers/foosnap1/rootfs" ]
   fi
 
   lxc delete foo/snap0
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ ! -d "${LXD_DIR}/snapshots/foo/snap0" ]
   fi
 
   # no CLI for this, so we use the API directly (rename a snapshot)
   wait_for "${LXD_ADDR}" my_curl -X POST "https://${LXD_ADDR}/1.0/containers/foo/snapshots/tester" -d "{\"name\":\"tester2\"}"
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ ! -d "${LXD_DIR}/snapshots/foo/tester" ]
   fi
 
   lxc move foo/tester2 foo/tester-two
   lxc delete foo/tester-two
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ ! -d "${LXD_DIR}/snapshots/foo/tester-two" ]
   fi
 
   lxc snapshot foo namechange
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/foo/namechange" ]
   fi
   lxc move foo foople
   [ ! -d "${LXD_DIR}/containers/foo" ]
   [ -d "${LXD_DIR}/containers/foople" ]
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$lxd_backend" = "dir" ]; then
     [ -d "${LXD_DIR}/snapshots/foople/namechange" ]
     [ -d "${LXD_DIR}/snapshots/foople/namechange" ]
   fi
@@ -89,7 +93,7 @@ snapshots() {
 test_snap_restore() {
   snap_restore
 
-  if [ "${LXD_BACKEND}" = "lvm" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" = "lvm" ]; then
     # Test that non-thinpool lvm backends work fine with snaphots.
     lxc storage create "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore" lvm lvm.use_thinpool=false volume.size=25MB
     lxc profile device set default root pool "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-lvm-snap-restore"
@@ -103,6 +107,10 @@ test_snap_restore() {
 }
 
 snap_restore() {
+  # shellcheck disable=2039
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
@@ -145,7 +153,7 @@ snap_restore() {
 
   ##########################################################
 
-  if [ "${LXD_BACKEND}" != "zfs" ]; then
+  if [ "$lxd_backend" != "zfs" ]; then
     # The problem here is that you can't `zfs rollback` to a snapshot with a
     # parent, which snap0 has (snap1).
     restore_and_compare_fs snap0
@@ -175,7 +183,7 @@ snap_restore() {
   # Start container and then restore snapshot to verify the running state after restore.
   lxc start bar
 
-  if [ "${LXD_BACKEND}" != "zfs" ]; then
+  if [ "$lxd_backend" != "zfs" ]; then
     # see comment above about snap0
     restore_and_compare_fs snap0
 
@@ -188,7 +196,7 @@ snap_restore() {
   lxc delete bar
 
   # Test if container's with hyphen's in their names are treated correctly.
-  if [ "${LXD_BACKEND}" = "lvm" ]; then
+  if [ "$lxd_backend" = "lvm" ]; then
     lxc launch testimage a-b
     lxc snapshot a-b base
     lxc restore a-b base
@@ -207,7 +215,7 @@ restore_and_compare_fs() {
   lxc restore bar "${snap}"
 
   # FIXME: make this backend agnostic
-  if [ "${LXD_BACKEND}" = "dir" ]; then
+  if [ "$(storage_backend "$LXD_DIR")" = "dir" ]; then
     # Recursive diff of container FS
     diff -r "${LXD_DIR}/containers/bar/rootfs" "${LXD_DIR}/snapshots/bar/${snap}/rootfs"
   fi

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -2,7 +2,9 @@
 
 test_storage() {
   # shellcheck disable=2039
+  local LXD_STORAGE_DIR lxd_backend  
 
+  lxd_backend=$(storage_backend "$LXD_DIR")
   LXD_STORAGE_DIR=$(mktemp -d -p "${TEST_DIR}" XXXXXXXXX)
   chmod +x "${LXD_STORAGE_DIR}"
   spawn_lxd "${LXD_STORAGE_DIR}" false
@@ -12,7 +14,7 @@ test_storage() {
     LXD_DIR="${LXD_STORAGE_DIR}"
 
     # shellcheck disable=SC1009
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
     # Create loop file zfs pool.
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" zfs
 
@@ -63,7 +65,7 @@ test_storage() {
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-valid-zfs-pool-config"
     fi
 
-    if [ "${LXD_BACKEND}" = "btrfs" ]; then
+    if [ "$lxd_backend" = "btrfs" ]; then
       # Create loop file btrfs pool.
       lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool3" btrfs
 
@@ -118,7 +120,7 @@ test_storage() {
     lxc storage create "lxdtest-$(basename "${LXD_DIR}")-valid-dir-pool-config" dir rsync.bwlimit=1024
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-valid-dir-pool-config"
 
-    if [ "${LXD_BACKEND}" = "lvm" ]; then
+    if [ "$lxd_backend" = "lvm" ]; then
       # Create lvm pool.
       configure_loop_device loop_file_3 loop_device_3
       # shellcheck disable=SC2154
@@ -181,7 +183,7 @@ test_storage() {
     ensure_import_testimage
 
     # Muck around with some containers on various pools.
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
       lxc init testimage c1pool1 -s "lxdtest-$(basename "${LXD_DIR}")-pool1"
       lxc list -c b c1pool1 | grep "lxdtest-$(basename "${LXD_DIR}")-pool1"
 
@@ -227,7 +229,7 @@ test_storage() {
       lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool2" c4pool2 c4pool2
     fi
 
-    if [ "${LXD_BACKEND}" = "btrfs" ]; then
+    if [ "$lxd_backend" = "btrfs" ]; then
       lxc init testimage c5pool3 -s "lxdtest-$(basename "${LXD_DIR}")-pool3"
       lxc list -c b c5pool3 | grep "lxdtest-$(basename "${LXD_DIR}")-pool3"
       lxc init testimage c6pool4 -s "lxdtest-$(basename "${LXD_DIR}")-pool4"
@@ -293,7 +295,7 @@ test_storage() {
     ! lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")-pool5" custom/c11pool5 c11pool5 testDevice2 /opt
     lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool5" c11pool5 c11pool5 testDevice
 
-    if [ "${LXD_BACKEND}" = "lvm" ]; then
+    if [ "$lxd_backend" = "lvm" ]; then
       lxc init testimage c10pool6 -s "lxdtest-$(basename "${LXD_DIR}")-pool6"
       lxc list -c b c10pool6 | grep "lxdtest-$(basename "${LXD_DIR}")-pool6"
 
@@ -432,7 +434,7 @@ test_storage() {
       lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-pool15" c12pool15 c12pool15 testDevice
     fi
 
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
       lxc launch testimage c13pool7 -s "lxdtest-$(basename "${LXD_DIR}")-pool7"
       lxc launch testimage c14pool7 -s "lxdtest-$(basename "${LXD_DIR}")-pool7"
 
@@ -491,7 +493,7 @@ test_storage() {
       lxc storage volume detach "lxdtest-$(basename "${LXD_DIR}")-pool9" c18pool9 c18pool9 testDevice
     fi
 
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
       lxc delete -f c1pool1
       lxc delete -f c3pool1
 
@@ -504,7 +506,7 @@ test_storage() {
       lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-pool2" c4pool2
     fi
 
-    if [ "${LXD_BACKEND}" = "btrfs" ]; then
+    if [ "$lxd_backend" = "btrfs" ]; then
       lxc delete -f c5pool3
       lxc delete -f c7pool3
 
@@ -523,7 +525,7 @@ test_storage() {
     lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-pool5" c9pool5
     lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-pool5" c11pool5
 
-    if [ "${LXD_BACKEND}" = "lvm" ]; then
+    if [ "$lxd_backend" = "lvm" ]; then
       lxc delete -f c10pool6
       lxc delete -f c12pool6
 
@@ -556,7 +558,7 @@ test_storage() {
       lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")-non-thinpool-pool15" c12pool15
     fi
 
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
       lxc delete -f c13pool7
       lxc delete -f c14pool7
 
@@ -576,7 +578,7 @@ test_storage() {
 
     lxc image delete testimage
 
-    if [ "${LXD_BACKEND}" = "zfs" ]; then
+    if [ "$lxd_backend" = "zfs" ]; then
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool7"
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool8"
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool9"
@@ -590,13 +592,13 @@ test_storage() {
       deconfigure_loop_device "${loop_file_1}" "${loop_device_1}"
     fi
 
-    if [ "${LXD_BACKEND}" = "btrfs" ]; then
+    if [ "$lxd_backend" = "btrfs" ]; then
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool4"
       # shellcheck disable=SC2154
       deconfigure_loop_device "${loop_file_2}" "${loop_device_2}"
     fi
 
-    if [ "${LXD_BACKEND}" = "lvm" ]; then
+    if [ "$lxd_backend" = "lvm" ]; then
       lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-pool6"
       # shellcheck disable=SC2154
       pvremove -ff "${loop_device_3}" || true


### PR DESCRIPTION
This selects a random backend for the second LXD instance used in tests, so that migration tests can be run cross-backend.

The LXD2_BACKEND can be specified to select a specific backend. The randomly-chosen backend is always different from LXD_BACKEND.