### PR TITLE
Make sure a client certificate is generated

### DIFF
--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -4,6 +4,7 @@ test_server_config() {
   LXD_SERVERCONFIG_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   spawn_lxd "${LXD_SERVERCONFIG_DIR}" true
 
+  ensure_has_localhost_remote "${LXD_ADDR}"
   lxc config set core.trust_password 123456
 
   config=$(lxc config show)


### PR DESCRIPTION
The serverconfig.sh relies on client.crt being generated, running
`lxc remote add` (via ensure_has_localhost_remote) does the trick.

With this branch "sudo -E ./main.sh server_config" will no longer
fail.