### PR TITLE
zfs: try to work around zfs EBUSY bug

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5145,7 +5145,7 @@ func (c *containerLXC) StorageStart() (bool, error) {
 	if c.IsSnapshot() {
 		isOurOperation, err = c.storage.ContainerSnapshotStart(c)
 	} else {
-		isOurOperation, err = c.storage.ContainerMount(c.Name(), c.Path())
+		isOurOperation, err = c.storage.ContainerMount(c)
 	}
 
 	return isOurOperation, err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1049,7 +1049,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// In case the new LVM logical volume for the
 				// container is not mounted mount it.
 				if !shared.IsMountPoint(newContainerMntPoint) {
-					_, err = ctStorage.ContainerMount(ctStruct.Name(), ctStruct.Path())
+					_, err = ctStorage.ContainerMount(ctStruct)
 					if err != nil {
 						logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s.", ct, err)
 						return err
@@ -1203,7 +1203,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					// for the snapshot is not mounted mount
 					// it.
 					if !shared.IsMountPoint(newSnapshotMntPoint) {
-						_, err = csStorage.ContainerMount(csStruct.Name(), csStruct.Path())
+						_, err = csStorage.ContainerMount(csStruct)
 						if err != nil {
 							logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s.", cs, err)
 							return err

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -197,7 +197,7 @@ type storage interface {
 	ContainerCanRestore(container container, sourceContainer container) error
 	ContainerDelete(container container) error
 	ContainerCopy(target container, source container, containerOnly bool) error
-	ContainerMount(name string, path string) (bool, error)
+	ContainerMount(c container) (bool, error)
 	ContainerUmount(name string, path string) (bool, error)
 	ContainerRename(container container, newName string) error
 	ContainerRestore(container container, sourceContainer container) error

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -888,7 +888,7 @@ func (s *storageBtrfs) ContainerCopy(target container, source container, contain
 	return nil
 }
 
-func (s *storageBtrfs) ContainerMount(name string, path string) (bool, error) {
+func (s *storageBtrfs) ContainerMount(c container) (bool, error) {
 	logger.Debugf("Mounting BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 
 	// The storage pool must be mounted.

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -474,7 +474,7 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 	return nil
 }
 
-func (s *storageDir) ContainerMount(name string, path string) (bool, error) {
+func (s *storageDir) ContainerMount(c container) (bool, error) {
 	return true, nil
 }
 

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1142,7 +1142,7 @@ func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
 
 	containerName := c.Name()
 	containerPath := c.Path()
-	_, err = s.ContainerMount(containerName, containerPath)
+	_, err = s.ContainerMount(c)
 	if err != nil {
 		return err
 	}
@@ -1205,7 +1205,7 @@ func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint s
 		}
 	}
 
-	ourMount, err := s.ContainerMount(containerName, containerPath)
+	ourMount, err := s.ContainerMount(container)
 	if err != nil {
 		return err
 	}
@@ -1485,7 +1485,8 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 	return nil
 }
 
-func (s *storageLvm) ContainerMount(name string, path string) (bool, error) {
+func (s *storageLvm) ContainerMount(c container) (bool, error) {
+	name := c.Name()
 	logger.Debugf("Mounting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 
 	containerLvmName := containerNameToLVName(name)
@@ -1701,7 +1702,7 @@ func (s *storageLvm) ContainerRestore(target container, source container) error 
 			return fmt.Errorf("Error creating snapshot LV: %v", err)
 		}
 	} else {
-		ourMount, err := target.Storage().ContainerMount(targetName, targetPath)
+		ourMount, err := target.Storage().ContainerMount(target)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -130,7 +130,7 @@ func (s *storageMock) ContainerCopy(target container, source container, containe
 	return nil
 }
 
-func (s *storageMock) ContainerMount(name string, path string) (bool, error) {
+func (s *storageMock) ContainerMount(c container) (bool, error) {
 	return true, nil
 }
 

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -406,7 +406,8 @@ func (s *storageZfs) StoragePoolVolumeUpdate(changedConfig []string) error {
 }
 
 // Things we don't need to care about
-func (s *storageZfs) ContainerMount(name string, path string) (bool, error) {
+func (s *storageZfs) ContainerMount(c container) (bool, error) {
+	name := c.Name()
 	logger.Debugf("Mounting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("containers/%s", name)
@@ -779,7 +780,7 @@ func (s *storageZfs) copyWithoutSnapshotsSparse(target container, source contain
 			s.zfsPoolVolumeDestroy(targetZfsDataset)
 		}()
 
-		ourMount, err := s.ContainerMount(targetContainerName, targetContainerPath)
+		ourMount, err := s.ContainerMount(target)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Until we have an upstream fix for https://github.com/zfsonlinux/zfs/issues/5796
we need to work around zfs's EBUSY bug. So use syscall.Mount() directly and
simply move on when EBUSY is returned.

Closes #3228.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>