### PR TITLE
Add a new shared/cmd package with initial command I/O logic

### DIFF
--- a/shared/cmd/context.go
+++ b/shared/cmd/context.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// Context captures the environment the sub-command is being run in,
+// such as in/out/err streams and command line arguments.
+type Context struct {
+	stdin  *bufio.Reader
+	stdout io.Writer
+	stderr io.Writer
+}
+
+// NewContext creates a new command context with the given parameters.
+func NewContext(stdin io.Reader, stdout, stderr io.Writer) *Context {
+	return &Context{
+		stdin:  bufio.NewReader(stdin),
+		stdout: stdout,
+		stderr: stderr,
+	}
+}
+
+// AskBool asks a question an expect a yes/no answer.
+func (c *Context) AskBool(question string, defaultAnswer string) bool {
+	for {
+		fmt.Fprintf(c.stdout, question)
+		answer := c.readAnswer(defaultAnswer)
+
+		if shared.StringInSlice(strings.ToLower(answer), []string{"yes", "y"}) {
+			return true
+		} else if shared.StringInSlice(strings.ToLower(answer), []string{"no", "n"}) {
+			return false
+		}
+
+		fmt.Fprintf(c.stderr, "Invalid input, try again.\n\n")
+	}
+}
+
+// Read the user's answer from the input stream, trimming newline and providing a default.
+func (c *Context) readAnswer(defaultAnswer string) string {
+	answer, _ := c.stdin.ReadString('\n')
+	answer = strings.TrimSuffix(answer, "\n")
+	if answer == "" {
+		answer = defaultAnswer
+	}
+	return answer
+}

--- a/shared/cmd/context_test.go
+++ b/shared/cmd/context_test.go
@@ -1,0 +1,47 @@
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/lxc/lxd/shared/cmd"
+)
+
+// AskBool returns a boolean result depending on the user input.
+func TestAskBool(t *testing.T) {
+	cases := []struct {
+		question      string
+		defaultAnswer string
+		output        string
+		error         string
+		input         string
+		result        bool
+	}{
+		{"Do you code?", "yes", "Do you code?", "", "\n", true},
+		{"Do you code?", "yes", "Do you code?", "", "yes\n", true},
+		{"Do you code?", "yes", "Do you code?", "", "y\n", true},
+		{"Do you code?", "yes", "Do you code?", "", "no\n", false},
+		{"Do you code?", "yes", "Do you code?", "", "n\n", false},
+		{"Do you code?", "yes", "Do you code?Do you code?", "Invalid input, try again.\n\n", "foo\nyes\n", true},
+	}
+	for _, c := range cases {
+		stdin := strings.NewReader(c.input)
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+		context := cmd.NewContext(stdin, stdout, stderr)
+		result := context.AskBool(c.question, c.defaultAnswer)
+
+		if result != c.result {
+			t.Errorf("Expected '%v' result got '%v'", c.result, result)
+		}
+
+		if output := stdout.String(); output != c.output {
+			t.Errorf("Expected '%s' output got '%s'", c.output, output)
+		}
+
+		if error := stderr.String(); error != c.error {
+			t.Errorf("Expected '%s' error got '%s'", c.error, error)
+		}
+	}
+}

--- a/shared/cmd/doc.go
+++ b/shared/cmd/doc.go
@@ -1,0 +1,11 @@
+/*
+
+The package cmd implements a simple abstraction around a "sub-command" for
+a main executable (e.g. "lxd init", where "init" is the sub-command).
+
+It is designed to make unit-testing easier, since OS-specific parts like
+standard in/out can be set in tests.
+
+*/
+
+package cmd

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -46,6 +46,7 @@ test_static_analysis() {
       golint -set_exit_status client/
       golint -set_exit_status lxc/config/
       golint -set_exit_status shared/api/
+      golint -set_exit_status shared/cmd/
       golint -set_exit_status shared/gnuflag/
       golint -set_exit_status shared/i18n/
       golint -set_exit_status shared/ioprogress/


### PR DESCRIPTION
This is a proof of concept of some unit-testable code that I'd like
to later use for making cmdInit testable (as per #2834).

It's small so should it be easy to review and because I wish to have
some feedback on the approach before moving forward. I hope that the
branch gives a feel of what further branches would look like.

As a general note, I feel it'd be important to improve coverage of the
parts that can be unit tested easily (so basically most higher-level
application logic except for system-level interactions). An advantage
of this type of approach is of course the possibility to work and test small
fragments of logic in isolation while developing them. I think this
can be done incrementally without too much disruption, if we agree.

Signed-off-by: Free Ekanayaka <free@ekanayaka.io>