### PR TITLE
Complete cmd.Context support for various AskXXX methods

### DIFF
--- a/shared/cmd/testing.go
+++ b/shared/cmd/testing.go
@@ -1,0 +1,45 @@
+// Utilities for testing cmd-related code.
+
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// MemoryStreams provide an in-memory version of the system
+// stdin/stdout/stderr streams.
+type MemoryStreams struct {
+	in  *strings.Reader
+	out *bytes.Buffer
+	err *bytes.Buffer
+}
+
+// NewMemoryStreams creates a new set of in-memory streams with the given
+// user input.
+func NewMemoryStreams(input string) *MemoryStreams {
+	return &MemoryStreams{
+		in:  strings.NewReader(input),
+		out: new(bytes.Buffer),
+		err: new(bytes.Buffer),
+	}
+}
+
+// AssertOutEqual checks that the given text matches the the out stream.
+func (s *MemoryStreams) AssertOutEqual(t *testing.T, expected string) {
+	assert.Equal(t, expected, s.out.String(), "Unexpected output stream")
+}
+
+// AssertErrEqual checks that the given text matches the the err stream.
+func (s *MemoryStreams) AssertErrEqual(t *testing.T, expected string) {
+	assert.Equal(t, expected, s.err.String(), "Unexpected error stream")
+}
+
+// NewMemoryContext creates a new command Context using the given in-memory
+// streams.
+func NewMemoryContext(streams *MemoryStreams) *Context {
+	return NewContext(streams.in, streams.out, streams.err)
+}


### PR DESCRIPTION
This branch is a mechanical follow-up of the first one introducing
cmd.Context. It adds the rest of AskXXX methods as defined in cmdInit,
and should be a step towards making cmdInit itself testable.

The logic is exactly the same as the inline functions currently
defined in main_init.go, although some boilerplate could be avoided by
factoring common logic together.

To get a sense of how this will be used in cmdInit, you can have a look at:

https://github.com/freeekanayaka/lxd/commit/f3b0847422a5f85f2d8bacc46ee433aee4b69858

which would be the followup change.

Signed-off-by: Free Ekanayaka <free@ekanayaka.io>