### PR TITLE
lxd import: bugfixes

### DIFF
--- a/lxd/db_storage_pools.go
+++ b/lxd/db_storage_pools.go
@@ -84,6 +84,9 @@ func dbStoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, err
 
 	err := dbQueryRowScan(db, query, inargs, outargs)
 	if err != nil {
+		if err == sql.ErrNoRows {
+			return -1, nil, NoSuchObjectError
+		}
 		return -1, nil, err
 	}
 

--- a/lxd/main_import.go
+++ b/lxd/main_import.go
@@ -1,10 +1,14 @@
 package main
 
 import (
+	"fmt"
 	"github.com/lxc/lxd/client"
 )
 
 func cmdImport(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("please specify a container to import")
+	}
 	name := args[1]
 	req := map[string]interface{}{
 		"name":  name,


### PR DESCRIPTION
Fixes this long-standing bug:
```
chb@conventiont|~
> ~/source/go/bin/lxd import
panic: runtime error: index out of range

goroutine 1 [running]:
main.cmdImport(0xc42008e090, 0x1, 0x1, 0x6, 0xffffffffffffffff)
        /home/chb/source/go/src/github.com/lxc/lxd/lxd/main_import.go:8 +0x320
main.run(0xc420120750, 0x0)
        /home/chb/source/go/src/github.com/lxc/lxd/lxd/main.go:217 +0x844
main.main()
        /home/chb/source/go/src/github.com/lxc/lxd/lxd/main.go:53 +0x26
```

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>