### PR TITLE
Testable cmd init

### DIFF
--- a/lxd/main_init_test.go
+++ b/lxd/main_init_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lxc/lxd/shared/cmd"
+	"github.com/stretchr/testify/suite"
+)
+
+type cmdInitTestSuite struct {
+	lxdTestSuite
+	context *cmd.Context
+	args    *CmdInitArgs
+	command *CmdInit
+}
+
+func (suite *cmdInitTestSuite) SetupSuite() {
+	suite.lxdTestSuite.SetupSuite()
+	suite.context = cmd.NewMemoryContext(cmd.NewMemoryStreams(""))
+	suite.args = &CmdInitArgs{
+		NetworkPort:       -1,
+		StorageCreateLoop: -1,
+	}
+	suite.command = &CmdInit{
+		Context:         suite.context,
+		Args:            suite.args,
+		RunningInUserns: false,
+		SocketPath:      suite.d.UnixSocket.Socket.Addr().String(),
+	}
+}
+
+// If any argument intended for --auto is passed in interactive mode, an
+// error is returned.
+func (suite *cmdInitTestSuite) TestCmdInit_InteractiveWithAutoArgs() {
+	suite.args.NetworkPort = 9999
+	err := suite.command.Run()
+	suite.Req.Equal(err.Error(), "Init configuration is only valid with --auto")
+}
+
+func TestCmdInitTestSuite(t *testing.T) {
+	suite.Run(t, new(cmdInitTestSuite))
+}

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -13,7 +14,8 @@ import (
 
 func mockStartDaemon() (*Daemon, error) {
 	d := &Daemon{
-		MockMode: true,
+		MockMode:  true,
+		tlsConfig: &tls.Config{},
 	}
 
 	if err := d.Init(); err != nil {


### PR DESCRIPTION
This branch consists of a couple of separate commits:

1) make cmdInit testable by extracting its global variables and "boundaries", so most of its logic can be run in isolation in a unit test. A sample unit test has been added as exemplification, I plan to add more as I add the logic for the new "pre-seed" feature as per #2834.

2) extract a few inline functions into methods, for easier reading of the core logic.

The commit messages of the individual commits provide a bit of extra narrative.

I'm bundling these two changes together for convenience, but I'm happy to split them in separate branches if more appropriate.