### PR TITLE
tree-wide: replace file Chmod() with os.Chmod()

### DIFF
--- a/client.go
+++ b/client.go
@@ -1974,7 +1974,7 @@ func (c *Client) RecursivePullFile(container string, p string, targetDir string)
 		}
 		defer f.Close()
 
-		err = f.Chmod(os.FileMode(mode))
+		err = os.Chmod(target, os.FileMode(mode))
 		if err != nil {
 			return err
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -331,7 +331,7 @@ func (c *fileCmd) pull(config *lxd.Config, args []string) error {
 			}
 			defer f.Close()
 
-			err = f.Chmod(os.FileMode(mode))
+			err = os.Chmod(targetPath, os.FileMode(mode))
 			if err != nil {
 				return err
 			}

--- a/shared/util.go
+++ b/shared/util.go
@@ -561,7 +561,8 @@ func TextEditor(inPath string, inContent []byte) ([]byte, error) {
 			return []byte{}, err
 		}
 
-		if err = f.Chmod(0600); err != nil {
+		err = os.Chmod(f.Name(), 0600)
+		if err != nil {
 			f.Close()
 			os.Remove(f.Name())
 			return []byte{}, err


### PR DESCRIPTION
The file chmod that go uses calls out to syscall.Fchmod() which is not
implemented for Windows. The os.Chmod() method call out to syscall.Chmod()
which seems to be implemented on all platforms if I read the go sources
correctly.

Closes #3275.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>