### PR TITLE
Return an error if an image already exists on import

### DIFF
--- a/lxd/db_test.go
+++ b/lxd/db_test.go
@@ -463,6 +463,41 @@ func Test_dbImageGet_for_missing_fingerprint(t *testing.T) {
 	}
 }
 
+func Test_dbImageExists_true(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	db = createTestDb(t)
+	defer db.Close()
+
+	exists, err := dbImageExists(db, "fingerprint")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("Image not found by fingerprint")
+	}
+
+}
+
+func Test_dbImageExists_false(t *testing.T) {
+	var db *sql.DB
+	var err error
+
+	db = createTestDb(t)
+	defer db.Close()
+
+	exists, err := dbImageExists(db, "foobar")
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Fatal("Image should not have been found")
+	}
+}
+
 func Test_dbImageAliasGet_alias_exists(t *testing.T) {
 	var db *sql.DB
 	var err error

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -620,6 +620,14 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, post *os.File) 
 		}
 	}
 
+	// Check if the image already exists
+	exists, err := dbImageExists(d.db, info.Fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	if exists {
+		return nil, fmt.Errorf("Image with same fingerprint already exists")
+	}
 	// Create the database entry
 	err = dbImageInsert(d.db, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties)
 	if err != nil {


### PR DESCRIPTION
Return a more meaningful error when trying to import an already existing image.

Closes #3244 