### PR TITLE
Correct device type name

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -137,7 +137,7 @@ LXD supports the following device types:
 ID (database)   | Name          | Description
 :--             | :--           | :--
 0               | none          | Inheritance blocker
-1               | ic            | Network interface
+1               | nic           | Network interface
 2               | disk          | Mountpoint inside the container
 3               | unix-char     | Unix character device
 4               | unix-block    | Unix block device


### PR DESCRIPTION
At line #140 device type _nic_ is written as _ic_.