### PR TITLE
Fix recursive file push on Windows

### DIFF
--- a/client.go
+++ b/client.go
@@ -1874,11 +1874,8 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 		return fmt.Errorf("This function isn't supported by public remotes.")
 	}
 
-	sourceDir := filepath.Dir(source)
+	sourceDir, _ := filepath.Split(source)
 	sourceLen := len(sourceDir)
-	if sourceDir == "." {
-		sourceLen--
-	}
 
 	sendFile := func(p string, fInfo os.FileInfo, err error) error {
 		if err != nil {

--- a/client.go
+++ b/client.go
@@ -1875,6 +1875,10 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 	}
 
 	sourceDir := filepath.Dir(source)
+	sourceLen := len(sourceDir)
+	if sourceDir == "." {
+		sourceLen--
+	}
 
 	sendFile := func(p string, fInfo os.FileInfo, err error) error {
 		if err != nil {
@@ -1886,12 +1890,7 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 			return fmt.Errorf("'%s' isn't a regular file or directory.", p)
 		}
 
-		appendLen := len(sourceDir)
-		if sourceDir == "." {
-			appendLen--
-		}
-
-		targetPath := path.Join(target, filepath.ToSlash(p[appendLen:]))
+		targetPath := path.Join(target, filepath.ToSlash(p[sourceLen:]))
 		if fInfo.IsDir() {
 			mode, uid, gid := shared.GetOwnerMode(fInfo)
 			return c.Mkdir(container, targetPath, mode, uid, gid)

--- a/client.go
+++ b/client.go
@@ -1891,7 +1891,7 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 			appendLen--
 		}
 
-		targetPath := path.Join(target, p[appendLen:])
+		targetPath := path.Join(target, filepath.ToSlash(p[appendLen:]))
 		if fInfo.IsDir() {
 			mode, uid, gid := shared.GetOwnerMode(fInfo)
 			return c.Mkdir(container, targetPath, mode, uid, gid)


### PR DESCRIPTION
filepath.Walk() sends filenames with backslashes there

Signed-off-by: anatoly techtonik <techtonik@gmail.com>