### PR TITLE
storage volumes: only delete custom volumes

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -379,6 +379,10 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
 	}
 
+	if volumeType != storagePoolVolumeTypeCustom {
+		return BadRequest(fmt.Errorf("storage volumes of type \"%s\" cannot be deleted with the storage api", volumeTypeName))
+	}
+
 	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volumeName, volumeTypeName)
 	if err != nil {
 		return InternalError(err)


### PR DESCRIPTION
We do currently not support deleting any other type of storage volume.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>