### PR TITLE
storage: handle btrfs migration on different lxds

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1971,6 +1971,10 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 		}
 
 		receivedSnapshot := fmt.Sprintf("%s/.migration-send", btrfsPath)
+		// handle older lxd versions
+		if !shared.PathExists(receivedSnapshot) {
+			receivedSnapshot = fmt.Sprintf("%s/.root", btrfsPath)
+		}
 		if isSnapshot {
 			receivedSnapshot = fmt.Sprintf("%s/%s", btrfsPath, snapName)
 			err = s.btrfsPoolVolumesSnapshot(receivedSnapshot, targetPath, true)


### PR DESCRIPTION
If we receive btrfs subvolumes from an older LXD instance they are not called
".migration-send" but rather ".root". Handle this case.

Closes #3323.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>