### PR TITLE
Don't depend on testify in the cmd package

### DIFF
--- a/shared/cmd/context_test.go
+++ b/shared/cmd/context_test.go
@@ -8,12 +8,22 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// AssertOutEqual checks that the given text matches the the out stream.
+func AssertOutEqual(t *testing.T, stream *cmd.MemoryStreams, expected string) {
+	assert.Equal(t, expected, stream.Out(), "Unexpected output stream")
+}
+
+// AssertErrEqual checks that the given text matches the the err stream.
+func AssertErrEqual(t *testing.T, stream *cmd.MemoryStreams, expected string) {
+	assert.Equal(t, expected, stream.Err(), "Unexpected error stream")
+}
+
 // Output prints the given message on standard output
 func TestOutput(t *testing.T) {
 	streams := cmd.NewMemoryStreams("")
 	context := cmd.NewMemoryContext(streams)
 	context.Output("Hello %s", "world")
-	streams.AssertOutEqual(t, "Hello world")
+	AssertOutEqual(t, streams, "Hello world")
 }
 
 // AskBool returns a boolean result depending on the user input.
@@ -39,8 +49,8 @@ func TestAskBool(t *testing.T) {
 		result := context.AskBool(c.question, c.defaultAnswer)
 
 		assert.Equal(t, c.result, result, "Unexpected answer result")
-		streams.AssertOutEqual(t, c.output)
-		streams.AssertErrEqual(t, c.error)
+		AssertOutEqual(t, streams, c.output)
+		AssertErrEqual(t, streams, c.error)
 	}
 }
 
@@ -65,8 +75,8 @@ func TestAskChoice(t *testing.T) {
 		result := context.AskChoice(c.question, c.choices, c.defaultAnswer)
 
 		assert.Equal(t, c.result, result, "Unexpected answer result")
-		streams.AssertOutEqual(t, c.output)
-		streams.AssertErrEqual(t, c.error)
+		AssertOutEqual(t, streams, c.output)
+		AssertErrEqual(t, streams, c.error)
 	}
 }
 
@@ -95,8 +105,8 @@ func TestAskInt(t *testing.T) {
 		result := context.AskInt(c.question, c.min, c.max, c.defaultAnswer)
 
 		assert.Equal(t, c.result, result, "Unexpected answer result")
-		streams.AssertOutEqual(t, c.output)
-		streams.AssertErrEqual(t, c.error)
+		AssertOutEqual(t, streams, c.output)
+		AssertErrEqual(t, streams, c.error)
 	}
 }
 
@@ -126,8 +136,8 @@ func TestAskString(t *testing.T) {
 		result := context.AskString(c.question, c.defaultAnswer, c.validate)
 
 		assert.Equal(t, c.result, result, "Unexpected answer result")
-		streams.AssertOutEqual(t, c.output)
-		streams.AssertErrEqual(t, c.error)
+		AssertOutEqual(t, streams, c.output)
+		AssertErrEqual(t, streams, c.error)
 	}
 }
 
@@ -150,8 +160,8 @@ func TestAskPassword(t *testing.T) {
 		result := context.AskPassword(c.question, c.reader)
 
 		assert.Equal(t, c.result, result, "Unexpected answer result")
-		streams.AssertOutEqual(t, c.output)
-		streams.AssertErrEqual(t, c.error)
+		AssertOutEqual(t, streams, c.output)
+		AssertErrEqual(t, streams, c.error)
 	}
 }
 

--- a/shared/cmd/testing.go
+++ b/shared/cmd/testing.go
@@ -1,4 +1,4 @@
-// Utilities for testing cmd-related code.
+// In-memory streams, useful for testing cmd-related code.
 
 package cmd
 
@@ -6,9 +6,6 @@ import (
 	"bytes"
 	"io/ioutil"
 	"strings"
-	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // MemoryStreams provide an in-memory version of the system
@@ -33,6 +30,16 @@ func NewMemoryStreams(input string) *MemoryStreams {
 func (s *MemoryStreams) InputRead() string {
 	bytes, _ := ioutil.ReadAll(s.in)
 	return string(bytes)
+}
+
+// Out returns the current content of the out stream.
+func (s *MemoryStreams) Out() string {
+	return s.out.String()
+}
+
+// Err returns the current content of the err stream.
+func (s *MemoryStreams) Err() string {
+	return s.err.String()
 }
 
 // InputReset replaces the data in the input stream.
@@ -61,16 +68,6 @@ func (s *MemoryStreams) InputAppendBoolAnswer(answer bool) {
 		line = "no"
 	}
 	s.InputAppendLine(line)
-}
-
-// AssertOutEqual checks that the given text matches the the out stream.
-func (s *MemoryStreams) AssertOutEqual(t *testing.T, expected string) {
-	assert.Equal(t, expected, s.out.String(), "Unexpected output stream")
-}
-
-// AssertErrEqual checks that the given text matches the the err stream.
-func (s *MemoryStreams) AssertErrEqual(t *testing.T, expected string) {
-	assert.Equal(t, expected, s.err.String(), "Unexpected error stream")
 }
 
 // NewMemoryContext creates a new command Context using the given in-memory


### PR DESCRIPTION
Move out the assertions to the test package instead.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>