### PR TITLE
Remove IPv6 leases on container delete

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2779,7 +2779,7 @@ func (c *containerLXC) Delete() error {
 			continue
 		}
 
-		networkClearLease(c.daemon, m["parent"], m["hwaddr"])
+		networkClearLease(c.daemon, m["parent"], c.Name())
 	}
 
 	logger.Info("Deleted container", ctxMap)

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -850,7 +850,7 @@ func networkSysctl(path string, value string) error {
 	return ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/%s", path), []byte(value), 0)
 }
 
-func networkClearLease(d *Daemon, network string, hwaddr string) error {
+func networkClearLease(d *Daemon, network string, name string) error {
 	leaseFile := shared.VarPath("networks", network, "dnsmasq.leases")
 
 	// Check that we are in fact running a dnsmasq for the network
@@ -888,7 +888,7 @@ func networkClearLease(d *Daemon, network string, hwaddr string) error {
 		}
 
 		fields := strings.Fields(lease)
-		if len(fields) > 2 && strings.ToLower(fields[1]) == strings.ToLower(hwaddr) {
+		if len(fields) > 2 && strings.ToLower(fields[3]) == strings.ToLower(name) {
 			continue
 		}
 


### PR DESCRIPTION
This is an addition to the fix of #2781 which also removes IPv6 leases on container delete.