### PR TITLE
Replace some uses of InternalError with SmartError.

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -231,7 +231,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 func api10Put(d *Daemon, r *http.Request) Response {
 	oldConfig, err := dbConfigValuesGet(d.db)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	err = etagCheck(r, daemonConfigRender())
@@ -250,7 +250,7 @@ func api10Put(d *Daemon, r *http.Request) Response {
 func api10Patch(d *Daemon, r *http.Request) Response {
 	oldConfig, err := dbConfigValuesGet(d.db)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	err = etagCheck(r, daemonConfigRender())

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -206,12 +206,12 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		// Create the storage pool db entry if it doesn't exist.
 		err := storagePoolDBCreate(d, containerPoolName, pool.Description, backup.Pool.Driver, backup.Pool.Config)
 		if err != nil {
-			return InternalError(err)
+			return SmartError(err)
 		}
 
 		poolID, err = dbStoragePoolGetID(d.db, containerPoolName)
 		if err != nil {
-			return InternalError(err)
+			return SmartError(err)
 		}
 	} else {
 		if backup.Pool.Name != containerPoolName {
@@ -227,7 +227,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 	_, volume, ctVolErr := dbStoragePoolVolumeGetType(d.db, req.Name, storagePoolVolumeTypeContainer, poolID)
 	if ctVolErr != nil {
 		if ctVolErr != NoSuchObjectError {
-			return InternalError(ctVolErr)
+			return SmartError(ctVolErr)
 		}
 	}
 	// If a storage volume entry exists only proceed if force was specified.
@@ -239,7 +239,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 	_, containerErr := dbContainerId(d.db, req.Name)
 	if containerErr != nil {
 		if containerErr != sql.ErrNoRows {
-			return InternalError(containerErr)
+			return SmartError(containerErr)
 		}
 	}
 	// If a db entry exists only proceed if force was specified.
@@ -291,7 +291,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		_, snapErr := dbContainerId(d.db, snap.Name)
 		if snapErr != nil {
 			if snapErr != sql.ErrNoRows {
-				return InternalError(snapErr)
+				return SmartError(snapErr)
 			}
 		}
 
@@ -304,7 +304,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		_, _, snapVolErr := dbStoragePoolVolumeGetType(d.db, snap.Name, storagePoolVolumeTypeContainer, poolID)
 		if snapVolErr != nil {
 			if snapVolErr != NoSuchObjectError {
-				return InternalError(snapVolErr)
+				return SmartError(snapVolErr)
 			}
 		}
 
@@ -340,7 +340,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		// force was specified.
 		err := dbContainerRemove(d.db, req.Name)
 		if err != nil {
-			return InternalError(err)
+			return SmartError(err)
 		}
 	}
 
@@ -377,7 +377,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		_, snapErr := dbContainerId(d.db, snapName)
 		if snapErr != nil {
 			if snapErr != sql.ErrNoRows {
-				return InternalError(snapErr)
+				return SmartError(snapErr)
 			}
 		}
 
@@ -390,7 +390,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		_, _, csVolErr := dbStoragePoolVolumeGetType(d.db, snapName, storagePoolVolumeTypeContainer, poolID)
 		if csVolErr != nil {
 			if csVolErr != NoSuchObjectError {
-				return InternalError(csVolErr)
+				return SmartError(csVolErr)
 			}
 		}
 
@@ -402,7 +402,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 		if snapErr == nil {
 			err := dbContainerRemove(d.db, snapName)
 			if err != nil {
-				return InternalError(err)
+				return SmartError(err)
 			}
 		}
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -247,7 +247,7 @@ func doCertificateUpdate(d *Daemon, fingerprint string, req api.CertificatePut) 
 
 	err := dbCertUpdate(d.db, fingerprint, req.Name, 1)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return EmptySyncResponse

--- a/lxd/container_get.go
+++ b/lxd/container_get.go
@@ -15,7 +15,7 @@ func containerGet(d *Daemon, r *http.Request) Response {
 
 	state, etag, err := c.Render()
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return SyncResponseETag(true, state, etag)

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -18,7 +18,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 		}
 		if !isDbLockedError(err) {
 			logger.Debugf("DBERR: containersGet: error %q", err)
-			return InternalError(err)
+			return SmartError(err)
 		}
 		// 1 s may seem drastic, but we really don't want to thrash
 		// perhaps we should use a random amount

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -32,7 +32,7 @@ func createFromImage(d *Daemon, req *api.ContainersPost) Response {
 		} else {
 			_, alias, err := dbImageAliasGet(d.db, req.Source.Alias, true)
 			if err != nil {
-				return InternalError(err)
+				return SmartError(err)
 			}
 
 			hash = alias.Target
@@ -44,7 +44,7 @@ func createFromImage(d *Daemon, req *api.ContainersPost) Response {
 
 		hashes, err := dbImagesGet(d.db, false)
 		if err != nil {
-			return InternalError(err)
+			return SmartError(err)
 		}
 
 		var image *api.Image
@@ -213,7 +213,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 		for _, pName := range req.Profiles {
 			_, p, err := dbProfileGet(d.db, pName)
 			if err != nil {
-				return InternalError(err)
+				return SmartError(err)
 			}
 
 			k, v, _ := containerGetRootDiskDevice(p.Devices)
@@ -233,7 +233,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 			if err == NoSuchObjectError {
 				return BadRequest(fmt.Errorf("This LXD instance does not have any storage pools configured."))
 			}
-			return InternalError(err)
+			return SmartError(err)
 		}
 
 		if len(pools) == 1 {
@@ -508,7 +508,7 @@ func containersPost(d *Daemon, r *http.Request) Response {
 	if req.Name == "" {
 		cs, err := dbContainersList(d.db, cTypeRegular)
 		if err != nil {
-			return InternalError(err)
+			return SmartError(err)
 		}
 
 		i := 0

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1338,7 +1338,7 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 
 	err = dbImageAliasAdd(d.db, req.Name, id, req.Description)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return SyncResponseLocation(true, nil, fmt.Sprintf("/%s/images/aliases/%s", version.APIVersion, req.Name))

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -428,7 +428,7 @@ func operationAPIGet(d *Daemon, r *http.Request) Response {
 
 	_, body, err := op.Render()
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return SyncResponse(true, body)
@@ -511,7 +511,7 @@ func operationAPIWaitGet(d *Daemon, r *http.Request) Response {
 
 	_, body, err := op.Render()
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return SyncResponse(true, body)

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -90,7 +90,7 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 	// Update DB entry
 	_, err = dbProfileCreate(d.db, req.Name, req.Description, req.Config, req.Devices)
 	if err != nil {
-		return InternalError(
+		return SmartError(
 			fmt.Errorf("Error inserting %s into database: %s", req.Name, err))
 	}
 
@@ -159,7 +159,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 	id, profile, err := dbProfileGet(d.db, name)
 	if err != nil {
-		return InternalError(fmt.Errorf("Failed to retrieve profile='%s'", name))
+		return SmartError(fmt.Errorf("Failed to retrieve profile='%s'", name))
 	}
 
 	// Validate the ETag
@@ -182,7 +182,7 @@ func profilePatch(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 	id, profile, err := dbProfileGet(d.db, name)
 	if err != nil {
-		return InternalError(fmt.Errorf("Failed to retrieve profile='%s'", name))
+		return SmartError(fmt.Errorf("Failed to retrieve profile='%s'", name))
 	}
 
 	// Validate the ETag
@@ -273,7 +273,7 @@ func profilePost(d *Daemon, r *http.Request) Response {
 
 	err := dbProfileUpdate(d.db, name, req.Name)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return SyncResponseLocation(true, nil, fmt.Sprintf("/%s/profiles/%s", version.APIVersion, req.Name))

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -23,7 +23,7 @@ func storagePoolsGet(d *Daemon, r *http.Request) Response {
 
 	pools, err := dbStoragePools(d.db)
 	if err != nil && err != NoSuchObjectError {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	resultString := []string{}
@@ -216,7 +216,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 	// Check if the storage pool is still referenced in any profiles.
 	profiles, err := profilesUsingPoolGetNames(d.db, poolName)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 	if len(profiles) > 0 {
 		return BadRequest(fmt.Errorf("Storage pool \"%s\" has profiles using it:\n%s", poolName, strings.Join(profiles, "\n")))
@@ -234,7 +234,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 
 	err = dbStoragePoolDelete(d.db, poolName)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return EmptySyncResponse

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -101,7 +101,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
 	// attached to the storage pool.
 	volumes, err := dbStoragePoolVolumesGetType(d.db, volumeType, poolID)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	resultString := []string{}
@@ -121,7 +121,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
 
 			volumeUsedBy, err := storagePoolVolumeUsedByGet(d, vol.Name, vol.Type)
 			if err != nil {
-				return InternalError(err)
+				return SmartError(err)
 			}
 			vol.UsedBy = volumeUsedBy
 
@@ -204,7 +204,7 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request) Response {
 	// attached to.
 	poolID, err := dbStoragePoolGetID(d.db, poolName)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	// Get the storage volume.
@@ -215,7 +215,7 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request) Response {
 
 	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volume.Name, volume.Type)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 	volume.UsedBy = volumeUsedBy
 
@@ -278,7 +278,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request) Response {
 
 	err = storagePoolVolumeUpdate(d, poolName, volumeName, volumeType, req.Description, req.Config)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return EmptySyncResponse
@@ -351,7 +351,7 @@ func storagePoolVolumeTypePatch(d *Daemon, r *http.Request) Response {
 
 	err = storagePoolVolumeUpdate(d, poolName, volumeName, volumeType, req.Description, req.Config)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return EmptySyncResponse
@@ -385,7 +385,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 
 	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volumeName, volumeTypeName)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	if len(volumeUsedBy) > 0 {
@@ -399,17 +399,17 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 
 	err = s.StoragePoolVolumeDelete()
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	poolID, err := dbStoragePoolGetID(d.db, poolName)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	err = dbStoragePoolVolumeDelete(d.db, volumeName, volumeType, poolID)
 	if err != nil {
-		return InternalError(err)
+		return SmartError(err)
 	}
 
 	return EmptySyncResponse


### PR DESCRIPTION
Replace many uses of InternalError with SmartError, which can detect some specific errors and give a nicer error message for the user.
These are mostly db-related errors.

Closes #1927 