### PR TITLE
network: use lxc.network.<n>.*

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1187,6 +1187,7 @@ func (c *containerLXC) initLXC() error {
 	}
 
 	// Setup devices
+	networkidx := 0
 	for _, k := range c.expandedDevices.DeviceNames() {
 		m := c.expandedDevices[k]
 		if shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
@@ -1218,39 +1219,39 @@ func (c *containerLXC) initLXC() error {
 
 			// Interface type specific configuration
 			if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
-				err = lxcSetConfigItem(cc, "lxc.network.type", "veth")
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.type", networkidx), "veth")
 				if err != nil {
 					return err
 				}
 			} else if m["nictype"] == "physical" {
-				err = lxcSetConfigItem(cc, "lxc.network.type", "phys")
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.type", networkidx), "phys")
 				if err != nil {
 					return err
 				}
 			} else if m["nictype"] == "macvlan" {
-				err = lxcSetConfigItem(cc, "lxc.network.type", "macvlan")
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.type", networkidx), "macvlan")
 				if err != nil {
 					return err
 				}
 
-				err = lxcSetConfigItem(cc, "lxc.network.macvlan.mode", "bridge")
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.macvlan.mode", networkidx), "bridge")
 				if err != nil {
 					return err
 				}
 			}
 
-			err = lxcSetConfigItem(cc, "lxc.network.flags", "up")
+			err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.flags", networkidx), "up")
 			if err != nil {
 				return err
 			}
 
 			if shared.StringInSlice(m["nictype"], []string{"bridged", "physical"}) {
-				err = lxcSetConfigItem(cc, "lxc.network.link", m["parent"])
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.link", networkidx), m["parent"])
 				if err != nil {
 					return err
 				}
 			} else if m["nictype"] == "macvlan" {
-				err = lxcSetConfigItem(cc, "lxc.network.link", networkGetHostDevice(m["parent"], m["vlan"]))
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.link", networkidx), networkGetHostDevice(m["parent"], m["vlan"]))
 				if err != nil {
 					return err
 				}
@@ -1266,7 +1267,7 @@ func (c *containerLXC) initLXC() error {
 			}
 
 			if vethName != "" {
-				err = lxcSetConfigItem(cc, "lxc.network.veth.pair", vethName)
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.veth.pair", networkidx), vethName)
 				if err != nil {
 					return err
 				}
@@ -1274,7 +1275,7 @@ func (c *containerLXC) initLXC() error {
 
 			// MAC address
 			if m["hwaddr"] != "" {
-				err = lxcSetConfigItem(cc, "lxc.network.hwaddr", m["hwaddr"])
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.hwaddr", networkidx), m["hwaddr"])
 				if err != nil {
 					return err
 				}
@@ -1282,7 +1283,7 @@ func (c *containerLXC) initLXC() error {
 
 			// MTU
 			if m["mtu"] != "" {
-				err = lxcSetConfigItem(cc, "lxc.network.mtu", m["mtu"])
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.mtu", networkidx), m["mtu"])
 				if err != nil {
 					return err
 				}
@@ -1290,7 +1291,7 @@ func (c *containerLXC) initLXC() error {
 
 			// Name
 			if m["name"] != "" {
-				err = lxcSetConfigItem(cc, "lxc.network.name", m["name"])
+				err = lxcSetConfigItem(cc, fmt.Sprintf("lxc.network.%d.name", networkidx), m["name"])
 				if err != nil {
 					return err
 				}
@@ -1366,6 +1367,8 @@ func (c *containerLXC) initLXC() error {
 				}
 			}
 		}
+		// bump network index
+		networkidx++
 	}
 
 	// Setup shmounts


### PR DESCRIPTION
This deprecates defining multiple networks in the following format:

	lxc.network.type = veth
	lxc.network.flags = up
	lxc.network.link = lxdbr0
	lxc.network.hwaddr = 00:16:3e:09:7a:39
	lxc.network.name = eth0

	lxc.network.type = veth
	lxc.network.flags = up
	lxc.network.link = lxdbr1
	lxc.network.hwaddr = 00:16:3e:b2:8f:56
	lxc.network.name = eth1

in favor of:

	lxc.network.0.type = veth
	lxc.network.0.flags = up
	lxc.network.0.link = lxdbr0
	lxc.network.0.hwaddr = 00:16:3e:09:7a:39
	lxc.network.0.name = eth0

	lxc.network.1.type = veth
	lxc.network.1.flags = up
	lxc.network.1.link = lxdbr1
	lxc.network.1.hwaddr = 00:16:3e:b2:8f:56
	lxc.network.1.name = eth1

The former syntax is utterly misleading and difficult to handle in liblxc while
the latter will let liblxc nicely handle network configuration even if you
specify everything in random order. Cleaning out and updating will also work
much more reliable.

The regression potential for LXD is basically 0 since we regenerate the config
for the container each time we start it up.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>