### PR TITLE
dir: Unfreeze on rsync error

### DIFF
--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -609,13 +609,12 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 			logger.Errorf("Trying to freeze and rsync again failed.")
 			goto onSuccess
 		}
+		defer sourceContainer.Unfreeze()
 
 		err = rsync(snapshotContainer, sourceContainerMntPoint, targetContainerMntPoint, bwlimit)
 		if err != nil {
 			return err
 		}
-
-		defer sourceContainer.Unfreeze()
 	}
 
 onSuccess:


### PR DESCRIPTION
This ensures that we unfreeze the container even if rsync fails
for some reason.