### PR TITLE
zfs: improve dummy dataset creation

### DIFF
--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/lxc/lxd/shared"
@@ -10,4 +11,11 @@ import (
 func zfsPoolVolumeCreate(dataset string, properties ...string) (string, error) {
 	p := strings.Join(properties, ",")
 	return shared.RunCommand("zfs", "create", "-o", p, "-p", dataset)
+}
+
+func zfsPoolVolumeSet(dataset string, key string, value string) (string, error) {
+	return shared.RunCommand("zfs",
+		"set",
+		fmt.Sprintf("%s=%s", key, value),
+		dataset)
 }


### PR DESCRIPTION
Instead of creating the dataset and then setting its mountpoint let's create
the dataset with the mountpoint right away.

Closes #3399.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>