### PR TITLE
network: fix network indices

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1296,6 +1296,8 @@ func (c *containerLXC) initLXC() error {
 					return err
 				}
 			}
+			// bump network index
+			networkidx++
 		} else if m["type"] == "disk" {
 			// Prepare all the paths
 			srcPath := m["source"]
@@ -1367,8 +1369,6 @@ func (c *containerLXC) initLXC() error {
 				}
 			}
 		}
-		// bump network index
-		networkidx++
 	}
 
 	// Setup shmounts


### PR DESCRIPTION
Right now, liblxc is not yet able to handle configuring network devices
starting from arbitrary indices. For example, you couldn't start a network
configuration with:

lxc.network.1.type=veth
lxc.network.1.name=eth0

Also, arbitrary ordering the keys, e.g.

lxc.network.0.name=eth0
lxc.network.0.type=veth

does as of now also not work correctly. That is why we need to ensure in LXD
that the configuration keys are always set in correct order.

Now, about this commit. LXD did something dumb before. It bumped the index of
the network keys independent of whether the next configuration item was
actually a network key. This meant we would confuse liblxc by inserting keys
with different indices that actually should all have the same index since they
were meant to define a single network. Let's not do this and only bump the
index when we actually set a network key.

However, the real fix for this problem is obviously to enable liblxc to parse
network configuration way smarter. This goes hand-in-hand with deprecating the
aweful ordering based network configuration.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>