### PR TITLE
Fix crash when sorting images with custom columns

### DIFF
--- a/lxc/config.go
+++ b/lxc/config.go
@@ -310,7 +310,7 @@ func (c *configCmd) run(config *lxd.Config, args []string) error {
 				i18n.G("COMMON NAME"),
 				i18n.G("ISSUE DATE"),
 				i18n.G("EXPIRY DATE")})
-			sort.Sort(SortImage(data))
+			sort.Sort(StringList(data))
 			table.AppendBulk(data)
 			table.Render()
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -744,7 +744,7 @@ func (c *imageCmd) showImages(images []api.Image, filters []string, columns []im
 			data = append(data, row)
 		}
 
-		sort.Sort(SortImage(data))
+		sort.Sort(StringList(data))
 		return data
 	}
 
@@ -814,7 +814,7 @@ func (c *imageCmd) showAliases(aliases []api.ImageAliasesEntry, filters []string
 		i18n.G("ALIAS"),
 		i18n.G("FINGERPRINT"),
 		i18n.G("DESCRIPTION")})
-	sort.Sort(SortImage(data))
+	sort.Sort(StringList(data))
 	table.AppendBulk(data)
 	table.Render()
 

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -74,39 +74,33 @@ func (p *ProgressRenderer) UpdateOp(op api.Operation) {
 	}
 }
 
-// Image fingerprint and alias sorting
-type SortImage [][]string
+type StringList [][]string
 
-func (a SortImage) Len() int {
+func (a StringList) Len() int {
 	return len(a)
 }
 
-func (a SortImage) Swap(i, j int) {
+func (a StringList) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a SortImage) Less(i, j int) bool {
-	if a[i][0] == a[j][0] {
-		if a[i][3] == "" {
-			return false
+func (a StringList) Less(i, j int) bool {
+	x := 0
+	for x = range a[i] {
+		if a[i][x] != a[j][x] {
+			break
 		}
-
-		if a[j][3] == "" {
-			return true
-		}
-
-		return a[i][3] < a[j][3]
 	}
 
-	if a[i][0] == "" {
+	if a[i][x] == "" {
 		return false
 	}
 
-	if a[j][0] == "" {
+	if a[j][x] == "" {
 		return true
 	}
 
-	return a[i][0] < a[j][0]
+	return a[i][x] < a[j][x]
 }
 
 // Container name sorting

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type utilsTestSuite struct {
+	suite.Suite
+}
+
+func TestUtilsTestSuite(t *testing.T) {
+	suite.Run(t, new(utilsTestSuite))
+}
+
+// StringList can be used to sort a list of strings.
+func (s *utilsTestSuite) Test_StringList() {
+	data := [][]string{{"foo", "bar"}, {"baz", "bza"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"baz", "bza"}, {"foo", "bar"}}, data)
+}
+
+// The first different string is used in sorting.
+func (s *utilsTestSuite) Test_StringList_sort_by_column() {
+	data := [][]string{{"foo", "baz"}, {"foo", "bar"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"foo", "bar"}, {"foo", "baz"}}, data)
+}
+
+// Empty strings are sorted last.
+func (s *utilsTestSuite) Test_StringList_empty_strings() {
+	data := [][]string{{"", "bar"}, {"foo", "baz"}}
+	sort.Sort(StringList(data))
+	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
+}


### PR DESCRIPTION
Output is now sorted in column order.

I also renamed SortImage since it can now be used to sort any list of list of strings.

Closes #3413 