### PR TITLE
exec: detect POLLNVAL when poll()ing

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -227,10 +227,12 @@ func (s *execWs) Do(op *operation) error {
 			conn := s.conns[0]
 			s.connsLock.Unlock()
 
+			logger.Debugf("Starting to mirror websocket")
 			readDone, writeDone := shared.WebsocketExecMirror(conn, ptys[0], ptys[0], attachedChildIsDead, int(ptys[0].Fd()))
 
 			<-readDone
 			<-writeDone
+			logger.Debugf("Finished to mirror websocket")
 
 			conn.Close()
 			wgEOF.Done()


### PR DESCRIPTION
In case the child simply dies or the client exits the fd will be closed and we
will receive a POLLNVAL event. We need to handle this case otherwise we will
keep poll()ing without ever exiting.

Closes #2964.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>