### PR TITLE
clean the given source filepath

### DIFF
--- a/client.go
+++ b/client.go
@@ -1873,9 +1873,6 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 		return fmt.Errorf("This function isn't supported by public remotes.")
 	}
 
-	sourceDir, _ := filepath.Split(source)
-	sourceLen := len(sourceDir)
-
 	sendFile := func(p string, fInfo os.FileInfo, err error) error {
 		if err != nil {
 			return fmt.Errorf("Failed to walk path for %s: %s", p, err)
@@ -1886,7 +1883,7 @@ func (c *Client) RecursivePushFile(container string, source string, target strin
 			return fmt.Errorf("'%s' isn't a regular file or directory.", p)
 		}
 
-		targetPath := path.Join(target, filepath.ToSlash(p[sourceLen:]))
+		targetPath := path.Join(target, filepath.ToSlash(p))
 		if fInfo.IsDir() {
 			mode, uid, gid := shared.GetOwnerMode(fInfo)
 			return c.Mkdir(container, targetPath, mode, uid, gid)

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -103,6 +103,7 @@ func (c *fileCmd) push(config *lxd.Config, send_file_perms bool, args []string) 
 	var sourcefilenames []string
 	for _, fname := range args[:len(args)-1] {
 		if !strings.HasPrefix(fname, "--") {
+			fname = path.Clean(fname)
 			sourcefilenames = append(sourcefilenames, fname)
 		}
 	}


### PR DESCRIPTION
The source path given to the push command no longer assumes the path is normal. Now oddities like `././` normalize to `.`. This fixes the issue where `./` results in malformed destination paths (issue #3446).