### PR TITLE
storage: leave volume uninitialized

### DIFF
--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -309,7 +309,7 @@ func storageInit(d *Daemon, poolName string, volumeName string, volumeType int) 
 	}
 
 	// Load the storage volume.
-	volume := &api.StorageVolume{}
+	var volume *api.StorageVolume
 	if volumeName != "" && volumeType >= 0 {
 		_, volume, err = dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
 		if err != nil {


### PR DESCRIPTION
So far I've used a dummy initializer when only the pool was supposed to be
initialized. But I want to be able to check whether the volume is initialized
at all and kick out a bunch of get*() methods in the various storage drivers.
This will allow us to reduce the amount of helper functions well call and
increases performance. In essence, all information initialization can then be
done when we call StoragePoolInit() instead of additionally in each single
method.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>