### PR TITLE
storage: allow attaching storage volumes

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -6156,7 +6156,7 @@ func (c *containerLXC) createDiskDevice(name string, m types.Device) (string, er
 		// Initialize a new storage interface and check if the
 		// pool/volume is mounted. If it is not, mount it.
 		volumeType, _ := storagePoolVolumeTypeNameToType(volumeTypeName)
-		s, err := storagePoolVolumeInit(c.daemon, m["pool"], volumeName, volumeType)
+		s, err := storagePoolVolumeAttachInit(c.daemon, m["pool"], volumeName, volumeType, c)
 		if err != nil && !isOptional {
 			return "", fmt.Errorf("Failed to initialize storage volume \"%s\" of type \"%s\" on storage pool \"%s\": %s.",
 				volumeName,
@@ -6780,17 +6780,7 @@ func (c *containerLXC) idmapsetFromConfig(k string) (*shared.IdmapSet, error) {
 		return c.IdmapSet()
 	}
 
-	lastIdmap := new(shared.IdmapSet)
-	err := json.Unmarshal([]byte(lastJsonIdmap), &lastIdmap.Idmap)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(lastIdmap.Idmap) == 0 {
-		return nil, nil
-	}
-
-	return lastIdmap, nil
+	return idmapsetFromString(lastJsonIdmap)
 }
 
 func (c *containerLXC) NextIdmapSet() (*shared.IdmapSet, error) {

--- a/lxd/container_lxc_utils.go
+++ b/lxd/container_lxc_utils.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"encoding/json"
+
+	"github.com/lxc/lxd/shared"
+)
+
+func idmapsetFromString(idmap string) (*shared.IdmapSet, error) {
+	lastIdmap := new(shared.IdmapSet)
+	err := json.Unmarshal([]byte(idmap), &lastIdmap.Idmap)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(lastIdmap.Idmap) == 0 {
+		return nil, nil
+	}
+
+	return lastIdmap, nil
+}
+
+func idmapsetToJSON(idmap *shared.IdmapSet) (string, error) {
+	idmapBytes, err := json.Marshal(idmap.Idmap)
+	if err != nil {
+		return "", err
+	}
+
+	return string(idmapBytes), nil
+}

--- a/lxd/storage_volumes_config.go
+++ b/lxd/storage_volumes_config.go
@@ -23,6 +23,8 @@ var storageVolumeConfigKeys = map[string]func(value string) error{
 	},
 	"zfs.use_refquota":     shared.IsBool,
 	"zfs.remove_snapshots": shared.IsBool,
+	"volatile.idmap.last":  shared.IsAny,
+	"volatile.idmap.next":  shared.IsAny,
 }
 
 func storageVolumeValidateConfig(name string, config map[string]string, parentPool *api.StoragePool) error {

--- a/test/main.sh
+++ b/test/main.sh
@@ -627,5 +627,6 @@ run_test test_init_interactive "lxd init interactive"
 run_test test_init_preseed "lxd init preseed"
 run_test test_storage_profiles "storage profiles"
 run_test test_container_import "container import"
+run_test test_storage_volume_attach "attaching storage volumes"
 
 TEST_RESULT=success

--- a/test/suites/storage_volume_attach.sh
+++ b/test/suites/storage_volume_attach.sh
@@ -1,0 +1,95 @@
+test_storage_volume_attach() {
+  # Check that we have a big enough range for this test
+  if [ ! -e /etc/subuid ] && [ ! -e /etc/subgid ]; then
+    UIDs=1000000000
+    GIDs=1000000000
+    UID_BASE=1000000
+    GID_BASE=1000000
+  else
+    UIDs=0
+    GIDs=0
+    UID_BASE=0
+    GID_BASE=0
+    LARGEST_UIDs=0
+    LARGEST_GIDs=0
+
+    # shellcheck disable=SC2013
+    for entry in $(grep ^root: /etc/subuid); do
+      COUNT=$(echo "${entry}" | cut -d: -f3)
+      UIDs=$((UIDs+COUNT))
+
+      if [ "${COUNT}" -gt "${LARGEST_UIDs}" ]; then
+        LARGEST_UIDs=${COUNT}
+        UID_BASE=$(echo "${entry}" | cut -d: -f2)
+      fi
+    done
+
+    # shellcheck disable=SC2013
+    for entry in $(grep ^root: /etc/subgid); do
+      COUNT=$(echo "${entry}" | cut -d: -f3)
+      GIDs=$((GIDs+COUNT))
+
+      if [ "${COUNT}" -gt "${LARGEST_GIDs}" ]; then
+        LARGEST_GIDs=${COUNT}
+        GID_BASE=$(echo "${entry}" | cut -d: -f2)
+      fi
+    done
+  fi
+
+  ensure_import_testimage
+
+  # create storage volume
+  lxc storage volume create "lxdtest-$(basename "${LXD_DIR}")" testvolume
+
+  # create containers
+  lxc launch testimage c1 -c security.privileged=true
+  lxc launch testimage c2
+
+  # Attach to a single privileged container
+  lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")" testvolume c1 testvolume
+  PATH_TO_CHECK="${LXD_DIR}/storage-pools/lxdtest-$(basename "${LXD_DIR}")/custom/testvolume"
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "0:0" ]
+
+  # make container unprivileged
+  lxc config set c1 security.privileged false
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "0:0" ]
+
+  if [ "${UIDs}" -lt 500000 ] || [ "${GIDs}" -lt 500000 ]; then
+    echo "==> SKIP: The storage volume attach test requires at least 500000 uids and gids"
+    return
+  fi
+
+  # restart
+  lxc restart --force c1
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "${UID_BASE}:${GID_BASE}" ]
+
+  # give container isolated id mapping
+  lxc config set c1 security.idmap.isolated true
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "${UID_BASE}:${GID_BASE}" ]
+
+  # restart
+  lxc restart --force c1
+
+  # get new isolated base ids
+  ISOLATED_UID_BASE="$(lxc exec c1 -- cat /proc/self/uid_map | awk '{print $2}')"
+  ISOLATED_GID_BASE="$(lxc exec c1 -- cat /proc/self/gid_map | awk '{print $2}')"
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "${ISOLATED_UID_BASE}:${ISOLATED_GID_BASE}" ]
+
+  ! lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")" testvolume c2 testvolume
+
+  # give container standard mapping
+  lxc config set c1 security.idmap.isolated false
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "${ISOLATED_UID_BASE}:${ISOLATED_GID_BASE}" ]
+
+  # restart
+  lxc restart --force c1
+  [ "$(stat -c %u:%g "${PATH_TO_CHECK}")" = "${UID_BASE}:${GID_BASE}" ]
+
+  # attach second container
+  lxc storage volume attach "lxdtest-$(basename "${LXD_DIR}")" testvolume c2 testvolume
+
+  # delete containers
+  lxc delete -f c1
+  lxc delete -f c2
+  lxc storage volume delete "lxdtest-$(basename "${LXD_DIR}")" testvolume
+}


### PR DESCRIPTION
Since it's implementation the LXD storage API has supported attaching storage
volumes to containers. One of the oustanding challenges before a working
implementation of the shiftfs concept in the kernel is how to deal with id
mappings when mounting custom storage volumes. This spec tries to propose a
viable solution that aims at security.

When a new custom storage volume is created:

    lxc storage volume create <pool> <volume>

and attached to a container for the first time:

    lxc storage volume attach <pool> <volume> <container> <path-to-attach-to>

it will not have any prior id mapping associated with it.

1. Attaching a previously not id-mapped storage volume
The first container to attach the storage volume will perform an id mapping on
the storage volume. The serialized id mapping recorded in the containers config
file will then be stored as a volatile key in the storage volume's config.

2. Attaching an already id-mapped storage volume
When a storage volume is attached to a container it is checked whether the
volatile key is empty. If it is empty case 1. applies. If it is not empty it is
checked whether the id mapping of the container matched the idmap recorded in
the volatile key. If they match the container is allowed to attach the storage
volume. If they do not match it will be checked whether the storage volume is
atttached to any other containers. If it is attached to any other containers the
container is not allowed to attach the storage volume and an appriorate error is
returned. If it is not attached to any other containers the container is allowed
to attach the storage volume, map the ids and update the volatile key
appropriately.

3. Attaching a storage volume to multiple containers
When a storage volume is attached to multiple containers all containers must
have the same id mapping. This consensus must be upheld as long as multiple
containers share the same storage volume.

3. Changing the idmapping of a container with attached id-mapped storage volumes
If the idmapping of a container is changed that has an id-mapped storage volume
attached to it which is shared among multiple containers the change will not be
applied an approriate error is returned.

Closes #3389.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>