### PR TITLE
Don't specify mode for intermediate directories created with `push -p`

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4750,6 +4750,11 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int64, gid i
 		}
 	}
 
+	defaultMode := 0640
+	if srcpath == "" {
+		defaultMode = 0750
+	}
+
 	// Push the file to the container
 	out, err := shared.RunCommand(
 		execPath,
@@ -4763,7 +4768,7 @@ func (c *containerLXC) FilePush(srcpath string, dstpath string, uid int64, gid i
 		fmt.Sprintf("%d", mode),
 		fmt.Sprintf("%d", rootUid),
 		fmt.Sprintf("%d", rootGid),
-		fmt.Sprintf("%d", int(os.FileMode(0640)&os.ModePerm)),
+		fmt.Sprintf("%d", int(os.FileMode(defaultMode)&os.ModePerm)),
 		write,
 	)
 

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -198,7 +198,7 @@ func run() error {
 
 	// Process sub-commands
 	if len(os.Args) > 1 {
-		// "forkputfile", "forkgetfile", "forkmount" and "forkumount" are handled specially in nsexec.go
+		// "forkputfile", "forkgetfile", "forkmount" and "forkumount" are handled specially in main_nsexec.go
 		// "forkgetnet" is partially handled in nsexec.go (setns)
 		switch os.Args[1] {
 		// Main commands

--- a/test/suites/filemanip.sh
+++ b/test/suites/filemanip.sh
@@ -34,6 +34,16 @@ test_filemanip() {
 
   lxc exec filemanip -- rm -rf /tmp/ptest/source
 
+  # Check that file permissions are not applied to intermediate directories
+
+  lxc file push -p --mode=400 "${TEST_DIR}"/source/foo \
+      filemanip/tmp/ptest/d1/d2/foo
+
+  [ "$(lxc exec filemanip -- stat -c "%a" /tmp/ptest/d1)" = "750" ]
+  [ "$(lxc exec filemanip -- stat -c "%a" /tmp/ptest/d1/d2)" = "750" ]
+
+  lxc exec filemanip -- rm -rf /tmp/ptest/d1
+
   # Special case where we are in the same directory as the one we are currently
   # created.
   oldcwd=$(pwd)


### PR DESCRIPTION
Fixes #3450 