### PR TITLE
zfs: Set canmount=noauto on all mountable datasets

### DIFF
--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -15,8 +15,15 @@ import (
 
 // zfsPoolVolumeCreate creates a ZFS dataset with a set of given properties.
 func zfsPoolVolumeCreate(dataset string, properties ...string) (string, error) {
-	p := strings.Join(properties, ",")
-	return shared.RunCommand("zfs", "create", "-o", p, "-p", dataset)
+	cmd := []string{"zfs", "create"}
+
+	for _, prop := range properties {
+		cmd = append(cmd, []string{"-o", prop}...)
+	}
+
+	cmd = append(cmd, []string{"-p", dataset}...)
+
+	return shared.RunCommand(cmd[0], cmd[1:]...)
 }
 
 func zfsPoolVolumeSet(dataset string, key string, value string) (string, error) {
@@ -248,6 +255,7 @@ func (s *storageZfs) zfsPoolVolumeClone(source string, name string, dest string,
 		"clone",
 		"-p",
 		"-o", fmt.Sprintf("mountpoint=%s", mountpoint),
+		"-o", "canmount=noauto",
 		fmt.Sprintf("%s/%s@%s", poolName, source, name),
 		fmt.Sprintf("%s/%s", poolName, dest))
 	if err != nil {
@@ -278,6 +286,7 @@ func (s *storageZfs) zfsPoolVolumeClone(source string, name string, dest string,
 			"clone",
 			"-p",
 			"-o", fmt.Sprintf("mountpoint=%s", snapshotMntPoint),
+			"-o", "canmount=noauto",
 			fmt.Sprintf("%s/%s@%s", poolName, sub, name),
 			fmt.Sprintf("%s/%s", poolName, destSubvol))
 		if err != nil {

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -77,7 +77,7 @@ migration() {
   if [ "$lxd2_backend" != "lvm" ] && [ "$lxd2_backend" != "zfs" ]; then
     [ -d "${lxd2_dir}/containers/nonlive/rootfs" ]
   fi
-  lxc_remote stop l2:nonlive
+  lxc_remote stop l2:nonlive --force
 
   [ ! -d "${LXD_DIR}/containers/nonlive" ]
   # FIXME: make this backend agnostic
@@ -107,7 +107,7 @@ migration() {
   fi
   lxc_remote delete l2:nonlive3 --force
 
-  lxc_remote stop l2:nonlive
+  lxc_remote stop l2:nonlive --force
   lxc_remote copy l2:nonlive l2:nonlive2 --mode=push
   # should have the same base image tag
   [ "$(lxc_remote config get l2:nonlive volatile.base_image)" = "$(lxc_remote config get l2:nonlive2 volatile.base_image)" ]

--- a/test/suites/migration.sh
+++ b/test/suites/migration.sh
@@ -74,7 +74,7 @@ migration() {
   # perform existence check for various files.
   lxc_remote start l2:nonlive
   # FIXME: make this backend agnostic
-  if [ "$lxd2_backend" != "lvm" ]; then
+  if [ "$lxd2_backend" != "lvm" ] && [ "$lxd2_backend" != "zfs" ]; then
     [ -d "${lxd2_dir}/containers/nonlive/rootfs" ]
   fi
   lxc_remote stop l2:nonlive
@@ -91,7 +91,7 @@ migration() {
   lxc_remote start l2:nonlive
   [ -d "${LXD_DIR}/containers/nonlive2" ]
   # FIXME: make this backend agnostic
-  if [ "$lxd2_backend" != "lvm" ]; then
+  if [ "$lxd2_backend" != "lvm" ] && [ "$lxd2_backend" != "zfs" ]; then
     [ -d "${lxd2_dir}/containers/nonlive/rootfs/bin" ]
   fi
 
@@ -102,7 +102,7 @@ migration() {
 
   lxc_remote copy l1:nonlive2/snap0 l2:nonlive3 --mode=relay
   # FIXME: make this backend agnostic
-  if [ "$lxd2_backend" != "lvm" ]; then
+  if [ "$lxd2_backend" != "lvm" ] && [ "$lxd2_backend" != "zfs" ]; then
     [ -d "${lxd2_dir}/containers/nonlive3/rootfs/bin" ]
   fi
   lxc_remote delete l2:nonlive3 --force

--- a/test/suites/snapshots.sh
+++ b/test/suites/snapshots.sh
@@ -44,7 +44,7 @@ snapshots() {
 
   lxc copy foo/tester foosnap1
   # FIXME: make this backend agnostic
-  if [ "$lxd_backend" != "lvm" ]; then
+  if [ "$lxd_backend" != "lvm" ] && [ "${lxd_backend}" != "zfs" ]; then
     [ -d "${LXD_DIR}/containers/foosnap1/rootfs" ]
   fi
 

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -330,10 +330,10 @@ test_storage() {
       lxc list -c b c12pool6 | grep "lxdtest-$(basename "${LXD_DIR}")-pool6"
       # grow lv
       lxc config device set c12pool6 root size 30MB
-      lxc restart c12pool6
+      lxc restart c12pool6 --force
       # shrink lv
       lxc config device set c12pool6 root size 25MB
-      lxc restart c12pool6
+      lxc restart c12pool6 --force
 
       lxc init testimage c10pool11 -s "lxdtest-$(basename "${LXD_DIR}")-pool11"
       lxc list -c b c10pool11 | grep "lxdtest-$(basename "${LXD_DIR}")-pool11"


### PR DESCRIPTION
We don't want the container host to randomly mount stuff behind our back.

Closes #3437

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>