### PR TITLE
lxc/image: always use long fingerprint in exported filenames

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1533,7 +1533,7 @@ func imageExport(d *Daemon, r *http.Request) Response {
 	if err != nil {
 		ext = ""
 	}
-	filename := fmt.Sprintf("%s%s", fingerprint, ext)
+	filename := fmt.Sprintf("%s%s", imgInfo.Fingerprint, ext)
 
 	if shared.PathExists(rootfsPath) {
 		files := make([]fileResponseEntry, 2)
@@ -1548,7 +1548,7 @@ func imageExport(d *Daemon, r *http.Request) Response {
 		if err != nil {
 			ext = ""
 		}
-		filename = fmt.Sprintf("%s%s", fingerprint, ext)
+		filename = fmt.Sprintf("%s%s", imgInfo.Fingerprint, ext)
 
 		files[1].identifier = "rootfs"
 		files[1].path = rootfsPath


### PR DESCRIPTION
Use the complete fingerprint in exported filenames, even when the short one is passed to `lxc image export`