### PR TITLE
storage: allow deleting images via storage API

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -300,3 +300,7 @@ When set, this will instruct LXD to attach to the specified VLAN on the "parent"
 LXD will look for an existing interface for that "parent" and VLAN on the host.
 If one can't be found it will create one itself.
 Then, LXD will directly attach this interface to the container.
+
+## storage\_images\_delete
+This enabled the storage API to delete storage volumes for images from
+a specific storage pool.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -113,6 +113,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"file_symlinks",
 			"container_push_target",
 			"network_vlan_physical",
+			"storage_images_delete",
 		},
 		APIStatus:  "stable",
 		APIVersion: version.APIVersion,

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -561,6 +561,17 @@ func (s *storageBtrfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	err = dbStoragePoolVolumeDelete(
+		s.d.db,
+		s.volume.Name,
+		storagePoolVolumeTypeCustom,
+		s.poolID)
+	if err != nil {
+		logger.Errorf(`Failed to delete database entry for ZFS `+
+			`storage volume "%s" on storage pool "%s"`,
+			s.volume.Name, s.pool.Name)
+	}
+
 	logger.Infof("Deleted BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -203,6 +203,17 @@ func (s *storageDir) StoragePoolVolumeDelete() error {
 		return err
 	}
 
+	err = dbStoragePoolVolumeDelete(
+		s.d.db,
+		s.volume.Name,
+		storagePoolVolumeTypeCustom,
+		s.poolID)
+	if err != nil {
+		logger.Errorf(`Failed to delete database entry for ZFS `+
+			`storage volume "%s" on storage pool "%s"`,
+			s.volume.Name, s.pool.Name)
+	}
+
 	logger.Infof("Deleted DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -541,6 +541,17 @@ func (s *storageLvm) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	err = dbStoragePoolVolumeDelete(
+		s.d.db,
+		s.volume.Name,
+		storagePoolVolumeTypeCustom,
+		s.poolID)
+	if err != nil {
+		logger.Errorf(`Failed to delete database entry for ZFS `+
+			`storage volume "%s" on storage pool "%s"`,
+			s.volume.Name, s.pool.Name)
+	}
+
 	logger.Infof("Deleted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -401,13 +401,6 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 	if err != nil {
 		return SmartError(err)
 	}
-
-	poolID, err := dbStoragePoolGetID(d.db, poolName)
-	if err != nil {
-		return SmartError(err)
-	}
-
-	err = dbStoragePoolVolumeDelete(d.db, volumeName, volumeType, poolID)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -250,6 +250,17 @@ func (s *storageZfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
+	err = dbStoragePoolVolumeDelete(
+		s.d.db,
+		s.volume.Name,
+		storagePoolVolumeTypeCustom,
+		s.poolID)
+	if err != nil {
+		logger.Errorf(`Failed to delete database entry for ZFS `+
+			`storage volume "%s" on storage pool "%s"`,
+			s.volume.Name, s.pool.Name)
+	}
+
 	logger.Infof("Deleted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
 	return nil
 }


### PR DESCRIPTION
This commit introduces the ability to wipe storage volumes for images from a
specific storage pool.

Closes #3539.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>