### PR TITLE
Update image aliases when they already exist

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -339,8 +339,7 @@ func (c *imageCmd) doImageAlias(conf *config.Config, args []string) error {
 			return err
 		}
 
-		err = d.DeleteImageAlias(alias)
-		return err
+		return d.DeleteImageAlias(alias)
 	}
 	return errArgs
 }
@@ -389,16 +388,10 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 			return err
 		}
 
-		// Optimisation for simplestreams
+		// Attempt to resolve an image alias
 		var imgInfo *api.Image
 		image := inName
-		if conf.Remotes[remote].Protocol == "simplestreams" {
-			imgInfo = &api.Image{}
-			imgInfo.Fingerprint = image
-			imgInfo.Public = true
-		} else {
-
-			// Attempt to resolve an image alias
+		if c.copyAliases {
 			alias, _, err := d.GetImageAlias(image)
 			if err == nil {
 				image = alias.Target
@@ -409,21 +402,17 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 			if err != nil {
 				return err
 			}
-		}
-
-		// Setup the copy arguments
-		aliases := []api.ImageAlias{}
-		for _, entry := range c.addAliases {
-			alias := api.ImageAlias{}
-			alias.Name = entry
-			aliases = append(aliases, alias)
+		} else {
+			// Don't fetch full image info if we don't need aliases (since it's
+			// an expensive operation)
+			imgInfo = &api.Image{}
+			imgInfo.Fingerprint = image
+			imgInfo.Public = true
 		}
 
 		args := lxd.ImageCopyArgs{
-			Aliases:     aliases,
-			AutoUpdate:  c.autoUpdate,
-			CopyAliases: c.copyAliases,
-			Public:      c.publicImage,
+			AutoUpdate: c.autoUpdate,
+			Public:     c.publicImage,
 		}
 
 		// Do the copy
@@ -448,7 +437,20 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 		}
 
 		progress.Done(i18n.G("Image copied successfully!"))
-		return nil
+
+		// Ensure aliases
+		aliases := make([]api.ImageAlias, len(c.addAliases))
+		for i, entry := range c.addAliases {
+			aliases[i].Name = entry
+		}
+		if c.copyAliases {
+			// Also add the original aliases
+			for _, alias := range imgInfo.Aliases {
+				aliases = append(aliases, alias)
+			}
+		}
+		err = ensureImageAliases(dest, aliases, image)
+		return err
 
 	case "delete":
 		/* delete [<remote>:]<image> [<remote>:][<image>...] */
@@ -735,17 +737,16 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 		progress.Done(fmt.Sprintf(i18n.G("Image imported with fingerprint: %s"), fingerprint))
 
 		// Add the aliases
-		for _, entry := range c.addAliases {
-			alias := api.ImageAliasesPost{}
-			alias.Name = entry
-			alias.Target = fingerprint
-
-			err = d.CreateImageAlias(alias)
+		if len(c.addAliases) > 0 {
+			aliases := make([]api.ImageAlias, len(c.addAliases))
+			for i, entry := range c.addAliases {
+				aliases[i].Name = entry
+			}
+			err = ensureImageAliases(d, aliases, fingerprint)
 			if err != nil {
 				return err
 			}
 		}
-
 		return nil
 
 	case "list":

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -200,7 +200,6 @@ func (c *publishCmd) run(conf *config.Config, args []string) error {
 	}
 
 	if cRemote == iRemote {
-		req.Aliases = aliases
 		req.Public = c.makePublic
 	}
 
@@ -229,8 +228,7 @@ func (c *publishCmd) run(conf *config.Config, args []string) error {
 
 		// Image copy arguments
 		args := lxd.ImageCopyArgs{
-			Aliases: aliases,
-			Public:  c.makePublic,
+			Public: c.makePublic,
 		}
 
 		// Copy the image to the destination host
@@ -245,6 +243,10 @@ func (c *publishCmd) run(conf *config.Config, args []string) error {
 		}
 	}
 
+	err = ensureImageAliases(d, aliases, fingerprint)
+	if err != nil {
+		return err
+	}
 	fmt.Printf(i18n.G("Container published with fingerprint: %s")+"\n", fingerprint)
 
 	return nil

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
 	"strings"
 	"syscall"
 	"time"
@@ -346,4 +347,54 @@ func cancelableWait(op *lxd.RemoteOperation, progress *ProgressRenderer) error {
 			}
 		}
 	}
+}
+
+// Create the specified image alises, updating those that already exist
+func ensureImageAliases(client lxd.ContainerServer, aliases []api.ImageAlias, fingerprint string) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+
+	names := make([]string, len(aliases))
+	for i, alias := range aliases {
+		names[i] = alias.Name
+	}
+	sort.Strings(names)
+
+	resp, err := client.GetImageAliases()
+	if err != nil {
+		return err
+	}
+
+	// Delete existing aliases that match provided ones
+	for _, alias := range GetExistingAliases(names, resp) {
+		err := client.DeleteImageAlias(alias.Name)
+		if err != nil {
+			fmt.Println(i18n.G("Failed to remove alias %s"), alias.Name)
+		}
+	}
+	// Create new aliases
+	for _, alias := range aliases {
+		aliasPost := api.ImageAliasesPost{}
+		aliasPost.Name = alias.Name
+		aliasPost.Target = fingerprint
+		err := client.CreateImageAlias(aliasPost)
+		if err != nil {
+			fmt.Println(i18n.G("Failed to create alias %s"), alias.Name)
+		}
+	}
+	return nil
+}
+
+// GetExistingAliases returns the intersection between a list of aliases and all the existing ones.
+func GetExistingAliases(aliases []string, allAliases []api.ImageAliasesEntry) []api.ImageAliasesEntry {
+	existing := []api.ImageAliasesEntry{}
+	for _, alias := range allAliases {
+		name := alias.Name
+		pos := sort.SearchStrings(aliases, name)
+		if pos < len(aliases) && aliases[pos] == name {
+			existing = append(existing, alias)
+		}
+	}
+	return existing
 }

--- a/lxc/utils_test.go
+++ b/lxc/utils_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/lxc/lxd/shared/api"
 )
 
 type utilsTestSuite struct {
@@ -34,4 +36,24 @@ func (s *utilsTestSuite) Test_StringList_empty_strings() {
 	data := [][]string{{"", "bar"}, {"foo", "baz"}}
 	sort.Sort(StringList(data))
 	s.Equal([][]string{{"foo", "baz"}, {"", "bar"}}, data)
+}
+
+func (s *utilsTestSuite) TestGetExistingAliases() {
+	images := []api.ImageAliasesEntry{
+		{Name: "foo"},
+		{Name: "bar"},
+		{Name: "baz"},
+	}
+	aliases := GetExistingAliases([]string{"bar", "foo", "other"}, images)
+	s.Exactly([]api.ImageAliasesEntry{images[0], images[1]}, aliases)
+}
+
+func (s *utilsTestSuite) TestGetExistingAliasesEmpty() {
+	images := []api.ImageAliasesEntry{
+		{Name: "foo"},
+		{Name: "bar"},
+		{Name: "baz"},
+	}
+	aliases := GetExistingAliases([]string{"other1", "other2"}, images)
+	s.Exactly([]api.ImageAliasesEntry{}, aliases)
 }

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -237,7 +237,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -262,22 +262,22 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Admin password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -352,7 +352,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -371,7 +371,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, fuzzy, c-format
 msgid "Container published with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -385,7 +385,7 @@ msgstr "Kopiere Aliasse von der Quelle"
 msgid "Copy the container without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -398,7 +398,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -413,7 +413,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -441,7 +441,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -492,22 +492,27 @@ msgstr "Flüchtiger Container"
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -525,6 +530,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -534,7 +544,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -590,24 +600,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -656,12 +666,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -712,7 +722,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -785,7 +795,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -913,7 +923,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
@@ -922,7 +932,7 @@ msgstr "Eigenschaften:\n"
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -931,7 +941,7 @@ msgstr "Öffentlich: %s\n"
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -1038,7 +1048,7 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, fuzzy, c-format
 msgid "Size: %.2fMB"
 msgstr "Größe: %.2vMB\n"
@@ -1052,7 +1062,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1192,7 +1202,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -1218,7 +1228,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1261,7 +1271,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -2232,11 +2242,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -2250,7 +2260,7 @@ msgstr "Fehler: %v\n"
 msgid "error: unknown command: %s"
 msgstr "Fehler: unbekannter Befehl: %s\n"
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2305,7 +2315,7 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr "falsche Anzahl an Parametern für Unterbefehl"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -150,7 +150,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -175,21 +175,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -263,7 +263,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -282,7 +282,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -295,7 +295,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -308,7 +308,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -399,22 +399,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -431,6 +436,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -440,7 +450,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -493,24 +503,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -558,12 +568,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -612,7 +622,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -681,7 +691,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -750,7 +760,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -805,7 +815,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -813,7 +823,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -822,7 +832,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -926,7 +936,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -940,7 +950,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1071,7 +1081,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1096,7 +1106,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1139,7 +1149,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1947,11 +1957,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1965,7 +1975,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2019,6 +2029,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -227,7 +227,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -253,21 +253,21 @@ msgstr "Accepter le certificat"
 msgid "Admin password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -343,7 +343,7 @@ msgstr "Commandes:"
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -362,7 +362,7 @@ msgstr "Le nom du conteneur est obligatoire"
 msgid "Container name is: %s"
 msgstr "Le nom du conteneur est : %s"
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr "Conteneur publié avec l'empreinte : %s"
@@ -376,7 +376,7 @@ msgstr "Copier les alias depuis la source"
 msgid "Copy the container without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -389,7 +389,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -403,7 +403,7 @@ msgstr "Création de %s"
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -431,7 +431,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -480,23 +480,28 @@ msgstr "Conteneur éphémère"
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
+
+#: lxc/image.go:1273
+#, fuzzy, c-format
+msgid "Failed to create alias %s"
+msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
 #: lxc/manpage.go:62
 #, c-format
@@ -513,6 +518,11 @@ msgstr "Échec lors de la génération de 'lxc.1': %v"
 msgid "Failed to get the new container name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -523,7 +533,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -579,25 +589,25 @@ msgstr "Ignorer les alias pour déterminer la commande à exécuter"
 msgid "Ignore the container state (only for start)"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -646,12 +656,12 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "Socket LXD introuvable ; LXD est-il installé et actif ?"
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -702,7 +712,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -772,7 +782,7 @@ msgstr "Seul les volumes \"personnalisés\" peuvent être attaché aux conteneur
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
@@ -842,7 +852,7 @@ msgstr "Pid : %d"
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
@@ -897,7 +907,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Profiles: %s"
 msgstr "Profils : %s"
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr "Propriétés :"
 
@@ -905,7 +915,7 @@ msgstr "Propriétés :"
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -914,7 +924,7 @@ msgstr "Public : %s"
 msgid "Recursively push or pull files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -1021,7 +1031,7 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "Taille : %.2f Mo"
@@ -1035,7 +1045,7 @@ msgstr "Instantanés :"
 msgid "Some containers failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr "Source :"
 
@@ -1179,7 +1189,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -1205,7 +1215,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
@@ -1248,7 +1258,7 @@ msgstr "Impossible de lire le certificat TLS distant"
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -2514,11 +2524,11 @@ msgstr "par défaut"
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr "activé"
 
@@ -2532,7 +2542,7 @@ msgstr "erreur : %v"
 msgid "error: unknown command: %s"
 msgstr "erreur : commande inconnue: %s"
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr "non"
 
@@ -2586,7 +2596,7 @@ msgstr "pris à %s"
 msgid "wrong number of subcommand arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr "oui"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-06-15 22:46+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -171,7 +171,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -196,21 +196,21 @@ msgstr "Accetta certificato"
 msgid "Admin password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -302,7 +302,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -315,7 +315,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -328,7 +328,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -342,7 +342,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -370,7 +370,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "il remote %s esiste già"
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -418,22 +418,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -450,6 +455,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -459,7 +469,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -512,24 +522,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -577,12 +587,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -630,7 +640,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -698,7 +708,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -767,7 +777,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -822,7 +832,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -830,7 +840,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -839,7 +849,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -943,7 +953,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -957,7 +967,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1089,7 +1099,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1114,7 +1124,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1157,7 +1167,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1966,11 +1976,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1984,7 +1994,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr "no"
 
@@ -2038,7 +2048,7 @@ msgstr "salvato alle %s"
 msgid "wrong number of subcommand arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-03-23 12:03+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -150,7 +150,7 @@ msgstr "'/' はスナップショットの名前には使用できません"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -175,21 +175,21 @@ msgstr "証明書を受け入れます"
 msgid "Admin password for %s: "
 msgstr "%s の管理者パスワード: "
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "(不正なイメージプロパティ形式: %s\n"
@@ -264,7 +264,7 @@ msgstr "コマンド:"
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -283,7 +283,7 @@ msgstr "コンテナ名を指定する必要があります"
 msgid "Container name is: %s"
 msgstr "コンテナ名: %s"
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr "コンテナは以下のフィンガープリントで publish されます: %s"
@@ -297,7 +297,7 @@ msgstr "ソースからエイリアスをコピーしました"
 msgid "Copy the container without its snapshots"
 msgstr "コンテナを強制シャットダウンします"
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -310,7 +310,7 @@ msgstr "サーバ証明書格納用のディレクトリを作成できません
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -324,7 +324,7 @@ msgstr "%s を作成中"
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -352,7 +352,7 @@ msgstr "デバイス %s が %s から削除されました"
 msgid "Device already exists: %s"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -400,23 +400,28 @@ msgstr "Ephemeral コンテナ"
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのインポート中: %s"
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
 msgstr ""
+
+#: lxc/image.go:1273
+#, fuzzy, c-format
+msgid "Failed to create alias %s"
+msgstr "'lxc.%s.1' の生成が失敗しました: %v"
 
 #: lxc/manpage.go:62
 #, c-format
@@ -433,6 +438,11 @@ msgstr "'lxc.1' の生成が失敗しました: %v"
 msgid "Failed to get the new container name"
 msgstr "新しいコンテナに適用するプロファイル"
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -443,7 +453,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -496,25 +506,25 @@ msgstr "どのコマンドを実行するか決める際にエイリアスを無
 msgid "Ignore the container state (only for start)"
 msgstr "コンテナの状態を無視します (startのみ)"
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "イメージのコピーが成功しました!"
@@ -563,12 +573,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "LXD のソケットが見つかりません。LXD が実行されていますか?"
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -619,7 +629,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "コンテナを強制シャットダウンします"
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -687,7 +697,7 @@ msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチ�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr "リモートイメージのインポートは https:// のみをサポートします。"
 
@@ -756,7 +766,7 @@ msgstr "Pid: %d"
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
 
@@ -811,7 +821,7 @@ msgstr "プロファイル %s が %s に追加されました"
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr "プロパティ:"
 
@@ -819,7 +829,7 @@ msgstr "プロパティ:"
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -828,7 +838,7 @@ msgstr "パブリック: %s"
 msgid "Recursively push or pull files"
 msgstr "再帰的にファイルをpush/pullします"
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの取得中: %s"
@@ -933,7 +943,7 @@ msgstr "コンテナログの最後の 100 行を表示しますか?"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "サイズ: %.2fMB"
@@ -947,7 +957,7 @@ msgstr "スナップショット:"
 msgid "Some containers failed to %s"
 msgstr "一部のコンテナで %s が失敗しました"
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr "取得元:"
 
@@ -1088,7 +1098,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "コンテナを強制停止するまでの時間"
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -1117,7 +1127,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
@@ -1160,7 +1170,7 @@ msgstr "リモートの TLS 証明書を読めません"
 msgid "Unknown file type '%s'"
 msgstr "未知の設定コマンド %s"
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -2577,11 +2587,11 @@ msgstr ""
 "サーバから変更されたイメージ、コンテナ、スナップショットを取得できませんで\n"
 "した"
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr "有効"
 
@@ -2595,7 +2605,7 @@ msgstr "エラー: %v"
 msgid "error: unknown command: %s"
 msgstr "エラー: 未知のコマンド: %s"
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2649,7 +2659,7 @@ msgstr "%s に取得しました"
 msgid "wrong number of subcommand arguments"
 msgstr "サブコマンドの引数の数が正しくありません"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-07-12 00:41+0200\n"
+        "POT-Creation-Date: 2017-07-18 14:38+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,7 +141,7 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid   "ALIAS"
 msgstr  ""
 
@@ -166,21 +166,21 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -253,7 +253,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -271,7 +271,7 @@ msgstr  ""
 msgid   "Container name is: %s"
 msgstr  ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid   "Container published with fingerprint: %s"
 msgstr  ""
@@ -284,7 +284,7 @@ msgstr  ""
 msgid   "Copy the container without its snapshots"
 msgstr  ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -297,7 +297,7 @@ msgstr  ""
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -311,7 +311,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:654 lxc/storage.go:749
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -338,7 +338,7 @@ msgstr  ""
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -386,22 +386,27 @@ msgstr  ""
 msgid   "Event type to listen for"
 msgstr  ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid   "FINGERPRINT"
+msgstr  ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid   "Failed to create alias %s"
 msgstr  ""
 
 #: lxc/manpage.go:62
@@ -418,6 +423,11 @@ msgstr  ""
 msgid   "Failed to get the new container name"
 msgstr  ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid   "Failed to remove alias %s"
+msgstr  ""
+
 #: lxc/file.go:125
 #, c-format
 msgid   "Failed to walk path for %s: %s"
@@ -427,7 +437,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -480,24 +490,24 @@ msgstr  ""
 msgid   "Ignore the container state (only for start)"
 msgstr  ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -545,12 +555,12 @@ msgstr  ""
 msgid   "LXD socket not found; is LXD installed and running?"
 msgstr  ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid   "Last used: never"
 msgstr  ""
 
@@ -598,7 +608,7 @@ msgstr  ""
 msgid   "Move the container without its snapshots"
 msgstr  ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -665,7 +675,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
@@ -734,7 +744,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -789,7 +799,7 @@ msgstr  ""
 msgid   "Profiles: %s"
 msgstr  ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid   "Properties:"
 msgstr  ""
 
@@ -797,7 +807,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -806,7 +816,7 @@ msgstr  ""
 msgid   "Recursively push or pull files"
 msgstr  ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -910,7 +920,7 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
@@ -924,7 +934,7 @@ msgstr  ""
 msgid   "Some containers failed to %s"
 msgstr  ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid   "Source:"
 msgstr  ""
 
@@ -1051,7 +1061,7 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it"
 msgstr  ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -1076,7 +1086,7 @@ msgstr  ""
 msgid   "Transferring container: %s"
 msgstr  ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
@@ -1119,7 +1129,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -1845,11 +1855,11 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid   "enabled"
 msgstr  ""
 
@@ -1863,7 +1873,7 @@ msgstr  ""
 msgid   "error: unknown command: %s"
 msgstr  ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid   "no"
 msgstr  ""
 
@@ -1917,7 +1927,7 @@ msgstr  ""
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid   "yes"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -172,21 +172,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -394,22 +394,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -426,6 +431,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -435,7 +445,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -488,24 +498,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -553,12 +563,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -606,7 +616,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -674,7 +684,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -743,7 +753,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -798,7 +808,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -806,7 +816,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -815,7 +825,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -919,7 +929,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -933,7 +943,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1064,7 +1074,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1089,7 +1099,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1132,7 +1142,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1940,11 +1950,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1958,7 +1968,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2012,6 +2022,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: 2017-06-06 13:55+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -218,7 +218,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -244,21 +244,21 @@ msgstr "Принять сертификат"
 msgid "Admin password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -332,7 +332,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -351,7 +351,7 @@ msgstr "Имя контейнера является обязательным"
 msgid "Container name is: %s"
 msgstr "Имя контейнера: %s"
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -364,7 +364,7 @@ msgstr "Копировать псевдонимы из источника"
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -377,7 +377,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -391,7 +391,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -468,22 +468,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -500,6 +505,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -509,7 +519,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -562,24 +572,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -627,12 +637,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -681,7 +691,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -750,7 +760,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -819,7 +829,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -874,7 +884,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -882,7 +892,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -891,7 +901,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -995,7 +1005,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -1009,7 +1019,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1140,7 +1150,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1165,7 +1175,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1208,7 +1218,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -2024,11 +2034,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -2042,7 +2052,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2096,7 +2106,7 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr "да"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -172,21 +172,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -394,22 +394,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -426,6 +431,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -435,7 +445,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -488,24 +498,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -553,12 +563,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -606,7 +616,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -674,7 +684,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -743,7 +753,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -798,7 +808,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -806,7 +816,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -815,7 +825,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -919,7 +929,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -933,7 +943,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1064,7 +1074,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1089,7 +1099,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1132,7 +1142,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1940,11 +1950,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1958,7 +1968,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2012,6 +2022,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -172,21 +172,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -394,22 +394,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -426,6 +431,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -435,7 +445,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -488,24 +498,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -553,12 +563,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -606,7 +616,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -674,7 +684,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -743,7 +753,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -798,7 +808,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -806,7 +816,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -815,7 +825,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -919,7 +929,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -933,7 +943,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1064,7 +1074,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1089,7 +1099,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1132,7 +1142,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1940,11 +1950,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1958,7 +1968,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2012,6 +2022,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-12 00:41+0200\n"
+"POT-Creation-Date: 2017-07-18 14:38+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -147,7 +147,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1065
+#: lxc/image.go:227 lxc/image.go:1072
 msgid "ALIAS"
 msgstr ""
 
@@ -172,21 +172,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:576
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:551 lxc/info.go:104
+#: lxc/image.go:554 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:581
+#: lxc/image.go:584
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:655
+#: lxc/image.go:658
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -259,7 +259,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1120 lxc/network.go:418
+#: lxc/config.go:647 lxc/config.go:712 lxc/image.go:1127 lxc/network.go:418
 #: lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -278,7 +278,7 @@ msgstr ""
 msgid "Container name is: %s"
 msgstr ""
 
-#: lxc/publish.go:248
+#: lxc/publish.go:250
 #, c-format
 msgid "Container published with fingerprint: %s"
 msgstr ""
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:423
+#: lxc/image.go:413
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -304,7 +304,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:556 lxc/info.go:106
+#: lxc/image.go:559 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1067 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1074 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -346,7 +346,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1219
+#: lxc/image.go:1226
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -394,22 +394,27 @@ msgstr ""
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:560
+#: lxc/image.go:563
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:562
+#: lxc/image.go:565
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:861
+#: lxc/image.go:868
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1066
+#: lxc/config.go:348 lxc/image.go:229 lxc/image.go:1073
 msgid "FINGERPRINT"
+msgstr ""
+
+#: lxc/image.go:1273
+#, c-format
+msgid "Failed to create alias %s"
 msgstr ""
 
 #: lxc/manpage.go:62
@@ -426,6 +431,11 @@ msgstr ""
 msgid "Failed to get the new container name"
 msgstr ""
 
+#: lxc/image.go:1263
+#, c-format
+msgid "Failed to remove alias %s"
+msgstr ""
+
 #: lxc/file.go:125
 #, c-format
 msgid "Failed to walk path for %s: %s"
@@ -435,7 +445,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:549
+#: lxc/image.go:552
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -488,24 +498,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:512
+#: lxc/image.go:515
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:437
+#: lxc/image.go:427
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:911
+#: lxc/image.go:918
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:722
+#: lxc/image.go:725
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:510
+#: lxc/image.go:513
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -553,12 +563,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:568
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:570
 msgid "Last used: never"
 msgstr ""
 
@@ -606,7 +616,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1221
+#: lxc/image.go:1228
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -674,7 +684,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:636
+#: lxc/image.go:639
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -743,7 +753,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1121
+#: lxc/config.go:648 lxc/config.go:713 lxc/image.go:1128
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -798,7 +808,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:569
+#: lxc/image.go:572
 msgid "Properties:"
 msgstr ""
 
@@ -806,7 +816,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:552
+#: lxc/image.go:555
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -815,7 +825,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:490
+#: lxc/image.go:493
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -919,7 +929,7 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:550
+#: lxc/image.go:553
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -933,7 +943,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:583
+#: lxc/image.go:586
 msgid "Source:"
 msgstr ""
 
@@ -1064,7 +1074,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:553
+#: lxc/image.go:556
 msgid "Timestamps:"
 msgstr ""
 
@@ -1089,7 +1099,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:661
+#: lxc/image.go:664
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1132,7 +1142,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:558
+#: lxc/image.go:561
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1940,11 +1950,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:544
+#: lxc/image.go:547
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:546
+#: lxc/image.go:549
 msgid "enabled"
 msgstr ""
 
@@ -1958,7 +1968,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:539
+#: lxc/image.go:206 lxc/image.go:542
 msgid "no"
 msgstr ""
 
@@ -2012,6 +2022,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:541
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:544
 msgid "yes"
 msgstr ""

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -115,6 +115,17 @@ test_basic_usage() {
   curl -k -s --cert "${LXD_CONF}/client3.crt" --key "${LXD_CONF}/client3.key" -X GET "https://${LXD_ADDR}/1.0/images" | grep "/1.0/images/" && false
   lxc image delete foo-image
 
+  # Test container publish with existing alias
+  lxc publish bar --alias=foo-image --alias=foo-image2
+  lxc launch testimage baz
+  # change the container filesystem so the resulting image is different
+  lxc exec baz touch /somefile
+  lxc stop baz
+  # publishing another image with same alias doesn't fail
+  lxc publish baz --alias=foo-image
+  lxc delete baz
+  lxc image delete foo-image foo-image2
+
   # Test image compression on publish
   lxc publish bar --alias=foo-image-compressed --compression=bzip2 prop=val1
   lxc image show foo-image-compressed | grep val1

--- a/test/suites/image.sh
+++ b/test/suites/image.sh
@@ -69,3 +69,15 @@ test_image_import_dir() {
     tar tvf "$exported" | grep -Fq metadata.yaml
     rm "$exported"
 }
+
+test_image_import_existing_alias() {
+    ensure_import_testimage
+    lxc init testimage c
+    lxc publish c --alias newimage --alias image2
+    lxc delete c
+    lxc image export testimage testimage.file
+    lxc image delete testimage
+    # the image can be imported with an existing alias
+    lxc image import testimage.file --alias newimage
+    lxc image delete newimage image2
+}


### PR DESCRIPTION
This makes the CLI explicitly remove existing aliases that conflict with the ones of the image being copied/imported, and recreate them.

Closes #3560