### PR TITLE
Fix config dir on Windows

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"os/user"
 	"path"
 	"path/filepath"
 	"strings"
@@ -48,9 +49,16 @@ func run() error {
 	forceLocal := gnuflag.Bool("force-local", false, i18n.G("Force using the local unix socket"))
 	noAlias := gnuflag.Bool("no-alias", false, i18n.G("Ignore aliases when determining what command to run"))
 
-	configDir := "$HOME/.config/lxc"
+	var configDir string
 	if os.Getenv("LXD_CONF") != "" {
 		configDir = os.Getenv("LXD_CONF")
+	} else {
+		user, err := user.Current()
+		if err != nil {
+			return err
+		}
+
+		configDir = path.Join(user.HomeDir, ".config", "lxc")
 	}
 	configPath = os.ExpandEnv(path.Join(configDir, "config.yml"))
 

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -71,6 +71,14 @@ func (c *remoteCmd) flags() {
 }
 
 func (c *remoteCmd) generateClientCertificate(conf *config.Config) error {
+	// Create the config path if needed
+	if !shared.PathExists(conf.ConfigDir) {
+		err := os.MkdirAll(conf.ConfigDir, 0750)
+		if err != nil {
+			return fmt.Errorf(i18n.G("Could not create config dir"))
+		}
+	}
+
 	// Generate a client certificate if necessary.  The default repositories are
 	// either local or public, neither of which requires a client certificate.
 	// Generation of the cert is delayed to avoid unnecessary overhead, e.g in

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -299,7 +299,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -372,12 +372,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
@@ -400,7 +400,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -432,7 +432,12 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+#, fuzzy
+msgid "Could not create config dir"
+msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -508,12 +513,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 #, fuzzy
 msgid "Enable debug mode"
 msgstr "Aktiviert Debug Modus"
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 #, fuzzy
 msgid "Enable verbose mode"
 msgstr "Aktiviert ausführliche Ausgabe"
@@ -604,7 +609,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -612,7 +617,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -629,11 +634,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -663,7 +668,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -704,7 +709,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -773,12 +778,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -833,7 +838,7 @@ msgstr "Kein Fingerabdruck angegeben."
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -845,7 +850,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -865,11 +870,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -891,12 +896,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Path to an alternate server directory"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 #, fuzzy
 msgid "Pause containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -1015,7 +1020,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 #, fuzzy
 msgid "Restart containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1041,7 +1046,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -1049,11 +1054,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
@@ -1108,7 +1113,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 #, fuzzy
 msgid "Start containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1123,7 +1128,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 #, fuzzy
 msgid "Stop containers."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1257,7 +1262,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1292,7 +1297,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1304,7 +1309,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -2255,7 +2260,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -2273,11 +2278,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a source container name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2285,7 +2290,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -2301,12 +2306,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, fuzzy, c-format
 msgid "error: unknown command: %s"
 msgstr "Fehler: unbekannter Befehl: %s\n"
@@ -2315,12 +2320,12 @@ msgstr "Fehler: unbekannter Befehl: %s\n"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 #, fuzzy
 msgid "ok (y/n)?"
 msgstr "OK (y/n)? "
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2329,22 +2334,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2362,7 +2367,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr "falsche Anzahl an Parametern für Unterbefehl"
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -194,7 +194,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -266,12 +266,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -293,7 +293,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -324,7 +324,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -399,11 +403,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -491,7 +495,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -499,7 +503,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -515,11 +519,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -548,7 +552,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -588,7 +592,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -654,12 +658,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -711,7 +715,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -723,7 +727,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -743,11 +747,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -767,11 +771,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -887,7 +891,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -912,7 +916,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -920,11 +924,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -978,7 +982,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -992,7 +996,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1117,7 +1121,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1164,7 +1168,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1954,7 +1958,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1970,11 +1974,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1982,7 +1986,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1998,12 +2002,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2012,11 +2016,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2025,22 +2029,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2058,7 +2062,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -290,7 +290,7 @@ msgstr "ARCHITECTURE"
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -364,12 +364,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr "Impossible de fournir le nom du conteneur à lister"
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %x"
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr "Certificat client enregistré sur le serveur : "
 
@@ -391,7 +391,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr "Connexion refusée ; LXD est-il actif ?"
 
@@ -423,7 +423,12 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+#, fuzzy
+msgid "Could not create config dir"
+msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -498,11 +503,11 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr "Activer le mode de débogage"
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr "Activer le mode verbeux"
 
@@ -592,7 +597,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of stopped containers"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -600,7 +605,7 @@ msgstr "Forcer l'utilisation de la socket unix locale"
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -616,14 +621,14 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 #, fuzzy
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 "Si c'est la première fois que vous lancez LXD, vous devriez aussi lancer : "
 "sudo lxd init"
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr "Ignorer les alias pour déterminer la commande à exécuter"
 
@@ -654,7 +659,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -694,7 +699,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "Socket LXD introuvable ; LXD est-il installé et actif ?"
 
@@ -762,12 +767,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr "NON"
 
@@ -820,7 +825,7 @@ msgstr "Aucune empreinte n'a été indiquée."
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "Seul les volumes \"personnalisés\" peuvent être attaché aux conteneurs"
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -832,7 +837,7 @@ msgstr "Seul https:// est supporté par l'import d'images distantes."
 msgid "Only managed networks can be modified."
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr "Options :"
 
@@ -852,11 +857,11 @@ msgstr "PID"
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -876,12 +881,12 @@ msgstr "Chemin vers un dossier de configuration client alternatif"
 msgid "Path to an alternate server directory"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 #, fuzzy
 msgid "Pause containers."
 msgstr "Création du conteneur"
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr "Permission refusée, êtes-vous dans le groupe lxd ?"
 
@@ -998,7 +1003,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 #, fuzzy
 msgid "Restart containers."
 msgstr "Création du conteneur"
@@ -1024,7 +1029,7 @@ msgstr "SOURCE"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -1032,11 +1037,11 @@ msgstr "STATIQUE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
@@ -1091,7 +1096,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 #, fuzzy
 msgid "Start containers."
 msgstr "Création du conteneur"
@@ -1106,7 +1111,7 @@ msgstr "Démarrage de %s"
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 #, fuzzy
 msgid "Stop containers."
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1243,7 +1248,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
@@ -1279,7 +1284,7 @@ msgstr "Type : persistant"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr "URL"
 
@@ -1291,7 +1296,7 @@ msgstr "UTILISÉ PAR"
 msgid "Unable to find help2man."
 msgstr "Impossible de trouver help2man"
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr "Impossible de lire le certificat TLS distant"
 
@@ -2535,7 +2540,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr "OUI"
 
@@ -2553,13 +2558,13 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a source container name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 "La commande `lxc config profile` est dépréciée, merci d'utiliser `lxc "
 "profile`"
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
@@ -2567,7 +2572,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr "par défaut"
 
@@ -2583,12 +2588,12 @@ msgstr "désactivé"
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr "erreur : commande inconnue: %s"
@@ -2597,11 +2602,11 @@ msgstr "erreur : commande inconnue: %s"
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr "ok (y/n) ?"
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "l'analyse des alias a échoué %s\n"
@@ -2610,22 +2615,22 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr "l'édition récursive ne fait aucun sens :("
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -2643,7 +2648,7 @@ msgstr "sans suivi d'état"
 msgid "taken at %s"
 msgstr "pris à %s"
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-07-13 19:23+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -215,7 +215,7 @@ msgstr "ARCHITETTURA"
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Password amministratore per %s: "
@@ -286,12 +286,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr "Certificato del client salvato dal server: "
 
@@ -313,7 +313,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -344,7 +344,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -418,11 +422,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr "Abilita modalità verbosa"
 
@@ -510,7 +514,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -518,7 +522,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -534,11 +538,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -567,7 +571,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -607,7 +611,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -672,12 +676,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -728,7 +732,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -740,7 +744,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -784,11 +788,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -904,7 +908,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -929,7 +933,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -937,11 +941,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -995,7 +999,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -1009,7 +1013,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1134,7 +1138,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1169,7 +1173,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1181,7 +1185,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1971,7 +1975,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1987,11 +1991,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1999,7 +2003,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -2015,12 +2019,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2029,11 +2033,11 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "errore di processamento degli alias %s\n"
@@ -2042,22 +2046,22 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -2075,7 +2079,7 @@ msgstr "senza stato"
 msgid "taken at %s"
 msgstr "salvato alle %s"
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr "numero errato di argomenti del sottocomando"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-07-20 00:30+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -195,7 +195,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr "%s の管理者パスワード: "
@@ -268,12 +268,12 @@ msgstr "キー '%s' が指定されていないので削除できません。"
 msgid "Cannot provide container name to list"
 msgstr "コンテナ名を取得できません"
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr "クライアント証明書がサーバに格納されました: "
 
@@ -295,7 +295,7 @@ msgstr "新しいコンテナに適用するキー/値の設定"
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr "接続が拒否されました。LXDが実行されていますか?"
 
@@ -326,7 +326,12 @@ msgstr "コンテナをコピーします (スナップショットはコピー�
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+#, fuzzy
+msgid "Could not create config dir"
+msgstr "サーバ証明書格納用のディレクトリを作成できません"
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -400,11 +405,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr "デバッグモードを有効にします"
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr "詳細モードを有効にします"
 
@@ -493,7 +498,7 @@ msgstr "コンテナを強制シャットダウンします"
 msgid "Force the removal of stopped containers"
 msgstr "停止したコンテナを強制的に削除します"
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -501,7 +506,7 @@ msgstr "強制的にローカルのUNIXソケットを使います"
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -517,11 +522,11 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr "初めて LXD を使う場合、lxd init と実行する必要があります"
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr "どのコマンドを実行するか決める際にエイリアスを無視します"
 
@@ -550,7 +555,7 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -590,7 +595,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "LXD のソケットが見つかりません。LXD が実行されていますか?"
 
@@ -657,12 +662,12 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -713,7 +718,7 @@ msgstr "フィンガープリントが指定されていません。"
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチできます。"
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -725,7 +730,7 @@ msgstr "リモートイメージのインポートは https:// のみをサポ�
 msgid "Only managed networks can be modified."
 msgstr "管理対象のネットワークのみ変更できます。"
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr "オプション:"
 
@@ -745,11 +750,11 @@ msgstr "PID"
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -769,11 +774,11 @@ msgstr "別のクライアント用設定ディレクトリ"
 msgid "Path to an alternate server directory"
 msgstr "別のサーバ用設定ディレクトリ"
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr "コンテナを一時停止します。"
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr "アクセスが拒否されました。lxd グループに所属していますか?"
 
@@ -889,7 +894,7 @@ msgstr "ユーザの確認を要求する"
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr "コンテナを再起動します。"
 
@@ -914,7 +919,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -922,11 +927,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr "サーバが我々の証明書を追加した後我々を信頼していません"
 
@@ -980,7 +985,7 @@ msgstr "一部のコンテナで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr "コンテナを起動します。"
 
@@ -994,7 +999,7 @@ msgstr "%s を起動中"
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr "コンテナを停止します。"
 
@@ -1130,7 +1135,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 "初めてコンテナを起動するには、\"lxc launch ubuntu:16.04\" と実行してみてくだ"
@@ -1167,7 +1172,7 @@ msgstr "タイプ: persistent"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1179,7 +1184,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr "help2man が見つかりません。"
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr "リモートの TLS 証明書を読めません"
 
@@ -2616,7 +2621,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -2633,11 +2638,11 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a source container name"
 msgstr "コピー元のコンテナ名を指定してください"
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr "`lxc config profile` は廃止されました。`lxc profile` を使ってください"
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -2645,7 +2650,7 @@ msgstr "デフォルトのリモートは削除できません"
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -2663,12 +2668,12 @@ msgstr "無効"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr "エラー: 未知のコマンド: %s"
@@ -2677,11 +2682,11 @@ msgstr "エラー: 未知のコマンド: %s"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "エイリアスの処理が失敗しました %s\n"
@@ -2690,22 +2695,22 @@ msgstr "エイリアスの処理が失敗しました %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr "再帰的な edit は意味がありません :("
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -2723,7 +2728,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr "%s に取得しました"
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr "サブコマンドの引数の数が正しくありません"
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-07-21 14:25+0200\n"
+        "POT-Creation-Date: 2017-07-21 15:33+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -184,7 +184,7 @@ msgstr  ""
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -255,12 +255,12 @@ msgstr  ""
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -281,7 +281,7 @@ msgstr  ""
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid   "Connection refused; is LXD running?"
 msgstr  ""
 
@@ -312,7 +312,11 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid   "Could not create config dir"
+msgstr  ""
+
+#: lxc/remote.go:251
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -385,11 +389,11 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid   "Enable debug mode"
 msgstr  ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid   "Enable verbose mode"
 msgstr  ""
 
@@ -477,7 +481,7 @@ msgstr  ""
 msgid   "Force the removal of stopped containers"
 msgstr  ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -485,7 +489,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -501,11 +505,11 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid   "If this is your first time using LXD, you should also run: lxd init"
 msgstr  ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid   "Ignore aliases when determining what command to run"
 msgstr  ""
 
@@ -534,7 +538,7 @@ msgstr  ""
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -574,7 +578,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid   "LXD socket not found; is LXD installed and running?"
 msgstr  ""
 
@@ -639,11 +643,11 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406 lxc/storage.go:653 lxc/storage.go:748
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414 lxc/storage.go:653 lxc/storage.go:748
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid   "NO"
 msgstr  ""
 
@@ -694,7 +698,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to containers."
 msgstr  ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -706,7 +710,7 @@ msgstr  ""
 msgid   "Only managed networks can be modified."
 msgstr  ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid   "Options:"
 msgstr  ""
 
@@ -726,11 +730,11 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -750,11 +754,11 @@ msgstr  ""
 msgid   "Path to an alternate server directory"
 msgstr  ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid   "Pause containers."
 msgstr  ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid   "Permission denied, are you in the lxd group?"
 msgstr  ""
 
@@ -870,7 +874,7 @@ msgstr  ""
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid   "Restart containers."
 msgstr  ""
 
@@ -895,7 +899,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid   "STATIC"
 msgstr  ""
 
@@ -903,11 +907,11 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid   "Server doesn't trust us after adding our cert"
 msgstr  ""
 
@@ -961,7 +965,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid   "Start containers."
 msgstr  ""
 
@@ -975,7 +979,7 @@ msgstr  ""
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid   "Stop containers."
 msgstr  ""
 
@@ -1096,7 +1100,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
 
@@ -1131,7 +1135,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid   "URL"
 msgstr  ""
 
@@ -1143,7 +1147,7 @@ msgstr  ""
 msgid   "Unable to find help2man."
 msgstr  ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid   "Unable to read remote TLS certificate"
 msgstr  ""
 
@@ -1850,7 +1854,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid   "YES"
 msgstr  ""
 
@@ -1866,11 +1870,11 @@ msgstr  ""
 msgid   "You must specify a source container name"
 msgstr  ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid   "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr  ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid   "can't remove the default remote"
 msgstr  ""
 
@@ -1878,7 +1882,7 @@ msgstr  ""
 msgid   "can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid   "default"
 msgstr  ""
 
@@ -1894,12 +1898,12 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid   "error: unknown command: %s"
 msgstr  ""
@@ -1908,11 +1912,11 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -1921,22 +1925,22 @@ msgstr  ""
 msgid   "recursive edit doesn't make sense :("
 msgstr  ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid   "remote %s is static and cannot be modified"
 msgstr  ""
@@ -1954,7 +1958,7 @@ msgstr  ""
 msgid   "taken at %s"
 msgstr  ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: 2017-06-06 13:55+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -281,7 +281,7 @@ msgstr "АРХИТЕКТУРА"
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -353,12 +353,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr "Сертификат клиента хранится на сервере: "
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr "В соединении отказано; LXD запущен?"
 
@@ -411,7 +411,12 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+#, fuzzy
+msgid "Could not create config dir"
+msgstr "Не удалось создать каталог сертификата сервера"
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -486,11 +491,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -578,7 +583,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -586,7 +591,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -602,11 +607,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -635,7 +640,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -675,7 +680,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -741,12 +746,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -798,7 +803,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -810,7 +815,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -830,11 +835,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -854,11 +859,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -974,7 +979,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -999,7 +1004,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -1007,11 +1012,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -1065,7 +1070,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -1079,7 +1084,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1204,7 +1209,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1239,7 +1244,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1251,7 +1256,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -2049,7 +2054,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -2065,11 +2070,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2077,7 +2082,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -2093,12 +2098,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2107,11 +2112,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2120,22 +2125,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2153,7 +2158,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-21 14:25+0200\n"
+"POT-Creation-Date: 2017-07-21 15:33+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -191,7 +191,7 @@ msgstr ""
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/remote.go:281
+#: lxc/remote.go:289
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -262,12 +262,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:228
+#: lxc/remote.go:236
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:316
+#: lxc/remote.go:324
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -289,7 +289,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:35
+#: lxc/main.go:36
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -320,7 +320,11 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:243
+#: lxc/remote.go:78
+msgid "Could not create config dir"
+msgstr ""
+
+#: lxc/remote.go:251
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -394,11 +398,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:48
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:46
+#: lxc/main.go:47
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -486,7 +490,7 @@ msgstr ""
 msgid "Force the removal of stopped containers"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:49
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:81
+#: lxc/remote.go:89
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -510,11 +514,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:153
+#: lxc/main.go:161
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:50
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -543,7 +547,7 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
-#: lxc/remote.go:151
+#: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -583,7 +587,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:33
+#: lxc/main.go:34
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -648,12 +652,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:406
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:414
 #: lxc/storage.go:653 lxc/storage.go:748
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:490 lxc/remote.go:380 lxc/remote.go:385
+#: lxc/network.go:490 lxc/remote.go:388 lxc/remote.go:393
 msgid "NO"
 msgstr ""
 
@@ -704,7 +708,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:136
+#: lxc/remote.go:144
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -716,7 +720,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:120 lxc/main.go:177
+#: lxc/help.go:71 lxc/main.go:128 lxc/main.go:185
 msgid "Options:"
 msgstr ""
 
@@ -736,11 +740,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:408
+#: lxc/remote.go:416
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:230 lxc/remote.go:409
+#: lxc/image.go:230 lxc/remote.go:417
 msgid "PUBLIC"
 msgstr ""
 
@@ -760,11 +764,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:216
+#: lxc/main.go:224
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:37
+#: lxc/main.go:38
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -880,7 +884,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:224
+#: lxc/main.go:232
 msgid "Restart containers."
 msgstr ""
 
@@ -905,7 +909,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:410
+#: lxc/remote.go:418
 msgid "STATIC"
 msgstr ""
 
@@ -913,11 +917,11 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:236
+#: lxc/remote.go:244
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:313
+#: lxc/remote.go:321
 msgid "Server doesn't trust us after adding our cert"
 msgstr ""
 
@@ -971,7 +975,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:234
+#: lxc/main.go:242
 msgid "Start containers."
 msgstr ""
 
@@ -985,7 +989,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:240
+#: lxc/main.go:248
 msgid "Stop containers."
 msgstr ""
 
@@ -1110,7 +1114,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:154
+#: lxc/main.go:162
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1145,7 +1149,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:415
 msgid "URL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/remote.go:111
+#: lxc/remote.go:119
 msgid "Unable to read remote TLS certificate"
 msgstr ""
 
@@ -1947,7 +1951,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:492 lxc/remote.go:382 lxc/remote.go:387
+#: lxc/network.go:492 lxc/remote.go:390 lxc/remote.go:395
 msgid "YES"
 msgstr ""
 
@@ -1963,11 +1967,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:66
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:370
+#: lxc/remote.go:378
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -1975,7 +1979,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:396
+#: lxc/remote.go:404
 msgid "default"
 msgstr ""
 
@@ -1991,12 +1995,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:28 lxc/main.go:173
+#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:181
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:114
+#: lxc/help.go:37 lxc/main.go:122
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2005,11 +2009,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:229
+#: lxc/remote.go:237
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:345 lxc/main.go:349
+#: lxc/main.go:353 lxc/main.go:357
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2018,22 +2022,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:432
+#: lxc/remote.go:440
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:362 lxc/remote.go:424 lxc/remote.go:459 lxc/remote.go:475
+#: lxc/remote.go:370 lxc/remote.go:432 lxc/remote.go:467 lxc/remote.go:483
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:353
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:366 lxc/remote.go:428 lxc/remote.go:463
+#: lxc/remote.go:374 lxc/remote.go:436 lxc/remote.go:471
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2051,7 +2055,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:276
+#: lxc/main.go:284
 msgid "wrong number of subcommand arguments"
 msgstr ""
 


### PR DESCRIPTION
This fixes the config dir handling of LXD on Windows.

Before this, it'd fail if the config dir didn't exist AND defaulted to c:\.config\lxc as the default path, which is obviously wrong and unsuitable for unprivileged Windows users.

This solves it by moving things under the user's home directory and also creates the paths as needed.

This will require a manual fix for existing users. Moving c:\.config to c:\Users\USERNAME\.config but it's unlikely that we had very many functional users given that bug so it shouldn't end up being too painful a fix.

@techtonik FYI, as this is likely to affect you.