### PR TITLE
client: Add container template files operations

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -89,6 +89,12 @@ type ContainerServer interface {
 	GetContainerMetadata(name string) (*api.ImageMetadata, string, error)
 	SetContainerMetadata(name string, metadata api.ImageMetadata, ETag string) error
 
+	GetContainerTemplateFiles(containerName string) (templates []string, err error)
+	GetContainerTemplateFile(containerName string, templateName string) (content io.ReadCloser, err error)
+	CreateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) (err error)
+	UpdateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) (err error)
+	DeleteContainerTemplateFile(name string, templateName string) (err error)
+
 	// Event handling functions
 	GetEvents() (listener *EventListener, err error)
 

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1304,3 +1304,102 @@ func (r *ProtocolLXD) SetContainerMetadata(name string, metadata api.ImageMetada
 
 	return nil
 }
+
+// GetContainerTemplateFiles returns the list of names of template files for a container.
+func (r *ProtocolLXD) GetContainerTemplateFiles(containerName string) ([]string, error) {
+	if !r.HasExtension("container_edit_metadata") {
+		return nil, fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
+	}
+
+	templates := []string{}
+
+	url := fmt.Sprintf("/containers/%s/metadata/templates", containerName)
+	_, err := r.queryStruct("GET", url, nil, "", &templates)
+	if err != nil {
+		return nil, err
+	}
+
+	return templates, nil
+}
+
+// GetContainerTemplateFile returns the content of a template file for a container.
+func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateName string) (io.ReadCloser, error) {
+	if !r.HasExtension("container_edit_metadata") {
+		return nil, fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
+	}
+
+	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, containerName, templateName)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// Set the user agent
+	if r.httpUserAgent != "" {
+		req.Header.Set("User-Agent", r.httpUserAgent)
+	}
+
+	// Send the request
+	resp, err := r.http.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	// Check the return value for a cleaner error
+	if resp.StatusCode != http.StatusOK {
+		_, _, err := r.parseResponse(resp)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return resp.Body, err
+}
+
+// CreateContainerTemplateFile creates an a template for a container.
+func (r *ProtocolLXD) CreateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) error {
+	return r.setContainerTemplateFile(containerName, templateName, content, "POST")
+}
+
+// UpdateContainerTemplateFile updates the content for a container template file.
+func (r *ProtocolLXD) UpdateContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker) error {
+	return r.setContainerTemplateFile(containerName, templateName, content, "PUT")
+}
+
+func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateName string, content io.ReadSeeker, httpMethod string) error {
+	if !r.HasExtension("container_edit_metadata") {
+		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
+	}
+
+	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, containerName, templateName)
+	req, err := http.NewRequest(httpMethod, url, content)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	// Set the user agent
+	if r.httpUserAgent != "" {
+		req.Header.Set("User-Agent", r.httpUserAgent)
+	}
+
+	// Send the request
+	resp, err := r.http.Do(req)
+	// Check the return value for a cleaner error
+	if resp.StatusCode != http.StatusOK {
+		_, _, err := r.parseResponse(resp)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+// DeleteContainerTemplateFile deletes a template file for a container.
+func (r *ProtocolLXD) DeleteContainerTemplateFile(name string, templateName string) error {
+	if !r.HasExtension("container_edit_metadata") {
+		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
+	}
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/metadata/templates?path=%s", name, templateName), nil, "")
+	return err
+}

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -1268,7 +1268,7 @@ Return:
 * Operation: Sync
 * Return: the content of the template
 
-## POST (?path=\<template\>)
+### POST (?path=\<template\>)
 * Description: Add a continer template
 * Introduced: with API extension "container\_edit\_metadata"
 * Authentication: trusted

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -75,7 +75,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild\n"
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the configuration.\n"
@@ -114,7 +114,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
@@ -279,7 +279,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -304,22 +304,22 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Admin password for %s: "
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 #, fuzzy
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, fuzzy, c-format
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
@@ -332,7 +332,7 @@ msgstr "Bytes empfangen"
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -353,17 +353,17 @@ msgstr "ERSTELLT AM"
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -394,7 +394,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
@@ -431,7 +431,7 @@ msgstr "Kopiere Aliasse von der Quelle"
 msgid "Copy the container without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -449,7 +449,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -477,12 +477,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, fuzzy, c-format
 msgid "Device %s added to %s"
 msgstr "Gerät %s wurde zu %s hinzugefügt\n"
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, fuzzy, c-format
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
@@ -492,7 +492,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr " Prozessorauslastung:"
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -539,25 +539,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr "Flüchtiger Container"
 
+#: lxc/config.go:1381
+#, fuzzy, c-format
+msgid "Error updating template file: %s"
+msgstr "Fehler beim hinzufügen des Alias %s\n"
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -595,7 +604,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, fuzzy, c-format
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
@@ -634,7 +643,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -651,24 +660,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -677,7 +686,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
@@ -717,12 +726,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -773,7 +782,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -819,7 +828,7 @@ msgstr "Profil %s erstellt\n"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 #, fuzzy
 msgid "No certificate provided to add"
 msgstr "Kein Zertifikat zum hinzufügen bereitgestellt"
@@ -834,7 +843,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No device found for this storage volume."
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr "Kein Fingerabdruck angegeben."
 
@@ -846,7 +855,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -918,7 +927,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -974,7 +984,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 #, fuzzy
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
@@ -983,7 +993,7 @@ msgstr "Eigenschaften:\n"
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, fuzzy, c-format
 msgid "Public: %s"
 msgstr "Öffentlich: %s\n"
@@ -992,7 +1002,7 @@ msgstr "Öffentlich: %s\n"
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -1095,11 +1105,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, fuzzy, c-format
 msgid "Size: %.2fMB"
 msgstr "Größe: %.2vMB\n"
@@ -1113,7 +1123,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1206,13 +1216,13 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 #, fuzzy
 msgid "The device already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 #, fuzzy
 msgid "The device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -1253,7 +1263,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "Wartezeit bevor der Container gestoppt wird."
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 #, fuzzy
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
@@ -1279,7 +1289,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1322,7 +1332,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1345,7 +1355,7 @@ msgstr ""
 "Benutzung: lxc [Unterbefehl] [Optionen]\n"
 "Verfügbare Befehle:\n"
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 #, fuzzy
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
@@ -1378,6 +1388,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -2302,11 +2331,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2320,7 +2349,7 @@ msgstr "Fehler: %v\n"
 msgid "error: unknown command: %s"
 msgstr "Fehler: unbekannter Befehl: %s\n"
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2375,7 +2404,7 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr "falsche Anzahl an Parametern für Unterbefehl"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""
 
@@ -2459,10 +2488,6 @@ msgstr ""
 #~ "Erstellt einen schreibgeschützten Sicherungspunkt des Containers.\n"
 #~ "\n"
 #~ "lxc snapshot <Quelle> <Sicherungspunkt> [--stateful]\n"
-
-#, fuzzy
-#~ msgid "Error adding alias %s"
-#~ msgstr "Fehler beim hinzufügen des Alias %s\n"
 
 #, fuzzy
 #~ msgid ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -174,7 +174,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -199,21 +199,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -226,7 +226,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -247,17 +247,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -287,7 +287,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -323,7 +323,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -354,7 +354,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -367,12 +367,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -382,7 +382,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -403,7 +403,7 @@ msgstr "  Χρήση CPU:"
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -427,25 +427,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -482,7 +491,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -519,7 +528,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -535,24 +544,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -561,7 +570,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -600,12 +609,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -654,7 +663,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -699,7 +708,7 @@ msgstr "  Χρήση δικτύου:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -711,7 +720,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -723,7 +732,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -792,7 +801,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -847,7 +857,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -855,7 +865,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -864,7 +874,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -964,11 +974,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -982,7 +992,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1071,12 +1081,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1113,7 +1123,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1138,7 +1148,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1181,7 +1191,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1198,7 +1208,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1230,6 +1240,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1998,11 +2027,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2016,7 +2045,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2070,6 +2099,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -71,7 +71,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -109,7 +109,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
@@ -269,7 +269,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -295,21 +295,21 @@ msgstr "Accepter le certificat"
 msgid "Admin password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -322,7 +322,7 @@ msgstr "Octets reçus"
 msgid "Bytes sent"
 msgstr "Octets émis"
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
@@ -343,18 +343,18 @@ msgstr "CRÉÉ À"
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -385,7 +385,7 @@ msgstr "Commandes:"
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -422,7 +422,7 @@ msgstr "Copier les alias depuis la source"
 msgid "Copy the container without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
@@ -440,7 +440,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -454,7 +454,7 @@ msgstr "Création de %s"
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -467,12 +467,12 @@ msgstr "PILOTE"
 msgid "Define a compression algorithm: for image or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr "Périphérique %s ajouté à %s"
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
@@ -482,7 +482,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -503,7 +503,7 @@ msgstr "  Disque utilisé :"
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
@@ -527,25 +527,35 @@ msgstr "Environnement :"
 msgid "Ephemeral container"
 msgstr "Conteneur éphémère"
 
+#: lxc/config.go:1381
+#, fuzzy, c-format
+msgid "Error updating template file: %s"
+msgstr "Import de l'image : %s"
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr "Expire : %s"
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+#, fuzzy
+msgid "FILENAME"
+msgstr "NOM"
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -584,7 +594,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
@@ -621,7 +631,7 @@ msgstr "IPv4"
 msgid "IPV6"
 msgstr "IPv6"
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
@@ -640,25 +650,25 @@ msgstr "Ignorer les alias pour déterminer la commande à exécuter"
 msgid "Ignore the container state (only for start)"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -668,7 +678,7 @@ msgstr "Image copiée avec succès !"
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
@@ -707,12 +717,12 @@ msgstr "DERNIÈRE UTILISATION À"
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "Socket LXD introuvable ; LXD est-il installé et actif ?"
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr "Dernière utilisation : %s"
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
@@ -763,7 +773,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -808,7 +818,7 @@ msgstr "  Réseau utilisé :"
 msgid "New alias to define at target"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr "Un certificat à ajouter n'a pas été fourni"
 
@@ -821,7 +831,7 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No device found for this storage volume."
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr "Aucune empreinte n'a été indiquée."
 
@@ -833,7 +843,7 @@ msgstr "Seul les volumes \"personnalisés\" peuvent être attaché aux conteneur
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
@@ -903,7 +913,8 @@ msgstr "Pid : %d"
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
@@ -958,7 +969,7 @@ msgstr "Profils %s appliqués à %s"
 msgid "Profiles: %s"
 msgstr "Profils : %s"
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr "Propriétés :"
 
@@ -966,7 +977,7 @@ msgstr "Propriétés :"
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr "Public : %s"
@@ -975,7 +986,7 @@ msgstr "Public : %s"
 msgid "Recursively push or pull files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -1078,11 +1089,11 @@ msgstr "Afficher la version du client"
 msgid "Show the container's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "Taille : %.2f Mo"
@@ -1096,7 +1107,7 @@ msgstr "Instantanés :"
 msgid "Some containers failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr "Source :"
 
@@ -1191,13 +1202,13 @@ msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 #, fuzzy
 msgid "The device already exists"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
@@ -1240,7 +1251,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
@@ -1266,7 +1277,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
@@ -1309,7 +1320,7 @@ msgstr "Impossible de lire le certificat TLS distant"
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
@@ -1329,7 +1340,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr "Utilisation : lxc <commande> [options]"
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 #, fuzzy
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
@@ -1362,6 +1373,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -2584,11 +2614,11 @@ msgstr "par défaut"
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr "activé"
 
@@ -2602,7 +2632,7 @@ msgstr "erreur : %v"
 msgid "error: unknown command: %s"
 msgstr "erreur : commande inconnue: %s"
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr "non"
 
@@ -2656,7 +2686,7 @@ msgstr "pris à %s"
 msgid "wrong number of subcommand arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr "oui"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-07-13 19:23+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -85,7 +85,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -220,21 +220,21 @@ msgstr "Accetta certificato"
 msgid "Admin password for %s: "
 msgstr "Password amministratore per %s: "
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
@@ -247,7 +247,7 @@ msgstr "Bytes ricevuti"
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
@@ -267,17 +267,17 @@ msgstr "CREATO IL"
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -307,7 +307,7 @@ msgstr "Comandi:"
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -343,7 +343,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -374,7 +374,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -387,12 +387,12 @@ msgstr "DRIVER"
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -402,7 +402,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -422,7 +422,7 @@ msgstr "Utilizzo disco:"
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
@@ -446,25 +446,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -501,7 +510,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -538,7 +547,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -554,24 +563,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -580,7 +589,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -619,12 +628,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -672,7 +681,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -728,7 +737,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -740,7 +749,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -809,7 +818,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -864,7 +874,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -872,7 +882,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -881,7 +891,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -981,11 +991,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -999,7 +1009,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1088,12 +1098,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr "La periferica esiste già"
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1130,7 +1140,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1155,7 +1165,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1198,7 +1208,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1215,7 +1225,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1247,6 +1257,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -2015,11 +2044,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2033,7 +2062,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr "no"
 
@@ -2087,7 +2116,7 @@ msgstr "salvato alle %s"
 msgid "wrong number of subcommand arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-07-20 00:30+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -71,7 +71,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgstr "'/' はスナップショットの名前には使用できません"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -200,21 +200,21 @@ msgstr "証明書を受け入れます"
 msgid "Admin password for %s: "
 msgstr "%s の管理者パスワード: "
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
@@ -227,7 +227,7 @@ msgstr "受信バイト数"
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -249,17 +249,17 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が指定されていないので削除できません。"
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr "キー '%s' が指定されていないので削除できません。"
@@ -289,7 +289,7 @@ msgstr "コマンド:"
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -325,7 +325,7 @@ msgstr "ソースからエイリアスをコピーしました"
 msgid "Copy the container without its snapshots"
 msgstr "コンテナをコピーします (スナップショットはコピーしません)"
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
@@ -343,7 +343,7 @@ msgstr "サーバ証明書格納用のディレクトリを作成できません
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -357,7 +357,7 @@ msgstr "%s を作成中"
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -370,12 +370,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr "圧縮アルゴリズムを指定します: 圧縮アルゴリズム名 or none"
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr "デバイス %s が %s に追加されました"
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
@@ -385,7 +385,7 @@ msgstr "デバイス %s が %s から削除されました"
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -405,7 +405,7 @@ msgstr "ディスク使用量:"
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -429,25 +429,34 @@ msgstr "環境変数:"
 msgid "Ephemeral container"
 msgstr "Ephemeral コンテナ"
 
+#: lxc/config.go:1381
+#, fuzzy, c-format
+msgid "Error updating template file: %s"
+msgstr "イメージのエクスポート中: %s"
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr "失効日時: %s"
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -485,7 +494,7 @@ msgstr "パス %s にアクセスできませんでした: %s"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
@@ -522,7 +531,7 @@ msgstr "IPV4"
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -538,24 +547,24 @@ msgstr "どのコマンドを実行するか決める際にエイリアスを無
 msgid "Ignore the container state (only for start)"
 msgstr "コンテナの状態を無視します (startのみ)"
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -564,7 +573,7 @@ msgstr "イメージの更新が成功しました!"
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
@@ -603,12 +612,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "LXD のソケットが見つかりません。LXD が実行されていますか?"
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr "最終使用: %s"
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
@@ -658,7 +667,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "コンテナを移動します (スナップショットは移動しません)"
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -702,7 +711,7 @@ msgstr "ネットワーク使用状況:"
 msgid "New alias to define at target"
 msgstr "新しいエイリアスを定義する"
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr "追加すべき証明書が提供されていません"
 
@@ -714,7 +723,7 @@ msgstr "このネットワークに対するデバイスがありません"
 msgid "No device found for this storage volume."
 msgstr "このストレージボリュームに対するデバイスがありません。"
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr "フィンガープリントが指定されていません。"
 
@@ -726,7 +735,7 @@ msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチ�
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr "リモートイメージのインポートは https:// のみをサポートします。"
 
@@ -795,7 +804,8 @@ msgstr "Pid: %d"
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
 
@@ -850,7 +860,7 @@ msgstr "プロファイル %s が %s に追加されました"
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr "プロパティ:"
 
@@ -858,7 +868,7 @@ msgstr "プロパティ:"
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr "パブリック: %s"
@@ -867,7 +877,7 @@ msgstr "パブリック: %s"
 msgid "Recursively push or pull files"
 msgstr "再帰的にファイルをpush/pullします"
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -967,11 +977,11 @@ msgstr "クライアントのバージョンを表示します"
 msgid "Show the container's last 100 log lines?"
 msgstr "コンテナログの最後の 100 行を表示しますか?"
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "サイズ: %.2fMB"
@@ -985,7 +995,7 @@ msgstr "スナップショット:"
 msgid "Some containers failed to %s"
 msgstr "一部のコンテナで %s が失敗しました"
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr "取得元:"
 
@@ -1076,12 +1086,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたコンテナに接続されているネットワークがありません。"
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr "デバイスはすでに存在します"
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr "デバイスが存在しません"
 
@@ -1125,7 +1135,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr "コンテナを強制停止するまでの時間"
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
@@ -1154,7 +1164,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transferring container: %s"
 msgstr "コンテナを転送中: %s"
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
@@ -1197,7 +1207,7 @@ msgstr "リモートの TLS 証明書を読めません"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
@@ -1217,7 +1227,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr "使い方: lxc <コマンド> [オプション]"
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 #, fuzzy
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
@@ -1250,6 +1260,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -2664,11 +2693,11 @@ msgstr ""
 "サーバから変更されたイメージ、コンテナ、スナップショットを取得できませんで\n"
 "した"
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr "有効"
 
@@ -2682,7 +2711,7 @@ msgstr "エラー: %v"
 msgid "error: unknown command: %s"
 msgstr "エラー: 未知のコマンド: %s"
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2736,7 +2765,7 @@ msgstr "%s に取得しました"
 msgid "wrong number of subcommand arguments"
 msgstr "サブコマンドの引数の数が正しくありません"
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-07-22 20:08+0200\n"
+        "POT-Creation-Date: 2017-07-25 09:22+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgid   "### This is a yaml representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid   "### This is a yaml representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -65,7 +65,7 @@ msgid   "### This is a yaml representation of the configuration.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid   "### This is a yaml representation of the container metadata.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -164,7 +164,7 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid   "ALIAS"
 msgstr  ""
 
@@ -189,21 +189,21 @@ msgstr  ""
 msgid   "Admin password for %s: "
 msgstr  ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid   "Bad property: %s"
 msgstr  ""
@@ -216,7 +216,7 @@ msgstr  ""
 msgid   "Bytes sent"
 msgstr  ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid   "COMMON NAME"
 msgstr  ""
 
@@ -236,17 +236,17 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
@@ -276,7 +276,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -311,7 +311,7 @@ msgstr  ""
 msgid   "Copy the container without its snapshots"
 msgstr  ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid   "Copying the image: %s"
 msgstr  ""
@@ -328,7 +328,7 @@ msgstr  ""
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -342,7 +342,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:654 lxc/storage.go:749
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -354,12 +354,12 @@ msgstr  ""
 msgid   "Define a compression algorithm: for image or none"
 msgstr  ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid   "Device %s added to %s"
 msgstr  ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid   "Device %s removed from %s"
 msgstr  ""
@@ -369,7 +369,7 @@ msgstr  ""
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -389,7 +389,7 @@ msgstr  ""
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -413,25 +413,34 @@ msgstr  ""
 msgid   "Ephemeral container"
 msgstr  ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid   "Error updating template file: %s"
+msgstr  ""
+
 #: lxc/monitor.go:56
 msgid   "Event type to listen for"
 msgstr  ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid   "Expires: %s"
 msgstr  ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid   "FILENAME"
+msgstr  ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -468,7 +477,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid   "Fingerprint: %s"
 msgstr  ""
@@ -505,7 +514,7 @@ msgstr  ""
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid   "ISSUE DATE"
 msgstr  ""
 
@@ -521,24 +530,24 @@ msgstr  ""
 msgid   "Ignore the container state (only for start)"
 msgstr  ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid   "Image already up to date."
 msgstr  ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -547,7 +556,7 @@ msgstr  ""
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid   "Invalid certificate"
 msgstr  ""
 
@@ -586,12 +595,12 @@ msgstr  ""
 msgid   "LXD socket not found; is LXD installed and running?"
 msgstr  ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid   "Last used: %s"
 msgstr  ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid   "Last used: never"
 msgstr  ""
 
@@ -639,7 +648,7 @@ msgstr  ""
 msgid   "Move the container without its snapshots"
 msgstr  ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -682,7 +691,7 @@ msgstr  ""
 msgid   "New alias to define at target"
 msgstr  ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid   "No certificate provided to add"
 msgstr  ""
 
@@ -694,7 +703,7 @@ msgstr  ""
 msgid   "No device found for this storage volume."
 msgstr  ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid   "No fingerprint specified."
 msgstr  ""
 
@@ -706,7 +715,7 @@ msgstr  ""
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid   "Only https:// is supported for remote image import."
 msgstr  ""
 
@@ -775,7 +784,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382 lxc/image.go:1145
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -830,7 +839,7 @@ msgstr  ""
 msgid   "Profiles: %s"
 msgstr  ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid   "Properties:"
 msgstr  ""
 
@@ -838,7 +847,7 @@ msgstr  ""
 msgid   "Public image server"
 msgstr  ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid   "Public: %s"
 msgstr  ""
@@ -847,7 +856,7 @@ msgstr  ""
 msgid   "Recursively push or pull files"
 msgstr  ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -947,11 +956,11 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
@@ -965,7 +974,7 @@ msgstr  ""
 msgid   "Some containers failed to %s"
 msgstr  ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid   "Source:"
 msgstr  ""
 
@@ -1052,11 +1061,11 @@ msgstr  ""
 msgid   "The container you are starting doesn't have any network attached to it."
 msgstr  ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid   "The device already exists"
 msgstr  ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966 lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068 lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid   "The device doesn't exist"
 msgstr  ""
 
@@ -1092,7 +1101,7 @@ msgstr  ""
 msgid   "Time to wait for the container before killing it"
 msgstr  ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid   "Timestamps:"
 msgstr  ""
 
@@ -1117,7 +1126,7 @@ msgstr  ""
 msgid   "Transferring container: %s"
 msgstr  ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
@@ -1160,7 +1169,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid   "Uploaded: %s"
 msgstr  ""
@@ -1176,7 +1185,7 @@ msgstr  ""
 msgid   "Usage: lxc <command> [options]"
 msgstr  ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid   "Usage: lxc config <subcommand> [options]\n"
         "\n"
         "Change container or server configuration options.\n"
@@ -1205,6 +1214,24 @@ msgid   "Usage: lxc config <subcommand> [options]\n"
         "\n"
         "lxc config metadata edit [<remote>:][container]\n"
         "    Edit the container metadata.yaml, either by launching external editor or reading STDIN.\n"
+        "\n"
+        "*Container templates*\n"
+        "\n"
+        "lxc config template list [<remote>:][container]\n"
+        "    List the names of template files for a container.\n"
+        "\n"
+        "lxc config template show [<remote>:][container] [template]\n"
+        "    Show the content of a template file for a container.\n"
+        "\n"
+        "lxc config template create [<remote>:][container] [template]\n"
+        "    Add an empty template file for a container.\n"
+        "\n"
+        "lxc config template edit [<remote>:][container] [template]\n"
+        "    Edit the content of a template file for a container, either by launching external editor or reading STDIN.\n"
+        "\n"
+        "lxc config template delete [<remote>:][container] [template]\n"
+        "    Delete a template file for a container.\n"
+        "\n"
         "\n"
         "*Device management*\n"
         "\n"
@@ -1894,11 +1921,11 @@ msgstr  ""
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid   "enabled"
 msgstr  ""
 
@@ -1912,7 +1939,7 @@ msgstr  ""
 msgid   "error: unknown command: %s"
 msgstr  ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid   "no"
 msgstr  ""
 
@@ -1966,7 +1993,7 @@ msgstr  ""
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid   "yes"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: 2017-06-06 13:55+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -68,7 +68,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -106,7 +106,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
@@ -260,7 +260,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -286,21 +286,21 @@ msgstr "Принять сертификат"
 msgid "Admin password for %s: "
 msgstr "Пароль администратора для %s: "
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -313,7 +313,7 @@ msgstr "Получено байтов"
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
@@ -334,17 +334,17 @@ msgstr "СОЗДАН"
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -374,7 +374,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -410,7 +410,7 @@ msgstr "Копировать псевдонимы из источника"
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
@@ -428,7 +428,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -442,7 +442,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -455,12 +455,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgstr " Использование диска:"
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -515,25 +515,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, fuzzy, c-format
+msgid "Error updating template file: %s"
+msgstr "Копирование образа: %s"
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -570,7 +579,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -607,7 +616,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -623,24 +632,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -649,7 +658,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -688,12 +697,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -742,7 +751,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -787,7 +796,7 @@ msgstr " Использование сети:"
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -799,7 +808,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -811,7 +820,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -880,7 +889,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -935,7 +945,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -943,7 +953,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -952,7 +962,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -1052,11 +1062,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -1070,7 +1080,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1159,12 +1169,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1201,7 +1211,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1226,7 +1236,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1269,7 +1279,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1289,7 +1299,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1321,6 +1331,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -2094,11 +2123,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2112,7 +2141,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2166,7 +2195,7 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr "да"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-22 20:08+0200\n"
+"POT-Creation-Date: 2017-07-25 09:22+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:39
+#: lxc/config.go:40
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -68,7 +68,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/config.go:60
+#: lxc/config.go:61
 msgid ""
 "### This is a yaml representation of the container metadata.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1084
+#: lxc/image.go:227 lxc/image.go:1089
 msgid "ALIAS"
 msgstr ""
 
@@ -196,21 +196,21 @@ msgstr ""
 msgid "Admin password for %s: "
 msgstr ""
 
-#: lxc/image.go:588
+#: lxc/image.go:593
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:566 lxc/info.go:104
+#: lxc/image.go:571 lxc/info.go:104
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
 
-#: lxc/image.go:596
+#: lxc/image.go:601
 #, c-format
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/image.go:670
+#: lxc/image.go:675
 #, c-format
 msgid "Bad property: %s"
 msgstr ""
@@ -223,7 +223,7 @@ msgstr ""
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/config.go:381
+#: lxc/config.go:400
 msgid "COMMON NAME"
 msgstr ""
 
@@ -243,17 +243,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:188 lxc/network.go:542
+#: lxc/config.go:207 lxc/network.go:542
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/config.go:201
+#: lxc/config.go:220
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/config.go:243 lxc/config.go:269
+#: lxc/config.go:262 lxc/config.go:288
 #, c-format
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:714 lxc/config.go:779 lxc/config.go:1229 lxc/image.go:1139
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1144
 #: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
 #, c-format
 msgid "Config parsing error: %s"
@@ -319,7 +319,7 @@ msgstr ""
 msgid "Copy the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:425
+#: lxc/image.go:430
 #, c-format
 msgid "Copying the image: %s"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:571 lxc/info.go:106
+#: lxc/image.go:576 lxc/info.go:106
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -350,7 +350,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1086 lxc/list.go:463 lxc/network.go:507
+#: lxc/image.go:231 lxc/image.go:1091 lxc/list.go:463 lxc/network.go:507
 #: lxc/storage.go:654 lxc/storage.go:749
 msgid "DESCRIPTION"
 msgstr ""
@@ -363,12 +363,12 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/config.go:870
+#: lxc/config.go:972
 #, c-format
 msgid "Device %s added to %s"
 msgstr ""
 
-#: lxc/config.go:1106
+#: lxc/config.go:1208
 #, c-format
 msgid "Device %s removed from %s"
 msgstr ""
@@ -378,7 +378,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1238
+#: lxc/image.go:1243
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config.go:383
+#: lxc/config.go:402
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -422,25 +422,34 @@ msgstr ""
 msgid "Ephemeral container"
 msgstr ""
 
+#: lxc/config.go:1381
+#, c-format
+msgid "Error updating template file: %s"
+msgstr ""
+
 #: lxc/monitor.go:56
 msgid "Event type to listen for"
 msgstr ""
 
-#: lxc/image.go:575
+#: lxc/image.go:580
 #, c-format
 msgid "Expires: %s"
 msgstr ""
 
-#: lxc/image.go:577
+#: lxc/image.go:582
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:880
+#: lxc/image.go:885
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config.go:380 lxc/image.go:229 lxc/image.go:1085
+#: lxc/config.go:756
+msgid "FILENAME"
+msgstr ""
+
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1090
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -477,7 +486,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/image.go:564
+#: lxc/image.go:569
 #, c-format
 msgid "Fingerprint: %s"
 msgstr ""
@@ -514,7 +523,7 @@ msgstr ""
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config.go:382
+#: lxc/config.go:401
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -530,24 +539,24 @@ msgstr ""
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
-#: lxc/image.go:527
+#: lxc/image.go:532
 msgid "Image already up to date."
 msgstr ""
 
-#: lxc/image.go:439
+#: lxc/image.go:444
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:930
+#: lxc/image.go:935
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:737
+#: lxc/image.go:742
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:525
+#: lxc/image.go:530
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -556,7 +565,7 @@ msgstr ""
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config.go:361
+#: lxc/config.go:380
 msgid "Invalid certificate"
 msgstr ""
 
@@ -595,12 +604,12 @@ msgstr ""
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
-#: lxc/image.go:580
+#: lxc/image.go:585
 #, c-format
 msgid "Last used: %s"
 msgstr ""
 
-#: lxc/image.go:582
+#: lxc/image.go:587
 msgid "Last used: never"
 msgstr ""
 
@@ -648,7 +657,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1240
+#: lxc/image.go:1245
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -692,7 +701,7 @@ msgstr ""
 msgid "New alias to define at target"
 msgstr ""
 
-#: lxc/config.go:392
+#: lxc/config.go:411
 msgid "No certificate provided to add"
 msgstr ""
 
@@ -704,7 +713,7 @@ msgstr ""
 msgid "No device found for this storage volume."
 msgstr ""
 
-#: lxc/config.go:424
+#: lxc/config.go:443
 msgid "No fingerprint specified."
 msgstr ""
 
@@ -716,7 +725,7 @@ msgstr ""
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
-#: lxc/image.go:651
+#: lxc/image.go:656
 msgid "Only https:// is supported for remote image import."
 msgstr ""
 
@@ -785,7 +794,8 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:715 lxc/config.go:780 lxc/config.go:1230 lxc/image.go:1140
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
+#: lxc/image.go:1145
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -840,7 +850,7 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/image.go:584
+#: lxc/image.go:589
 msgid "Properties:"
 msgstr ""
 
@@ -848,7 +858,7 @@ msgstr ""
 msgid "Public image server"
 msgstr ""
 
-#: lxc/image.go:567
+#: lxc/image.go:572
 #, c-format
 msgid "Public: %s"
 msgstr ""
@@ -857,7 +867,7 @@ msgstr ""
 msgid "Recursively push or pull files"
 msgstr ""
 
-#: lxc/image.go:505
+#: lxc/image.go:510
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -957,11 +967,11 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/config.go:35
+#: lxc/config.go:36
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/image.go:565
+#: lxc/image.go:570
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
@@ -975,7 +985,7 @@ msgstr ""
 msgid "Some containers failed to %s"
 msgstr ""
 
-#: lxc/image.go:598
+#: lxc/image.go:603
 msgid "Source:"
 msgstr ""
 
@@ -1064,12 +1074,12 @@ msgstr ""
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
-#: lxc/config.go:837 lxc/config.go:854
+#: lxc/config.go:939 lxc/config.go:956
 msgid "The device already exists"
 msgstr ""
 
-#: lxc/config.go:900 lxc/config.go:912 lxc/config.go:948 lxc/config.go:966
-#: lxc/config.go:1012 lxc/config.go:1029 lxc/config.go:1072 lxc/config.go:1090
+#: lxc/config.go:1002 lxc/config.go:1014 lxc/config.go:1050 lxc/config.go:1068
+#: lxc/config.go:1114 lxc/config.go:1131 lxc/config.go:1174 lxc/config.go:1192
 msgid "The device doesn't exist"
 msgstr ""
 
@@ -1106,7 +1116,7 @@ msgstr ""
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
-#: lxc/image.go:568
+#: lxc/image.go:573
 msgid "Timestamps:"
 msgstr ""
 
@@ -1131,7 +1141,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:676
+#: lxc/image.go:681
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1174,7 +1184,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/image.go:573
+#: lxc/image.go:578
 #, c-format
 msgid "Uploaded: %s"
 msgstr ""
@@ -1191,7 +1201,7 @@ msgstr ""
 msgid "Usage: lxc <command> [options]"
 msgstr ""
 
-#: lxc/config.go:84
+#: lxc/config.go:85
 msgid ""
 "Usage: lxc config <subcommand> [options]\n"
 "\n"
@@ -1223,6 +1233,25 @@ msgid ""
 "lxc config metadata edit [<remote>:][container]\n"
 "    Edit the container metadata.yaml, either by launching external editor or "
 "reading STDIN.\n"
+"\n"
+"*Container templates*\n"
+"\n"
+"lxc config template list [<remote>:][container]\n"
+"    List the names of template files for a container.\n"
+"\n"
+"lxc config template show [<remote>:][container] [template]\n"
+"    Show the content of a template file for a container.\n"
+"\n"
+"lxc config template create [<remote>:][container] [template]\n"
+"    Add an empty template file for a container.\n"
+"\n"
+"lxc config template edit [<remote>:][container] [template]\n"
+"    Edit the content of a template file for a container, either by launching "
+"external editor or reading STDIN.\n"
+"\n"
+"lxc config template delete [<remote>:][container] [template]\n"
+"    Delete a template file for a container.\n"
+"\n"
 "\n"
 "*Device management*\n"
 "\n"
@@ -1991,11 +2020,11 @@ msgstr ""
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 
-#: lxc/image.go:559
+#: lxc/image.go:564
 msgid "disabled"
 msgstr ""
 
-#: lxc/image.go:561
+#: lxc/image.go:566
 msgid "enabled"
 msgstr ""
 
@@ -2009,7 +2038,7 @@ msgstr ""
 msgid "error: unknown command: %s"
 msgstr ""
 
-#: lxc/image.go:206 lxc/image.go:554
+#: lxc/image.go:206 lxc/image.go:559
 msgid "no"
 msgstr ""
 
@@ -2063,6 +2092,6 @@ msgstr ""
 msgid "wrong number of subcommand arguments"
 msgstr ""
 
-#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:556
+#: lxc/delete.go:45 lxc/image.go:204 lxc/image.go:561
 msgid "yes"
 msgstr ""

--- a/test/suites/config.sh
+++ b/test/suites/config.sh
@@ -273,18 +273,22 @@ test_container_metadata() {
     lxc config metadata show c | grep -q BB
 
     # templates can be listed
-    curl -s --unix-socket "${LXD_DIR}/unix.socket" lxd/1.0/containers/c/metadata/templates | grep -q template.tpl
+    lxc config template list c | grep -q template.tpl
 
     # template content can be returned
-    curl -s --unix-socket "${LXD_DIR}/unix.socket" "lxd/1.0/containers/c/metadata/templates?path=template.tpl" | grep -q "name:"
+    lxc config template show c template.tpl | grep -q "name:"
 
     # templates can be added
-    curl -s --unix-socket "${LXD_DIR}/unix.socket" "lxd/1.0/containers/c/metadata/templates?path=my.tpl" -H 'Content-type: application/octet-stream' -d "some content"
-    curl -s --unix-socket "${LXD_DIR}/unix.socket" "lxd/1.0/containers/c/metadata/templates?path=my.tpl" | grep -q "some content"
+    lxc config template create c my.tpl
+    lxc config template list c | grep -q my.tpl
+
+    # template content can be updated
+    echo "some content" | lxc config template edit c my.tpl
+    lxc config template show c my.tpl | grep -q "some content"
     
     # templates can be removed
-    curl -s --unix-socket "${LXD_DIR}/unix.socket" "lxd/1.0/containers/c/metadata/templates?path=my.tpl" -X DELETE
-    ! (curl -s --unix-socket "${LXD_DIR}/unix.socket" lxd/1.0/containers/c/metadata/templates | grep -q my.tpl)
+    lxc config template delete c my.tpl
+    ! (lxc config template list c | grep -q my.tpl)
 
     lxc delete c
 }


### PR DESCRIPTION
Add a new `lxc config template <op>` section to the CLI to perform operations related to template files.