### PR TITLE
Implement instance types as proxy for limits

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -318,3 +318,7 @@ This adds a ceph storage driver.
 
 ## storage\_ceph\_user\_name
 This adds the ability to specify the ceph user.
+
+## instance\_types
+This adds the "instance\_type" field to the container creation request.
+Its value is expanded to LXD resource limits.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -423,6 +423,7 @@ Input (container based on a local image with the "ubuntu/devel" alias):
                 "type": "unix-char"
             },
         },
+        "instance_type": "c2.micro",                                        # An optional instance type to use as basis for limits
         "source": {"type": "image",                                         # Can be: "image", "migration", "copy" or "none"
                    "alias": "ubuntu/devel"},                                # Name of the alias
     }

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -61,11 +61,12 @@ func (f *profileList) Set(value string) error {
 var initRequestedEmptyProfiles bool
 
 type initCmd struct {
-	profArgs    profileList
-	confArgs    configList
-	ephem       bool
-	network     string
-	storagePool string
+	profArgs     profileList
+	confArgs     configList
+	ephem        bool
+	network      string
+	storagePool  string
+	instanceType string
 }
 
 func (c *initCmd) showByDefault() bool {
@@ -74,7 +75,7 @@ func (c *initCmd) showByDefault() bool {
 
 func (c *initCmd) usage() string {
 	return i18n.G(
-		`Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]
+		`Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>] [--type|-t <instance type>]
 
 Create containers from images.
 
@@ -143,6 +144,7 @@ func (c *initCmd) flags() {
 	gnuflag.StringVar(&c.network, "n", "", i18n.G("Network name"))
 	gnuflag.StringVar(&c.storagePool, "storage", "", i18n.G("Storage pool name"))
 	gnuflag.StringVar(&c.storagePool, "s", "", i18n.G("Storage pool name"))
+	gnuflag.StringVar(&c.instanceType, "t", "", i18n.G("Instance type"))
 }
 
 func (c *initCmd) run(conf *config.Config, args []string) error {
@@ -244,7 +246,8 @@ func (c *initCmd) create(conf *config.Config, args []string) (lxd.ContainerServe
 
 	// Setup container creation request
 	req := api.ContainersPost{
-		Name: name,
+		Name:         name,
+		InstanceType: c.instanceType,
 	}
 	req.Config = configMap
 	req.Devices = devicesMap

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -18,7 +18,7 @@ func (c *launchCmd) showByDefault() bool {
 
 func (c *launchCmd) usage() string {
 	return i18n.G(
-		`Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]
+		`Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>] [--type|-t <instance type>]
 
 Create and start containers from images.
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -120,6 +120,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"container_snapshot_stateful_migration",
 			"storage_driver_ceph",
 			"storage_ceph_user_name",
+			"resource_limits",
 		},
 		APIStatus:  "stable",
 		APIVersion: version.APIVersion,

--- a/lxd/container_instance_types.go
+++ b/lxd/container_instance_types.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/version"
+)
+
+type instanceType struct {
+	// Amount of CPUs (can be a fraction)
+	CPU float32 `yaml:"cpu"`
+
+	// Amount of memory in GB
+	Memory float32 `yaml:"mem"`
+}
+
+var instanceTypes map[string]map[string]*instanceType
+
+func instanceSaveCache() error {
+	if instanceTypes == nil {
+		return nil
+	}
+
+	data, err := yaml.Marshal(&instanceTypes)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(shared.CachePath("instance_types.yaml"), data, 0600)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func instanceLoadCache() error {
+	if !shared.PathExists(shared.CachePath("instance_types.yaml")) {
+		return nil
+	}
+
+	content, err := ioutil.ReadFile(shared.CachePath("instance_types.yaml"))
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(content, &instanceTypes)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func instanceRefreshTypes(d *Daemon) error {
+	logger.Info("Updating instance types")
+
+	// Attempt to download the new definitions
+	downloadParse := func(filename string, target interface{}) error {
+		url := fmt.Sprintf("https://images.linuxcontainers.org/meta/instance-types/%s", filename)
+
+		httpClient, err := d.httpClient("")
+		if err != nil {
+			return err
+		}
+
+		httpReq, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return err
+		}
+
+		httpReq.Header.Set("User-Agent", version.UserAgent)
+
+		resp, err := httpClient.Do(httpReq)
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			return fmt.Errorf("Failed to get %s", url)
+		}
+
+		content, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		err = yaml.Unmarshal(content, target)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Set an initial value from the cache
+	if instanceTypes == nil {
+		instanceLoadCache()
+	}
+
+	// Get the list of instance type sources
+	sources := map[string]string{}
+	err := downloadParse(".yaml", &sources)
+	if err != nil {
+		logger.Warnf("Failed to update instance types: %v", err)
+		return err
+	}
+
+	// Parse the individual files
+	newInstanceTypes := map[string]map[string]*instanceType{}
+	for name, filename := range sources {
+		types := map[string]*instanceType{}
+		err = downloadParse(filename, &types)
+		if err != nil {
+			logger.Warnf("Failed to update instance types: %v", err)
+			return err
+		}
+
+		newInstanceTypes[name] = types
+	}
+
+	// Update the global map
+	instanceTypes = newInstanceTypes
+
+	// And save in the cache
+	err = instanceSaveCache()
+	if err != nil {
+		logger.Warnf("Failed to update instance types cache: %v", err)
+		return err
+	}
+
+	logger.Infof("Done updating instance types")
+	return nil
+}
+
+func instanceParseType(value string) (map[string]string, error) {
+	sourceName := ""
+	sourceType := ""
+	fields := strings.SplitN(value, ":", 2)
+
+	// Check if the name of the source was provided
+	if len(fields) != 2 {
+		sourceType = value
+	} else {
+		sourceName = fields[0]
+		sourceType = fields[1]
+	}
+
+	// If not, lets go look for a match
+	if instanceTypes != nil && sourceName == "" {
+		for name, types := range instanceTypes {
+			_, ok := types[sourceType]
+			if ok {
+				if sourceName != "" {
+					return nil, fmt.Errorf("Ambiguous instance type provided: %s", value)
+				}
+
+				sourceName = name
+			}
+		}
+	}
+
+	// Check if we have a limit for the provided value
+	limits, ok := instanceTypes[sourceName][sourceType]
+	if !ok {
+		// Check if it's maybe just a resource limit
+		if sourceName == "" && value != "" {
+			newLimits := instanceType{}
+			fields := strings.Split(value, "-")
+			for _, field := range fields {
+				if len(field) < 2 || (field[0] != 'c' && field[0] != 'm') {
+					return nil, fmt.Errorf("Bad instance type: %s", value)
+				}
+
+				value, err := strconv.ParseFloat(field[1:], 32)
+				if err != nil {
+					return nil, err
+				}
+
+				if field[0] == 'c' {
+					newLimits.CPU = float32(value)
+				} else if field[0] == 'm' {
+					newLimits.Memory = float32(value)
+				}
+			}
+
+			limits = &newLimits
+		}
+
+		if limits == nil {
+			return nil, fmt.Errorf("Provided instance type doesn't exist: %s", value)
+		}
+	}
+	out := map[string]string{}
+
+	// Handle CPU
+	if limits.CPU > 0 {
+		cpuCores := int(limits.CPU)
+		if float32(cpuCores) < limits.CPU {
+			cpuCores++
+		}
+		cpuTime := int(limits.CPU / float32(cpuCores) * 100.0)
+
+		out["limits.cpu"] = fmt.Sprintf("%d", cpuCores)
+		if cpuTime < 100 {
+			out["limits.cpu.allowance"] = fmt.Sprintf("%d%%", cpuTime)
+		}
+	}
+
+	// Handle memory
+	if limits.Memory > 0 {
+		rawLimit := int64(limits.Memory * 1024)
+		out["limits.memory"] = fmt.Sprintf("%dMB", rawLimit)
+	}
+
+	return out, nil
+}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -546,6 +546,19 @@ func containersPost(d *Daemon, r *http.Request) Response {
 		req.Config = map[string]string{}
 	}
 
+	if req.InstanceType != "" {
+		conf, err := instanceParseType(req.InstanceType)
+		if err != nil {
+			return BadRequest(err)
+		}
+
+		for k, v := range conf {
+			if req.Config[k] == "" {
+				req.Config[k] = v
+			}
+		}
+	}
+
 	if strings.Contains(req.Name, shared.SnapshotDelimiter) {
 		return BadRequest(fmt.Errorf("Invalid container name: '%s' is reserved for snapshots", shared.SnapshotDelimiter))
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1107,6 +1107,9 @@ func (d *Daemon) Ready() error {
 		}
 	}()
 
+	/* Auto-update instance types */
+	go instanceRefreshTypes(d)
+
 	/* Restore containers */
 	containersRestart(d)
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 #, fuzzy
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -454,12 +454,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 #, fuzzy
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -535,7 +535,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr "Flüchtiger Container"
 
@@ -681,6 +681,10 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -815,7 +819,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -969,7 +973,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 #, fuzzy
 msgid "Profile to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1039,7 +1043,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1170,7 +1174,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -1212,7 +1216,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1227,7 +1231,7 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "The device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1268,11 +1272,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1708,12 +1712,12 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 #, fuzzy
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1740,7 +1744,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2327,7 +2331,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -283,7 +283,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -345,12 +345,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -423,7 +423,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -565,6 +565,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -695,7 +699,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -843,7 +847,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -909,7 +913,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1037,7 +1041,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1077,7 +1081,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1090,7 +1094,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1127,11 +1131,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1506,11 +1510,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1525,7 +1529,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2023,7 +2027,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -381,7 +381,7 @@ msgstr "Colonnes"
 msgid "Commands:"
 msgstr "Commandes:"
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
@@ -399,7 +399,7 @@ msgstr "Connexion refusée ; LXD est-il actif ?"
 msgid "Container name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -445,12 +445,12 @@ msgstr "Créer tous répertoires nécessaires"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
@@ -523,7 +523,7 @@ msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 msgid "Environment:"
 msgstr "Environnement :"
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr "Conteneur éphémère"
 
@@ -673,6 +673,10 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -805,7 +809,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr "Nom du réseau"
 
@@ -955,7 +959,7 @@ msgstr "Profil %s supprimé"
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr "Profil à appliquer au nouveau conteneur"
 
@@ -1023,7 +1027,7 @@ msgstr "Ressources :"
 msgid "Restart containers."
 msgstr "Création du conteneur"
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -1154,7 +1158,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -1197,7 +1201,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
@@ -1212,7 +1216,7 @@ msgstr "Le périphérique n'existe pas"
 msgid "The device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -1255,11 +1259,11 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -1828,12 +1832,12 @@ msgstr ""
 "lxc info [<serveur distant>:]\n"
 "    Pour l'information du serveur LXD."
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 #, fuzzy
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1861,7 +1865,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2610,7 +2614,7 @@ msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 msgid "default"
 msgstr "par défaut"
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-07-13 19:23+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -303,7 +303,7 @@ msgstr "Colonne"
 msgid "Commands:"
 msgstr "Comandi:"
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -321,7 +321,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr "Il nome del container è: %s"
@@ -365,12 +365,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
@@ -442,7 +442,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -584,6 +584,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -713,7 +717,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -860,7 +864,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -926,7 +930,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1054,7 +1058,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1094,7 +1098,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1107,7 +1111,7 @@ msgstr "La periferica esiste già"
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1144,11 +1148,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1523,11 +1527,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1542,7 +1546,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2040,7 +2044,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-07-20 00:30+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -285,7 +285,7 @@ msgstr "カラムレイアウト"
 msgid "Commands:"
 msgstr "コマンド:"
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
@@ -303,7 +303,7 @@ msgstr "接続が拒否されました。LXDが実行されていますか?"
 msgid "Container name is mandatory"
 msgstr "コンテナ名を指定する必要があります"
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr "コンテナ名: %s"
@@ -348,12 +348,12 @@ msgstr "必要なディレクトリをすべて作成します"
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
@@ -425,7 +425,7 @@ msgstr "環境変数を設定します (例: HOME=/home/foo)"
 msgid "Environment:"
 msgstr "環境変数:"
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr "Ephemeral コンテナ"
 
@@ -568,6 +568,10 @@ msgstr "イメージは以下のフィンガープリントでインポートさ
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -699,7 +703,7 @@ msgstr "ネットワーク %s を作成しました"
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr "ネットワーク名:"
 
@@ -846,7 +850,7 @@ msgstr "プロファイル %s を削除しました"
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr "新しいコンテナに適用するプロファイル"
 
@@ -912,7 +916,7 @@ msgstr "リソース:"
 msgid "Restart containers."
 msgstr "コンテナを再起動します。"
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -1040,7 +1044,7 @@ msgstr "ストレージプール %s を作成しました"
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -1082,7 +1086,7 @@ msgstr ""
 "コンテナは現在実行中です。停止して、再起動するために --force を使用してくだ\n"
 "さい。"
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたコンテナに接続されているネットワークがありません。"
 
@@ -1095,7 +1099,7 @@ msgstr "デバイスはすでに存在します"
 msgid "The device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1139,12 +1143,12 @@ msgstr "コンテナを強制停止するまでの時間"
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 "コンテナにネットワークを接続するには、lxc network attach を使用してください"
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -1757,11 +1761,12 @@ msgstr ""
 "lxc info [<remote>:]\n"
 "    LXD サーバの情報を表示します。"
 
-#: lxc/init.go:76
+#: lxc/init.go:77
+#, fuzzy
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1784,10 +1789,11 @@ msgstr ""
 "    lxc init ubuntu:16.04 u1"
 
 #: lxc/launch.go:20
+#, fuzzy
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2687,7 +2693,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、コンテナ、スナップショットを取得できませんで\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-07-25 09:22+0200\n"
+        "POT-Creation-Date: 2017-07-27 18:42-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -272,7 +272,7 @@ msgstr  ""
 msgid   "Commands:"
 msgstr  ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
@@ -289,7 +289,7 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid   "Container name is: %s"
 msgstr  ""
@@ -333,12 +333,12 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid   "Creating the container"
 msgstr  ""
 
@@ -409,7 +409,7 @@ msgstr  ""
 msgid   "Environment:"
 msgstr  ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid   "Ephemeral container"
 msgstr  ""
 
@@ -551,6 +551,10 @@ msgstr  ""
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
+#: lxc/init.go:147
+msgid   "Instance type"
+msgstr  ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
@@ -679,7 +683,7 @@ msgstr  ""
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid   "Network name"
 msgstr  ""
 
@@ -825,7 +829,7 @@ msgstr  ""
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
@@ -891,7 +895,7 @@ msgstr  ""
 msgid   "Restart containers."
 msgstr  ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -1019,7 +1023,7 @@ msgstr  ""
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -1057,7 +1061,7 @@ msgstr  ""
 msgid   "The container is currently running. Use --force to have it stopped and restarted."
 msgstr  ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid   "The container you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -1069,7 +1073,7 @@ msgstr  ""
 msgid   "The device doesn't exist"
 msgstr  ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
@@ -1105,11 +1109,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid   "To attach a network to a container, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -1452,8 +1456,8 @@ msgid   "Usage: lxc info [<remote>:][<container>] [--show-log]\n"
         "    For LXD server information."
 msgstr  ""
 
-#: lxc/init.go:76
-msgid   "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]\n"
+#: lxc/init.go:77
+msgid   "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
         "\n"
         "Create containers from images.\n"
         "\n"
@@ -1465,7 +1469,7 @@ msgid   "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e]
 msgstr  ""
 
 #: lxc/launch.go:20
-msgid   "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>]\n"
+msgid   "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n <network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
         "\n"
         "Create and start containers from images.\n"
         "\n"
@@ -1917,7 +1921,7 @@ msgstr  ""
 msgid   "default"
 msgstr  ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid   "didn't get any affected image, container or snapshot from server"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: 2017-06-06 13:55+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -370,7 +370,7 @@ msgstr "Столбцы"
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -388,7 +388,7 @@ msgstr "В соединении отказано; LXD запущен?"
 msgid "Container name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr "Имя контейнера: %s"
@@ -433,12 +433,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -511,7 +511,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -653,6 +653,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -783,7 +787,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -931,7 +935,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -997,7 +1001,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1125,7 +1129,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1165,7 +1169,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1178,7 +1182,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1215,11 +1219,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1602,11 +1606,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1621,7 +1625,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2119,7 +2123,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-07-25 09:22+0200\n"
+"POT-Creation-Date: 2017-07-27 18:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "Commands:"
 msgstr ""
 
-#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:136 lxc/init.go:137
+#: lxc/copy.go:35 lxc/copy.go:36 lxc/init.go:137 lxc/init.go:138
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -297,7 +297,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:229 lxc/init.go:314
+#: lxc/copy.go:229 lxc/init.go:317
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -341,12 +341,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:194
+#: lxc/init.go:196
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:192
+#: lxc/init.go:194
 msgid "Creating the container"
 msgstr ""
 
@@ -418,7 +418,7 @@ msgstr ""
 msgid "Environment:"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:140 lxc/init.go:141
+#: lxc/copy.go:39 lxc/copy.go:40 lxc/init.go:141 lxc/init.go:142
 msgid "Ephemeral container"
 msgstr ""
 
@@ -560,6 +560,10 @@ msgstr ""
 msgid "Image refreshed successfully!"
 msgstr ""
 
+#: lxc/init.go:147
+msgid "Instance type"
+msgstr ""
+
 #: lxc/remote.go:159
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
@@ -689,7 +693,7 @@ msgstr ""
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/init.go:142 lxc/init.go:143
+#: lxc/init.go:143 lxc/init.go:144
 msgid "Network name"
 msgstr ""
 
@@ -836,7 +840,7 @@ msgstr ""
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:138 lxc/init.go:139
+#: lxc/copy.go:37 lxc/copy.go:38 lxc/init.go:139 lxc/init.go:140
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -902,7 +906,7 @@ msgstr ""
 msgid "Restart containers."
 msgstr ""
 
-#: lxc/init.go:286
+#: lxc/init.go:289
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/init.go:144 lxc/init.go:145
+#: lxc/init.go:145 lxc/init.go:146
 msgid "Storage pool name"
 msgstr ""
 
@@ -1070,7 +1074,7 @@ msgid ""
 "restarted."
 msgstr ""
 
-#: lxc/init.go:359
+#: lxc/init.go:362
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -1083,7 +1087,7 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:343
+#: lxc/init.go:346
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -1120,11 +1124,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:361
+#: lxc/init.go:364
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:360
+#: lxc/init.go:363
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:76
+#: lxc/init.go:77
 msgid ""
 "Usage: lxc init [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create containers from images.\n"
 "\n"
@@ -1518,7 +1522,7 @@ msgstr ""
 msgid ""
 "Usage: lxc launch [<remote>:]<image> [<remote>:][<name>] [--ephemeral|-e] [--"
 "profile|-p <profile>...] [--config|-c <key=value>...] [--network|-n "
-"<network>] [--storage|-s <pool>]\n"
+"<network>] [--storage|-s <pool>] [--type|-t <instance type>]\n"
 "\n"
 "Create and start containers from images.\n"
 "\n"
@@ -2016,7 +2020,7 @@ msgstr ""
 msgid "default"
 msgstr ""
 
-#: lxc/init.go:308
+#: lxc/init.go:311
 msgid "didn't get any affected image, container or snapshot from server"
 msgstr ""
 

--- a/shared/api/container.go
+++ b/shared/api/container.go
@@ -10,6 +10,8 @@ type ContainersPost struct {
 
 	Name   string          `json:"name" yaml:"name"`
 	Source ContainerSource `json:"source" yaml:"source"`
+
+	InstanceType string `json:"instance_type" yaml:"instance_type"`
 }
 
 // ContainerPost represents the fields required to rename/move a LXD container

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -286,6 +286,13 @@ test_basic_usage() {
     false
   fi
 
+  # Test instance types
+  lxc launch testimage test-limits -t c0.5-m0.2
+  [ "$(lxc config get test-limits limits.cpu)" = "1" ]
+  [ "$(lxc config get test-limits limits.cpu.allowance)" = "50%" ]
+  [ "$(lxc config get test-limits limits.memory)" = "204MB" ]
+  lxc delete -f test-limits
+
   # Test last_used_at field is working properly
   lxc init testimage last-used-at-test
   lxc list last-used-at-test  --format json | jq -r '.[].last_used_at' | grep '1970-01-01T00:00:00Z'


### PR DESCRIPTION
This makes it possible to use standard instance types as used by major
cloud providers to define LXD resource limits.

  lxc launch ubuntu:16.04 c1 -t t2.micro
  lxc launch ubuntu:16.04 c2 -t n1-highcpu-16
  lxc launch ubuntu:16.04 c3 -t Standard_A8_v2

LXD will attempt to find a unique match for the instance type.
If it's ambiguous, the cloud provider can be specified with:

  lxc launch ubuntu:16.04 c4 -t azure:A11

This can also be used with an internal format string to specify simple limits:

  lxc launch ubuntu:16.04 c5 -t c2.5-m2

    stgraber@castiana:~$ lxc config show c5 | grep limits
      limits.cpu: "3"
      limits.cpu.allowance: 83%
      limits.memory: 2048MB
    
All provided memory amounts are in GB, LXD will convert internally to MB
to allow for fractions. For fractions of CPU, LXD will apply both hard
CPU limits through pinning and a limit on CPU time to match the exact
provided limit when under load.