### PR TITLE
Add missing refresh code for instance types

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1108,7 +1108,13 @@ func (d *Daemon) Ready() error {
 	}()
 
 	/* Auto-update instance types */
-	go instanceRefreshTypes(d)
+	go func() {
+		// Background update
+		for {
+			instanceRefreshTypes(d)
+			time.Sleep(24 * time.Hour)
+		}
+	}()
 
 	/* Restore containers */
 	containersRestart(d)


### PR DESCRIPTION
Since cloud instance type definitions change pretty regularly (new ones
added), lets try to refresh our cache once a day.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>