### PR TITLE
Initial support for external authentication via Macaroons 

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/simplestreams"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // ConnectionArgs represents a set of common connection properties
@@ -29,6 +30,9 @@ type ConnectionArgs struct {
 
 	// Authentication type
 	AuthType string
+
+	// Authentication interactor
+	AuthInteractor httpbakery.Interactor
 
 	// Custom proxy
 	Proxy func(*http.Request) (*url.URL, error)
@@ -154,10 +158,11 @@ func httpsLXD(url string, args *ConnectionArgs) (ContainerServer, error) {
 
 	// Initialize the client struct
 	server := ProtocolLXD{
-		httpCertificate: args.TLSServerCert,
-		httpHost:        url,
-		httpProtocol:    "https",
-		httpUserAgent:   args.UserAgent,
+		httpCertificate:  args.TLSServerCert,
+		httpHost:         url,
+		httpProtocol:     "https",
+		httpUserAgent:    args.UserAgent,
+		bakeryInteractor: args.AuthInteractor,
 	}
 	if args.AuthType == "macaroons" {
 		server.RequireAuthenticated(true)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -46,6 +46,7 @@ type ContainerServer interface {
 	GetServerResources() (*api.Resources, error)
 	UpdateServer(server api.ServerPut, ETag string) (err error)
 	HasExtension(extension string) bool
+	RequireAuthenticated(authenticated bool)
 
 	// Certificate functions
 	GetCertificateFingerprints() (fingerprints []string, err error)

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -11,13 +11,11 @@ import (
 	"github.com/gorilla/websocket"
 	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
 	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
-	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 
-	schemaform "gopkg.in/juju/environschema.v1/form"
 	neturl "net/url"
 )
 
@@ -35,6 +33,7 @@ type ProtocolLXD struct {
 	httpUserAgent   string
 
 	bakeryClient         *httpbakery.Client
+	bakeryInteractor     httpbakery.Interactor
 	requireAuthenticated bool
 }
 
@@ -327,5 +326,7 @@ func (r *ProtocolLXD) websocket(path string) (*websocket.Conn, error) {
 func (r *ProtocolLXD) setupBakeryClient() {
 	r.bakeryClient = httpbakery.NewClient()
 	r.bakeryClient.Client = r.http
-	r.bakeryClient.AddInteractor(form.Interactor{Filler: schemaform.IOFiller{}})
+	if r.bakeryInteractor != nil {
+		r.bakeryClient.AddInteractor(r.bakeryInteractor)
+	}
 }

--- a/client/lxd.go
+++ b/client/lxd.go
@@ -9,10 +9,16 @@ import (
 	"sync"
 
 	"github.com/gorilla/websocket"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
+
+	schemaform "gopkg.in/juju/environschema.v1/form"
+	neturl "net/url"
 )
 
 // ProtocolLXD represents a LXD API server
@@ -27,6 +33,9 @@ type ProtocolLXD struct {
 	httpHost        string
 	httpProtocol    string
 	httpUserAgent   string
+
+	bakeryClient         *httpbakery.Client
+	requireAuthenticated bool
 }
 
 // GetConnectionInfo returns the basic connection information used to interact with the server
@@ -60,6 +69,28 @@ func (r *ProtocolLXD) GetHTTPClient() (*http.Client, error) {
 	}
 
 	return r.http, nil
+}
+
+// Do performs a Request, using macaroon authentication if set.
+func (r *ProtocolLXD) do(req *http.Request) (*http.Response, error) {
+	if r.bakeryClient != nil {
+		r.addMacaroonHeaders(req)
+		return r.bakeryClient.Do(req)
+	}
+	return r.http.Do(req)
+}
+
+func (r *ProtocolLXD) addMacaroonHeaders(req *http.Request) {
+	req.Header.Set(httpbakery.BakeryProtocolHeader, fmt.Sprint(bakery.LatestVersion))
+
+	for _, cookie := range r.http.Jar.Cookies(req.URL) {
+		req.AddCookie(cookie)
+	}
+}
+
+// RequireAuthenticated sets whether we expect to be authenticated with the server
+func (r *ProtocolLXD) RequireAuthenticated(authenticated bool) {
+	r.requireAuthenticated = authenticated
 }
 
 // RawQuery allows directly querying the LXD API
@@ -127,7 +158,8 @@ func (r *ProtocolLXD) rawQuery(method string, url string, data interface{}, ETag
 		}
 
 		// Some data to be sent along with the request
-		req, err = http.NewRequest(method, url, &buf)
+		// Use a reader since the request body needs to be seekable
+		req, err = http.NewRequest(method, url, bytes.NewReader(buf.Bytes()))
 		if err != nil {
 			return nil, "", err
 		}
@@ -155,8 +187,13 @@ func (r *ProtocolLXD) rawQuery(method string, url string, data interface{}, ETag
 		req.Header.Set("If-Match", ETag)
 	}
 
+	// Set the authentication header
+	if r.requireAuthenticated {
+		req.Header.Set("X-LXD-authenticated", "true")
+	}
+
 	// Send the request
-	resp, err := r.http.Do(req)
+	resp, err := r.do(req)
 	if err != nil {
 		return nil, "", err
 	}
@@ -249,6 +286,20 @@ func (r *ProtocolLXD) rawWebsocket(url string) (*websocket.Conn, error) {
 		headers.Set("User-Agent", r.httpUserAgent)
 	}
 
+	if r.requireAuthenticated {
+		headers.Set("X-LXD-authenticated", "true")
+	}
+
+	// Set macaroon headers if needed
+	if r.bakeryClient != nil {
+		u, err := neturl.Parse(r.httpHost) // use the http url, not the ws one
+		if err != nil {
+			return nil, err
+		}
+		req := &http.Request{URL: u, Header: headers}
+		r.addMacaroonHeaders(req)
+	}
+
 	// Establish the connection
 	conn, _, err := dialer.Dial(url, headers)
 	if err != nil {
@@ -271,4 +322,10 @@ func (r *ProtocolLXD) websocket(path string) (*websocket.Conn, error) {
 	}
 
 	return r.rawWebsocket(url)
+}
+
+func (r *ProtocolLXD) setupBakeryClient() {
+	r.bakeryClient = httpbakery.NewClient()
+	r.bakeryClient.Client = r.http
+	r.bakeryClient.AddInteractor(form.Interactor{Filler: schemaform.IOFiller{}})
 }

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -718,7 +718,7 @@ func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.Re
 	}
 
 	// Send the request
-	resp, err := r.http.Do(req)
+	resp, err := r.do(req)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -824,7 +824,7 @@ func (r *ProtocolLXD) CreateContainerFile(containerName string, path string, arg
 	}
 
 	// Send the request
-	resp, err := r.http.Do(req)
+	resp, err := r.do(req)
 	if err != nil {
 		return err
 	}
@@ -1246,7 +1246,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 	}
 
 	// Send the request
-	resp, err := r.http.Do(req)
+	resp, err := r.do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -404,7 +404,7 @@ func (r *ProtocolLXD) CreateImage(image api.ImagesPost, args *ImageCreateArgs) (
 	}
 
 	// Send the request
-	resp, err := r.http.Do(req)
+	resp, err := r.do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -28,6 +28,11 @@ func (r *ProtocolLXD) GetServer() (*api.Server, string, error) {
 		}
 	}
 
+	if !server.Public && len(server.AuthMethods) == 0 {
+		// TLS is always available for LXD servers
+		server.AuthMethods = []string{"tls"}
+	}
+
 	// Add the value to the cache
 	r.server = &server
 

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -342,6 +342,7 @@ and xfs.
 
 ## resources
 This adds support for querying an LXD daemon for the system resources it has
+available.
 
 ## kernel\_limits
 This adds support for setting process limits such as maximum number of open
@@ -349,3 +350,6 @@ files for the container via `nofile`. The format is `limits.kernel.[limit name]`
 
 ## storage\_api\_volume\_rename
 This adds support for renaming custom storage volumes.
+
+## external\_authentication
+This adds support for external authentication via Macaroons.

--- a/doc/security.md
+++ b/doc/security.md
@@ -78,6 +78,22 @@ pre-generated files.
 
 After this is done, restarting the server will have it run in PKI mode.
 
+# Adding a remote with Macaroon-based authentication
+When LXD is configured with Macaroon-based authentication, it will request that
+clients trying to authenticating with it get a Discharge token from the
+authentication server specified by the `core.macaroon.endpoint` setting.
+
+The authentication server certificate needs to be trusted by the LXD server.
+
+To add a remote pointing to a LXD configured with Macaroon auth, run `lxc
+remote add REMOTE ENDPOINT --auth-type=macaroons`.  The client will prompt for
+the credentials required by the authentication server in order to verify the
+user. If the authentication is successful, it will connect to the LXD server
+presenting the token received from the authentication server.  The LXD server
+verifies the token, thus authenticating the request.  The token is stored as
+cookie and is presented by the client at each request to LXD.
+
+
 # Managing trusted clients
 The list of certificates trusted by a LXD server can be obtained with `lxc
 config trust list`.

--- a/doc/server.md
+++ b/doc/server.md
@@ -7,21 +7,22 @@ currently supported:
  - `core` (core daemon configuration)
  - `images` (image configuration)
 
-Key                             | Type      | Default   | API extension  | Description
-:--                             | :---      | :------   | :------------  | :----------
-core.https\_address             | string    | -         | -              | Address to bind for the remote API
-core.https\_allowed\_headers    | string    | -         | -              | Access-Control-Allow-Headers http header value
-core.https\_allowed\_methods    | string    | -         | -              | Access-Control-Allow-Methods http header value
-core.https\_allowed\_origin     | string    | -         | -              | Access-Control-Allow-Origin http header value
-core.https\_allowed\_credentials| boolean   | -         | -              | Whether to set Access-Control-Allow-Credentials http header value to "true"
-core.proxy\_http                | string    | -         | -              | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
-core.proxy\_https               | string    | -         | -              | https proxy to use, if any (falls back to HTTPS\_PROXY environment variable)
-core.proxy\_ignore\_hosts       | string    | -         | -              | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)
-core.trust\_password            | string    | -         | -              | Password to be provided by clients to setup a trust
-images.auto\_update\_cached     | boolean   | true      | -              | Whether to automatically update any image that LXD caches
-images.auto\_update\_interval   | integer   | 6         | -              | Interval in hours at which to look for update to cached images (0 disables it)
-images.compression\_algorithm   | string    | gzip      | -              | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
-images.remote\_cache\_expiry    | integer   | 10        | -              | Number of days after which an unused cached remote image will be flushed
+Key                             | Type      | Default   | API extension           | Description
+:--                             | :---      | :------   | :------------           | :----------
+core.macaroon.endpoint          | string    | -         | macaroon_authentication | URL of the the external authentication endpoint using Macaroons
+core.https\_address             | string    | -         | -                       | Address to bind for the remote API
+core.https\_allowed\_headers    | string    | -         | -                       | Access-Control-Allow-Headers http header value
+core.https\_allowed\_methods    | string    | -         | -                       | Access-Control-Allow-Methods http header value
+core.https\_allowed\_origin     | string    | -         | -                       | Access-Control-Allow-Origin http header value
+core.https\_allowed\_credentials| boolean   | -         | -                       | Whether to set Access-Control-Allow-Credentials http header value to "true"
+core.proxy\_http                | string    | -         | -                       | http proxy to use, if any (falls back to HTTP\_PROXY environment variable)
+core.proxy\_https               | string    | -         | -                       | https proxy to use, if any (falls back to HTTPS\_PROXY environment variable)
+core.proxy\_ignore\_hosts       | string    | -         | -                       | hosts which don't need the proxy for use (similar format to NO\_PROXY, e.g. 1.2.3.4,1.2.3.5, falls back to NO\_PROXY environment variable)
+core.trust\_password            | string    | -         | -                       | Password to be provided by clients to setup a trust
+images.auto\_update\_cached     | boolean   | true      | -                       | Whether to automatically update any image that LXD caches
+images.auto\_update\_interval   | integer   | 6         | -                       | Interval in hours at which to look for update to cached images (0 disables it)
+images.compression\_algorithm   | string    | gzip      | -                       | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
+images.remote\_cache\_expiry    | integer   | 10        | -                       | Number of days after which an unused cached remote image will be flushed
 
 Those keys can be set using the lxc tool with:
 

--- a/lxc/config/config.go
+++ b/lxc/config/config.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 
 	"github.com/juju/persistent-cookiejar"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
 )
 
 // Config holds settings to be used by a client or daemon
@@ -26,6 +27,8 @@ type Config struct {
 	// The UserAgent to pass for all queries
 	UserAgent string `yaml:"-"`
 
+	authInteractor httpbakery.Interactor
+
 	cookiejar *cookiejar.Jar
 }
 
@@ -40,6 +43,11 @@ func (c *Config) ConfigPath(paths ...string) string {
 // ServerCertPath returns the path for the remote's server certificate
 func (c *Config) ServerCertPath(remote string) string {
 	return c.ConfigPath("servercerts", fmt.Sprintf("%s.crt", remote))
+}
+
+// SetAuthInteractor sets the interactor for macaroon-based authorization
+func (c *Config) SetAuthInteractor(interactor httpbakery.Interactor) {
+	c.authInteractor = interactor
 }
 
 // SaveCookies saves cookies to file

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -136,9 +136,10 @@ func (c *Config) GetImageServer(name string) (lxd.ImageServer, error) {
 func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
 	remote, _ := c.Remotes[name]
 	args := lxd.ConnectionArgs{
-		UserAgent: c.UserAgent,
-		CookieJar: c.cookiejar,
-		AuthType:  remote.AuthType,
+		UserAgent:      c.UserAgent,
+		CookieJar:      c.cookiejar,
+		AuthType:       remote.AuthType,
+		AuthInteractor: c.authInteractor,
 	}
 
 	// Client certificate

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -14,6 +14,7 @@ type Remote struct {
 	Addr     string `yaml:"addr"`
 	Public   bool   `yaml:"public"`
 	Protocol string `yaml:"protocol,omitempty"`
+	AuthType string `yaml:"auth_type,omitempty"`
 	Static   bool   `yaml:"-"`
 }
 
@@ -133,8 +134,11 @@ func (c *Config) GetImageServer(name string) (lxd.ImageServer, error) {
 }
 
 func (c *Config) getConnectionArgs(name string) (*lxd.ConnectionArgs, error) {
+	remote, _ := c.Remotes[name]
 	args := lxd.ConnectionArgs{
 		UserAgent: c.UserAgent,
+		CookieJar: c.cookiejar,
+		AuthType:  remote.AuthType,
 	}
 
 	// Client certificate

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"syscall"
 
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
+
 	"github.com/lxc/lxd/lxc/config"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/gnuflag"
@@ -17,6 +19,8 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
 	"github.com/lxc/lxd/shared/version"
+
+	schemaform "gopkg.in/juju/environschema.v1/form"
 )
 
 var configPath string
@@ -99,6 +103,9 @@ func run() error {
 	} else {
 		conf = config.NewConfig(filepath.Dir(configPath), true)
 	}
+
+	// Add interactor for external authentication
+	conf.SetAuthInteractor(form.Interactor{Filler: schemaform.IOFiller{}})
 
 	// Save cookies on exit
 	defer conf.SaveCookies()

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -90,16 +90,18 @@ func run() error {
 	var err error
 
 	if *forceLocal {
-		conf = &config.DefaultConfig
+		conf = config.NewConfig("", true)
 	} else if shared.PathExists(configPath) {
 		conf, err = config.LoadConfig(configPath)
 		if err != nil {
 			return err
 		}
 	} else {
-		conf = &config.DefaultConfig
-		conf.ConfigDir = filepath.Dir(configPath)
+		conf = config.NewConfig(filepath.Dir(configPath), true)
 	}
+
+	// Save cookies on exit
+	defer conf.SaveCookies()
 
 	// Set the user agent
 	conf.UserAgent = version.UserAgent

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -225,7 +225,7 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 	var fingerprint string
 
 	if strings.Contains(image, ":") {
-		defaultConfig := config.DefaultConfig
+		defaultConfig := config.NewConfig("", true)
 		defaultConfig.UserAgent = version.UserAgent
 
 		remote, fp, err := defaultConfig.ParseRemote(image)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -99,7 +99,7 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 
 	// Access check
 	secret := daemonConfig["core.trust_password"].Get()
-	if !util.IsTrustedClient(r, d.clientCerts) && util.PasswordCheck(secret, req.Password) != nil {
+	if d.checkTrustedClient(r) != nil && util.PasswordCheck(secret, req.Password) != nil {
 		return Forbidden
 	}
 

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -189,6 +189,7 @@ func daemonConfigInit(db *sql.DB) error {
 		"core.proxy_https":               {valueType: "string", setter: daemonConfigSetProxy},
 		"core.proxy_ignore_hosts":        {valueType: "string", setter: daemonConfigSetProxy},
 		"core.trust_password":            {valueType: "string", hiddenValue: true, setter: daemonConfigSetPassword},
+		"core.macaroon.endpoint":         {valueType: "string", setter: daemonConfigSetMacaroonEndpoint},
 
 		"images.auto_update_cached":    {valueType: "bool", defaultValue: "true"},
 		"images.auto_update_interval":  {valueType: "int", defaultValue: "6", trigger: daemonConfigTriggerAutoUpdateInterval},
@@ -272,6 +273,15 @@ func daemonConfigSetPassword(d *Daemon, key string, value string) (string, error
 func daemonConfigSetAddress(d *Daemon, key string, value string) (string, error) {
 	// Update the current https address
 	err := d.UpdateHTTPsPort(value)
+	if err != nil {
+		return "", err
+	}
+
+	return value, nil
+}
+
+func daemonConfigSetMacaroonEndpoint(d *Daemon, key string, value string) (string, error) {
+	err := d.setupExternalAuthentication(value)
 	if err != nil {
 		return "", err
 	}

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -117,31 +117,10 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 // A function capable of proxing an HTTP request.
 type proxyFunc func(req *http.Request) (*url.URL, error)
 
-// IsTrustedClient checks if the given HTTP request comes from a trusted client
-// (i.e. either it's received via Unix socket, or via TLS with a trusted
-// certificate).
-func IsTrustedClient(r *http.Request, trustedCerts []x509.Certificate) bool {
-	if r.RemoteAddr == "@" {
-		// Unix socket
-		return true
-	}
-
-	if r.TLS == nil {
-		return false
-	}
-
-	for i := range r.TLS.PeerCertificates {
-		if checkTrustState(*r.TLS.PeerCertificates[i], trustedCerts) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// Check whether the given client certificate is trusted (i.e. it has a valid
-// time span and it belongs to the given list of trusted certificates).
-func checkTrustState(cert x509.Certificate, trustedCerts []x509.Certificate) bool {
+// CheckTrustState checks whether the given client certificate is trusted
+// (i.e. it has a valid time span and it belongs to the given list of trusted
+// certificates).
+func CheckTrustState(cert x509.Certificate, trustedCerts []x509.Certificate) bool {
 	// Extra validity check (should have been caught by TLS stack)
 	if time.Now().Before(cert.NotBefore) || time.Now().After(cert.NotAfter) {
 		return false

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -295,7 +295,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -303,7 +307,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -317,6 +321,11 @@ msgstr "Aliasse:\n"
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
+msgstr ""
 
 #: lxc/image.go:631
 #, c-format
@@ -389,12 +398,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
@@ -417,7 +426,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -453,7 +462,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -529,12 +538,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 #, fuzzy
 msgid "Enable debug mode"
 msgstr "Aktiviert Debug Modus"
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 #, fuzzy
 msgid "Enable verbose mode"
 msgstr "Aktiviert ausführliche Ausgabe"
@@ -634,7 +643,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -642,7 +651,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -659,11 +668,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -701,7 +710,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -718,6 +727,11 @@ msgstr ""
 #: lxc/file.go:528
 #, fuzzy, c-format
 msgid "Invalid path %s"
+msgstr "Ungültiges Ziel %s"
+
+#: lxc/remote.go:107
+#, fuzzy, c-format
+msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
 #: lxc/file.go:457
@@ -742,7 +756,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -811,12 +825,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -876,7 +890,7 @@ msgstr "Kein Fingerabdruck angegeben."
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -888,7 +902,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -908,11 +922,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -934,12 +948,12 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Path to an alternate server directory"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 #, fuzzy
 msgid "Pause containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -1023,7 +1037,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -1041,7 +1055,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
@@ -1073,7 +1087,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 #, fuzzy
 msgid "Restart containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1099,7 +1113,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -1107,16 +1121,21 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+#, fuzzy
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1174,7 +1193,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 #, fuzzy
 msgid "Start containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1189,7 +1208,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 #, fuzzy
 msgid "Stop containers."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1323,7 +1342,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1358,7 +1377,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -2155,7 +2174,7 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 #, fuzzy
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
@@ -2163,7 +2182,7 @@ msgid ""
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2377,7 +2396,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2395,11 +2414,11 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a source container name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2407,7 +2426,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2423,12 +2442,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, fuzzy, c-format
 msgid "error: unknown command: %s"
 msgstr "Fehler: unbekannter Befehl: %s\n"
@@ -2437,12 +2456,12 @@ msgstr "Fehler: unbekannter Befehl: %s\n"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 #, fuzzy
 msgid "ok (y/n)?"
 msgstr "OK (y/n)? "
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2451,22 +2470,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2484,7 +2503,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr "falsche Anzahl an Parametern für Unterbefehl"
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -190,7 +190,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -198,7 +202,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -210,6 +214,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -279,12 +288,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -306,7 +315,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -341,7 +350,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -416,11 +425,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -517,7 +526,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -525,7 +534,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -541,11 +550,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -582,7 +591,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -598,6 +607,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -622,7 +636,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -688,12 +702,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -750,7 +764,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -762,7 +776,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -782,11 +796,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -806,11 +820,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -892,7 +906,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -910,7 +924,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -941,7 +955,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -966,7 +980,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -974,15 +988,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1040,7 +1058,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1054,7 +1072,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1179,7 +1197,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1214,7 +1232,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1873,14 +1891,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2067,7 +2085,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2083,11 +2101,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2095,7 +2113,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2111,12 +2129,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2125,11 +2143,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2138,22 +2156,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2171,7 +2189,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -286,7 +286,12 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+#, fuzzy
+msgid "AUTH TYPE"
+msgstr "TYPE"
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -294,7 +299,7 @@ msgstr "Accepter le certificat"
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -307,6 +312,11 @@ msgstr "Alias :"
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
+msgstr ""
 
 #: lxc/image.go:631
 #, c-format
@@ -377,12 +387,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr "Impossible de fournir le nom du conteneur à lister"
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %x"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr "Certificat client enregistré sur le serveur : "
 
@@ -404,7 +414,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "Connexion refusée ; LXD est-il actif ?"
 
@@ -440,7 +450,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Copying the image: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -515,11 +525,11 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr "Activer le mode de débogage"
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr "Activer le mode verbeux"
 
@@ -620,7 +630,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running containers"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -628,7 +638,7 @@ msgstr "Forcer l'utilisation de la socket unix locale"
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -644,14 +654,14 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 #, fuzzy
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 "Si c'est la première fois que vous lancez LXD, vous devriez aussi lancer : "
 "sudo lxd init"
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr "Ignorer les alias pour déterminer la commande à exécuter"
 
@@ -690,7 +700,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -706,6 +716,11 @@ msgstr "Clé de configuration invalide"
 #: lxc/file.go:528
 #, fuzzy, c-format
 msgid "Invalid path %s"
+msgstr "Cible invalide %s"
+
+#: lxc/remote.go:107
+#, fuzzy, c-format
+msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
 #: lxc/file.go:457
@@ -730,7 +745,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "Socket LXD introuvable ; LXD est-il installé et actif ?"
 
@@ -798,12 +813,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr "NON"
 
@@ -861,7 +876,7 @@ msgstr "Aucune empreinte n'a été indiquée."
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "Seul les volumes \"personnalisés\" peuvent être attaché aux conteneurs"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -873,7 +888,7 @@ msgstr "Seul https:// est supporté par l'import d'images distantes."
 msgid "Only managed networks can be modified."
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr "Options :"
 
@@ -893,11 +908,11 @@ msgstr "PID"
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -917,12 +932,12 @@ msgstr "Chemin vers un dossier de configuration client alternatif"
 msgid "Path to an alternate server directory"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 #, fuzzy
 msgid "Pause containers."
 msgstr "Création du conteneur"
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr "Permission refusée, êtes-vous dans le groupe lxd ?"
 
@@ -1004,7 +1019,7 @@ msgstr "Profils : %s"
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -1022,7 +1037,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
@@ -1054,7 +1069,7 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 #, fuzzy
 msgid "Restart containers."
 msgstr "Création du conteneur"
@@ -1080,7 +1095,7 @@ msgstr "SOURCE"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -1088,16 +1103,21 @@ msgstr "STATIQUE"
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+#, fuzzy
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -1155,7 +1175,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 #, fuzzy
 msgid "Start containers."
 msgstr "Création du conteneur"
@@ -1170,7 +1190,7 @@ msgstr "Démarrage de %s"
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 #, fuzzy
 msgid "Stop containers."
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1307,7 +1327,7 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
@@ -1343,7 +1363,7 @@ msgstr "Type : persistant"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr "URL"
 
@@ -2402,7 +2422,7 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 #, fuzzy
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
@@ -2410,7 +2430,7 @@ msgid ""
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2659,7 +2679,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr "OUI"
 
@@ -2677,13 +2697,13 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a source container name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 "La commande `lxc config profile` est dépréciée, merci d'utiliser `lxc "
 "profile`"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
@@ -2691,7 +2711,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr "par défaut"
 
@@ -2707,12 +2727,12 @@ msgstr "désactivé"
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr "erreur : commande inconnue: %s"
@@ -2721,11 +2741,11 @@ msgstr "erreur : commande inconnue: %s"
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr "ok (y/n) ?"
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "l'analyse des alias a échoué %s\n"
@@ -2734,22 +2754,22 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr "l'édition récursive ne fait aucun sens :("
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -2767,7 +2787,7 @@ msgstr "sans suivi d'état"
 msgid "taken at %s"
 msgstr "pris à %s"
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -211,7 +211,11 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -219,7 +223,7 @@ msgstr "Accetta certificato"
 msgid "Action (defaults to GET)"
 msgstr "Azione (default a GET)"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Password amministratore per %s: "
@@ -232,6 +236,11 @@ msgstr "Alias:"
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
+msgstr ""
 
 #: lxc/image.go:631
 #, c-format
@@ -299,12 +308,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr "Certificato del client salvato dal server: "
 
@@ -326,7 +335,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -361,7 +370,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -435,11 +444,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr "Abilita modalità verbosa"
 
@@ -536,7 +545,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -544,7 +553,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -560,11 +569,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -601,7 +610,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -618,6 +627,11 @@ msgstr ""
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
+
+#: lxc/remote.go:107
+#, fuzzy, c-format
+msgid "Invalid protocol: %s"
+msgstr "Proprietà errata: %s"
 
 #: lxc/file.go:457
 #, c-format
@@ -641,7 +655,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -706,12 +720,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -767,7 +781,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -779,7 +793,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -823,11 +837,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -909,7 +923,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -927,7 +941,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -958,7 +972,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -983,7 +997,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -991,15 +1005,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1057,7 +1075,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1071,7 +1089,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1196,7 +1214,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1231,7 +1249,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1890,14 +1908,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2084,7 +2102,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2100,11 +2118,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2112,7 +2130,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2128,12 +2146,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2142,11 +2160,11 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "errore di processamento degli alias %s\n"
@@ -2155,22 +2173,22 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -2188,7 +2206,7 @@ msgstr "senza stato"
 msgid "taken at %s"
 msgstr "salvato alle %s"
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr "numero errato di argomenti del sottocomando"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -191,7 +191,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -199,7 +203,7 @@ msgstr "証明書を受け入れます"
 msgid "Action (defaults to GET)"
 msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr "%s の管理者パスワード: "
@@ -212,6 +216,11 @@ msgstr "エイリアス:"
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
+msgstr ""
 
 #: lxc/image.go:631
 #, c-format
@@ -281,12 +290,12 @@ msgstr "キー '%s' が指定されていないので削除できません。"
 msgid "Cannot provide container name to list"
 msgstr "コンテナ名を取得できません"
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr "クライアント証明書がサーバに格納されました: "
 
@@ -308,7 +317,7 @@ msgstr "新しいコンテナに適用するキー/値の設定"
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "接続が拒否されました。LXDが実行されていますか?"
 
@@ -343,7 +352,7 @@ msgstr "コンテナをコピーします (スナップショットはコピー�
 msgid "Copying the image: %s"
 msgstr "イメージのコピー中: %s"
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -417,11 +426,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr "デバッグモードを有効にします"
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr "詳細モードを有効にします"
 
@@ -519,7 +528,7 @@ msgstr "コンテナを強制シャットダウンします"
 msgid "Force the removal of running containers"
 msgstr "稼働中のコンテナを強制的に削除します"
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -527,7 +536,7 @@ msgstr "強制的にローカルのUNIXソケットを使います"
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -543,11 +552,11 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr "初めて LXD を使う場合、lxd init と実行する必要があります"
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr "どのコマンドを実行するか決める際にエイリアスを無視します"
 
@@ -584,7 +593,7 @@ msgstr "入力するデータ"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -600,6 +609,11 @@ msgstr "正しくない設定項目 (key) です"
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr "不正なパス %s"
+
+#: lxc/remote.go:107
+#, fuzzy, c-format
+msgid "Invalid protocol: %s"
 msgstr "不正なパス %s"
 
 #: lxc/file.go:457
@@ -624,7 +638,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr "LXD のソケットが見つかりません。LXD が実行されていますか?"
 
@@ -691,12 +705,12 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -752,7 +766,7 @@ msgstr "フィンガープリントが指定されていません。"
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチできます。"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -764,7 +778,7 @@ msgstr "リモートイメージのインポートは https:// のみをサポ�
 msgid "Only managed networks can be modified."
 msgstr "管理対象のネットワークのみ変更できます。"
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr "オプション:"
 
@@ -784,11 +798,11 @@ msgstr "PID"
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -808,11 +822,11 @@ msgstr "別のクライアント用設定ディレクトリ"
 msgid "Path to an alternate server directory"
 msgstr "別のサーバ用設定ディレクトリ"
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr "コンテナを一時停止します。"
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr "アクセスが拒否されました。lxd グループに所属していますか?"
 
@@ -894,7 +908,7 @@ msgstr "プロファイル: %s"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -912,7 +926,7 @@ msgstr "再帰的にファイルをpush/pullします"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
@@ -943,7 +957,7 @@ msgstr "ユーザの確認を要求する"
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr "コンテナを再起動します。"
 
@@ -968,7 +982,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -976,15 +990,20 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+#, fuzzy
+msgid "Server doesn't trust us after authentication"
 msgstr "サーバが我々の証明書を追加した後我々を信頼していません"
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -1042,7 +1061,7 @@ msgstr "一部のコンテナで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr "コンテナを起動します。"
 
@@ -1056,7 +1075,7 @@ msgstr "%s を起動中"
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr "コンテナを停止します。"
 
@@ -1192,7 +1211,7 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 "初めてコンテナを起動するには、\"lxc launch ubuntu:16.04\" と実行してみてくだ"
@@ -1229,7 +1248,7 @@ msgstr "タイプ: persistent"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -2435,14 +2454,15 @@ msgstr ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    ローカルのコンテナ \"c1\" を削除します。"
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
+#, fuzzy
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2777,7 +2797,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2794,11 +2814,11 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a source container name"
 msgstr "コピー元のコンテナ名を指定してください"
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr "`lxc config profile` は廃止されました。`lxc profile` を使ってください"
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
@@ -2806,7 +2826,7 @@ msgstr "デフォルトのリモートは削除できません"
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2824,12 +2844,12 @@ msgstr "無効"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr "エラー: 未知のコマンド: %s"
@@ -2838,11 +2858,11 @@ msgstr "エラー: 未知のコマンド: %s"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "エイリアスの処理が失敗しました %s\n"
@@ -2851,22 +2871,22 @@ msgstr "エイリアスの処理が失敗しました %s\n"
 msgid "recursive edit doesn't make sense :("
 msgstr "再帰的な edit は意味がありません :("
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -2884,7 +2904,7 @@ msgstr "ステートレス"
 msgid "taken at %s"
 msgstr "%s に取得しました"
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr "サブコマンドの引数の数が正しくありません"
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-10-17 05:05+0200\n"
+        "POT-Creation-Date: 2017-10-17 19:28+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -180,7 +180,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid   "AUTH TYPE"
+msgstr  ""
+
+#: lxc/remote.go:68
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -188,7 +192,7 @@ msgstr  ""
 msgid   "Action (defaults to GET)"
 msgstr  ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -200,6 +204,11 @@ msgstr  ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid   "Architecture: %s"
+msgstr  ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
 
 #: lxc/image.go:631
@@ -268,12 +277,12 @@ msgstr  ""
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -294,7 +303,7 @@ msgstr  ""
 msgid   "Config parsing error: %s"
 msgstr  ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid   "Connection refused; is LXD running?"
 msgstr  ""
 
@@ -329,7 +338,7 @@ msgstr  ""
 msgid   "Copying the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -402,11 +411,11 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid   "Enable debug mode"
 msgstr  ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid   "Enable verbose mode"
 msgstr  ""
 
@@ -503,7 +512,7 @@ msgstr  ""
 msgid   "Force the removal of running containers"
 msgstr  ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -511,7 +520,7 @@ msgstr  ""
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -527,11 +536,11 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid   "If this is your first time using LXD, you should also run: lxd init"
 msgstr  ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid   "Ignore aliases when determining what command to run"
 msgstr  ""
 
@@ -568,7 +577,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -584,6 +593,11 @@ msgstr  ""
 #: lxc/file.go:528
 #, c-format
 msgid   "Invalid path %s"
+msgstr  ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid   "Invalid protocol: %s"
 msgstr  ""
 
 #: lxc/file.go:457
@@ -608,7 +622,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid   "LXD socket not found; is LXD installed and running?"
 msgstr  ""
 
@@ -673,11 +687,11 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381 lxc/storage.go:681 lxc/storage.go:792
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409 lxc/storage.go:681 lxc/storage.go:792
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid   "NO"
 msgstr  ""
 
@@ -733,7 +747,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to containers."
 msgstr  ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -745,7 +759,7 @@ msgstr  ""
 msgid   "Only managed networks can be modified."
 msgstr  ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid   "Options:"
 msgstr  ""
 
@@ -765,11 +779,11 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -789,11 +803,11 @@ msgstr  ""
 msgid   "Path to an alternate server directory"
 msgstr  ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid   "Pause containers."
 msgstr  ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid   "Permission denied, are you in the lxd group?"
 msgstr  ""
 
@@ -874,7 +888,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid   "Public image server"
 msgstr  ""
 
@@ -892,7 +906,7 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid   "Remote admin password"
 msgstr  ""
 
@@ -923,7 +937,7 @@ msgstr  ""
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid   "Restart containers."
 msgstr  ""
 
@@ -948,7 +962,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid   "STATIC"
 msgstr  ""
 
@@ -956,15 +970,19 @@ msgstr  ""
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid   "Server authentication type (tls or macaroons)"
+msgstr  ""
+
+#: lxc/remote.go:211
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:288
-msgid   "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -1022,7 +1040,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid   "Start containers."
 msgstr  ""
 
@@ -1036,7 +1054,7 @@ msgstr  ""
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid   "Stop containers."
 msgstr  ""
 
@@ -1157,7 +1175,7 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
 
@@ -1192,7 +1210,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid   "URL"
 msgstr  ""
 
@@ -1784,12 +1802,12 @@ msgid   "Usage: lxc query [-X <action>] [-d <data>] [--wait] [--raw] [<remote>:]
         "    Delete local container \"c1\"."
 msgstr  ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid   "Usage: lxc remote <subcommand> [options]\n"
         "\n"
         "Manage the list of remote LXD servers.\n"
         "\n"
-        "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+        "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
         "    Add the remote <remote> at <url>.\n"
         "\n"
         "lxc remote remove <remote>\n"
@@ -1957,7 +1975,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid   "YES"
 msgstr  ""
 
@@ -1973,11 +1991,11 @@ msgstr  ""
 msgid   "You must specify a source container name"
 msgstr  ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid   "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr  ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid   "can't remove the default remote"
 msgstr  ""
 
@@ -1985,7 +2003,7 @@ msgstr  ""
 msgid   "can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid   "default"
 msgstr  ""
 
@@ -2001,12 +2019,12 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid   "error: %v"
 msgstr  ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid   "error: unknown command: %s"
 msgstr  ""
@@ -2015,11 +2033,11 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -2028,22 +2046,22 @@ msgstr  ""
 msgid   "recursive edit doesn't make sense :("
 msgstr  ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid   "remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid   "remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid   "remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid   "remote %s is static and cannot be modified"
 msgstr  ""
@@ -2061,7 +2079,7 @@ msgstr  ""
 msgid   "taken at %s"
 msgstr  ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -273,7 +273,11 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -281,7 +285,7 @@ msgstr "Принять сертификат"
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -294,6 +298,11 @@ msgstr "Псевдонимы:"
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
+msgstr ""
 
 #: lxc/image.go:631
 #, c-format
@@ -362,12 +371,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr "Сертификат клиента хранится на сервере: "
 
@@ -389,7 +398,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "В соединении отказано; LXD запущен?"
 
@@ -424,7 +433,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -499,11 +508,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -600,7 +609,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -608,7 +617,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -624,11 +633,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -665,7 +674,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -681,6 +690,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -705,7 +719,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -771,12 +785,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -833,7 +847,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -845,7 +859,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -865,11 +879,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -889,11 +903,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -975,7 +989,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -993,7 +1007,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -1024,7 +1038,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -1049,7 +1063,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -1057,15 +1071,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1123,7 +1141,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1137,7 +1155,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1262,7 +1280,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1297,7 +1315,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1964,14 +1982,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2162,7 +2180,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2178,11 +2196,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2190,7 +2208,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2206,12 +2224,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2220,11 +2238,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2233,22 +2251,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2266,7 +2284,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-10-17 05:05+0200\n"
+"POT-Creation-Date: 2017-10-17 19:28+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -187,7 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:67
+#: lxc/remote.go:412
+msgid "AUTH TYPE"
+msgstr ""
+
+#: lxc/remote.go:68
 msgid "Accept certificate"
 msgstr ""
 
@@ -195,7 +199,7 @@ msgstr ""
 msgid "Action (defaults to GET)"
 msgstr ""
 
-#: lxc/remote.go:256
+#: lxc/remote.go:276
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -207,6 +211,11 @@ msgstr ""
 #: lxc/image.go:600 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
+msgstr ""
+
+#: lxc/remote.go:259
+#, c-format
+msgid "Authentication type '%s' not supported by server"
 msgstr ""
 
 #: lxc/image.go:631
@@ -275,12 +284,12 @@ msgstr ""
 msgid "Cannot provide container name to list"
 msgstr ""
 
-#: lxc/remote.go:192
+#: lxc/remote.go:203
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:291
+#: lxc/remote.go:315
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -302,7 +311,7 @@ msgstr ""
 msgid "Config parsing error: %s"
 msgstr ""
 
-#: lxc/main.go:36
+#: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr ""
 
@@ -337,7 +346,7 @@ msgstr ""
 msgid "Copying the image: %s"
 msgstr ""
 
-#: lxc/remote.go:207
+#: lxc/remote.go:218
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -411,11 +420,11 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
-#: lxc/main.go:48
+#: lxc/main.go:52
 msgid "Enable debug mode"
 msgstr ""
 
-#: lxc/main.go:47
+#: lxc/main.go:51
 msgid "Enable verbose mode"
 msgstr ""
 
@@ -512,7 +521,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:49
+#: lxc/main.go:53
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -520,7 +529,7 @@ msgstr ""
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:166
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -536,11 +545,11 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:163
+#: lxc/main.go:172
 msgid "If this is your first time using LXD, you should also run: lxd init"
 msgstr ""
 
-#: lxc/main.go:50
+#: lxc/main.go:54
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
@@ -577,7 +586,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:107
+#: lxc/remote.go:118
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -593,6 +602,11 @@ msgstr ""
 #: lxc/file.go:528
 #, c-format
 msgid "Invalid path %s"
+msgstr ""
+
+#: lxc/remote.go:107
+#, c-format
+msgid "Invalid protocol: %s"
 msgstr ""
 
 #: lxc/file.go:457
@@ -617,7 +631,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/main.go:34
+#: lxc/main.go:38
 msgid "LXD socket not found; is LXD installed and running?"
 msgstr ""
 
@@ -682,12 +696,12 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:381
+#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:508 lxc/remote.go:355 lxc/remote.go:360
+#: lxc/network.go:508 lxc/remote.go:380 lxc/remote.go:385
 msgid "NO"
 msgstr ""
 
@@ -743,7 +757,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:101
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -755,7 +769,7 @@ msgstr ""
 msgid "Only managed networks can be modified."
 msgstr ""
 
-#: lxc/help.go:71 lxc/main.go:130 lxc/main.go:187
+#: lxc/help.go:71 lxc/main.go:139 lxc/main.go:196
 msgid "Options:"
 msgstr ""
 
@@ -775,11 +789,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:383
+#: lxc/remote.go:411
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:233 lxc/remote.go:384
+#: lxc/image.go:233 lxc/remote.go:413
 msgid "PUBLIC"
 msgstr ""
 
@@ -799,11 +813,11 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:228
+#: lxc/main.go:237
 msgid "Pause containers."
 msgstr ""
 
-#: lxc/main.go:38
+#: lxc/main.go:42
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
@@ -885,7 +899,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:70
+#: lxc/remote.go:72
 msgid "Public image server"
 msgstr ""
 
@@ -903,7 +917,7 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:68
+#: lxc/remote.go:69
 msgid "Remote admin password"
 msgstr ""
 
@@ -934,7 +948,7 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:236
+#: lxc/main.go:245
 msgid "Restart containers."
 msgstr ""
 
@@ -959,7 +973,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:385
+#: lxc/remote.go:414
 msgid "STATIC"
 msgstr ""
 
@@ -967,15 +981,19 @@ msgstr ""
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/remote.go:200
+#: lxc/remote.go:71
+msgid "Server authentication type (tls or macaroons)"
+msgstr ""
+
+#: lxc/remote.go:211
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:288
-msgid "Server doesn't trust us after adding our cert"
+#: lxc/remote.go:311
+msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:69
+#: lxc/remote.go:70
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -1033,7 +1051,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:246
+#: lxc/main.go:255
 msgid "Start containers."
 msgstr ""
 
@@ -1047,7 +1065,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:252
+#: lxc/main.go:261
 msgid "Stop containers."
 msgstr ""
 
@@ -1172,7 +1190,7 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
-#: lxc/main.go:164
+#: lxc/main.go:173
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
 
@@ -1207,7 +1225,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/remote.go:382
+#: lxc/remote.go:410
 msgid "URL"
 msgstr ""
 
@@ -1866,14 +1884,14 @@ msgid ""
 "    Delete local container \"c1\"."
 msgstr ""
 
-#: lxc/remote.go:39
+#: lxc/remote.go:40
 msgid ""
 "Usage: lxc remote <subcommand> [options]\n"
 "\n"
 "Manage the list of remote LXD servers.\n"
 "\n"
 "lxc remote add [<remote>] <IP|FQDN|URL> [--accept-certificate] [--"
-"password=PASSWORD] [--public] [--protocol=PROTOCOL]\n"
+"password=PASSWORD] [--public] [--protocol=PROTOCOL] [--auth-type=AUTH_TYPE]\n"
 "    Add the remote <remote> at <url>.\n"
 "\n"
 "lxc remote remove <remote>\n"
@@ -2060,7 +2078,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:510 lxc/remote.go:357 lxc/remote.go:362
+#: lxc/network.go:510 lxc/remote.go:382 lxc/remote.go:387
 msgid "YES"
 msgstr ""
 
@@ -2076,11 +2094,11 @@ msgstr ""
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/main.go:68
+#: lxc/main.go:72
 msgid "`lxc config profile` is deprecated, please use `lxc profile`"
 msgstr ""
 
-#: lxc/remote.go:345
+#: lxc/remote.go:370
 msgid "can't remove the default remote"
 msgstr ""
 
@@ -2088,7 +2106,7 @@ msgstr ""
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/remote.go:371
+#: lxc/remote.go:399
 msgid "default"
 msgstr ""
 
@@ -2104,12 +2122,12 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:29 lxc/main.go:183
+#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:192
 #, c-format
 msgid "error: %v"
 msgstr ""
 
-#: lxc/help.go:37 lxc/main.go:124
+#: lxc/help.go:37 lxc/main.go:133
 #, c-format
 msgid "error: unknown command: %s"
 msgstr ""
@@ -2118,11 +2136,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:193
+#: lxc/remote.go:204
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:356 lxc/main.go:360
+#: lxc/main.go:365 lxc/main.go:369
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2131,22 +2149,22 @@ msgstr ""
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 
-#: lxc/remote.go:407
+#: lxc/remote.go:436
 #, c-format
 msgid "remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:337 lxc/remote.go:399 lxc/remote.go:434 lxc/remote.go:450
+#: lxc/remote.go:362 lxc/remote.go:428 lxc/remote.go:463 lxc/remote.go:479
 #, c-format
 msgid "remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:320
+#: lxc/remote.go:345
 #, c-format
 msgid "remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:341 lxc/remote.go:403 lxc/remote.go:438
+#: lxc/remote.go:366 lxc/remote.go:432 lxc/remote.go:467
 #, c-format
 msgid "remote %s is static and cannot be modified"
 msgstr ""
@@ -2164,7 +2182,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:287
+#: lxc/main.go:296
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -29,6 +29,7 @@ type ServerUntrusted struct {
 	APIStatus     string   `json:"api_status" yaml:"api_status"`
 	APIVersion    string   `json:"api_version" yaml:"api_version"`
 	Auth          string   `json:"auth" yaml:"auth"`
+	AuthMethods   []string `json:"auth_methods" yaml:"auth_methods"`
 	Public        bool     `json:"public" yaml:"public"`
 }
 

--- a/test/godeps.list
+++ b/test/godeps.list
@@ -1,0 +1,16 @@
+github.com/golang/protobuf
+github.com/gorilla/websocket
+github.com/juju/go4
+github.com/juju/httprequest
+github.com/juju/loggo
+github.com/juju/persistent-cookiejar
+github.com/juju/webbrowser
+github.com/julienschmidt/httprouter
+github.com/rogpeppe/fastuuid
+golang.org/x/crypto
+golang.org/x/net
+gopkg.in/errgo.v1
+gopkg.in/macaroon-bakery.v2-unstable
+gopkg.in/macaroon.v2-unstable
+gopkg.in/retry.v1
+gopkg.in/yaml.v2

--- a/test/includes/external_auth.sh
+++ b/test/includes/external_auth.sh
@@ -1,0 +1,30 @@
+# Test helper for external authentication
+
+start_external_auth_daemon() {
+
+    (
+        cd macaroon-identity || return
+        go build ./...
+        go install ./...
+    )
+    # shellcheck disable=SC2039
+    local credentials_file tcp_port
+    credentials_file="$1/macaroon-identity-credentials.csv"
+    tcp_port="$(local_tcp_port)"
+    cat <<EOF >"$credentials_file"
+user1,pass1
+user2,pass2
+EOF
+
+    macaroon-identity -endpoint "localhost:$tcp_port" -creds "$credentials_file" &
+    set +x
+    echo $! > "${TEST_DIR}/macaroon-identity.pid"
+    echo "http://localhost:$tcp_port" > "${TEST_DIR}/macaroon-identity.endpoint"
+}
+
+kill_external_auth_daemon() {
+    # shellcheck disable=SC2039
+    local pidfile="$1/macaroon-identity.pid"
+    kill "$(cat "$pidfile")" || true
+    rm -f macaroon-identity/macaroon-identity
+}

--- a/test/macaroon-identity/auth.go
+++ b/test/macaroon-identity/auth.go
@@ -1,0 +1,143 @@
+package main
+
+import (
+	"encoding/base64"
+	"fmt"
+	"log"
+	"net/http"
+
+	"golang.org/x/net/context"
+
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/bakery/checkers"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
+
+	"github.com/juju/httprequest"
+	"github.com/rogpeppe/fastuuid"
+)
+
+const formURL string = "/form"
+
+type loginResponse struct {
+	Token *httpbakery.DischargeToken `json:"token"`
+}
+
+// AuthService is an HTTP service for authentication using macaroons.
+type AuthService struct {
+	HTTPService
+
+	KeyPair *bakery.KeyPair
+	Checker CredentialsChecker
+
+	userTokens    map[string]string // map user token to username
+	uuidGenerator *fastuuid.Generator
+}
+
+// NewAuthService returns an AuthService
+func NewAuthService(listenAddr string, logger *log.Logger) *AuthService {
+	key := bakery.MustGenerateKey()
+	mux := http.NewServeMux()
+	s := AuthService{
+		HTTPService: HTTPService{
+			Name:       "auth",
+			ListenAddr: listenAddr,
+			Logger:     logger,
+			Mux:        mux,
+		},
+		KeyPair:       key,
+		Checker:       NewCredentialsChecker(),
+		uuidGenerator: fastuuid.MustNewGenerator(),
+		userTokens:    map[string]string{},
+	}
+	mux.Handle(formURL, http.HandlerFunc(s.formHandler))
+
+	discharger := httpbakery.NewDischarger(
+		httpbakery.DischargerParams{
+			Key:     key,
+			Checker: httpbakery.ThirdPartyCaveatCheckerFunc(s.thirdPartyChecker),
+		})
+	discharger.AddMuxHandlers(mux, "/")
+	return &s
+}
+
+func (s *AuthService) thirdPartyChecker(ctx context.Context, req *http.Request, info *bakery.ThirdPartyCaveatInfo, token *httpbakery.DischargeToken) ([]checkers.Caveat, error) {
+	if token == nil {
+		err := httpbakery.NewInteractionRequiredError(nil, req)
+		err.SetInteraction("form", form.InteractionInfo{URL: formURL})
+		return nil, err
+	}
+
+	tokenString := string(token.Value)
+	username, ok := s.userTokens[tokenString]
+	if token.Kind != "form" || !ok {
+		return nil, fmt.Errorf("invalid token %#v", token)
+	}
+
+	_, _, err := checkers.ParseCaveat(string(info.Condition))
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse caveat %q: %s", info.Condition, err)
+	}
+
+	return []checkers.Caveat{
+		checkers.DeclaredCaveat("username", username),
+	}, nil
+}
+
+func (s *AuthService) formHandler(w http.ResponseWriter, req *http.Request) {
+	s.LogRequest(req)
+	switch req.Method {
+	case "GET":
+		httprequest.WriteJSON(w, http.StatusOK, schemaResponse)
+	case "POST":
+		params := httprequest.Params{
+			Response: w,
+			Request:  req,
+			Context:  context.TODO(),
+		}
+		loginRequest := form.LoginRequest{}
+		if err := httprequest.Unmarshal(params, &loginRequest); err != nil {
+			s.bakeryFail(w, "can't unmarshal login request")
+			return
+		}
+
+		form, err := fieldsChecker.Coerce(loginRequest.Body.Form, nil)
+		if err != nil {
+			s.bakeryFail(w, "invalid login form data: %v", err)
+			return
+		}
+
+		if !s.Checker.Check(form) {
+			s.bakeryFail(w, "invalid credentials")
+			return
+		}
+
+		username := form.(map[string]interface{})["username"].(string)
+		token := s.getRandomToken()
+		s.userTokens[token] = username
+
+		loginResponse := loginResponse{
+			Token: &httpbakery.DischargeToken{
+				Kind:  "form",
+				Value: []byte(token),
+			},
+		}
+		httprequest.WriteJSON(w, http.StatusOK, loginResponse)
+
+	default:
+		s.Fail(w, http.StatusMethodNotAllowed, "%s method not allowed", req.Method)
+		return
+	}
+}
+
+func (s *AuthService) getRandomToken() string {
+	uuid := make([]byte, 24)
+	for i, b := range s.uuidGenerator.Next() {
+		uuid[i] = b
+	}
+	return base64.StdEncoding.EncodeToString(uuid)
+}
+
+func (s *AuthService) bakeryFail(w http.ResponseWriter, msg string, args ...interface{}) {
+	httpbakery.WriteError(context.TODO(), w, fmt.Errorf(msg, args...))
+}

--- a/test/macaroon-identity/credentials.go
+++ b/test/macaroon-identity/credentials.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/csv"
+	"fmt"
+	"os"
+)
+
+type CredentialsChecker struct {
+	creds map[string]string
+}
+
+func NewCredentialsChecker() CredentialsChecker {
+	return CredentialsChecker{creds: map[string]string{}}
+}
+
+func (c *CredentialsChecker) Check(form interface{}) bool {
+	m := form.(map[string]interface{})
+	username := m["username"].(string)
+	password := m["password"].(string)
+	pass, ok := c.creds[username]
+	return ok && pass == password
+}
+
+func (c *CredentialsChecker) AddCreds(creds map[string]string) {
+	for user, pass := range creds {
+		c.creds[user] = pass
+	}
+}
+
+func (c *CredentialsChecker) LoadCreds(csvFile string) error {
+	f, err := os.Open(csvFile)
+	if err != nil {
+		return err
+	}
+
+	rows, err := csv.NewReader(f).ReadAll()
+	if err != nil {
+		return err
+	}
+
+	creds := map[string]string{}
+	for i, row := range rows {
+		if len(row) != 2 {
+			return fmt.Errorf("invalid length on row %d", i+1)
+		}
+		creds[row[0]] = row[1]
+	}
+	c.AddCreds(creds)
+	return nil
+}

--- a/test/macaroon-identity/formschema.go
+++ b/test/macaroon-identity/formschema.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"github.com/juju/schema"
+
+	"gopkg.in/juju/environschema.v1"
+	"gopkg.in/macaroon-bakery.v2-unstable/httpbakery/form"
+)
+
+var schemaResponse = form.SchemaResponse{
+	Schema: schemaFields,
+}
+
+var schemaFields = environschema.Fields{
+	"username": environschema.Attr{
+		Description: "username",
+		Type:        environschema.Tstring,
+		Mandatory:   true,
+	},
+	"password": environschema.Attr{
+		Description: "password",
+		Type:        environschema.Tstring,
+		Mandatory:   true,
+		Secret:      true,
+	},
+}
+
+var fieldsChecker = schema.FieldMap(validateSchema(schemaFields))
+
+func validateSchema(fields environschema.Fields) (schema.Fields, schema.Defaults) {
+	f, d, err := fields.ValidationSchema()
+	if err != nil {
+		panic(err)
+	}
+	return f, d
+}

--- a/test/macaroon-identity/http.go
+++ b/test/macaroon-identity/http.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+)
+
+type HTTPService struct {
+	Name       string
+	ListenAddr string
+	Logger     *log.Logger
+	Mux        http.Handler
+
+	listener net.Listener
+}
+
+func (s *HTTPService) Endpoint() string {
+	if s.listener == nil {
+		return ""
+	}
+
+	return "http://" + s.listener.Addr().String()
+}
+
+func (s *HTTPService) Start(background bool) error {
+	listener, err := net.Listen("tcp", s.ListenAddr)
+	if err != nil {
+		return err
+	}
+	s.listener = listener
+	if s.Name != "" {
+		s.Logger.Printf("%s - running at %s", s.Name, s.Endpoint())
+	}
+
+	if !background {
+		return http.Serve(s.listener, s.Mux)
+	}
+
+	go func() {
+		err := http.Serve(s.listener, s.Mux)
+		if err != nil {
+			panic(err)
+		}
+	}()
+	return nil
+}
+
+func (s *HTTPService) LogRequest(req *http.Request) {
+	s.Logger.Printf("%s - %s %s", s.Name, req.Method, req.URL.Path)
+}
+
+// Fail returns an HTTP error with the specified message
+func (s *HTTPService) Fail(w http.ResponseWriter, code int, msg string, args ...interface{}) {
+	http.Error(w, fmt.Sprintf(msg, args...), code)
+}

--- a/test/macaroon-identity/main.go
+++ b/test/macaroon-identity/main.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+)
+
+type flags struct {
+	Endpoint  string
+	CredsFile string
+}
+
+func main() {
+	flags := parseFlags()
+	logger := log.New(os.Stdout, "", log.Ldate|log.Ltime)
+	s := NewAuthService(flags.Endpoint, logger)
+	if err := s.Checker.LoadCreds(flags.CredsFile); err != nil {
+		panic(err)
+	}
+	if err := s.Start(false); err != nil {
+		panic(err)
+	}
+}
+
+func parseFlags() *flags {
+	endpoint := flag.String("endpoint", "localhost:8081", "service endpoint")
+	credsFile := flag.String("creds", "credentials.csv", "CSV file with credentials (username and password)")
+	flag.Parse()
+	f := &flags{
+		Endpoint:  *endpoint,
+		CredsFile: *credsFile,
+	}
+
+	return f
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -84,8 +84,8 @@ cleanup() {
 
   echo "==> Cleaning up"
 
+  kill_external_auth_daemon "$TEST_DIR"
   cleanup_lxds "$TEST_DIR"
-
 
   echo ""
   echo ""
@@ -122,6 +122,8 @@ chmod +x "${LXD_DIR}"
 spawn_lxd "${LXD_DIR}" true
 LXD_ADDR=$(cat "${LXD_DIR}/lxd.addr")
 export LXD_ADDR
+
+start_external_auth_daemon "${LXD_DIR}"
 
 run_test() {
   TEST_CURRENT=${1}
@@ -186,6 +188,7 @@ run_test test_storage_volume_attach "attaching storage volumes"
 run_test test_storage_driver_ceph "ceph storage driver"
 run_test test_resources "resources"
 run_test test_kernel_limits "kernel limits"
+run_test test_macaroon_auth "macaroon authentication"
 
 # shellcheck disable=SC2034
 TEST_RESULT=success

--- a/test/suites/external_auth.sh
+++ b/test/suites/external_auth.sh
@@ -1,0 +1,32 @@
+test_macaroon_auth() {
+    # shellcheck disable=SC2039
+    local identity_endpoint
+    # shellcheck disable=SC2086
+    identity_endpoint="$(cat ${TEST_DIR}/macaroon-identity.endpoint)"
+
+    ensure_has_localhost_remote "$LXD_ADDR"
+
+    lxc config set core.macaroon.endpoint "$identity_endpoint"
+
+    # invalid credentials make the remote add fail
+    # shellcheck disable=SC2039
+    ! cat <<EOF | lxc remote add macaroon-remote "https://$LXD_ADDR" --auth-type macaroons --accept-certificate
+wrong-user
+wrong-pass
+EOF
+
+    # valid credentials work
+    # shellcheck disable=SC2039
+    cat <<EOF | lxc remote add macaroon-remote "https://$LXD_ADDR" --auth-type macaroons --accept-certificate
+user1
+pass1
+EOF
+
+    # run a lxc command through the new remote
+    lxc config show macaroon-remote: | grep -q core.macaroon.endpoint
+
+    # cleanup
+    lxc config unset core.macaroon.endpoint
+    lxc config unset core.https_address
+    lxc remote remove macaroon-remote
+}

--- a/test/suites/remote.sh
+++ b/test/suites/remote.sh
@@ -15,6 +15,9 @@ test_remote_url() {
     urls="images.linuxcontainers.org https://images.linuxcontainers.org ${urls}"
   fi
 
+  # an invalid protocol returns an error
+  ! lxc_remote remote add test "${url}" --accept-certificate --password foo --protocol foo
+
   for url in ${urls}; do
     lxc_remote remote add test "${url}"
     lxc_remote remote remove test

--- a/test/suites/serverconfig.sh
+++ b/test/suites/serverconfig.sh
@@ -14,4 +14,13 @@ test_server_config() {
 
   # test untrusted server GET
   my_curl -X GET "https://$(cat "${LXD_SERVERCONFIG_DIR}/lxd.addr")/1.0" | grep -v -q environment
+
+  # test authentication type
+  curl --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq .metadata.auth_methods | grep tls
+  # only tls is enabled by default
+  ! curl --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq .metadata.auth_methods | grep macaroons
+  lxc config set core.macaroon.endpoint "https://localhost:8081"
+  # macaroons are also enabled
+  curl --unix-socket "$LXD_DIR/unix.socket" "lxd/1.0" | jq .metadata.auth_methods | grep macaroons
+  lxc config unset core.macaroon.endpoint
 }

--- a/test/suites/static_analysis.sh
+++ b/test/suites/static_analysis.sh
@@ -65,7 +65,7 @@ test_static_analysis() {
     fi
 
     if which godeps >/dev/null 2>&1; then
-      OUT=$(godeps -T ./client ./lxc/config ./shared/api 2> /dev/null | grep -v lxc/lxd | grep -v gorilla/websocket | grep -v yaml.v2 || true)
+      OUT=$(godeps -T ./client ./lxc/config ./shared/api 2>/dev/null | cut -f1 | diff -u test/godeps.list - || true)
       if [ -n "${OUT}" ]; then
         echo "ERROR: you added a new dependency to the client or shared; please make sure this is what you want"
         echo "${OUT}"


### PR DESCRIPTION
Add support for external authentication via macaroons (https://github.com/go-macaroon/macaroon)