### PR TITLE
lxc-to-lxd: permit defaults in lxc.mount.entry and lxc.cap.drop

### DIFF
--- a/scripts/lxc-to-lxd
+++ b/scripts/lxc-to-lxd
@@ -399,6 +399,10 @@ def convert_container(lxd_socket, container_name, args):
             print("Invalid mount configuration, skipping...")
             return False
 
+        # Ignore mounts that are present in LXD containers by default.
+        if mount[0] in ("proc", "sysfs"):
+            continue
+
         device = {'type': "disk"}
 
         # Deal with read-only mounts

--- a/scripts/lxc-to-lxd
+++ b/scripts/lxc-to-lxd
@@ -87,7 +87,7 @@ keys_to_check = [
     'lxc.rebootsignal',
     'lxc.stopsignal',
     'lxc.mount.entry',
-    'lxc.cap.drop'
+    'lxc.cap.drop',
     # 'lxc.cap.keep',
     'lxc.seccomp',
     # 'lxc.se_context',
@@ -476,8 +476,12 @@ def convert_container(lxd_socket, container_name, args):
     print("Processing container capabilities configuration")
     value = config_get(lxc_config, "lxc.cap.drop")
     if value:
-        print("Custom capabilities aren't supported, skipping...")
-        return False
+        for cap in value:
+            # Ignore capabilities that are dropped in LXD containers by default.
+            if cap in ("mac_admin", "mac_override", "sys_module", "sys_time"):
+                continue
+            print("Custom capabilities aren't supported, skipping...")
+            return False
 
     value = config_get(lxc_config, "lxc.cap.keep")
     if value:


### PR DESCRIPTION
Ignore sysfs and proc mounts, which are mounted
in LXD containers by default. If they're not ignored,
the os.path.exists test will fail.

Ignore lxc.cap.drop values that are dropped by
default in LXD containers, rather than bailing.
Also, add a missing comma at the end of the line
for lxc.cap.drop in the list of handled attributes.

Signed-off-by: Andrew Wilkins <axwalk@gmail.com>