### PR TITLE
Rework ZFS utility functions

### DIFF
--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -192,7 +192,7 @@ func (s *storageZfs) StoragePoolVolumeCreate() error {
 	}
 
 	if !shared.IsMountPoint(customPoolVolumeMntPoint) {
-		s.zfsPoolVolumeMount(fs)
+		zfsMount(poolName, fs)
 	}
 
 	// apply quota
@@ -271,7 +271,7 @@ func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
 	var customerr error
 	ourMount := false
 	if !shared.IsMountPoint(customPoolVolumeMntPoint) {
-		customerr = s.zfsPoolVolumeMount(fs)
+		customerr = zfsMount(s.getOnDiskPoolName(), fs)
 		ourMount = true
 	}
 
@@ -1521,7 +1521,7 @@ func (s *storageZfs) ContainerSnapshotStart(container container) (bool, error) {
 		return false, err
 	}
 
-	err = s.zfsPoolVolumeMount(destFs)
+	err = zfsMount(s.getOnDiskPoolName(), destFs)
 	if err != nil {
 		return false, err
 	}
@@ -1649,7 +1649,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 
 	// Make sure that the image actually got mounted.
 	if !shared.IsMountPoint(tmpImageDir) {
-		s.zfsPoolVolumeMount(fs)
+		zfsMount(poolName, fs)
 	}
 
 	// Unpack the image into the temporary mountpoint.
@@ -2078,7 +2078,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 	 * but sometimes it doesn't. Let's try to mount, but not complain about
 	 * failure.
 	 */
-	s.zfsPoolVolumeMount(zfsName)
+	zfsMount(poolName, zfsName)
 	return nil
 }
 

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -718,7 +718,7 @@ func (s *storageZfs) ContainerDelete(container container) error {
 
 		for _, snap := range snaps {
 			var err error
-			removable, err = s.zfsPoolVolumeSnapshotRemovable(fs, snap)
+			removable, err = zfsPoolVolumeSnapshotRemovable(poolName, fs, snap)
 			if err != nil {
 				return err
 			}
@@ -1377,7 +1377,7 @@ func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error 
 	snapName := fmt.Sprintf("snapshot-%s", sourceContainerSnapOnlyName)
 
 	if s.zfsFilesystemEntityExists(fmt.Sprintf("containers/%s@%s", sourceContainerName, snapName), true) {
-		removable, err := s.zfsPoolVolumeSnapshotRemovable(fmt.Sprintf("containers/%s", sourceContainerName), snapName)
+		removable, err := zfsPoolVolumeSnapshotRemovable(s.getOnDiskPoolName(), fmt.Sprintf("containers/%s", sourceContainerName), snapName)
 		if removable {
 			err = s.zfsPoolVolumeSnapshotDestroy(fmt.Sprintf("containers/%s", sourceContainerName), snapName)
 			if err != nil {
@@ -1697,16 +1697,17 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 func (s *storageZfs) ImageDelete(fingerprint string) error {
 	logger.Debugf("Deleting ZFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
 
+	poolName := s.getOnDiskPoolName()
 	fs := fmt.Sprintf("images/%s", fingerprint)
 
 	if s.zfsFilesystemEntityExists(fs, true) {
-		removable, err := s.zfsPoolVolumeSnapshotRemovable(fs, "readonly")
+		removable, err := zfsPoolVolumeSnapshotRemovable(poolName, fs, "readonly")
 		if err != nil {
 			return err
 		}
 
 		if removable {
-			err := zfsPoolVolumeDestroy(s.getOnDiskPoolName(), fs)
+			err := zfsPoolVolumeDestroy(poolName, fs)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -741,7 +741,7 @@ func (s *storageZfs) ContainerDelete(container container) error {
 				return err
 			}
 
-			err = s.zfsPoolVolumeCleanup(origin)
+			err = zfsPoolVolumeCleanup(poolName, origin)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -314,7 +314,7 @@ func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
 	var customerr error
 	ourUmount := false
 	if shared.IsMountPoint(customPoolVolumeMntPoint) {
-		customerr = s.zfsPoolVolumeUmount(fs, customPoolVolumeMntPoint)
+		customerr = zfsUmount(s.getOnDiskPoolName(), fs, customPoolVolumeMntPoint)
 		ourUmount = true
 	}
 
@@ -514,7 +514,7 @@ func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
 	var imgerr error
 	ourUmount := false
 	if shared.IsMountPoint(containerPoolVolumeMntPoint) {
-		imgerr = s.zfsPoolVolumeUmount(fs, containerPoolVolumeMntPoint)
+		imgerr = zfsUmount(s.getOnDiskPoolName(), fs, containerPoolVolumeMntPoint)
 		ourUmount = true
 	}
 
@@ -1672,7 +1672,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 
 	// Make sure that the image actually got unmounted.
 	if shared.IsMountPoint(tmpImageDir) {
-		s.zfsPoolVolumeUmount(fs, tmpImageDir)
+		zfsUmount(poolName, fs, tmpImageDir)
 	}
 
 	// Create a snapshot of that image on the storage pool which we clone for
@@ -1975,7 +1975,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 	zfsName := fmt.Sprintf("containers/%s", container.Name())
 	containerMntPoint := getContainerMountPoint(s.pool.Name, container.Name())
 	if shared.IsMountPoint(containerMntPoint) {
-		err := s.zfsPoolVolumeUmount(zfsName, containerMntPoint)
+		err := zfsUmount(poolName, zfsName, containerMntPoint)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -140,7 +140,7 @@ func (s *storageZfs) StoragePoolCreate() error {
 func (s *storageZfs) StoragePoolDelete() error {
 	logger.Infof("Deleting ZFS storage pool \"%s\".", s.pool.Name)
 
-	err := s.zfsFilesystemEntityDelete()
+	err := zfsFilesystemEntityDelete(s.pool.Config["source"], s.getOnDiskPoolName())
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -710,7 +710,7 @@ func (s *storageZfs) ContainerDelete(container container) error {
 
 	if s.zfsFilesystemEntityExists(fs, true) {
 		removable := true
-		snaps, err := s.zfsPoolListSnapshots(fs)
+		snaps, err := zfsPoolListSnapshots(s.getOnDiskPoolName(), fs)
 		if err != nil {
 			return err
 		}
@@ -1898,7 +1898,7 @@ func (s *storageZfs) MigrationSource(ct container, containerOnly bool) (Migratio
 	* is that we send the oldest to newest snapshot, hopefully saving on
 	* xfer costs. Then, after all that, we send the container itself.
 	 */
-	snapshots, err := s.zfsPoolListSnapshots(fmt.Sprintf("containers/%s", ct.Name()))
+	snapshots, err := zfsPoolListSnapshots(s.getOnDiskPoolName(), fmt.Sprintf("containers/%s", ct.Name()))
 	if err != nil {
 		return nil, err
 	}
@@ -2043,7 +2043,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 
 	defer func() {
 		/* clean up our migration-send snapshots that we got from recv. */
-		zfsSnapshots, err := s.zfsPoolListSnapshots(fmt.Sprintf("containers/%s", container.Name()))
+		zfsSnapshots, err := zfsPoolListSnapshots(poolName, fmt.Sprintf("containers/%s", container.Name()))
 		if err != nil {
 			logger.Errorf("failed listing snapshots post migration: %s.", err)
 			return

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -729,7 +729,7 @@ func (s *storageZfs) ContainerDelete(container container) error {
 		}
 
 		if removable {
-			origin, err := zfsFilesystemEntityPropertyGet(poolName, fs, "origin", true)
+			origin, err := zfsFilesystemEntityPropertyGet(poolName, fs, "origin")
 			if err != nil {
 				return err
 			}
@@ -1313,7 +1313,7 @@ func (s *storageZfs) ContainerGetUsage(container container) (int64, error) {
 		property = "usedbydataset"
 	}
 
-	value, err := zfsFilesystemEntityPropertyGet(s.getOnDiskPoolName(), fs, property, true)
+	value, err := zfsFilesystemEntityPropertyGet(s.getOnDiskPoolName(), fs, property)
 	if err != nil {
 		return -1, err
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -751,7 +751,7 @@ func (s *storageZfs) ContainerDelete(container container) error {
 				return err
 			}
 
-			err = s.zfsPoolVolumeRename(fs, fmt.Sprintf("deleted/containers/%s", uuid.NewRandom().String()))
+			err = zfsPoolVolumeRename(poolName, fs, fmt.Sprintf("deleted/containers/%s", uuid.NewRandom().String()))
 			if err != nil {
 				return err
 			}
@@ -1176,7 +1176,7 @@ func (s *storageZfs) ContainerRename(container container, newName string) error 
 	// Rename the dataset.
 	oldZfsDataset := fmt.Sprintf("containers/%s", oldName)
 	newZfsDataset := fmt.Sprintf("containers/%s", newName)
-	err = s.zfsPoolVolumeRename(oldZfsDataset, newZfsDataset)
+	err = zfsPoolVolumeRename(poolName, oldZfsDataset, newZfsDataset)
 	if err != nil {
 		return err
 	}
@@ -1588,8 +1588,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 	}()
 
 	if zfsFilesystemEntityExists(poolName, fmt.Sprintf("deleted/%s", fs)) {
-		err := s.zfsPoolVolumeRename(fmt.Sprintf("deleted/%s", fs), fs)
-		if err != nil {
+		if err := zfsPoolVolumeRename(poolName, fmt.Sprintf("deleted/%s", fs), fs); err != nil {
 			return err
 		}
 
@@ -1718,8 +1717,7 @@ func (s *storageZfs) ImageDelete(fingerprint string) error {
 				return err
 			}
 
-			err = s.zfsPoolVolumeRename(fs, fmt.Sprintf("deleted/%s", fs))
-			if err != nil {
+			if err := zfsPoolVolumeRename(poolName, fs, fmt.Sprintf("deleted/%s", fs)); err != nil {
 				return err
 			}
 		}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -36,24 +36,6 @@ func (s *storageZfs) getOnDiskPoolName() string {
 	return s.pool.Name
 }
 
-func zfsIsEnabled() bool {
-	out, err := exec.LookPath("zfs")
-	if err != nil || len(out) == 0 {
-		return false
-	}
-
-	return true
-}
-
-func zfsModuleVersionGet() (string, error) {
-	zfsVersion, err := ioutil.ReadFile("/sys/module/zfs/version")
-	if err != nil {
-		return "", fmt.Errorf("could not determine ZFS module version")
-	}
-
-	return strings.TrimSpace(string(zfsVersion)), nil
-}
-
 // Only initialize the minimal information we need about a given storage type.
 func (s *storageZfs) StorageCoreInit() error {
 	s.sType = storageTypeZfs

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1285,7 +1285,7 @@ func (s *storageZfs) ContainerRestore(target container, source container) error 
 	cName, snapOnlyName, _ := containerGetParentAndSnapshotName(source.Name())
 	snapName := fmt.Sprintf("snapshot-%s", snapOnlyName)
 
-	err = s.zfsPoolVolumeSnapshotRestore(fmt.Sprintf("containers/%s", cName), snapName)
+	err = zfsPoolVolumeSnapshotRestore(s.getOnDiskPoolName(), fmt.Sprintf("containers/%s", cName), snapName)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -320,23 +320,21 @@ func (s *storageZfs) zfsPoolVolumeClone(source string, name string, dest string,
 	return nil
 }
 
-func (s *storageZfs) zfsFilesystemEntityDelete() error {
+func zfsFilesystemEntityDelete(vdev string, pool string) error {
 	var output string
 	var err error
-	poolName := s.getOnDiskPoolName()
-	if strings.Contains(poolName, "/") {
+	if strings.Contains(pool, "/") {
 		// Command to destroy a zfs dataset.
-		output, err = shared.RunCommand("zfs", "destroy", "-r", poolName)
+		output, err = shared.RunCommand("zfs", "destroy", "-r", pool)
 	} else {
 		// Command to destroy a zfs pool.
-		output, err = shared.RunCommand("zpool", "destroy", "-f", poolName)
+		output, err = shared.RunCommand("zpool", "destroy", "-f", pool)
 	}
 	if err != nil {
 		return fmt.Errorf("Failed to delete the ZFS pool: %s", output)
 	}
 
 	// Cleanup storage
-	vdev := s.pool.Config["source"]
 	if filepath.IsAbs(vdev) && !shared.IsBlockdevPath(vdev) {
 		os.RemoveAll(vdev)
 	}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -12,6 +14,26 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
+
+// zfsIsEnabled returns whether zfs backend is supported.
+func zfsIsEnabled() bool {
+	out, err := exec.LookPath("zfs")
+	if err != nil || len(out) == 0 {
+		return false
+	}
+
+	return true
+}
+
+// zfsModuleVersionGet returhs the ZFS module version
+func zfsModuleVersionGet() (string, error) {
+	zfsVersion, err := ioutil.ReadFile("/sys/module/zfs/version")
+	if err != nil {
+		return "", fmt.Errorf("could not determine ZFS module version")
+	}
+
+	return strings.TrimSpace(string(zfsVersion)), nil
+}
 
 // zfsPoolVolumeCreate creates a ZFS dataset with a set of given properties.
 func zfsPoolVolumeCreate(dataset string, properties ...string) (string, error) {

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -439,18 +439,17 @@ func zfsFilesystemEntityPropertyGet(pool string, path string, key string) (strin
 	return strings.TrimRight(output, "\n"), nil
 }
 
-func (s *storageZfs) zfsPoolVolumeRename(source string, dest string) error {
+func zfsPoolVolumeRename(pool string, source string, dest string) error {
 	var err error
 	var output string
 
-	poolName := s.getOnDiskPoolName()
 	for i := 0; i < 20; i++ {
 		output, err = shared.RunCommand(
 			"zfs",
 			"rename",
 			"-p",
-			fmt.Sprintf("%s/%s", poolName, source),
-			fmt.Sprintf("%s/%s", poolName, dest))
+			fmt.Sprintf("%s/%s", pool, source),
+			fmt.Sprintf("%s/%s", pool, dest))
 
 		// Success
 		if err == nil {
@@ -458,7 +457,7 @@ func (s *storageZfs) zfsPoolVolumeRename(source string, dest string) error {
 		}
 
 		// zfs rename can fail because of descendants, yet still manage the rename
-		if !zfsFilesystemEntityExists(poolName, source) && zfsFilesystemEntityExists(poolName, dest) {
+		if !zfsFilesystemEntityExists(pool, source) && zfsFilesystemEntityExists(pool, dest) {
 			return nil
 		}
 

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -709,41 +709,6 @@ func zfsPoolVolumeSnapshotRemovable(pool string, path string, name string) (bool
 	return false, nil
 }
 
-func (s *storageZfs) zfsPoolGetUsers() ([]string, error) {
-	poolName := s.getOnDiskPoolName()
-	subvols, err := zfsPoolListSubvolumes(poolName, poolName)
-	if err != nil {
-		return []string{}, err
-	}
-
-	exceptions := []string{
-		"containers",
-		"images",
-		"snapshots",
-		"deleted",
-		"deleted/containers",
-		"deleted/images"}
-
-	users := []string{}
-	for _, subvol := range subvols {
-		path := strings.Split(subvol, "/")
-
-		// Only care about plausible LXD paths
-		if !shared.StringInSlice(path[0], exceptions) {
-			continue
-		}
-
-		// Ignore empty paths
-		if shared.StringInSlice(subvol, exceptions) {
-			continue
-		}
-
-		users = append(users, subvol)
-	}
-
-	return users, nil
-}
-
 func zfsFilesystemEntityExists(zfsEntity string) bool {
 	output, err := shared.RunCommand(
 		"zfs",

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -637,10 +637,6 @@ func zfsUmount(poolName string, path string, mountpoint string) error {
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeUmount(path string, mountpoint string) error {
-	return zfsUmount(s.getOnDiskPoolName(), path, mountpoint)
-}
-
 func (s *storageZfs) zfsPoolListSubvolumes(path string) ([]string, error) {
 	output, err := shared.RunCommand(
 		"zfs",

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -63,196 +62,23 @@ func zfsPoolCheck(pool string) error {
 	return nil
 }
 
-func (s *storageZfs) zfsPoolCreate() error {
-	zpoolName := s.getOnDiskPoolName()
-	vdev := s.pool.Config["source"]
-	if vdev == "" {
-		vdev = filepath.Join(shared.VarPath("disks"), fmt.Sprintf("%s.img", s.pool.Name))
-		s.pool.Config["source"] = vdev
-
-		if s.pool.Config["zfs.pool_name"] == "" {
-			s.pool.Config["zfs.pool_name"] = zpoolName
-		}
-
-		f, err := os.Create(vdev)
-		if err != nil {
-			return fmt.Errorf("Failed to open %s: %s", vdev, err)
-		}
-		defer f.Close()
-
-		err = f.Chmod(0600)
-		if err != nil {
-			return fmt.Errorf("Failed to chmod %s: %s", vdev, err)
-		}
-
-		size, err := shared.ParseByteSizeString(s.pool.Config["size"])
-		if err != nil {
-			return err
-		}
-		err = f.Truncate(size)
-		if err != nil {
-			return fmt.Errorf("Failed to create sparse file %s: %s", vdev, err)
-		}
-
+func zfsPoolCreate(pool string, vdev string) error {
+	var output string
+	var err error
+	if pool == "" {
 		output, err := shared.RunCommand(
-			"zpool",
-			"create", zpoolName, vdev,
-			"-f", "-m", "none", "-O", "compression=on")
+			"zfs", "create", "-p", "-o", "mountpoint=none", vdev)
 		if err != nil {
-			return fmt.Errorf("Failed to create the ZFS pool: %s", output)
+			logger.Errorf("zfs create failed: %s.", output)
+			return fmt.Errorf("Failed to create ZFS filesystem: %s", output)
 		}
 	} else {
-		// Unset size property since it doesn't make sense.
-		s.pool.Config["size"] = ""
-
-		if filepath.IsAbs(vdev) {
-			if !shared.IsBlockdevPath(vdev) {
-				return fmt.Errorf("custom loop file locations are not supported")
-			}
-
-			if s.pool.Config["zfs.pool_name"] == "" {
-				s.pool.Config["zfs.pool_name"] = zpoolName
-			}
-
-			// This is a block device. Note, that we do not store the
-			// block device path or UUID or PARTUUID or similar in
-			// the database. All of those might change or might be
-			// used in a special way (For example, zfs uses a single
-			// UUID in a multi-device pool for all devices.). The
-			// safest way is to just store the name of the zfs pool
-			// we create.
-			s.pool.Config["source"] = zpoolName
-			output, err := shared.RunCommand(
-				"zpool",
-				"create", zpoolName, vdev,
-				"-f", "-m", "none", "-O", "compression=on")
-			if err != nil {
-				return fmt.Errorf("Failed to create the ZFS pool: %s", output)
-			}
-		} else {
-			if s.pool.Config["zfs.pool_name"] != "" {
-				return fmt.Errorf("invalid combination of \"source\" and \"zfs.pool_name\" property")
-			}
-			s.pool.Config["zfs.pool_name"] = vdev
-			s.dataset = vdev
-
-			if strings.Contains(vdev, "/") {
-				if !zfsFilesystemEntityExists(vdev, "") {
-					output, err := shared.RunCommand(
-						"zfs",
-						"create",
-						"-p",
-						"-o",
-						"mountpoint=none",
-						vdev)
-					if err != nil {
-						logger.Errorf("zfs create failed: %s.", output)
-						return fmt.Errorf("Failed to create ZFS filesystem: %s", output)
-					}
-				} else {
-					if err := zfsPoolVolumeSet(vdev, "", "mountpoint", "none"); err != nil {
-						return err
-					}
-				}
-			} else {
-				err := zfsPoolCheck(vdev)
-				if err != nil {
-					return err
-				}
-
-				subvols, err := zfsPoolListSubvolumes(zpoolName, vdev)
-				if err != nil {
-					return err
-				}
-
-				if len(subvols) > 0 {
-					return fmt.Errorf("Provided ZFS pool (or dataset) isn't empty")
-				}
-
-				if err := zfsPoolVolumeSet(vdev, "", "mountpoint", "none"); err != nil {
-					return err
-				}
-			}
+		output, err = shared.RunCommand(
+			"zpool", "create", pool, vdev, "-f", "-m", "none", "-O", "compression=on")
+		if err != nil {
+			logger.Errorf("zfs create failed: %s.", output)
+			return fmt.Errorf("Failed to create the ZFS pool: %s", output)
 		}
-	}
-
-	// Create default dummy datasets to avoid zfs races during container
-	// creation.
-	poolName := s.getOnDiskPoolName()
-	dataset := fmt.Sprintf("%s/containers", poolName)
-	msg, err := zfsPoolVolumeCreate(dataset, "mountpoint=none")
-	if err != nil {
-		logger.Errorf("failed to create containers dataset: %s", msg)
-		return err
-	}
-
-	fixperms := shared.VarPath("storage-pools", s.pool.Name, "containers")
-	err = os.MkdirAll(fixperms, containersDirMode)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	err = os.Chmod(fixperms, containersDirMode)
-	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(containersDirMode), 8), err)
-	}
-
-	dataset = fmt.Sprintf("%s/images", poolName)
-	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
-	if err != nil {
-		logger.Errorf("failed to create images dataset: %s", msg)
-		return err
-	}
-
-	fixperms = shared.VarPath("storage-pools", s.pool.Name, "images")
-	err = os.MkdirAll(fixperms, imagesDirMode)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	err = os.Chmod(fixperms, imagesDirMode)
-	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(imagesDirMode), 8), err)
-	}
-
-	dataset = fmt.Sprintf("%s/custom", poolName)
-	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
-	if err != nil {
-		logger.Errorf("failed to create custom dataset: %s", msg)
-		return err
-	}
-
-	fixperms = shared.VarPath("storage-pools", s.pool.Name, "custom")
-	err = os.MkdirAll(fixperms, customDirMode)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	err = os.Chmod(fixperms, customDirMode)
-	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(customDirMode), 8), err)
-	}
-
-	dataset = fmt.Sprintf("%s/deleted", poolName)
-	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
-	if err != nil {
-		logger.Errorf("failed to create deleted dataset: %s", msg)
-		return err
-	}
-
-	dataset = fmt.Sprintf("%s/snapshots", poolName)
-	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
-	if err != nil {
-		logger.Errorf("failed to create snapshots dataset: %s", msg)
-		return err
-	}
-
-	fixperms = shared.VarPath("storage-pools", s.pool.Name, "snapshots")
-	err = os.MkdirAll(fixperms, snapshotsDirMode)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	err = os.Chmod(fixperms, snapshotsDirMode)
-	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(snapshotsDirMode), 8), err)
 	}
 
 	return nil

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -55,7 +55,7 @@ func zfsPoolVolumeSet(dataset string, key string, value string) (string, error) 
 		dataset)
 }
 
-func (s *storageZfs) zfsPoolCheck(pool string) error {
+func zfsPoolCheck(pool string) error {
 	output, err := shared.RunCommand(
 		"zfs", "get", "type", "-H", "-o", "value", pool)
 	if err != nil {
@@ -165,7 +165,7 @@ func (s *storageZfs) zfsPoolCreate() error {
 					}
 				}
 			} else {
-				err := s.zfsPoolCheck(vdev)
+				err := zfsPoolCheck(vdev)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -376,7 +376,7 @@ func (s *storageZfs) zfsPoolVolumeCleanup(path string) error {
 
 	if strings.HasPrefix(path, "deleted/") {
 		// Cleanup of filesystems kept for refcount reason
-		removablePath, err := s.zfsPoolVolumeSnapshotRemovable(path, "")
+		removablePath, err := zfsPoolVolumeSnapshotRemovable(poolName, path, "")
 		if err != nil {
 			return err
 		}
@@ -703,7 +703,7 @@ func zfsPoolListSnapshots(pool string, path string) ([]string, error) {
 	return children, nil
 }
 
-func (s *storageZfs) zfsPoolVolumeSnapshotRemovable(path string, name string) (bool, error) {
+func zfsPoolVolumeSnapshotRemovable(pool string, path string, name string) (bool, error) {
 	var snap string
 	if name == "" {
 		snap = path
@@ -711,7 +711,7 @@ func (s *storageZfs) zfsPoolVolumeSnapshotRemovable(path string, name string) (b
 		snap = fmt.Sprintf("%s@%s", path, name)
 	}
 
-	clones, err := zfsFilesystemEntityPropertyGet(s.getOnDiskPoolName(), snap, "clones", true)
+	clones, err := zfsFilesystemEntityPropertyGet(pool, snap, "clones", true)
 	if err != nil {
 		return false, err
 	}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -342,9 +342,8 @@ func zfsFilesystemEntityDelete(vdev string, pool string) error {
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeDestroy(path string) error {
-	poolName := s.getOnDiskPoolName()
-	mountpoint, err := zfsFilesystemEntityPropertyGet(poolName, path, "mountpoint", true)
+func zfsPoolVolumeDestroy(pool string, path string) error {
+	mountpoint, err := zfsFilesystemEntityPropertyGet(pool, path, "mountpoint", true)
 	if err != nil {
 		return err
 	}
@@ -362,7 +361,7 @@ func (s *storageZfs) zfsPoolVolumeDestroy(path string) error {
 		"zfs",
 		"destroy",
 		"-r",
-		fmt.Sprintf("%s/%s", poolName, path))
+		fmt.Sprintf("%s/%s", pool, path))
 
 	if err != nil {
 		logger.Errorf("zfs destroy failed: %s.", output)
@@ -386,7 +385,7 @@ func (s *storageZfs) zfsPoolVolumeCleanup(path string) error {
 		if removablePath {
 			if strings.Contains(path, "@") {
 				// Cleanup snapshots
-				err = s.zfsPoolVolumeDestroy(path)
+				err = zfsPoolVolumeDestroy(poolName, path)
 				if err != nil {
 					return err
 				}
@@ -410,10 +409,9 @@ func (s *storageZfs) zfsPoolVolumeCleanup(path string) error {
 				if err != nil {
 					return err
 				}
-				poolName := s.getOnDiskPoolName()
 				origin = strings.TrimPrefix(origin, fmt.Sprintf("%s/", poolName))
 
-				err = s.zfsPoolVolumeDestroy(path)
+				err = zfsPoolVolumeDestroy(poolName, path)
 				if err != nil {
 					return err
 				}
@@ -431,7 +429,7 @@ func (s *storageZfs) zfsPoolVolumeCleanup(path string) error {
 		}
 	} else if strings.HasPrefix(path, "containers") && strings.Contains(path, "@copy-") {
 		// Just remove the copy- snapshot for copies of active containers
-		err := s.zfsPoolVolumeDestroy(path)
+		err := zfsPoolVolumeDestroy(poolName, path)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -620,10 +620,6 @@ func zfsMount(poolName string, path string) error {
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeMount(path string) error {
-	return zfsMount(s.getOnDiskPoolName(), path)
-}
-
 func zfsUmount(poolName string, path string, mountpoint string) error {
 	output, err := shared.TryRunCommand(
 		"zfs",

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -291,7 +291,7 @@ func (s *storageZfs) zfsPoolVolumeClone(source string, name string, dest string,
 	}
 
 	for _, sub := range subvols {
-		snaps, err := s.zfsPoolListSnapshots(sub)
+		snaps, err := zfsPoolListSnapshots(poolName, sub)
 		if err != nil {
 			return err
 		}
@@ -391,7 +391,7 @@ func (s *storageZfs) zfsPoolVolumeCleanup(path string) error {
 
 				// Check if the parent can now be deleted
 				subPath := strings.SplitN(path, "@", 2)[0]
-				snaps, err := s.zfsPoolListSnapshots(subPath)
+				snaps, err := zfsPoolListSnapshots(s.getOnDiskPoolName(), subPath)
 				if err != nil {
 					return err
 				}
@@ -570,7 +570,7 @@ func (s *storageZfs) zfsPoolVolumeSnapshotRestore(path string, name string) erro
 	}
 
 	for _, sub := range subvols {
-		snaps, err := s.zfsPoolListSnapshots(sub)
+		snaps, err := zfsPoolListSnapshots(poolName, sub)
 		if err != nil {
 			return err
 		}
@@ -667,12 +667,11 @@ func (s *storageZfs) zfsPoolListSubvolumes(path string) ([]string, error) {
 	return children, nil
 }
 
-func (s *storageZfs) zfsPoolListSnapshots(path string) ([]string, error) {
-	poolName := s.getOnDiskPoolName()
+func zfsPoolListSnapshots(pool string, path string) ([]string, error) {
 	path = strings.TrimRight(path, "/")
-	fullPath := poolName
+	fullPath := pool
 	if path != "" {
-		fullPath = fmt.Sprintf("%s/%s", poolName, path)
+		fullPath = fmt.Sprintf("%s/%s", pool, path)
 	}
 
 	output, err := shared.RunCommand(

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -170,7 +170,7 @@ func (s *storageZfs) zfsPoolCreate() error {
 					return err
 				}
 
-				subvols, err := s.zfsPoolListSubvolumes(vdev)
+				subvols, err := zfsPoolListSubvolumes(zpoolName, vdev)
 				if err != nil {
 					return err
 				}
@@ -285,7 +285,7 @@ func (s *storageZfs) zfsPoolVolumeClone(source string, name string, dest string,
 		return fmt.Errorf("Failed to clone the filesystem: %s", output)
 	}
 
-	subvols, err := s.zfsPoolListSubvolumes(fmt.Sprintf("%s/%s", poolName, source))
+	subvols, err := zfsPoolListSubvolumes(poolName, fmt.Sprintf("%s/%s", poolName, source))
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func (s *storageZfs) zfsPoolVolumeSnapshotRestore(path string, name string) erro
 		return fmt.Errorf("Failed to restore ZFS snapshot: %s", output)
 	}
 
-	subvols, err := s.zfsPoolListSubvolumes(fmt.Sprintf("%s/%s", poolName, path))
+	subvols, err := zfsPoolListSubvolumes(poolName, fmt.Sprintf("%s/%s", poolName, path))
 	if err != nil {
 		return err
 	}
@@ -637,7 +637,7 @@ func zfsUmount(poolName string, path string, mountpoint string) error {
 	return nil
 }
 
-func (s *storageZfs) zfsPoolListSubvolumes(path string) ([]string, error) {
+func zfsPoolListSubvolumes(pool string, path string) ([]string, error) {
 	output, err := shared.RunCommand(
 		"zfs",
 		"list",
@@ -660,8 +660,7 @@ func (s *storageZfs) zfsPoolListSubvolumes(path string) ([]string, error) {
 			continue
 		}
 
-		poolName := s.getOnDiskPoolName()
-		children = append(children, strings.TrimPrefix(entry, fmt.Sprintf("%s/", poolName)))
+		children = append(children, strings.TrimPrefix(entry, fmt.Sprintf("%s/", pool)))
 	}
 
 	return children, nil
@@ -726,7 +725,7 @@ func (s *storageZfs) zfsPoolVolumeSnapshotRemovable(path string, name string) (b
 
 func (s *storageZfs) zfsPoolGetUsers() ([]string, error) {
 	poolName := s.getOnDiskPoolName()
-	subvols, err := s.zfsPoolListSubvolumes(poolName)
+	subvols, err := zfsPoolListSubvolumes(poolName, poolName)
 	if err != nil {
 		return []string{}, err
 	}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -330,7 +330,7 @@ func zfsFilesystemEntityDelete(vdev string, pool string) error {
 }
 
 func zfsPoolVolumeDestroy(pool string, path string) error {
-	mountpoint, err := zfsFilesystemEntityPropertyGet(pool, path, "mountpoint", true)
+	mountpoint, err := zfsFilesystemEntityPropertyGet(pool, path, "mountpoint")
 	if err != nil {
 		return err
 	}
@@ -390,7 +390,7 @@ func zfsPoolVolumeCleanup(pool string, path string) error {
 				}
 			} else {
 				// Cleanup filesystems
-				origin, err := zfsFilesystemEntityPropertyGet(pool, path, "origin", true)
+				origin, err := zfsFilesystemEntityPropertyGet(pool, path, "origin")
 				if err != nil {
 					return err
 				}
@@ -423,14 +423,7 @@ func zfsPoolVolumeCleanup(pool string, path string) error {
 	return nil
 }
 
-func zfsFilesystemEntityPropertyGet(pool string, path string, key string, prefixPathWithPool bool) (string, error) {
-	// If prefixPathWithPool is false we assume that the path passed in
-	// already is a valid zfs entity we want to check for.
-	fsToCheck := path
-	if prefixPathWithPool {
-		fsToCheck = fmt.Sprintf("%s/%s", pool, path)
-	}
-
+func zfsFilesystemEntityPropertyGet(pool string, path string, key string) (string, error) {
 	output, err := shared.RunCommand(
 		"zfs",
 		"get",
@@ -438,7 +431,7 @@ func zfsFilesystemEntityPropertyGet(pool string, path string, key string, prefix
 		"-p",
 		"-o", "value",
 		key,
-		fsToCheck)
+		fmt.Sprintf("%s/%s", pool, path))
 	if err != nil {
 		return "", fmt.Errorf("Failed to get ZFS config: %s", output)
 	}
@@ -679,7 +672,7 @@ func zfsPoolVolumeSnapshotRemovable(pool string, path string, name string) (bool
 		snap = fmt.Sprintf("%s@%s", path, name)
 	}
 
-	clones, err := zfsFilesystemEntityPropertyGet(pool, snap, "clones", true)
+	clones, err := zfsFilesystemEntityPropertyGet(pool, snap, "clones")
 	if err != nil {
 		return false, err
 	}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -537,13 +537,12 @@ func (s *storageZfs) zfsPoolVolumeSnapshotCreate(path string, name string) error
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeSnapshotDestroy(path string, name string) error {
-	poolName := s.getOnDiskPoolName()
+func zfsPoolVolumeSnapshotDestroy(pool, path string, name string) error {
 	output, err := shared.RunCommand(
 		"zfs",
 		"destroy",
 		"-r",
-		fmt.Sprintf("%s/%s@%s", poolName, path, name))
+		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
 		logger.Errorf("zfs destroy failed: %s.", output)
 		return fmt.Errorf("Failed to destroy ZFS snapshot: %s", output)

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -552,24 +552,23 @@ func (s *storageZfs) zfsPoolVolumeSnapshotDestroy(path string, name string) erro
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeSnapshotRestore(path string, name string) error {
-	poolName := s.getOnDiskPoolName()
+func zfsPoolVolumeSnapshotRestore(pool string, path string, name string) error {
 	output, err := shared.TryRunCommand(
 		"zfs",
 		"rollback",
-		fmt.Sprintf("%s/%s@%s", poolName, path, name))
+		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
 		logger.Errorf("zfs rollback failed: %s.", output)
 		return fmt.Errorf("Failed to restore ZFS snapshot: %s", output)
 	}
 
-	subvols, err := zfsPoolListSubvolumes(poolName, fmt.Sprintf("%s/%s", poolName, path))
+	subvols, err := zfsPoolListSubvolumes(pool, fmt.Sprintf("%s/%s", pool, path))
 	if err != nil {
 		return err
 	}
 
 	for _, sub := range subvols {
-		snaps, err := zfsPoolListSnapshots(poolName, sub)
+		snaps, err := zfsPoolListSnapshots(pool, sub)
 		if err != nil {
 			return err
 		}
@@ -581,7 +580,7 @@ func (s *storageZfs) zfsPoolVolumeSnapshotRestore(path string, name string) erro
 		output, err := shared.TryRunCommand(
 			"zfs",
 			"rollback",
-			fmt.Sprintf("%s/%s@%s", poolName, sub, name))
+			fmt.Sprintf("%s/%s@%s", pool, sub, name))
 		if err != nil {
 			logger.Errorf("zfs rollback failed: %s.", output)
 			return fmt.Errorf("Failed to restore ZFS sub-volume snapshot: %s", output)

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -522,13 +522,12 @@ func (s *storageZfs) zfsPoolVolumeSet(path string, key string, value string) err
 	return nil
 }
 
-func (s *storageZfs) zfsPoolVolumeSnapshotCreate(path string, name string) error {
-	poolName := s.getOnDiskPoolName()
+func zfsPoolVolumeSnapshotCreate(pool string, path string, name string) error {
 	output, err := shared.RunCommand(
 		"zfs",
 		"snapshot",
 		"-r",
-		fmt.Sprintf("%s/%s@%s", poolName, path, name))
+		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
 		logger.Errorf("zfs snapshot failed: %s.", output)
 		return fmt.Errorf("Failed to create ZFS snapshot: %s", output)


### PR DESCRIPTION
Convert all `zfsXxx` functions in `lxd/storage_zfs_utils.go` to standalone function, so that `storageZfs` methods are all in `lxd/storage_zfs.go`, passing pool/dataset names as parameters.

Closes #3472