### PR TITLE
gpu: fix gpu attach

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1812,6 +1812,7 @@ func (c *containerLXC) startCommon() (string, error) {
 			}
 
 			sawNvidia := false
+			found := false
 			for _, gpu := range gpus {
 				if (m["vendorid"] != "" && gpu.vendorid != m["vendorid"]) ||
 					(m["pci"] != "" && gpu.pci != m["pci"]) ||
@@ -1819,6 +1820,8 @@ func (c *containerLXC) startCommon() (string, error) {
 					(m["id"] != "" && gpu.id != m["id"]) {
 					continue
 				}
+
+				found = true
 
 				err := c.setupUnixDevice(k, m, gpu.major, gpu.minor, gpu.path, true)
 				if err != nil {
@@ -1844,6 +1847,12 @@ func (c *containerLXC) startCommon() (string, error) {
 						return "", err
 					}
 				}
+			}
+
+			if !found {
+				msg := "Failed to detect requested GPU device"
+				logger.Error(msg)
+				return "", fmt.Errorf(msg)
 			}
 		} else if m["type"] == "disk" {
 			if m["path"] != "/" {
@@ -3859,6 +3868,7 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 				}
 
 				sawNvidia := false
+				found := false
 				for _, gpu := range gpus {
 					if (m["vendorid"] != "" && gpu.vendorid != m["vendorid"]) ||
 						(m["pci"] != "" && gpu.pci != m["pci"]) ||
@@ -3866,6 +3876,8 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 						(m["id"] != "" && gpu.id != m["id"]) {
 						continue
 					}
+
+					found = true
 
 					err = c.insertUnixDeviceNum(m, gpu.major, gpu.minor, gpu.path)
 					if err != nil {
@@ -3897,6 +3909,12 @@ func (c *containerLXC) Update(args containerArgs, userRequested bool) error {
 							return err
 						}
 					}
+				}
+
+				if !found {
+					msg := "Failed to detect requested GPU device"
+					logger.Error(msg)
+					return fmt.Errorf(msg)
 				}
 			}
 		}


### PR DESCRIPTION
The previous code assumes that the nvidia card index and the dri card index are
identical, i.e. for a given pair {/dev/card\<card-idx\>, /dev/nvidia\<nvidia-idx\>}
it was assumed that \<card-idx\> == \<nvidia-idx\> but it is definitely possible
that \<card-idx\> != \<nvidia-idx\>.

Also, let's report an error when we don't find the gpu device that the user
requested.

Closes #3642.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>