### PR TITLE
Drop dependencies on Daemon in db.go

### DIFF
--- a/lxd/.dir-locals.el
+++ b/lxd/.dir-locals.el
@@ -1,0 +1,3 @@
+;;; Directory Local Variables
+;;; For more information see (info "(emacs) Directory Variables")
+((go-mode . ((go-test-args . "-tags libsqlite3"))))

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1405,17 +1405,10 @@ func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 
 // Create a database connection and perform any updates needed.
 func initializeDbObject(d *Daemon, path string) error {
-	var openPath string
 	var err error
 
-	timeout := 5 // TODO - make this command-line configurable?
-
-	// These are used to tune the transaction BEGIN behavior instead of using the
-	// similar "locking_mode" pragma (locking for the whole database connection).
-	openPath = fmt.Sprintf("%s?_busy_timeout=%d&_txlock=exclusive", path, timeout*1000)
-
 	// Open the database. If the file doesn't exist it is created.
-	d.db, err = sql.Open("sqlite3_with_fk", openPath)
+	d.db, err = openDb(path)
 	if err != nil {
 		return err
 	}

--- a/lxd/db.go
+++ b/lxd/db.go
@@ -224,6 +224,18 @@ func init() {
 	sql.Register("sqlite3_with_fk", &sqlite3.SQLiteDriver{ConnectHook: enableForeignKeys})
 }
 
+// Open the database with the correct parameters for LXD.
+func openDb(path string) (*sql.DB, error) {
+	timeout := 5 // TODO - make this command-line configurable?
+
+	// These are used to tune the transaction BEGIN behavior instead of using the
+	// similar "locking_mode" pragma (locking for the whole database connection).
+	openPath := fmt.Sprintf("%s?_busy_timeout=%d&_txlock=exclusive", path, timeout*1000)
+
+	// Open the database. If the file doesn't exist it is created.
+	return sql.Open("sqlite3_with_fk", openPath)
+}
+
 // Create the initial (current) schema for a given SQLite DB connection.
 func createDb(db *sql.DB) (err error) {
 	latestVersion := dbGetSchema(db)


### PR DESCRIPTION
This branch drops any mention of the Daemon structure in db.go, and is
a step towards making the db functionality self-contained (in order to
put it in a separate db/ package).
