### PR TITLE
Move db*.go files into their own store/ sub-package

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -10,6 +10,7 @@ import (
 
 	"gopkg.in/lxc/go-lxc.v2"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -242,7 +243,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 }
 
 func api10Put(d *Daemon, r *http.Request) Response {
-	oldConfig, err := dbConfigValuesGet(d.db)
+	oldConfig, err := db.ConfigValuesGet(d.db)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -261,7 +262,7 @@ func api10Put(d *Daemon, r *http.Request) Response {
 }
 
 func api10Patch(d *Daemon, r *http.Request) Response {
-	oldConfig, err := dbConfigValuesGet(d.db)
+	oldConfig, err := db.ConfigValuesGet(d.db)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_patch.go
+++ b/lxd/container_patch.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -99,7 +100,7 @@ func containerPatch(d *Daemon, r *http.Request) Response {
 	}
 
 	// Update container configuration
-	args := containerArgs{
+	args := db.ContainerArgs{
 		Architecture: architecture,
 		Description:  req.Description,
 		Config:       req.Config,

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -80,7 +81,7 @@ func containerPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Check that the name isn't already in use
-	id, _ := dbContainerId(d.db, req.Name)
+	id, _ := db.ContainerId(d.db, req.Name)
 	if id > 0 {
 		return Conflict
 	}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -47,7 +48,7 @@ func containerPut(d *Daemon, r *http.Request) Response {
 	if configRaw.Restore == "" {
 		// Update container configuration
 		do = func(op *operation) error {
-			args := containerArgs{
+			args := db.ContainerArgs{
 				Architecture: architecture,
 				Description:  configRaw.Description,
 				Config:       configRaw.Config,

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
@@ -67,9 +68,9 @@ func nextSnapshot(d *Daemon, name string) int {
 	length := len(base)
 	q := fmt.Sprintf("SELECT name FROM containers WHERE type=? AND SUBSTR(name,1,?)=?")
 	var numstr string
-	inargs := []interface{}{cTypeSnapshot, length, base}
+	inargs := []interface{}{db.CTypeSnapshot, length, base}
 	outfmt := []interface{}{numstr}
-	results, err := dbQueryScan(d.db, q, inargs, outfmt)
+	results, err := db.QueryScan(d.db, q, inargs, outfmt)
 	if err != nil {
 		return 0
 	}
@@ -132,9 +133,9 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 		req.Name
 
 	snapshot := func(op *operation) error {
-		args := containerArgs{
+		args := db.ContainerArgs{
 			Name:         fullName,
-			Ctype:        cTypeSnapshot,
+			Ctype:        db.CTypeSnapshot,
 			Config:       c.LocalConfig(),
 			Profiles:     c.Profiles(),
 			Ephemeral:    c.IsEphemeral(),
@@ -282,7 +283,7 @@ func snapshotPost(d *Daemon, r *http.Request, sc container, containerName string
 	fullName := containerName + shared.SnapshotDelimiter + newName
 
 	// Check that the name isn't already in use
-	id, _ := dbContainerId(d.db, fullName)
+	id, _ := db.ContainerId(d.db, fullName)
 	if id > 0 {
 		return Conflict
 	}

--- a/lxd/container_state.go
+++ b/lxd/container_state.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -99,7 +100,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 
 			if ephemeral {
 				// Unset ephemeral flag
-				args := containerArgs{
+				args := db.ContainerArgs{
 					Description:  c.Description(),
 					Architecture: c.Architecture(),
 					Config:       c.LocalConfig(),

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -15,8 +16,8 @@ type containerTestSuite struct {
 }
 
 func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Name:      "testFoo",
 	}
@@ -39,7 +40,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 
 func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 	// Create an unprivileged profile
-	_, err := dbProfileCreate(
+	_, err := db.ProfileCreate(
 		suite.d.db,
 		"unprivileged",
 		"unprivileged",
@@ -48,11 +49,11 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 
 	suite.Req.Nil(err, "Failed to create the unprivileged profile.")
 	defer func() {
-		dbProfileDelete(suite.d.db, "unprivileged")
+		db.ProfileDelete(suite.d.db, "unprivileged")
 	}()
 
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Profiles:  []string{"default", "unprivileged"},
 		Name:      "testFoo",
@@ -74,8 +75,8 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 }
 
 func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
 		Devices: types.Devices{
@@ -104,8 +105,8 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 }
 
 func (suite *containerTestSuite) TestContainer_LoadFromDB() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
 		Devices: types.Devices{
@@ -136,8 +137,8 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 
 func (suite *containerTestSuite) TestContainer_Path_Regular() {
 	// Regular
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Name:      "testFoo",
 	}
@@ -153,8 +154,8 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 
 func (suite *containerTestSuite) TestContainer_Path_Snapshot() {
 	// Snapshot
-	args := containerArgs{
-		Ctype:     cTypeSnapshot,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeSnapshot,
 		Ephemeral: false,
 		Name:      "test/snap0",
 	}
@@ -173,8 +174,8 @@ func (suite *containerTestSuite) TestContainer_Path_Snapshot() {
 }
 
 func (suite *containerTestSuite) TestContainer_LogPath() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Name:      "testFoo",
 	}
@@ -187,8 +188,8 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 }
 
 func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
 		Name:      "testFoo",
@@ -202,8 +203,8 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 }
 
 func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "false"},
 		Name:      "testFoo",
@@ -217,8 +218,8 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 }
 
 func (suite *containerTestSuite) TestContainer_Rename() {
-	args := containerArgs{
-		Ctype:     cTypeRegular,
+	args := db.ContainerArgs{
+		Ctype:     db.CTypeRegular,
 		Ephemeral: false,
 		Name:      "testFoo",
 	}
@@ -232,8 +233,8 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
-	c1, err := containerCreateInternal(suite.d, containerArgs{
-		Ctype: cTypeRegular,
+	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
@@ -242,8 +243,8 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	suite.Req.Nil(err)
 	defer c1.Delete()
 
-	c2, err := containerCreateInternal(suite.d, containerArgs{
-		Ctype: cTypeRegular,
+	c2, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		Ctype: db.CTypeRegular,
 		Name:  "isol-2",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
@@ -273,8 +274,8 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
-	c1, err := containerCreateInternal(suite.d, containerArgs{
-		Ctype: cTypeRegular,
+	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
@@ -283,8 +284,8 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	suite.Req.Nil(err)
 	defer c1.Delete()
 
-	c2, err := containerCreateInternal(suite.d, containerArgs{
-		Ctype: cTypeRegular,
+	c2, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		Ctype: db.CTypeRegular,
 		Name:  "isol-2",
 		Config: map[string]string{
 			"security.idmap.isolated": "true",
@@ -314,8 +315,8 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
-	c1, err := containerCreateInternal(suite.d, containerArgs{
-		Ctype: cTypeRegular,
+	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
 			"security.idmap.isolated": "false",
@@ -353,8 +354,8 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 	maps := []*shared.IdmapSet{}
 
 	for i := 0; i < 7; i++ {
-		c, err := containerCreateInternal(suite.d, containerArgs{
-			Ctype: cTypeRegular,
+		c, err := containerCreateInternal(suite.d, db.ContainerArgs{
+			Ctype: db.CTypeRegular,
 			Name:  fmt.Sprintf("isol-%d", i),
 			Config: map[string]string{
 				"security.idmap.isolated": "true",

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -97,7 +98,7 @@ func (slice containerAutostartList) Swap(i, j int) {
 
 func containersRestart(d *Daemon) error {
 	// Get all the containers
-	result, err := dbContainersList(d.db, cTypeRegular)
+	result, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -144,13 +145,13 @@ func containersShutdown(d *Daemon) error {
 	var wg sync.WaitGroup
 
 	// Get all the containers
-	results, err := dbContainersList(d.db, cTypeRegular)
+	results, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Reset all container states
-	_, err = dbExec(d.db, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
+	_, err = db.Exec(d.db, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
 	if err != nil {
 		return err
 	}
@@ -198,7 +199,7 @@ func containerDeleteSnapshots(d *Daemon, cname string) error {
 	logger.Debug("containerDeleteSnapshots",
 		log.Ctx{"container": cname})
 
-	results, err := dbContainerGetSnapshots(d.db, cname)
+	results, err := db.ContainerGetSnapshots(d.db, cname)
 	if err != nil {
 		return err
 	}

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -16,7 +17,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 		if err == nil {
 			return SyncResponse(true, result)
 		}
-		if !isDbLockedError(err) {
+		if !db.IsDbLockedError(err) {
 			logger.Debugf("DBERR: containersGet: error %q", err)
 			return SmartError(err)
 		}
@@ -31,7 +32,7 @@ func containersGet(d *Daemon, r *http.Request) Response {
 }
 
 func doContainersGet(d *Daemon, recursion bool) (interface{}, error) {
-	result, err := dbContainersList(d.db, cTypeRegular)
+	result, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/crypto/scrypt"
 	log "gopkg.in/inconshreveable/log15.v2"
 
+	dbapi "github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -127,7 +128,7 @@ func (k *daemonConfigKey) Set(d *Daemon, value string) error {
 	k.currentValue = value
 	daemonConfigLock.Unlock()
 
-	err = dbConfigValueSet(d.db, name, value)
+	err = dbapi.ConfigValueSet(d.db, name, value)
 	if err != nil {
 		return err
 	}
@@ -201,7 +202,7 @@ func daemonConfigInit(db *sql.DB) error {
 	}
 
 	// Load the values from the DB
-	dbValues, err := dbConfigValuesGet(db)
+	dbValues, err := dbapi.ConfigValuesGet(db)
 	if err != nil {
 		return err
 	}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
@@ -230,14 +231,14 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	// auto-update is on).
 	interval := daemonConfig["images.auto_update_interval"].GetInt64()
 	if preferCached && interval > 0 && alias != fp {
-		cachedFingerprint, err := dbImageSourceGetCachedFingerprint(d.db, server, protocol, alias)
+		cachedFingerprint, err := db.ImageSourceGetCachedFingerprint(d.db, server, protocol, alias)
 		if err == nil && cachedFingerprint != fp {
 			fp = cachedFingerprint
 		}
 	}
 
 	// Check if the image already exists (partial hash match)
-	_, imgInfo, err := dbImageGet(d.db, fp, false, true)
+	_, imgInfo, err := db.ImageGet(d.db, fp, false, true)
 	if err == nil {
 		logger.Debug("Image already exists in the db", log.Ctx{"image": fp})
 		info = imgInfo
@@ -248,13 +249,13 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		}
 
 		// Get the ID of the target storage pool
-		poolID, err := dbStoragePoolGetID(d.db, storagePool)
+		poolID, err := db.StoragePoolGetID(d.db, storagePool)
 		if err != nil {
 			return nil, err
 		}
 
 		// Check if the image is already in the pool
-		poolIDs, err := dbImageGetPools(d.db, info.Fingerprint)
+		poolIDs, err := db.ImageGetPools(d.db, info.Fingerprint)
 		if err != nil {
 			return nil, err
 		}
@@ -291,7 +292,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		<-waitChannel
 
 		// Grab the database entry
-		_, imgInfo, err := dbImageGet(d.db, fp, false, true)
+		_, imgInfo, err := db.ImageGet(d.db, fp, false, true)
 		if err != nil {
 			// Other download failed, lets try again
 			logger.Error("Other image download didn't succeed", log.Ctx{"image": fp})
@@ -504,7 +505,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	}
 
 	// Create the database entry
-	err = dbImageInsert(d.db, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties)
+	err = db.ImageInsert(d.db, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties)
 	if err != nil {
 		return nil, err
 	}
@@ -513,12 +514,12 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	failure = false
 
 	if alias != fp {
-		id, _, err := dbImageGet(d.db, fp, false, true)
+		id, _, err := db.ImageGet(d.db, fp, false, true)
 		if err != nil {
 			return nil, err
 		}
 
-		err = dbImageSourceInsert(d.db, id, server, protocol, certificate, alias)
+		err = db.ImageSourceInsert(d.db, id, server, protocol, certificate, alias)
 		if err != nil {
 			return nil, err
 		}
@@ -534,7 +535,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 
 	// Mark the image as "cached" if downloading for a container
 	if forContainer {
-		err := dbImageLastAccessInit(d.db, fp)
+		err := db.ImageLastAccessInit(d.db, fp)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/daemon_images_test.go
+++ b/lxd/daemon_images_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/stretchr/testify/suite"
 )
@@ -19,11 +20,11 @@ type daemonImagesTestSuite struct {
 // newer image even if available, and just use the cached one.
 func (suite *daemonImagesTestSuite) TestUseCachedImagesIfAvailable() {
 	// Create an image with alias "test" and fingerprint "abcd".
-	err := dbImageInsert(suite.d.db, "abcd", "foo.xz", 1, false, true, "amd64", time.Now(), time.Now(), map[string]string{})
+	err := db.ImageInsert(suite.d.db, "abcd", "foo.xz", 1, false, true, "amd64", time.Now(), time.Now(), map[string]string{})
 	suite.Req.Nil(err)
-	id, _, err := dbImageGet(suite.d.db, "abcd", false, true)
+	id, _, err := db.ImageGet(suite.d.db, "abcd", false, true)
 	suite.Req.Nil(err)
-	err = dbImageSourceInsert(suite.d.db, id, "img.srv", "simplestreams", "", "test")
+	err = db.ImageSourceInsert(suite.d.db, id, "img.srv", "simplestreams", "", "test")
 	suite.Req.Nil(err)
 
 	// Pretend we have already a non-expired entry for the remote

--- a/lxd/db/config.go
+++ b/lxd/db/config.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -6,7 +6,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 )
 
-func dbConfigValuesGet(db *sql.DB) (map[string]string, error) {
+func ConfigValuesGet(db *sql.DB) (map[string]string, error) {
 	q := "SELECT key, value FROM config"
 	rows, err := dbQuery(db, q)
 	if err != nil {
@@ -25,8 +25,8 @@ func dbConfigValuesGet(db *sql.DB) (map[string]string, error) {
 	return results, nil
 }
 
-func dbConfigValueSet(db *sql.DB, key string, value string) error {
-	tx, err := dbBegin(db)
+func ConfigValueSet(db *sql.DB, key string, value string) error {
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
@@ -52,7 +52,7 @@ func dbConfigValueSet(db *sql.DB, key string, value string) error {
 		}
 	}
 
-	err = txCommit(tx)
+	err = TxCommit(tx)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/db_test.go
+++ b/lxd/db/db_test.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -54,10 +54,10 @@ func (s *dbTestSuite) CreateTestDb() *sql.DB {
 		s.Nil(err)
 	}
 
-	db, err := openDb(":memory:")
+	db, err := OpenDb(":memory:")
 	s.Nil(err)
-	s.Nil(createDb(db))
-	s.Nil(dbUpdatesApplyAll(db, false, nil))
+	s.Nil(CreateDb(db, []string{}))
+	s.Nil(UpdatesApplyAll(db, false, nil))
 	return db
 
 }
@@ -161,12 +161,12 @@ func (s *dbTestSuite) Test_deleting_an_image_cascades_on_related_tables() {
 }
 
 func (s *dbTestSuite) Test_initializing_db_is_idempotent() {
-	// This calls "createDb" once already.
+	// This calls "CreateDb" once already.
 	db := s.CreateTestDb()
 	defer db.Close()
 
 	// Let's call it a second time.
-	s.Nil(createDb(db))
+	s.Nil(CreateDb(db, []string{}))
 }
 
 func (s *dbTestSuite) Test_get_schema_returns_0_on_uninitialized_db() {
@@ -175,11 +175,11 @@ func (s *dbTestSuite) Test_get_schema_returns_0_on_uninitialized_db() {
 
 	db, err = sql.Open("sqlite3", ":memory:")
 	s.Nil(err)
-	result := dbGetSchema(db)
+	result := GetSchema(db)
 	s.Equal(0, result, "getSchema should return 0 on uninitialized db!")
 }
 
-func (s *dbTestSuite) Test_running_dbUpdateFromV6_adds_on_delete_cascade() {
+func (s *dbTestSuite) Test_running_UpdateFromV6_adds_on_delete_cascade() {
 	// Upgrading the database schema with updateFromV6 adds ON DELETE CASCADE
 	// to sqlite tables that require it, and conserve the data.
 
@@ -313,11 +313,11 @@ INSERT INTO containers_config (container_id, key, value) VALUES (1, 'thekey', 't
 
 	// The "foreign key" on containers_config now points to nothing.
 	// Let's run the schema upgrades.
-	err = dbUpdatesApplyAll(db, false, nil)
+	err = UpdatesApplyAll(db, false, nil)
 	s.Nil(err)
 
-	result := dbGetSchema(db)
-	s.Equal(result, dbGetLatestSchema(), "The schema is not at the latest version after update!")
+	result := GetSchema(db)
+	s.Equal(result, GetLatestSchema(), "The schema is not at the latest version after update!")
 
 	// Make sure there are 0 containers_config entries left.
 	statements = `SELECT count(*) FROM containers_config;`
@@ -326,11 +326,11 @@ INSERT INTO containers_config (container_id, key, value) VALUES (1, 'thekey', 't
 	s.Equal(count, 0, "updateDb did not delete orphaned child entries after adding ON DELETE CASCADE!")
 }
 
-func (s *dbTestSuite) Test_dbImageGet_finds_image_for_fingerprint() {
+func (s *dbTestSuite) Test_ImageGet_finds_image_for_fingerprint() {
 	var err error
 	var result *api.Image
 
-	_, result, err = dbImageGet(s.db, "fingerprint", false, false)
+	_, result, err = ImageGet(s.db, "fingerprint", false, false)
 	s.Nil(err)
 	s.NotNil(result)
 	s.Equal(result.Filename, "filename")
@@ -339,79 +339,79 @@ func (s *dbTestSuite) Test_dbImageGet_finds_image_for_fingerprint() {
 	s.Equal(result.UploadedAt.UTC(), time.Unix(1431547176, 0).UTC())
 }
 
-func (s *dbTestSuite) Test_dbImageGet_for_missing_fingerprint() {
+func (s *dbTestSuite) Test_ImageGet_for_missing_fingerprint() {
 	var err error
 
-	_, _, err = dbImageGet(s.db, "unknown", false, false)
+	_, _, err = ImageGet(s.db, "unknown", false, false)
 	s.Equal(err, sql.ErrNoRows)
 }
 
-func (s *dbTestSuite) Test_dbImageExists_true() {
+func (s *dbTestSuite) Test_ImageExists_true() {
 	var err error
 
-	exists, err := dbImageExists(s.db, "fingerprint")
+	exists, err := ImageExists(s.db, "fingerprint")
 	s.Nil(err)
 	s.True(exists)
 }
 
-func (s *dbTestSuite) Test_dbImageExists_false() {
+func (s *dbTestSuite) Test_ImageExists_false() {
 	var err error
 
-	exists, err := dbImageExists(s.db, "foobar")
+	exists, err := ImageExists(s.db, "foobar")
 	s.Nil(err)
 	s.False(exists)
 }
 
-func (s *dbTestSuite) Test_dbImageAliasGet_alias_exists() {
+func (s *dbTestSuite) Test_ImageAliasGet_alias_exists() {
 	var err error
 
-	_, alias, err := dbImageAliasGet(s.db, "somealias", true)
+	_, alias, err := ImageAliasGet(s.db, "somealias", true)
 	s.Nil(err)
 	s.Equal(alias.Target, "fingerprint")
 }
 
-func (s *dbTestSuite) Test_dbImageAliasGet_alias_does_not_exists() {
+func (s *dbTestSuite) Test_ImageAliasGet_alias_does_not_exists() {
 	var err error
 
-	_, _, err = dbImageAliasGet(s.db, "whatever", true)
+	_, _, err = ImageAliasGet(s.db, "whatever", true)
 	s.Equal(err, NoSuchObjectError)
 }
 
-func (s *dbTestSuite) Test_dbImageAliasAdd() {
+func (s *dbTestSuite) Test_ImageAliasAdd() {
 	var err error
 
-	err = dbImageAliasAdd(s.db, "Chaosphere", 1, "Someone will like the name")
+	err = ImageAliasAdd(s.db, "Chaosphere", 1, "Someone will like the name")
 	s.Nil(err)
 
-	_, alias, err := dbImageAliasGet(s.db, "Chaosphere", true)
+	_, alias, err := ImageAliasGet(s.db, "Chaosphere", true)
 	s.Nil(err)
 	s.Equal(alias.Target, "fingerprint")
 }
 
-func (s *dbTestSuite) Test_dbImageSourceGetCachedFingerprint() {
-	imageID, _, err := dbImageGet(s.db, "fingerprint", false, false)
+func (s *dbTestSuite) Test_ImageSourceGetCachedFingerprint() {
+	imageID, _, err := ImageGet(s.db, "fingerprint", false, false)
 	s.Nil(err)
 
-	err = dbImageSourceInsert(s.db, imageID, "server.remote", "simplestreams", "", "test")
+	err = ImageSourceInsert(s.db, imageID, "server.remote", "simplestreams", "", "test")
 	s.Nil(err)
 
-	fingerprint, err := dbImageSourceGetCachedFingerprint(s.db, "server.remote", "simplestreams", "test")
+	fingerprint, err := ImageSourceGetCachedFingerprint(s.db, "server.remote", "simplestreams", "test")
 	s.Nil(err)
 	s.Equal(fingerprint, "fingerprint")
 }
 
-func (s *dbTestSuite) Test_dbImageSourceGetCachedFingerprint_no_match() {
-	imageID, _, err := dbImageGet(s.db, "fingerprint", false, false)
+func (s *dbTestSuite) Test_ImageSourceGetCachedFingerprint_no_match() {
+	imageID, _, err := ImageGet(s.db, "fingerprint", false, false)
 	s.Nil(err)
 
-	err = dbImageSourceInsert(s.db, imageID, "server.remote", "simplestreams", "", "test")
+	err = ImageSourceInsert(s.db, imageID, "server.remote", "simplestreams", "", "test")
 	s.Nil(err)
 
-	_, err = dbImageSourceGetCachedFingerprint(s.db, "server.remote", "lxd", "test")
+	_, err = ImageSourceGetCachedFingerprint(s.db, "server.remote", "lxd", "test")
 	s.Equal(err, NoSuchObjectError)
 }
 
-func (s *dbTestSuite) Test_dbContainerConfig() {
+func (s *dbTestSuite) Test_ContainerConfig() {
 	var err error
 	var result map[string]string
 	var expected map[string]string
@@ -419,7 +419,7 @@ func (s *dbTestSuite) Test_dbContainerConfig() {
 	_, err = s.db.Exec("INSERT INTO containers_config (container_id, key, value) VALUES (1, 'something', 'something else');")
 	s.Nil(err)
 
-	result, err = dbContainerConfig(s.db, 1)
+	result, err = ContainerConfig(s.db, 1)
 	s.Nil(err)
 
 	expected = map[string]string{"thekey": "thevalue", "something": "something else"}
@@ -438,7 +438,7 @@ func (s *dbTestSuite) Test_dbProfileConfig() {
 	_, err = s.db.Exec("INSERT INTO profiles_config (profile_id, key, value) VALUES (2, 'something', 'something else');")
 	s.Nil(err)
 
-	result, err = dbProfileConfig(s.db, "theprofile")
+	result, err = ProfileConfig(s.db, "theprofile")
 	s.Nil(err)
 
 	expected = map[string]string{"thekey": "thevalue", "something": "something else"}
@@ -449,13 +449,13 @@ func (s *dbTestSuite) Test_dbProfileConfig() {
 	}
 }
 
-func (s *dbTestSuite) Test_dbContainerProfiles() {
+func (s *dbTestSuite) Test_ContainerProfiles() {
 	var err error
 	var result []string
 	var expected []string
 
 	expected = []string{"theprofile"}
-	result, err = dbContainerProfiles(s.db, 1)
+	result, err = ContainerProfiles(s.db, 1)
 	s.Nil(err)
 
 	for i := range expected {
@@ -470,7 +470,7 @@ func (s *dbTestSuite) Test_dbDevices_profiles() {
 	var subresult types.Device
 	var expected types.Device
 
-	result, err = dbDevices(s.db, "theprofile", true)
+	result, err = Devices(s.db, "theprofile", true)
 	s.Nil(err)
 
 	expected = types.Device{"type": "nic", "devicekey": "devicevalue"}
@@ -488,7 +488,7 @@ func (s *dbTestSuite) Test_dbDevices_containers() {
 	var subresult types.Device
 	var expected types.Device
 
-	result, err = dbDevices(s.db, "thename", false)
+	result, err = Devices(s.db, "thename", false)
 	s.Nil(err)
 
 	expected = types.Device{"type": "nic", "configkey": "configvalue"}

--- a/lxd/db/devices.go
+++ b/lxd/db/devices.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -51,7 +51,7 @@ func dbDeviceTypeToInt(t string) (int, error) {
 	}
 }
 
-func dbDevicesAdd(tx *sql.Tx, w string, cID int64, devices types.Devices) error {
+func DevicesAdd(tx *sql.Tx, w string, cID int64, devices types.Devices) error {
 	// Prepare the devices entry SQL
 	str1 := fmt.Sprintf("INSERT INTO %ss_devices (%s_id, name, type) VALUES (?, ?, ?)", w, w)
 	stmt1, err := tx.Prepare(str1)
@@ -115,7 +115,7 @@ func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (types.Device, error) {
 		query = `SELECT key, value FROM containers_devices_config WHERE container_device_id=?`
 	}
 
-	results, err := dbQueryScan(db, query, inargs, outfmt)
+	results, err := QueryScan(db, query, inargs, outfmt)
 
 	if err != nil {
 		return newdev, err
@@ -130,7 +130,7 @@ func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (types.Device, error) {
 	return newdev, nil
 }
 
-func dbDevices(db *sql.DB, qName string, isprofile bool) (types.Devices, error) {
+func Devices(db *sql.DB, qName string, isprofile bool) (types.Devices, error) {
 	var q string
 	if isprofile {
 		q = `SELECT profiles_devices.id, profiles_devices.name, profiles_devices.type
@@ -147,7 +147,7 @@ func dbDevices(db *sql.DB, qName string, isprofile bool) (types.Devices, error) 
 	var name, stype string
 	inargs := []interface{}{qName}
 	outfmt := []interface{}{id, name, dtype}
-	results, err := dbQueryScan(db, q, inargs, outfmt)
+	results, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -11,13 +11,13 @@ import (
 	"github.com/lxc/lxd/shared/osarch"
 )
 
-var dbImageSourceProtocol = map[int]string{
+var ImageSourceProtocol = map[int]string{
 	0: "lxd",
 	1: "direct",
 	2: "simplestreams",
 }
 
-func dbImagesGet(db *sql.DB, public bool) ([]string, error) {
+func ImagesGet(db *sql.DB, public bool) ([]string, error) {
 	q := "SELECT fingerprint FROM images"
 	if public == true {
 		q = "SELECT fingerprint FROM images WHERE public=1"
@@ -26,7 +26,7 @@ func dbImagesGet(db *sql.DB, public bool) ([]string, error) {
 	var fp string
 	inargs := []interface{}{}
 	outfmt := []interface{}{fp}
-	dbResults, err := dbQueryScan(db, q, inargs, outfmt)
+	dbResults, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
 	}
@@ -39,13 +39,13 @@ func dbImagesGet(db *sql.DB, public bool) ([]string, error) {
 	return results, nil
 }
 
-func dbImagesGetExpired(db *sql.DB, expiry int64) ([]string, error) {
+func ImagesGetExpired(db *sql.DB, expiry int64) ([]string, error) {
 	q := `SELECT fingerprint FROM images WHERE cached=1 AND creation_date<=strftime('%s', date('now', '-` + fmt.Sprintf("%d", expiry) + ` day'))`
 
 	var fp string
 	inargs := []interface{}{}
 	outfmt := []interface{}{fp}
-	dbResults, err := dbQueryScan(db, q, inargs, outfmt)
+	dbResults, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
 	}
@@ -58,11 +58,11 @@ func dbImagesGetExpired(db *sql.DB, expiry int64) ([]string, error) {
 	return results, nil
 }
 
-func dbImageSourceInsert(db *sql.DB, imageId int, server string, protocol string, certificate string, alias string) error {
+func ImageSourceInsert(db *sql.DB, imageId int, server string, protocol string, certificate string, alias string) error {
 	stmt := `INSERT INTO images_source (image_id, server, protocol, certificate, alias) values (?, ?, ?, ?, ?)`
 
 	protocolInt := -1
-	for protoInt, protoString := range dbImageSourceProtocol {
+	for protoInt, protoString := range ImageSourceProtocol {
 		if protoString == protocol {
 			protocolInt = protoInt
 		}
@@ -72,11 +72,11 @@ func dbImageSourceInsert(db *sql.DB, imageId int, server string, protocol string
 		return fmt.Errorf("Invalid protocol: %s", protocol)
 	}
 
-	_, err := dbExec(db, stmt, imageId, server, protocolInt, certificate, alias)
+	_, err := Exec(db, stmt, imageId, server, protocolInt, certificate, alias)
 	return err
 }
 
-func dbImageSourceGet(db *sql.DB, imageId int) (int, api.ImageSource, error) {
+func ImageSourceGet(db *sql.DB, imageId int) (int, api.ImageSource, error) {
 	q := `SELECT id, server, protocol, certificate, alias FROM images_source WHERE image_id=?`
 
 	id := 0
@@ -94,7 +94,7 @@ func dbImageSourceGet(db *sql.DB, imageId int) (int, api.ImageSource, error) {
 		return -1, api.ImageSource{}, err
 	}
 
-	protocol, found := dbImageSourceProtocol[protocolInt]
+	protocol, found := ImageSourceProtocol[protocolInt]
 	if !found {
 		return -1, api.ImageSource{}, fmt.Errorf("Invalid protocol: %d", protocolInt)
 	}
@@ -108,9 +108,9 @@ func dbImageSourceGet(db *sql.DB, imageId int) (int, api.ImageSource, error) {
 // Try to find a source entry of a locally cached image that matches
 // the given remote details (server, protocol and alias). Return the
 // fingerprint linked to the matching entry, if any.
-func dbImageSourceGetCachedFingerprint(db *sql.DB, server string, protocol string, alias string) (string, error) {
+func ImageSourceGetCachedFingerprint(db *sql.DB, server string, protocol string, alias string) (string, error) {
 	protocolInt := -1
-	for protoInt, protoString := range dbImageSourceProtocol {
+	for protoInt, protoString := range ImageSourceProtocol {
 		if protoString == protocol {
 			protocolInt = protoInt
 		}
@@ -144,7 +144,7 @@ func dbImageSourceGetCachedFingerprint(db *sql.DB, server string, protocol strin
 }
 
 // Whether an image with the given fingerprint exists.
-func dbImageExists(db *sql.DB, fingerprint string) (bool, error) {
+func ImageExists(db *sql.DB, fingerprint string) (bool, error) {
 	var exists bool
 	var err error
 	query := "SELECT COUNT(*) > 0 FROM images WHERE fingerprint=?"
@@ -154,12 +154,12 @@ func dbImageExists(db *sql.DB, fingerprint string) (bool, error) {
 	return exists, err
 }
 
-// dbImageGet gets an Image object from the database.
+// ImageGet gets an Image object from the database.
 // If strictMatching is false, The fingerprint argument will be queried with a LIKE query, means you can
 // pass a shortform and will get the full fingerprint.
 // There can never be more than one image with a given fingerprint, as it is
 // enforced by a UNIQUE constraint in the schema.
-func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool) (int, *api.Image, error) {
+func ImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool) (int, *api.Image, error) {
 	var err error
 	var create, expire, used, upload *time.Time // These hold the db-returned times
 
@@ -241,7 +241,7 @@ func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool
 	var key, value, name, desc string
 	inargs = []interface{}{id}
 	outfmt = []interface{}{key, value}
-	results, err := dbQueryScan(db, q, inargs, outfmt)
+	results, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -259,7 +259,7 @@ func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool
 	q = "SELECT name, description FROM images_aliases WHERE image_id=?"
 	inargs = []interface{}{id}
 	outfmt = []interface{}{name, desc}
-	results, err = dbQueryScan(db, q, inargs, outfmt)
+	results, err = QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -274,7 +274,7 @@ func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool
 
 	image.Aliases = aliases
 
-	_, source, err := dbImageSourceGet(db, id)
+	_, source, err := ImageSourceGet(db, id)
 	if err == nil {
 		image.UpdateSource = &source
 	}
@@ -282,8 +282,8 @@ func dbImageGet(db *sql.DB, fingerprint string, public bool, strictMatching bool
 	return id, &image, nil
 }
 
-func dbImageDelete(db *sql.DB, id int) error {
-	_, err := dbExec(db, "DELETE FROM images WHERE id=?", id)
+func ImageDelete(db *sql.DB, id int) error {
+	_, err := Exec(db, "DELETE FROM images WHERE id=?", id)
 	if err != nil {
 		return err
 	}
@@ -291,7 +291,7 @@ func dbImageDelete(db *sql.DB, id int) error {
 	return nil
 }
 
-func dbImageAliasGet(db *sql.DB, name string, isTrustedClient bool) (int, api.ImageAliasesEntry, error) {
+func ImageAliasGet(db *sql.DB, name string, isTrustedClient bool) (int, api.ImageAliasesEntry, error) {
 	q := `SELECT images_aliases.id, images.fingerprint, images_aliases.description
 			 FROM images_aliases
 			 INNER JOIN images
@@ -323,53 +323,53 @@ func dbImageAliasGet(db *sql.DB, name string, isTrustedClient bool) (int, api.Im
 	return id, entry, nil
 }
 
-func dbImageAliasRename(db *sql.DB, id int, name string) error {
-	_, err := dbExec(db, "UPDATE images_aliases SET name=? WHERE id=?", name, id)
+func ImageAliasRename(db *sql.DB, id int, name string) error {
+	_, err := Exec(db, "UPDATE images_aliases SET name=? WHERE id=?", name, id)
 	return err
 }
 
-func dbImageAliasDelete(db *sql.DB, name string) error {
-	_, err := dbExec(db, "DELETE FROM images_aliases WHERE name=?", name)
+func ImageAliasDelete(db *sql.DB, name string) error {
+	_, err := Exec(db, "DELETE FROM images_aliases WHERE name=?", name)
 	return err
 }
 
-func dbImageAliasesMove(db *sql.DB, source int, destination int) error {
-	_, err := dbExec(db, "UPDATE images_aliases SET image_id=? WHERE image_id=?", destination, source)
+func ImageAliasesMove(db *sql.DB, source int, destination int) error {
+	_, err := Exec(db, "UPDATE images_aliases SET image_id=? WHERE image_id=?", destination, source)
 	return err
 }
 
 // Insert an alias ento the database.
-func dbImageAliasAdd(db *sql.DB, name string, imageID int, desc string) error {
+func ImageAliasAdd(db *sql.DB, name string, imageID int, desc string) error {
 	stmt := `INSERT INTO images_aliases (name, image_id, description) values (?, ?, ?)`
-	_, err := dbExec(db, stmt, name, imageID, desc)
+	_, err := Exec(db, stmt, name, imageID, desc)
 	return err
 }
 
-func dbImageAliasUpdate(db *sql.DB, id int, imageID int, desc string) error {
+func ImageAliasUpdate(db *sql.DB, id int, imageID int, desc string) error {
 	stmt := `UPDATE images_aliases SET image_id=?, description=? WHERE id=?`
-	_, err := dbExec(db, stmt, imageID, desc, id)
+	_, err := Exec(db, stmt, imageID, desc, id)
 	return err
 }
 
-func dbImageLastAccessUpdate(db *sql.DB, fingerprint string, date time.Time) error {
+func ImageLastAccessUpdate(db *sql.DB, fingerprint string, date time.Time) error {
 	stmt := `UPDATE images SET last_use_date=? WHERE fingerprint=?`
-	_, err := dbExec(db, stmt, date, fingerprint)
+	_, err := Exec(db, stmt, date, fingerprint)
 	return err
 }
 
-func dbImageLastAccessInit(db *sql.DB, fingerprint string) error {
+func ImageLastAccessInit(db *sql.DB, fingerprint string) error {
 	stmt := `UPDATE images SET cached=1, last_use_date=strftime("%s") WHERE fingerprint=?`
-	_, err := dbExec(db, stmt, fingerprint)
+	_, err := Exec(db, stmt, fingerprint)
 	return err
 }
 
-func dbImageUpdate(db *sql.DB, id int, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string) error {
+func ImageUpdate(db *sql.DB, id int, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string) error {
 	arch, err := osarch.ArchitectureId(architecture)
 	if err != nil {
 		arch = 0
 	}
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
@@ -413,20 +413,20 @@ func dbImageUpdate(db *sql.DB, id int, fname string, sz int64, public bool, auto
 		}
 	}
 
-	if err := txCommit(tx); err != nil {
+	if err := TxCommit(tx); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func dbImageInsert(db *sql.DB, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string) error {
+func ImageInsert(db *sql.DB, fp string, fname string, sz int64, public bool, autoUpdate bool, architecture string, createdAt time.Time, expiresAt time.Time, properties map[string]string) error {
 	arch, err := osarch.ArchitectureId(architecture)
 	if err != nil {
 		arch = 0
 	}
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
@@ -482,7 +482,7 @@ func dbImageInsert(db *sql.DB, fp string, fname string, sz int64, public bool, a
 
 	}
 
-	if err := txCommit(tx); err != nil {
+	if err := TxCommit(tx); err != nil {
 		return err
 	}
 
@@ -490,13 +490,13 @@ func dbImageInsert(db *sql.DB, fp string, fname string, sz int64, public bool, a
 }
 
 // Get the names of all storage pools on which a given image exists.
-func dbImageGetPools(db *sql.DB, imageFingerprint string) ([]int64, error) {
+func ImageGetPools(db *sql.DB, imageFingerprint string) ([]int64, error) {
 	poolID := int64(-1)
 	query := "SELECT storage_pool_id FROM storage_volumes WHERE name=? AND type=?"
-	inargs := []interface{}{imageFingerprint, storagePoolVolumeTypeImage}
+	inargs := []interface{}{imageFingerprint, StoragePoolVolumeTypeImage}
 	outargs := []interface{}{poolID}
 
-	result, err := dbQueryScan(db, query, inargs, outargs)
+	result, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return []int64{}, err
 	}
@@ -510,7 +510,7 @@ func dbImageGetPools(db *sql.DB, imageFingerprint string) ([]int64, error) {
 }
 
 // Get the names of all storage pools on which a given image exists.
-func dbImageGetPoolNamesFromIDs(db *sql.DB, poolIDs []int64) ([]string, error) {
+func ImageGetPoolNamesFromIDs(db *sql.DB, poolIDs []int64) ([]string, error) {
 	var poolName string
 	query := "SELECT name FROM storage_pools WHERE id=?"
 
@@ -519,7 +519,7 @@ func dbImageGetPoolNamesFromIDs(db *sql.DB, poolIDs []int64) ([]string, error) {
 		inargs := []interface{}{poolID}
 		outargs := []interface{}{poolName}
 
-		result, err := dbQueryScan(db, query, inargs, outargs)
+		result, err := QueryScan(db, query, inargs, outargs)
 		if err != nil {
 			return []string{}, err
 		}

--- a/lxd/db/patches.go
+++ b/lxd/db/patches.go
@@ -1,16 +1,16 @@
-package main
+package db
 
 import (
 	"database/sql"
 	"fmt"
 )
 
-func dbPatches(db *sql.DB) ([]string, error) {
+func Patches(db *sql.DB) ([]string, error) {
 	inargs := []interface{}{}
 	outfmt := []interface{}{""}
 
 	query := fmt.Sprintf("SELECT name FROM patches")
-	result, err := dbQueryScan(db, query, inargs, outfmt)
+	result, err := QueryScan(db, query, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
 	}
@@ -23,7 +23,7 @@ func dbPatches(db *sql.DB) ([]string, error) {
 	return response, nil
 }
 
-func dbPatchesMarkApplied(db *sql.DB, patch string) error {
+func PatchesMarkApplied(db *sql.DB, patch string) error {
 	stmt := `INSERT INTO patches (name, applied_at) VALUES (?, strftime("%s"));`
 	_, err := db.Exec(stmt, patch)
 	return err

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -10,13 +10,13 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// dbProfiles returns a string list of profiles.
-func dbProfiles(db *sql.DB) ([]string, error) {
+// Profiles returns a string list of profiles.
+func Profiles(db *sql.DB) ([]string, error) {
 	q := fmt.Sprintf("SELECT name FROM profiles")
 	inargs := []interface{}{}
 	var name string
 	outfmt := []interface{}{name}
-	result, err := dbQueryScan(db, q, inargs, outfmt)
+	result, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return []string{}, err
 	}
@@ -29,7 +29,7 @@ func dbProfiles(db *sql.DB) ([]string, error) {
 	return response, nil
 }
 
-func dbProfileGet(db *sql.DB, name string) (int64, *api.Profile, error) {
+func ProfileGet(db *sql.DB, name string) (int64, *api.Profile, error) {
 	id := int64(-1)
 	description := sql.NullString{}
 
@@ -41,12 +41,12 @@ func dbProfileGet(db *sql.DB, name string) (int64, *api.Profile, error) {
 		return -1, nil, err
 	}
 
-	config, err := dbProfileConfig(db, name)
+	config, err := ProfileConfig(db, name)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	devices, err := dbDevices(db, name, true)
+	devices, err := Devices(db, name, true)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -62,10 +62,10 @@ func dbProfileGet(db *sql.DB, name string) (int64, *api.Profile, error) {
 	return id, &profile, nil
 }
 
-func dbProfileCreate(db *sql.DB, profile string, description string, config map[string]string,
+func ProfileCreate(db *sql.DB, profile string, description string, config map[string]string,
 	devices types.Devices) (int64, error) {
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return -1, err
 	}
@@ -80,19 +80,19 @@ func dbProfileCreate(db *sql.DB, profile string, description string, config map[
 		return -1, err
 	}
 
-	err = dbProfileConfigAdd(tx, id, config)
+	err = ProfileConfigAdd(tx, id, config)
 	if err != nil {
 		tx.Rollback()
 		return -1, err
 	}
 
-	err = dbDevicesAdd(tx, "profile", id, devices)
+	err = DevicesAdd(tx, "profile", id, devices)
 	if err != nil {
 		tx.Rollback()
 		return -1, err
 	}
 
-	err = txCommit(tx)
+	err = TxCommit(tx)
 	if err != nil {
 		return -1, err
 	}
@@ -100,15 +100,15 @@ func dbProfileCreate(db *sql.DB, profile string, description string, config map[
 	return id, nil
 }
 
-func dbProfileCreateDefault(db *sql.DB) error {
-	id, _, _ := dbProfileGet(db, "default")
+func ProfileCreateDefault(db *sql.DB) error {
+	id, _, _ := ProfileGet(db, "default")
 
 	if id != -1 {
 		// default profile already exists
 		return nil
 	}
 
-	_, err := dbProfileCreate(db, "default", "Default LXD profile", map[string]string{}, types.Devices{})
+	_, err := ProfileCreate(db, "default", "Default LXD profile", map[string]string{}, types.Devices{})
 	if err != nil {
 		return err
 	}
@@ -117,7 +117,7 @@ func dbProfileCreateDefault(db *sql.DB) error {
 }
 
 // Get the profile configuration map from the DB
-func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
+func ProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 	var key, value string
 	query := `
         SELECT
@@ -127,7 +127,7 @@ func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 		WHERE name=?`
 	inargs := []interface{}{name}
 	outfmt := []interface{}{key, value}
-	results, err := dbQueryScan(db, query, inargs, outfmt)
+	results, err := QueryScan(db, query, inargs, outfmt)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get profile '%s'", name)
 	}
@@ -139,7 +139,7 @@ func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 		 */
 		query := "SELECT id FROM profiles WHERE name=?"
 		var id int
-		results, err := dbQueryScan(db, query, []interface{}{name}, []interface{}{id})
+		results, err := QueryScan(db, query, []interface{}{name}, []interface{}{id})
 		if err != nil {
 			return nil, err
 		}
@@ -161,13 +161,13 @@ func dbProfileConfig(db *sql.DB, name string) (map[string]string, error) {
 	return config, nil
 }
 
-func dbProfileDelete(db *sql.DB, name string) error {
-	id, _, err := dbProfileGet(db, name)
+func ProfileDelete(db *sql.DB, name string) error {
+	id, _, err := ProfileGet(db, name)
 	if err != nil {
 		return err
 	}
 
-	_, err = dbExec(db, "DELETE FROM profiles WHERE id=?", id)
+	_, err = Exec(db, "DELETE FROM profiles WHERE id=?", id)
 	if err != nil {
 		return err
 	}
@@ -175,8 +175,8 @@ func dbProfileDelete(db *sql.DB, name string) error {
 	return nil
 }
 
-func dbProfileUpdate(db *sql.DB, name string, newName string) error {
-	tx, err := dbBegin(db)
+func ProfileUpdate(db *sql.DB, name string, newName string) error {
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
@@ -187,17 +187,17 @@ func dbProfileUpdate(db *sql.DB, name string, newName string) error {
 		return err
 	}
 
-	err = txCommit(tx)
+	err = TxCommit(tx)
 
 	return err
 }
 
-func dbProfileDescriptionUpdate(tx *sql.Tx, id int64, description string) error {
+func ProfileDescriptionUpdate(tx *sql.Tx, id int64, description string) error {
 	_, err := tx.Exec("UPDATE profiles SET description=? WHERE id=?", description, id)
 	return err
 }
 
-func dbProfileConfigClear(tx *sql.Tx, id int64) error {
+func ProfileConfigClear(tx *sql.Tx, id int64) error {
 	_, err := tx.Exec("DELETE FROM profiles_config WHERE profile_id=?", id)
 	if err != nil {
 		return err
@@ -218,7 +218,7 @@ func dbProfileConfigClear(tx *sql.Tx, id int64) error {
 	return nil
 }
 
-func dbProfileConfigAdd(tx *sql.Tx, id int64, config map[string]string) error {
+func ProfileConfigAdd(tx *sql.Tx, id int64, config map[string]string) error {
 	str := fmt.Sprintf("INSERT INTO profiles_config (profile_id, key, value) VALUES(?, ?, ?)")
 	stmt, err := tx.Prepare(str)
 	defer stmt.Close()
@@ -233,7 +233,7 @@ func dbProfileConfigAdd(tx *sql.Tx, id int64, config map[string]string) error {
 	return nil
 }
 
-func dbProfileContainersGet(db *sql.DB, profile string) ([]string, error) {
+func ProfileContainersGet(db *sql.DB, profile string) ([]string, error) {
 	q := `SELECT containers.name FROM containers JOIN containers_profiles
 		ON containers.id == containers_profiles.container_id
 		JOIN profiles ON containers_profiles.profile_id == profiles.id
@@ -244,7 +244,7 @@ func dbProfileContainersGet(db *sql.DB, profile string) ([]string, error) {
 	var name string
 	outfmt := []interface{}{name}
 
-	output, err := dbQueryScan(db, q, inargs, outfmt)
+	output, err := QueryScan(db, q, inargs, outfmt)
 	if err != nil {
 		return results, err
 	}

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -1,22 +1,22 @@
-package main
+package db
 
 import (
 	"database/sql"
+	"fmt"
 
 	_ "github.com/mattn/go-sqlite3"
 
-	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
 // Get all storage pools.
-func dbStoragePools(db *sql.DB) ([]string, error) {
+func StoragePools(db *sql.DB) ([]string, error) {
 	var name string
 	query := "SELECT name FROM storage_pools"
 	inargs := []interface{}{}
 	outargs := []interface{}{name}
 
-	result, err := dbQueryScan(db, query, inargs, outargs)
+	result, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return []string{}, err
 	}
@@ -34,13 +34,13 @@ func dbStoragePools(db *sql.DB) ([]string, error) {
 }
 
 // Get the names of all storage volumes attached to a given storage pool.
-func dbStoragePoolsGetDrivers(db *sql.DB) ([]string, error) {
+func StoragePoolsGetDrivers(db *sql.DB) ([]string, error) {
 	var poolDriver string
 	query := "SELECT DISTINCT driver FROM storage_pools"
 	inargs := []interface{}{}
 	outargs := []interface{}{poolDriver}
 
-	result, err := dbQueryScan(db, query, inargs, outargs)
+	result, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return []string{}, err
 	}
@@ -58,7 +58,7 @@ func dbStoragePoolsGetDrivers(db *sql.DB) ([]string, error) {
 }
 
 // Get id of a single storage pool.
-func dbStoragePoolGetID(db *sql.DB, poolName string) (int64, error) {
+func StoragePoolGetID(db *sql.DB, poolName string) (int64, error) {
 	poolID := int64(-1)
 	query := "SELECT id FROM storage_pools WHERE name=?"
 	inargs := []interface{}{poolName}
@@ -75,7 +75,7 @@ func dbStoragePoolGetID(db *sql.DB, poolName string) (int64, error) {
 }
 
 // Get a single storage pool.
-func dbStoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, error) {
+func StoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, error) {
 	var poolDriver string
 	poolID := int64(-1)
 	description := sql.NullString{}
@@ -92,7 +92,7 @@ func dbStoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, err
 		return -1, nil, err
 	}
 
-	config, err := dbStoragePoolConfigGet(db, poolID)
+	config, err := StoragePoolConfigGet(db, poolID)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -108,13 +108,13 @@ func dbStoragePoolGet(db *sql.DB, poolName string) (int64, *api.StoragePool, err
 }
 
 // Get config of a storage pool.
-func dbStoragePoolConfigGet(db *sql.DB, poolID int64) (map[string]string, error) {
+func StoragePoolConfigGet(db *sql.DB, poolID int64) (map[string]string, error) {
 	var key, value string
 	query := "SELECT key, value FROM storage_pools_config WHERE storage_pool_id=?"
 	inargs := []interface{}{poolID}
 	outargs := []interface{}{key, value}
 
-	results, err := dbQueryScan(db, query, inargs, outargs)
+	results, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return nil, err
 	}
@@ -132,8 +132,8 @@ func dbStoragePoolConfigGet(db *sql.DB, poolID int64) (map[string]string, error)
 }
 
 // Create new storage pool.
-func dbStoragePoolCreate(db *sql.DB, poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
-	tx, err := dbBegin(db)
+func StoragePoolCreate(db *sql.DB, poolName string, poolDescription string, poolDriver string, poolConfig map[string]string) (int64, error) {
+	tx, err := Begin(db)
 	if err != nil {
 		return -1, err
 	}
@@ -150,31 +150,22 @@ func dbStoragePoolCreate(db *sql.DB, poolName string, poolDescription string, po
 		return -1, err
 	}
 
-	err = dbStoragePoolConfigAdd(tx, id, poolConfig)
+	err = StoragePoolConfigAdd(tx, id, poolConfig)
 	if err != nil {
 		tx.Rollback()
 		return -1, err
 	}
 
-	err = txCommit(tx)
+	err = TxCommit(tx)
 	if err != nil {
 		return -1, err
 	}
-
-	// Update the storage drivers cache in api_1.0.go.
-	storagePoolDriversCacheLock.Lock()
-	drivers := readStoragePoolDriversCache()
-	if !shared.StringInSlice(poolDriver, drivers) {
-		drivers = append(drivers, poolDriver)
-	}
-	storagePoolDriversCacheVal.Store(drivers)
-	storagePoolDriversCacheLock.Unlock()
 
 	return id, nil
 }
 
 // Add new storage pool config.
-func dbStoragePoolConfigAdd(tx *sql.Tx, poolID int64, poolConfig map[string]string) error {
+func StoragePoolConfigAdd(tx *sql.Tx, poolID int64, poolConfig map[string]string) error {
 	str := "INSERT INTO storage_pools_config (storage_pool_id, key, value) VALUES(?, ?, ?)"
 	stmt, err := tx.Prepare(str)
 	defer stmt.Close()
@@ -194,46 +185,46 @@ func dbStoragePoolConfigAdd(tx *sql.Tx, poolID int64, poolConfig map[string]stri
 }
 
 // Update storage pool.
-func dbStoragePoolUpdate(db *sql.DB, poolName, description string, poolConfig map[string]string) error {
-	poolID, _, err := dbStoragePoolGet(db, poolName)
+func StoragePoolUpdate(db *sql.DB, poolName, description string, poolConfig map[string]string) error {
+	poolID, _, err := StoragePoolGet(db, poolName)
 	if err != nil {
 		return err
 	}
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
 
-	err = dbStoragePoolUpdateDescription(tx, poolID, description)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	err = dbStoragePoolConfigClear(tx, poolID)
+	err = StoragePoolUpdateDescription(tx, poolID, description)
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
 
-	err = dbStoragePoolConfigAdd(tx, poolID, poolConfig)
+	err = StoragePoolConfigClear(tx, poolID)
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
 
-	return txCommit(tx)
+	err = StoragePoolConfigAdd(tx, poolID, poolConfig)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return TxCommit(tx)
 }
 
 // Update the storage pool description.
-func dbStoragePoolUpdateDescription(tx *sql.Tx, id int64, description string) error {
+func StoragePoolUpdateDescription(tx *sql.Tx, id int64, description string) error {
 	_, err := tx.Exec("UPDATE storage_pools SET description=? WHERE id=?", description, id)
 	return err
 }
 
 // Delete storage pool config.
-func dbStoragePoolConfigClear(tx *sql.Tx, poolID int64) error {
+func StoragePoolConfigClear(tx *sql.Tx, poolID int64) error {
 	_, err := tx.Exec("DELETE FROM storage_pools_config WHERE storage_pool_id=?", poolID)
 	if err != nil {
 		return err
@@ -243,42 +234,28 @@ func dbStoragePoolConfigClear(tx *sql.Tx, poolID int64) error {
 }
 
 // Delete storage pool.
-func dbStoragePoolDelete(db *sql.DB, poolName string) error {
-	poolID, pool, err := dbStoragePoolGet(db, poolName)
+func StoragePoolDelete(db *sql.DB, poolName string) (*api.StoragePool, error) {
+	poolID, pool, err := StoragePoolGet(db, poolName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	_, err = dbExec(db, "DELETE FROM storage_pools WHERE id=?", poolID)
+	_, err = Exec(db, "DELETE FROM storage_pools WHERE id=?", poolID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	// Update the storage drivers cache in api_1.0.go.
-	storagePoolDriversCacheLock.Lock()
-	drivers := readStoragePoolDriversCache()
-	for i := 0; i < len(drivers); i++ {
-		if drivers[i] == pool.Driver {
-			drivers[i] = drivers[len(drivers)-1]
-			drivers[len(drivers)-1] = ""
-			drivers = drivers[:len(drivers)-1]
-			break
-		}
-	}
-	storagePoolDriversCacheVal.Store(drivers)
-	storagePoolDriversCacheLock.Unlock()
-
-	return nil
+	return pool, nil
 }
 
 // Get the names of all storage volumes attached to a given storage pool.
-func dbStoragePoolVolumesGetNames(db *sql.DB, poolID int64) (int, error) {
+func StoragePoolVolumesGetNames(db *sql.DB, poolID int64) (int, error) {
 	var volumeName string
 	query := "SELECT name FROM storage_volumes WHERE storage_pool_id=?"
 	inargs := []interface{}{poolID}
 	outargs := []interface{}{volumeName}
 
-	result, err := dbQueryScan(db, query, inargs, outargs)
+	result, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return -1, err
 	}
@@ -291,17 +268,17 @@ func dbStoragePoolVolumesGetNames(db *sql.DB, poolID int64) (int, error) {
 }
 
 // Get all storage volumes attached to a given storage pool.
-func dbStoragePoolVolumesGet(db *sql.DB, poolID int64, volumeTypes []int) ([]*api.StorageVolume, error) {
+func StoragePoolVolumesGet(db *sql.DB, poolID int64, volumeTypes []int) ([]*api.StorageVolume, error) {
 	// Get all storage volumes of all types attached to a given storage
 	// pool.
 	result := []*api.StorageVolume{}
 	for _, volumeType := range volumeTypes {
-		volumeNames, err := dbStoragePoolVolumesGetType(db, volumeType, poolID)
+		volumeNames, err := StoragePoolVolumesGetType(db, volumeType, poolID)
 		if err != nil && err != sql.ErrNoRows {
 			return nil, err
 		}
 		for _, volumeName := range volumeNames {
-			_, volume, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+			_, volume, err := StoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
 			if err != nil {
 				return nil, err
 			}
@@ -318,13 +295,13 @@ func dbStoragePoolVolumesGet(db *sql.DB, poolID int64, volumeTypes []int) ([]*ap
 
 // Get all storage volumes attached to a given storage pool of a given volume
 // type.
-func dbStoragePoolVolumesGetType(db *sql.DB, volumeType int, poolID int64) ([]string, error) {
+func StoragePoolVolumesGetType(db *sql.DB, volumeType int, poolID int64) ([]string, error) {
 	var poolName string
 	query := "SELECT name FROM storage_volumes WHERE storage_pool_id=? AND type=?"
 	inargs := []interface{}{poolID, volumeType}
 	outargs := []interface{}{poolName}
 
-	result, err := dbQueryScan(db, query, inargs, outargs)
+	result, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return []string{}, err
 	}
@@ -338,23 +315,23 @@ func dbStoragePoolVolumesGetType(db *sql.DB, volumeType int, poolID int64) ([]st
 }
 
 // Get a single storage volume attached to a given storage pool of a given type.
-func dbStoragePoolVolumeGetType(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, *api.StorageVolume, error) {
-	volumeID, err := dbStoragePoolVolumeGetTypeID(db, volumeName, volumeType, poolID)
+func StoragePoolVolumeGetType(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, *api.StorageVolume, error) {
+	volumeID, err := StoragePoolVolumeGetTypeID(db, volumeName, volumeType, poolID)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	volumeConfig, err := dbStorageVolumeConfigGet(db, volumeID)
+	volumeConfig, err := StorageVolumeConfigGet(db, volumeID)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	volumeDescription, err := dbStorageVolumeDescriptionGet(db, volumeID)
+	volumeDescription, err := StorageVolumeDescriptionGet(db, volumeID)
 	if err != nil {
 		return -1, nil, err
 	}
 
-	volumeTypeName, err := storagePoolVolumeTypeToName(volumeType)
+	volumeTypeName, err := StoragePoolVolumeTypeToName(volumeType)
 	if err != nil {
 		return -1, nil, err
 	}
@@ -370,46 +347,46 @@ func dbStoragePoolVolumeGetType(db *sql.DB, volumeName string, volumeType int, p
 }
 
 // Update storage volume attached to a given storage pool.
-func dbStoragePoolVolumeUpdate(db *sql.DB, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
-	volumeID, _, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+func StoragePoolVolumeUpdate(db *sql.DB, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
+	volumeID, _, err := StoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
 	if err != nil {
 		return err
 	}
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
 
-	err = dbStorageVolumeConfigClear(tx, volumeID)
-	if err != nil {
-		tx.Rollback()
-		return err
-	}
-
-	err = dbStorageVolumeConfigAdd(tx, volumeID, volumeConfig)
+	err = StorageVolumeConfigClear(tx, volumeID)
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
 
-	err = dbStorageVolumeDescriptionUpdate(tx, volumeID, volumeDescription)
+	err = StorageVolumeConfigAdd(tx, volumeID, volumeConfig)
 	if err != nil {
 		tx.Rollback()
 		return err
 	}
 
-	return txCommit(tx)
+	err = StorageVolumeDescriptionUpdate(tx, volumeID, volumeDescription)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	return TxCommit(tx)
 }
 
 // Delete storage volume attached to a given storage pool.
-func dbStoragePoolVolumeDelete(db *sql.DB, volumeName string, volumeType int, poolID int64) error {
-	volumeID, _, err := dbStoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
+func StoragePoolVolumeDelete(db *sql.DB, volumeName string, volumeType int, poolID int64) error {
+	volumeID, _, err := StoragePoolVolumeGetType(db, volumeName, volumeType, poolID)
 	if err != nil {
 		return err
 	}
 
-	_, err = dbExec(db, "DELETE FROM storage_volumes WHERE id=?", volumeID)
+	_, err = Exec(db, "DELETE FROM storage_volumes WHERE id=?", volumeID)
 	if err != nil {
 		return err
 	}
@@ -418,13 +395,13 @@ func dbStoragePoolVolumeDelete(db *sql.DB, volumeName string, volumeType int, po
 }
 
 // Rename storage volume attached to a given storage pool.
-func dbStoragePoolVolumeRename(db *sql.DB, oldVolumeName string, newVolumeName string, volumeType int, poolID int64) error {
-	volumeID, _, err := dbStoragePoolVolumeGetType(db, oldVolumeName, volumeType, poolID)
+func StoragePoolVolumeRename(db *sql.DB, oldVolumeName string, newVolumeName string, volumeType int, poolID int64) error {
+	volumeID, _, err := StoragePoolVolumeGetType(db, oldVolumeName, volumeType, poolID)
 	if err != nil {
 		return err
 	}
 
-	tx, err := dbBegin(db)
+	tx, err := Begin(db)
 	if err != nil {
 		return err
 	}
@@ -435,12 +412,12 @@ func dbStoragePoolVolumeRename(db *sql.DB, oldVolumeName string, newVolumeName s
 		return err
 	}
 
-	return txCommit(tx)
+	return TxCommit(tx)
 }
 
 // Create new storage volume attached to a given storage pool.
-func dbStoragePoolVolumeCreate(db *sql.DB, volumeName, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string) (int64, error) {
-	tx, err := dbBegin(db)
+func StoragePoolVolumeCreate(db *sql.DB, volumeName, volumeDescription string, volumeType int, poolID int64, volumeConfig map[string]string) (int64, error) {
+	tx, err := Begin(db)
 	if err != nil {
 		return -1, err
 	}
@@ -458,13 +435,13 @@ func dbStoragePoolVolumeCreate(db *sql.DB, volumeName, volumeDescription string,
 		return -1, err
 	}
 
-	err = dbStorageVolumeConfigAdd(tx, volumeID, volumeConfig)
+	err = StorageVolumeConfigAdd(tx, volumeID, volumeConfig)
 	if err != nil {
 		tx.Rollback()
 		return -1, err
 	}
 
-	err = txCommit(tx)
+	err = TxCommit(tx)
 	if err != nil {
 		return -1, err
 	}
@@ -474,7 +451,7 @@ func dbStoragePoolVolumeCreate(db *sql.DB, volumeName, volumeDescription string,
 
 // Get ID of a storage volume on a given storage pool of a given storage volume
 // type.
-func dbStoragePoolVolumeGetTypeID(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, error) {
+func StoragePoolVolumeGetTypeID(db *sql.DB, volumeName string, volumeType int, poolID int64) (int64, error) {
 	volumeID := int64(-1)
 	query := `SELECT storage_volumes.id
 FROM storage_volumes
@@ -491,4 +468,36 @@ AND storage_volumes.name=? AND storage_volumes.type=?`
 	}
 
 	return volumeID, nil
+}
+
+// XXX: this was extracted from lxd/storage_volume_utils.go, we find a way to
+//      factor it independently from both the db and main packages.
+const (
+	StoragePoolVolumeTypeContainer = iota
+	StoragePoolVolumeTypeImage
+	StoragePoolVolumeTypeCustom
+)
+
+// Leave the string type in here! This guarantees that go treats this is as a
+// typed string constant. Removing it causes go to treat these as untyped string
+// constants which is not what we want.
+const (
+	StoragePoolVolumeTypeNameContainer string = "container"
+	StoragePoolVolumeTypeNameImage     string = "image"
+	StoragePoolVolumeTypeNameCustom    string = "custom"
+)
+
+// StoragePoolVolumeTypeToName converts a volume integer type code to its
+// human-readable name.
+func StoragePoolVolumeTypeToName(volumeType int) (string, error) {
+	switch volumeType {
+	case StoragePoolVolumeTypeContainer:
+		return StoragePoolVolumeTypeNameContainer, nil
+	case StoragePoolVolumeTypeImage:
+		return StoragePoolVolumeTypeNameImage, nil
+	case StoragePoolVolumeTypeCustom:
+		return StoragePoolVolumeTypeNameCustom, nil
+	}
+
+	return "", fmt.Errorf("invalid storage volume type")
 }

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -7,13 +7,13 @@ import (
 )
 
 // Get config of a storage volume.
-func dbStorageVolumeConfigGet(db *sql.DB, volumeID int64) (map[string]string, error) {
+func StorageVolumeConfigGet(db *sql.DB, volumeID int64) (map[string]string, error) {
 	var key, value string
 	query := "SELECT key, value FROM storage_volumes_config WHERE storage_volume_id=?"
 	inargs := []interface{}{volumeID}
 	outargs := []interface{}{key, value}
 
-	results, err := dbQueryScan(db, query, inargs, outargs)
+	results, err := QueryScan(db, query, inargs, outargs)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func dbStorageVolumeConfigGet(db *sql.DB, volumeID int64) (map[string]string, er
 }
 
 // Get the description of a storage volume.
-func dbStorageVolumeDescriptionGet(db *sql.DB, volumeID int64) (string, error) {
+func StorageVolumeDescriptionGet(db *sql.DB, volumeID int64) (string, error) {
 	description := sql.NullString{}
 	query := "SELECT description FROM storage_volumes WHERE id=?"
 	inargs := []interface{}{volumeID}
@@ -48,13 +48,13 @@ func dbStorageVolumeDescriptionGet(db *sql.DB, volumeID int64) (string, error) {
 }
 
 // Update description of a storage volume.
-func dbStorageVolumeDescriptionUpdate(tx *sql.Tx, volumeID int64, description string) error {
+func StorageVolumeDescriptionUpdate(tx *sql.Tx, volumeID int64, description string) error {
 	_, err := tx.Exec("UPDATE storage_volumes SET description=? WHERE id=?", description, volumeID)
 	return err
 }
 
 // Add new storage volume config into database.
-func dbStorageVolumeConfigAdd(tx *sql.Tx, volumeID int64, volumeConfig map[string]string) error {
+func StorageVolumeConfigAdd(tx *sql.Tx, volumeID int64, volumeConfig map[string]string) error {
 	str := "INSERT INTO storage_volumes_config (storage_volume_id, key, value) VALUES(?, ?, ?)"
 	stmt, err := tx.Prepare(str)
 	defer stmt.Close()
@@ -74,7 +74,7 @@ func dbStorageVolumeConfigAdd(tx *sql.Tx, volumeID int64, volumeConfig map[strin
 }
 
 // Delete storage volume config.
-func dbStorageVolumeConfigClear(tx *sql.Tx, volumeID int64) error {
+func StorageVolumeConfigClear(tx *sql.Tx, volumeID int64) error {
 	_, err := tx.Exec("DELETE FROM storage_volumes_config WHERE storage_volume_id=?", volumeID)
 	if err != nil {
 		return err

--- a/lxd/db/update.go
+++ b/lxd/db/update.go
@@ -1,4 +1,4 @@
-package main
+package db
 
 import (
 	"database/sql"
@@ -98,8 +98,8 @@ func (u *dbUpdate) apply(currentVersion int, db *sql.DB) error {
 // of now "postApply" is only used by the daemon as a mean to apply
 // the legacy V10 and V15 non-db updates during the database upgrade
 // sequence to, avoid changing semantics see PR #3322).
-func dbUpdatesApplyAll(db *sql.DB, doBackup bool, postApply func(int) error) error {
-	currentVersion := dbGetSchema(db)
+func UpdatesApplyAll(db *sql.DB, doBackup bool, postApply func(int) error) error {
+	currentVersion := GetSchema(db)
 
 	backup := false
 	for _, update := range dbUpdates {
@@ -344,7 +344,7 @@ func dbUpdateFromV18(currentVersion int, version int, db *sql.DB) error {
 	var value string
 
 	// Update container config
-	rows, err := dbQueryScan(db, "SELECT id, value FROM containers_config WHERE key='limits.memory'", nil, []interface{}{id, value})
+	rows, err := QueryScan(db, "SELECT id, value FROM containers_config WHERE key='limits.memory'", nil, []interface{}{id, value})
 	if err != nil {
 		return err
 	}
@@ -381,7 +381,7 @@ func dbUpdateFromV18(currentVersion int, version int, db *sql.DB) error {
 	}
 
 	// Update profiles config
-	rows, err = dbQueryScan(db, "SELECT id, value FROM profiles_config WHERE key='limits.memory'", nil, []interface{}{id, value})
+	rows, err = QueryScan(db, "SELECT id, value FROM profiles_config WHERE key='limits.memory'", nil, []interface{}{id, value})
 	if err != nil {
 		return err
 	}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -19,6 +19,7 @@ import (
 
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -589,7 +590,7 @@ func deviceTaskBalance(d *Daemon) {
 	}
 
 	// Iterate through the containers
-	containers, err := dbContainersList(d.db, cTypeRegular)
+	containers, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		logger.Error("problem loading containers list", log.Ctx{"err": err})
 		return
@@ -715,7 +716,7 @@ func deviceNetworkPriority(d *Daemon, netif string) {
 		return
 	}
 
-	containers, err := dbContainersList(d.db, cTypeRegular)
+	containers, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return
 	}
@@ -746,7 +747,7 @@ func deviceNetworkPriority(d *Daemon, netif string) {
 }
 
 func deviceUSBEvent(d *Daemon, usb usbDevice) {
-	containers, err := dbContainersList(d.db, cTypeRegular)
+	containers, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		logger.Error("problem loading containers list", log.Ctx{"err": err})
 		return

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -371,7 +372,7 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 		return nil, err
 	}
 
-	containers, err := dbContainersList(d.db, cTypeRegular)
+	containers, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -51,7 +52,7 @@ func cmdActivateIfNeeded() error {
 	}
 
 	// Look for auto-started or previously started containers
-	result, err := dbContainersList(d.db, cTypeRegular)
+	result, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -87,7 +88,7 @@ func (suite *lxdTestSuite) SetupTest() {
 	mockStorage, _ := storageTypeToString(storageTypeMock)
 	// Create the database entry for the storage pool.
 	poolDescription := fmt.Sprintf("%s storage pool", lxdTestSuiteDefaultStoragePool)
-	_, err := dbStoragePoolCreate(suite.d.db, lxdTestSuiteDefaultStoragePool, poolDescription, mockStorage, poolConfig)
+	_, err := dbStoragePoolCreateAndUpdateCache(suite.d.db, lxdTestSuiteDefaultStoragePool, poolDescription, mockStorage, poolConfig)
 	if err != nil {
 		os.Exit(1)
 	}
@@ -99,17 +100,17 @@ func (suite *lxdTestSuite) SetupTest() {
 	devicesMap := map[string]map[string]string{}
 	devicesMap["root"] = rootDev
 
-	defaultID, _, err := dbProfileGet(suite.d.db, "default")
+	defaultID, _, err := db.ProfileGet(suite.d.db, "default")
 	if err != nil {
 		os.Exit(1)
 	}
 
-	tx, err := dbBegin(suite.d.db)
+	tx, err := db.Begin(suite.d.db)
 	if err != nil {
 		os.Exit(1)
 	}
 
-	err = dbDevicesAdd(tx, "profile", defaultID, devicesMap)
+	err = db.DevicesAdd(tx, "profile", defaultID, devicesMap)
 	if err != nil {
 		tx.Rollback()
 		os.Exit(1)

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -19,11 +19,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 )
 
 func networkAutoAttach(d *Daemon, devName string) error {
-	_, dbInfo, err := dbNetworkGetInterface(d.db, devName)
+	_, dbInfo, err := db.NetworkGetInterface(d.db, devName)
 	if err != nil {
 		// No match found, move on
 		return nil
@@ -71,7 +72,7 @@ func networkDetachInterface(netName string, devName string) error {
 }
 
 func networkGetInterfaces(d *Daemon) ([]string, error) {
-	networks, err := dbNetworks(d.db)
+	networks, err := db.Networks(d.db)
 	if err != nil {
 		return nil, err
 	}
@@ -723,7 +724,7 @@ func networkKillDnsmasq(name string, reload bool) error {
 
 func networkUpdateStatic(d *Daemon, name string) error {
 	// Get all the containers
-	containers, err := dbContainersList(d.db, cTypeRegular)
+	containers, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -731,7 +732,7 @@ func networkUpdateStatic(d *Daemon, name string) error {
 	networks := []string{}
 	if name == "" {
 		// Get all the networks
-		networks, err = dbNetworks(d.db)
+		networks, err = db.Networks(d.db)
 		if err != nil {
 			return err
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -60,7 +61,7 @@ func (p *patch) apply(d *Daemon) error {
 		return err
 	}
 
-	err = dbPatchesMarkApplied(d.db, p.name)
+	err = db.PatchesMarkApplied(d.db, p.name)
 	if err != nil {
 		return err
 	}
@@ -68,8 +69,17 @@ func (p *patch) apply(d *Daemon) error {
 	return nil
 }
 
+// Return the names of all available patches.
+func patchesGetNames() []string {
+	names := make([]string, len(patches))
+	for i, patch := range patches {
+		names[i] = patch.name
+	}
+	return names
+}
+
 func patchesApplyAll(d *Daemon) error {
-	appliedPatches, err := dbPatches(d.db)
+	appliedPatches, err := db.Patches(d.db)
 	if err != nil {
 		return err
 	}
@@ -105,7 +115,7 @@ DELETE FROM profiles_devices_config WHERE profile_device_id NOT IN (SELECT id FR
 }
 
 func patchInvalidProfileNames(name string, d *Daemon) error {
-	profiles, err := dbProfiles(d.db)
+	profiles, err := db.Profiles(d.db)
 	if err != nil {
 		return err
 	}
@@ -113,7 +123,7 @@ func patchInvalidProfileNames(name string, d *Daemon) error {
 	for _, profile := range profiles {
 		if strings.Contains(profile, "/") || shared.StringInSlice(profile, []string{".", ".."}) {
 			logger.Info("Removing unreachable profile (invalid name)", log.Ctx{"name": profile})
-			err := dbProfileDelete(d.db, profile)
+			err := db.ProfileDelete(d.db, profile)
 			if err != nil {
 				return err
 			}
@@ -125,7 +135,7 @@ func patchInvalidProfileNames(name string, d *Daemon) error {
 
 func patchNetworkPermissions(name string, d *Daemon) error {
 	// Get the list of networks
-	networks, err := dbNetworks(d.db)
+	networks, err := db.Networks(d.db)
 	if err != nil {
 		return err
 	}
@@ -192,25 +202,25 @@ func patchStorageApi(name string, d *Daemon) error {
 	// Check if this LXD instace currently has any containers, snapshots, or
 	// images configured. If so, we create a default storage pool in the
 	// database. Otherwise, the user will have to run LXD init.
-	cRegular, err := dbContainersList(d.db, cTypeRegular)
+	cRegular, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing snapshots.
-	cSnapshots, err := dbContainersList(d.db, cTypeSnapshot)
+	cSnapshots, err := db.ContainersList(d.db, db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing public images.
-	imgPublic, err := dbImagesGet(d.db, true)
+	imgPublic, err := db.ImagesGet(d.db, true)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing private images.
-	imgPrivate, err := dbImagesGet(d.db, false)
+	imgPrivate, err := db.ImagesGet(d.db, false)
 	if err != nil {
 		return err
 	}
@@ -291,7 +301,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 	}
 
 	poolID := int64(-1)
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
@@ -300,7 +310,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
-		tmp, pool, err := dbStoragePoolGet(d.db, defaultPoolName)
+		tmp, pool, err := db.StoragePoolGet(d.db, defaultPoolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s.", err)
 			return err
@@ -313,12 +323,12 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		if pool.Config == nil {
 			pool.Config = poolConfig
 		}
-		err = dbStoragePoolUpdate(d.db, defaultPoolName, "", pool.Config)
+		err = db.StoragePoolUpdate(d.db, defaultPoolName, "", pool.Config)
 		if err != nil {
 			return err
 		}
-	} else if err == NoSuchObjectError { // Likely a pristine upgrade.
-		tmp, err := dbStoragePoolCreate(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
+	} else if err == db.NoSuchObjectError { // Likely a pristine upgrade.
+		tmp, err := dbStoragePoolCreateAndUpdateCache(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
 		}
@@ -350,7 +360,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 	}
 
 	// Get storage pool from the db after having updated it above.
-	_, defaultPool, err := dbStoragePoolGet(d.db, defaultPoolName)
+	_, defaultPool, err := db.StoragePoolGet(d.db, defaultPoolName)
 	if err != nil {
 		return err
 	}
@@ -364,16 +374,16 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container.")
-			err := dbStoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
 				return err
@@ -422,7 +432,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		ctSnapshots, err := db.ContainerGetSnapshots(d.db, ct)
 		if err != nil {
 			return err
 		}
@@ -452,16 +462,16 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 				return err
 			}
 
-			_, err = dbStoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
+			_, err = db.StoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
-				err := dbStoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := db.StoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
-			} else if err == NoSuchObjectError {
+			} else if err == db.NoSuchObjectError {
 				// Insert storage volumes for containers into the database.
-				_, err := dbStoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
+				_, err := db.StoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
 					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
 					return err
@@ -533,16 +543,16 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image.")
-			err := dbStoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
 				return err
@@ -588,7 +598,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 	}
 
 	poolID := int64(-1)
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
@@ -597,7 +607,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
-		tmp, pool, err := dbStoragePoolGet(d.db, defaultPoolName)
+		tmp, pool, err := db.StoragePoolGet(d.db, defaultPoolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s.", err)
 			return err
@@ -610,12 +620,12 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		if pool.Config == nil {
 			pool.Config = poolConfig
 		}
-		err = dbStoragePoolUpdate(d.db, defaultPoolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, defaultPoolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
-	} else if err == NoSuchObjectError { // Likely a pristine upgrade.
-		tmp, err := dbStoragePoolCreate(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
+	} else if err == db.NoSuchObjectError { // Likely a pristine upgrade.
+		tmp, err := dbStoragePoolCreateAndUpdateCache(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
 		}
@@ -636,7 +646,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 	}
 
 	// Get storage pool from the db after having updated it above.
-	_, defaultPool, err := dbStoragePoolGet(d.db, defaultPoolName)
+	_, defaultPool, err := db.StoragePoolGet(d.db, defaultPoolName)
 	if err != nil {
 		return err
 	}
@@ -651,16 +661,16 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container.")
-			err := dbStoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
 				return err
@@ -768,16 +778,16 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
-			err := dbStoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
 				return err
@@ -798,16 +808,16 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image.")
-			err := dbStoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
 				return err
@@ -881,7 +891,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	// are already configured. If so, we can assume that a partial upgrade
 	// has been performed and can skip the next steps.
 	poolID := int64(-1)
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
@@ -890,7 +900,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
-		tmp, pool, err := dbStoragePoolGet(d.db, defaultPoolName)
+		tmp, pool, err := db.StoragePoolGet(d.db, defaultPoolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s.", err)
 			return err
@@ -903,12 +913,12 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		if pool.Config == nil {
 			pool.Config = poolConfig
 		}
-		err = dbStoragePoolUpdate(d.db, defaultPoolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, defaultPoolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
-	} else if err == NoSuchObjectError { // Likely a pristine upgrade.
-		tmp, err := dbStoragePoolCreate(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
+	} else if err == db.NoSuchObjectError { // Likely a pristine upgrade.
+		tmp, err := dbStoragePoolCreateAndUpdateCache(d.db, defaultPoolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			return err
 		}
@@ -939,7 +949,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	}
 
 	// Get storage pool from the db after having updated it above.
-	_, defaultPool, err := dbStoragePoolGet(d.db, defaultPoolName)
+	_, defaultPool, err := db.StoragePoolGet(d.db, defaultPoolName)
 	if err != nil {
 		return err
 	}
@@ -954,16 +964,16 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container.")
-			err := dbStoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
 				return err
@@ -1092,7 +1102,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		ctSnapshots, err := db.ContainerGetSnapshots(d.db, ct)
 		if err != nil {
 			return err
 		}
@@ -1109,16 +1119,16 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				return err
 			}
 
-			_, err = dbStoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
+			_, err = db.StoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
-				err := dbStoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := db.StoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
-			} else if err == NoSuchObjectError {
+			} else if err == db.NoSuchObjectError {
 				// Insert storage volumes for containers into the database.
-				_, err := dbStoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
+				_, err := db.StoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
 					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
 					return err
@@ -1280,16 +1290,16 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image.")
-			err := dbStoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
 				return err
@@ -1341,7 +1351,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			// This image didn't exist as a logical volume on the
 			// old LXD instance so we need to kick it from the
 			// storage volumes database for this pool.
-			err := dbStoragePoolVolumeDelete(d.db, img, storagePoolVolumeTypeImage, poolID)
+			err := db.StoragePoolVolumeDelete(d.db, img, storagePoolVolumeTypeImage, poolID)
 			if err != nil {
 				return err
 			}
@@ -1381,7 +1391,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 	// are already configured. If so, we can assume that a partial upgrade
 	// has been performed and can skip the next steps.
 	poolID := int64(-1)
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(poolName, pools) {
@@ -1390,7 +1400,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
-		tmp, pool, err := dbStoragePoolGet(d.db, poolName)
+		tmp, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s.", err)
 			return err
@@ -1403,11 +1413,11 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if pool.Config == nil {
 			pool.Config = poolConfig
 		}
-		err = dbStoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
-	} else if err == NoSuchObjectError { // Likely a pristine upgrade.
+	} else if err == db.NoSuchObjectError { // Likely a pristine upgrade.
 		if shared.PathExists(oldLoopFilePath) {
 			// This is a loop file pool.
 			poolConfig["source"] = shared.VarPath("disks", poolName+".img")
@@ -1435,7 +1445,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// (Use a tmp variable as Go's scoping is freaking me out.)
-		tmp, err := dbStoragePoolCreate(d.db, poolName, "", defaultStorageTypeName, poolConfig)
+		tmp, err := dbStoragePoolCreateAndUpdateCache(d.db, poolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
 			logger.Warnf("Storage pool already exists in the database. Proceeding...")
 		}
@@ -1446,7 +1456,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 	}
 
 	// Get storage pool from the db after having updated it above.
-	_, defaultPool, err := dbStoragePoolGet(d.db, poolName)
+	_, defaultPool, err := db.StoragePoolGet(d.db, poolName)
 	if err != nil {
 		return err
 	}
@@ -1471,16 +1481,16 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container.")
-			err := dbStoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
 				return err
@@ -1538,7 +1548,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		// Check if we need to account for snapshots for this container.
-		ctSnapshots, err := dbContainerGetSnapshots(d.db, ct)
+		ctSnapshots, err := db.ContainerGetSnapshots(d.db, ct)
 		if err != nil {
 			logger.Errorf("Failed to query database")
 			return err
@@ -1557,16 +1567,16 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 				return err
 			}
 
-			_, err = dbStoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
+			_, err = db.StoragePoolVolumeGetTypeID(d.db, cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
-				err := dbStoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := db.StoragePoolVolumeUpdate(d.db, cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
-			} else if err == NoSuchObjectError {
+			} else if err == db.NoSuchObjectError {
 				// Insert storage volumes for containers into the database.
-				_, err := dbStoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
+				_, err := db.StoragePoolVolumeCreate(d.db, cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
 					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
 					return err
@@ -1613,16 +1623,16 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 
-		_, err = dbStoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
+		_, err = db.StoragePoolVolumeGetTypeID(d.db, img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image.")
-			err := dbStoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := db.StoragePoolVolumeUpdate(d.db, img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
-		} else if err == NoSuchObjectError {
+		} else if err == db.NoSuchObjectError {
 			// Insert storage volumes for containers into the database.
-			_, err := dbStoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
+			_, err := db.StoragePoolVolumeCreate(d.db, img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
 				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
 				return err
@@ -1681,10 +1691,10 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 	// appropriate device including a pool is added to the default profile
 	// or the user explicitly passes the pool the container's storage volume
 	// is supposed to be created on.
-	profiles, err := dbProfiles(d.db)
+	profiles, err := db.Profiles(d.db)
 	if err == nil {
 		for _, pName := range profiles {
-			pID, p, err := dbProfileGet(d.db, pName)
+			pID, p, err := db.ProfileGet(d.db, pName)
 			if err != nil {
 				logger.Errorf("Could not query database: %s.", err)
 				return err
@@ -1725,26 +1735,26 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 			// This is nasty, but we need to clear the profiles config and
 			// devices in order to add the new root device including the
 			// newly added storage pool.
-			tx, err := dbBegin(d.db)
+			tx, err := db.Begin(d.db)
 			if err != nil {
 				return err
 			}
 
-			err = dbProfileConfigClear(tx, pID)
+			err = db.ProfileConfigClear(tx, pID)
 			if err != nil {
 				logger.Errorf("Failed to clear old profile configuration for profile %s: %s.", pName, err)
 				tx.Rollback()
 				continue
 			}
 
-			err = dbProfileConfigAdd(tx, pID, p.Config)
+			err = db.ProfileConfigAdd(tx, pID, p.Config)
 			if err != nil {
 				logger.Errorf("Failed to add new profile configuration: %s: %s.", pName, err)
 				tx.Rollback()
 				continue
 			}
 
-			err = dbDevicesAdd(tx, "profile", pID, p.Devices)
+			err = db.DevicesAdd(tx, "profile", pID, p.Devices)
 			if err != nil {
 				logger.Errorf("Failed to add new profile profile root disk device: %s: %s.", pName, err)
 				tx.Rollback()
@@ -1767,7 +1777,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 			continue
 		}
 
-		args := containerArgs{
+		args := db.ContainerArgs{
 			Architecture: c.Architecture(),
 			Config:       c.LocalConfig(),
 			Ephemeral:    c.IsEphemeral(),
@@ -1778,9 +1788,9 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 		}
 
 		if c.IsSnapshot() {
-			args.Ctype = cTypeSnapshot
+			args.Ctype = db.CTypeSnapshot
 		} else {
-			args.Ctype = cTypeRegular
+			args.Ctype = db.CTypeRegular
 		}
 
 		// Check if the container already has a valid root device entry (profile or previous upgrade)
@@ -1827,8 +1837,8 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 }
 
 func patchStorageApiV1(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
-	if err != nil && err == NoSuchObjectError {
+	pools, err := db.StoragePools(d.db)
+	if err != nil && err == db.NoSuchObjectError {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -1843,13 +1853,13 @@ func patchStorageApiV1(name string, d *Daemon) error {
 		return nil
 	}
 
-	cRegular, err := dbContainersList(d.db, cTypeRegular)
+	cRegular, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing snapshots.
-	cSnapshots, err := dbContainersList(d.db, cTypeSnapshot)
+	cSnapshots, err := db.ContainersList(d.db, db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
@@ -1864,7 +1874,7 @@ func patchStorageApiV1(name string, d *Daemon) error {
 }
 
 func patchStorageApiDirCleanup(name string, d *Daemon) error {
-	_, err := dbExec(d.db, "DELETE FROM storage_volumes WHERE type=? AND name NOT IN (SELECT fingerprint FROM images);", storagePoolVolumeTypeImage)
+	_, err := db.Exec(d.db, "DELETE FROM storage_volumes WHERE type=? AND name NOT IN (SELECT fingerprint FROM images);", storagePoolVolumeTypeImage)
 	if err != nil {
 		return err
 	}
@@ -1873,12 +1883,12 @@ func patchStorageApiDirCleanup(name string, d *Daemon) error {
 }
 
 func patchStorageApiLvmKeys(name string, d *Daemon) error {
-	_, err := dbExec(d.db, "UPDATE storage_pools_config SET key='lvm.thinpool_name' WHERE key='volume.lvm.thinpool_name';")
+	_, err := db.Exec(d.db, "UPDATE storage_pools_config SET key='lvm.thinpool_name' WHERE key='volume.lvm.thinpool_name';")
 	if err != nil {
 		return err
 	}
 
-	_, err = dbExec(d.db, "DELETE FROM storage_volumes_config WHERE key='lvm.thinpool_name';")
+	_, err = db.Exec(d.db, "DELETE FROM storage_volumes_config WHERE key='lvm.thinpool_name';")
 	if err != nil {
 		return err
 	}
@@ -1887,8 +1897,8 @@ func patchStorageApiLvmKeys(name string, d *Daemon) error {
 }
 
 func patchStorageApiKeys(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
-	if err != nil && err == NoSuchObjectError {
+	pools, err := db.StoragePools(d.db)
+	if err != nil && err == db.NoSuchObjectError {
 		// No pool was configured in the previous update. So we're on a
 		// pristine LXD instance.
 		return nil
@@ -1899,7 +1909,7 @@ func patchStorageApiKeys(name string, d *Daemon) error {
 	}
 
 	for _, poolName := range pools {
-		_, pool, err := dbStoragePoolGet(d.db, poolName)
+		_, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s", err)
 			return err
@@ -1932,7 +1942,7 @@ func patchStorageApiKeys(name string, d *Daemon) error {
 		}
 
 		// Update the config in the database.
-		err = dbStoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
@@ -1944,9 +1954,9 @@ func patchStorageApiKeys(name string, d *Daemon) error {
 // In case any of the objects images/containers/snapshots are missing storage
 // volume configuration entries, let's add the defaults.
 func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err != nil {
-		if err == NoSuchObjectError {
+		if err == db.NoSuchObjectError {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -1954,7 +1964,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 	}
 
 	for _, poolName := range pools {
-		poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+		poolID, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s", err)
 			return err
@@ -2020,15 +2030,15 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 		}
 
 		// Update the storage pool config.
-		err = dbStoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
 
 		// Get all storage volumes on the storage pool.
-		volumes, err := dbStoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
+		volumes, err := db.StoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
 		if err != nil {
-			if err == NoSuchObjectError {
+			if err == db.NoSuchObjectError {
 				continue
 			}
 			return err
@@ -2081,7 +2091,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 			// exist in the db, so it's safe to ignore the error.
 			volumeType, _ := storagePoolVolumeTypeNameToType(volume.Type)
 			// Update the volume config.
-			err = dbStoragePoolVolumeUpdate(d.db, volume.Name, volumeType, poolID, volume.Description, volume.Config)
+			err = db.StoragePoolVolumeUpdate(d.db, volume.Name, volumeType, poolID, volume.Description, volume.Config)
 			if err != nil {
 				return err
 			}
@@ -2092,9 +2102,9 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 }
 
 func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err != nil {
-		if err == NoSuchObjectError {
+		if err == db.NoSuchObjectError {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -2102,7 +2112,7 @@ func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 	}
 
 	for _, poolName := range pools {
-		_, pool, err := dbStoragePoolGet(d.db, poolName)
+		_, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s", err)
 			return err
@@ -2137,7 +2147,7 @@ func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 		pool.Config["source"] = getStoragePoolMountPoint(poolName)
 
 		// Update the storage pool config.
-		err = dbStoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
+		err = db.StoragePoolUpdate(d.db, poolName, pool.Description, pool.Config)
 		if err != nil {
 			return err
 		}
@@ -2149,9 +2159,9 @@ func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 }
 
 func patchStorageApiDetectLVSize(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err != nil {
-		if err == NoSuchObjectError {
+		if err == db.NoSuchObjectError {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -2159,7 +2169,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 	}
 
 	for _, poolName := range pools {
-		poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+		poolID, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s", err)
 			return err
@@ -2182,9 +2192,9 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 		}
 
 		// Get all storage volumes on the storage pool.
-		volumes, err := dbStoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
+		volumes, err := db.StoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
 		if err != nil {
-			if err == NoSuchObjectError {
+			if err == db.NoSuchObjectError {
 				continue
 			}
 			return err
@@ -2229,7 +2239,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 			// exist in the db, so it's safe to ignore the error.
 			volumeType, _ := storagePoolVolumeTypeNameToType(volume.Type)
 			// Update the volume config.
-			err = dbStoragePoolVolumeUpdate(d.db, volume.Name, volumeType, poolID, volume.Description, volume.Config)
+			err = db.StoragePoolVolumeUpdate(d.db, volume.Name, volumeType, poolID, volume.Description, volume.Config)
 			if err != nil {
 				return err
 			}
@@ -2240,7 +2250,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 }
 
 func patchStorageApiInsertZfsDriver(name string, d *Daemon) error {
-	_, err := dbExec(d.db, "UPDATE storage_pools SET driver='zfs', description='' WHERE driver=''")
+	_, err := db.Exec(d.db, "UPDATE storage_pools SET driver='zfs', description='' WHERE driver=''")
 	if err != nil {
 		return err
 	}
@@ -2249,9 +2259,9 @@ func patchStorageApiInsertZfsDriver(name string, d *Daemon) error {
 }
 
 func patchStorageZFSnoauto(name string, d *Daemon) error {
-	pools, err := dbStoragePools(d.db)
+	pools, err := db.StoragePools(d.db)
 	if err != nil {
-		if err == NoSuchObjectError {
+		if err == db.NoSuchObjectError {
 			return nil
 		}
 		logger.Errorf("Failed to query database: %s", err)
@@ -2259,7 +2269,7 @@ func patchStorageZFSnoauto(name string, d *Daemon) error {
 	}
 
 	for _, poolName := range pools {
-		_, pool, err := dbStoragePoolGet(d.db, poolName)
+		_, pool, err := db.StoragePoolGet(d.db, poolName)
 		if err != nil {
 			logger.Errorf("Failed to query database: %s", err)
 			return err
@@ -2347,7 +2357,7 @@ func patchUpdateFromV10(d *Daemon) error {
 }
 
 func patchUpdateFromV11(d *Daemon) error {
-	cNames, err := dbContainersList(d.db, cTypeSnapshot)
+	cNames, err := db.ContainersList(d.db, db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
@@ -2418,7 +2428,7 @@ func patchUpdateFromV15(d *Daemon) error {
 	// munge all LVM-backed containers' LV names to match what is
 	// required for snapshot support
 
-	cNames, err := dbContainersList(d.db, cTypeRegular)
+	cNames, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return err
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -21,7 +22,7 @@ import (
 
 /* This is used for both profiles post and profile put */
 func profilesGet(d *Daemon, r *http.Request) Response {
-	results, err := dbProfiles(d.db)
+	results, err := db.Profiles(d.db)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -64,7 +65,7 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("No name provided"))
 	}
 
-	_, profile, _ := dbProfileGet(d.db, req.Name)
+	_, profile, _ := db.ProfileGet(d.db, req.Name)
 	if profile != nil {
 		return BadRequest(fmt.Errorf("The profile already exists"))
 	}
@@ -88,7 +89,7 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Update DB entry
-	_, err = dbProfileCreate(d.db, req.Name, req.Description, req.Config, req.Devices)
+	_, err = db.ProfileCreate(d.db, req.Name, req.Description, req.Config, req.Devices)
 	if err != nil {
 		return SmartError(
 			fmt.Errorf("Error inserting %s into database: %s", req.Name, err))
@@ -103,12 +104,12 @@ var profilesCmd = Command{
 	post: profilesPost}
 
 func doProfileGet(d *Daemon, name string) (*api.Profile, error) {
-	_, profile, err := dbProfileGet(d.db, name)
+	_, profile, err := db.ProfileGet(d.db, name)
 	if err != nil {
 		return nil, err
 	}
 
-	cts, err := dbProfileContainersGet(d.db, name)
+	cts, err := db.ProfileContainersGet(d.db, name)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +138,7 @@ func profileGet(d *Daemon, r *http.Request) Response {
 func getContainersWithProfile(d *Daemon, profile string) []container {
 	results := []container{}
 
-	output, err := dbProfileContainersGet(d.db, profile)
+	output, err := db.ProfileContainersGet(d.db, profile)
 	if err != nil {
 		return results
 	}
@@ -157,7 +158,7 @@ func getContainersWithProfile(d *Daemon, profile string) []container {
 func profilePut(d *Daemon, r *http.Request) Response {
 	// Get the profile
 	name := mux.Vars(r)["name"]
-	id, profile, err := dbProfileGet(d.db, name)
+	id, profile, err := db.ProfileGet(d.db, name)
 	if err != nil {
 		return SmartError(fmt.Errorf("Failed to retrieve profile='%s'", name))
 	}
@@ -180,7 +181,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 func profilePatch(d *Daemon, r *http.Request) Response {
 	// Get the profile
 	name := mux.Vars(r)["name"]
-	id, profile, err := dbProfileGet(d.db, name)
+	id, profile, err := db.ProfileGet(d.db, name)
 	if err != nil {
 		return SmartError(fmt.Errorf("Failed to retrieve profile='%s'", name))
 	}
@@ -258,7 +259,7 @@ func profilePost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Check that the name isn't already in use
-	id, _, _ := dbProfileGet(d.db, req.Name)
+	id, _, _ := db.ProfileGet(d.db, req.Name)
 	if id > 0 {
 		return Conflict
 	}
@@ -271,7 +272,7 @@ func profilePost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Invalid profile name '%s'", req.Name))
 	}
 
-	err := dbProfileUpdate(d.db, name, req.Name)
+	err := db.ProfileUpdate(d.db, name, req.Name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -293,7 +294,7 @@ func profileDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Profile is currently in use"))
 	}
 
-	err = dbProfileDelete(d.db, name)
+	err = db.ProfileDelete(d.db, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/profiles_test.go
+++ b/lxd/profiles_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"database/sql"
 	"testing"
+
+	dbapi "github.com/lxc/lxd/lxd/db"
 )
 
 func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing.T) {
@@ -28,14 +30,14 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 		t.Fatal(err)
 	}
 
-	// Delete the profile we just created with dbProfileDelete
-	err = dbProfileDelete(db, "theprofile")
+	// Delete the profile we just created with dbapi.ProfileDelete
+	err = dbapi.ProfileDelete(db, "theprofile")
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// Make sure there are 0 profiles_devices entries left.
-	devices, err := dbDevices(d.db, "theprofile", true)
+	devices, err := dbapi.Devices(d.db, "theprofile", true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,7 +46,7 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 	}
 
 	// Make sure there are 0 profiles_config entries left.
-	config, err := dbProfileConfig(d.db, "theprofile")
+	config, err := dbapi.ProfileConfig(d.db, "theprofile")
 	if err == nil {
 		t.Fatal("found the profile!")
 	}

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattn/go-sqlite3"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -320,11 +321,11 @@ func SmartError(err error) Response {
 		return NotFound
 	case sql.ErrNoRows:
 		return NotFound
-	case NoSuchObjectError:
+	case db.NoSuchObjectError:
 		return NotFound
 	case os.ErrPermission:
 		return Forbidden
-	case DbErrAlreadyDefined:
+	case db.DbErrAlreadyDefined:
 		return Conflict
 	case sqlite3.ErrConstraintUnique:
 		return Conflict

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/ioprogress"
@@ -317,7 +318,7 @@ func storageCoreInit(driver string) (storage, error) {
 
 func storageInit(d *Daemon, poolName string, volumeName string, volumeType int) (storage, error) {
 	// Load the storage pool.
-	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	poolID, pool, err := db.StoragePoolGet(d.db, poolName)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +333,7 @@ func storageInit(d *Daemon, poolName string, volumeName string, volumeType int) 
 	// Load the storage volume.
 	volume := &api.StorageVolume{}
 	if volumeName != "" && volumeType >= 0 {
-		_, volume, err = dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+		_, volume, err = db.StoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
 		if err != nil {
 			return nil, err
 		}
@@ -545,11 +546,11 @@ func storagePoolVolumeAttachInit(d *Daemon, poolName string, volumeName string, 
 
 	st.SetStoragePoolVolumeWritable(&poolVolumePut)
 
-	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	poolID, err := db.StoragePoolGetID(d.db, poolName)
 	if err != nil {
 		return nil, err
 	}
-	err = dbStoragePoolVolumeUpdate(d.db, volumeName, volumeType, poolID, poolVolumePut.Description, poolVolumePut.Config)
+	err = db.StoragePoolVolumeUpdate(d.db, volumeName, volumeType, poolID, poolVolumePut.Description, poolVolumePut.Config)
 	if err != nil {
 		return nil, err
 	}
@@ -572,7 +573,7 @@ func storagePoolVolumeContainerCreateInit(d *Daemon, poolName string, containerN
 
 func storagePoolVolumeContainerLoadInit(d *Daemon, containerName string) (storage, error) {
 	// Get the storage pool of a given container.
-	poolName, err := dbContainerPool(d.db, containerName)
+	poolName, err := db.ContainerPool(d.db, containerName)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -562,7 +563,7 @@ func (s *storageBtrfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
-	err = dbStoragePoolVolumeDelete(
+	err = db.StoragePoolVolumeDelete(
 		s.d.db,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
@@ -1463,7 +1464,7 @@ func btrfsSubVolumeQGroup(subvol string) (string, error) {
 		"-f")
 
 	if err != nil {
-		return "", NoSuchObjectError
+		return "", db.NoSuchObjectError
 	}
 
 	var qgroup string
@@ -2159,7 +2160,7 @@ func (s *storageBtrfs) StorageEntitySetQuota(volumeType int, size int64, data in
 
 	_, err := btrfsSubVolumeQGroup(subvol)
 	if err != nil {
-		if err != NoSuchObjectError {
+		if err != db.NoSuchObjectError {
 			return err
 		}
 

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -487,7 +488,7 @@ func (s *storageCeph) StoragePoolVolumeDelete() error {
 	logger.Debugf(`Deleted RBD storage volume "%s" on storage pool "%s"`,
 		s.volume.Name, s.pool.Name)
 
-	err = dbStoragePoolVolumeDelete(
+	err = db.StoragePoolVolumeDelete(
 		s.d.db,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
@@ -2321,7 +2322,7 @@ func (s *storageCeph) ImageDelete(fingerprint string) error {
 		fingerprint, storagePoolVolumeTypeNameImage, "readonly",
 		s.UserName)
 	if err != nil {
-		if err != NoSuchObjectError {
+		if err != db.NoSuchObjectError {
 			logger.Errorf(`Failed to list clones of RBD storage `+
 				`volume for image "%s" on storage pool "%s":
 				%s`, fingerprint, s.pool.Name, err)

--- a/lxd/storage_ceph_migration.go
+++ b/lxd/storage_ceph_migration.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -160,7 +161,7 @@ func (s *storageCeph) MigrationSource(c container, containerOnly bool) (Migratio
 		s.OSDPoolName, containerName,
 		storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		if err != NoSuchObjectError {
+		if err != db.NoSuchObjectError {
 			logger.Errorf(`Failed to list snapshots for RBD storage volume "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 			return nil, err
 		}

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -356,7 +357,7 @@ func cephRBDSnapshotListClones(clusterName string, poolName string,
 	msg = strings.TrimSpace(msg)
 	clones := strings.Fields(msg)
 	if len(clones) == 0 {
-		return nil, NoSuchObjectError
+		return nil, db.NoSuchObjectError
 	}
 
 	return clones, nil
@@ -462,7 +463,7 @@ func cephRBDVolumeSnapshotRename(clusterName string, poolName string,
 // cephRBDVolumeGetParent will return the snapshot the RBD clone was created
 // from
 // - If the RBD storage volume is not a clone then this function will return
-//   NoSuchObjectError.
+//   db.NoSuchObjectError.
 // - The snapshot will be returned as
 //   <osd-pool-name>/<rbd-volume-name>@<rbd-snapshot-name>
 //   The caller will usually want to parse this according to its needs. This
@@ -482,7 +483,7 @@ func cephRBDVolumeGetParent(clusterName string, poolName string,
 
 	idx := strings.Index(msg, "parent: ")
 	if idx == -1 {
-		return "", NoSuchObjectError
+		return "", db.NoSuchObjectError
 	}
 
 	msg = msg[(idx + len("parent: ")):]
@@ -585,7 +586,7 @@ func cephRBDVolumeListSnapshots(clusterName string, poolName string,
 	}
 
 	if len(snapshots) == 0 {
-		return []string{}, NoSuchObjectError
+		return []string{}, db.NoSuchObjectError
 	}
 
 	return snapshots, nil
@@ -958,7 +959,7 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 			return 1
 		}
 	} else {
-		if err != NoSuchObjectError {
+		if err != db.NoSuchObjectError {
 			logger.Errorf(`Failed to retrieve snapshots of RBD `+
 				`storage volume: %s`, err)
 			return -1
@@ -1026,7 +1027,7 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 
 			return 0
 		} else {
-			if err != NoSuchObjectError {
+			if err != db.NoSuchObjectError {
 				logger.Errorf(`Failed to retrieve parent of `+
 					`RBD storage volume "%s"`, logEntry)
 				return -1
@@ -1088,7 +1089,7 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 	clones, err := cephRBDSnapshotListClones(clusterName, poolName,
 		volumeName, volumeType, snapshotName, userName)
 	if err != nil {
-		if err != NoSuchObjectError {
+		if err != db.NoSuchObjectError {
 			logger.Errorf(`Failed to list clones of RBD `+
 				`snapshot "%s" of RBD storage volume "%s": %s`,
 				logSnapshotEntry, logImageEntry, err)

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -205,7 +206,7 @@ func (s *storageDir) StoragePoolVolumeDelete() error {
 		return err
 	}
 
-	err = dbStoragePoolVolumeDelete(
+	err = db.StoragePoolVolumeDelete(
 		s.d.db,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -543,7 +544,7 @@ func (s *storageLvm) StoragePoolVolumeDelete() error {
 		}
 	}
 
-	err = dbStoragePoolVolumeDelete(
+	err = db.StoragePoolVolumeDelete(
 		s.d.db,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
@@ -1708,7 +1709,7 @@ func (s *storageLvm) StorageEntitySetQuota(volumeType int, size int64, data inte
 
 	// Update the database
 	s.volume.Config["size"] = shared.GetByteSizeString(size, 0)
-	err = dbStoragePoolVolumeUpdate(
+	err = db.StoragePoolVolumeUpdate(
 		s.d.db,
 		s.volume.Name,
 		volumeType,

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -671,7 +672,7 @@ func storageLVMThinpoolExists(vgName string, poolName string) (bool, error) {
 func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 	results := []string{}
 
-	cNames, err := dbContainersList(d.db, cTypeRegular)
+	cNames, err := db.ContainersList(d.db, db.CTypeRegular)
 	if err != nil {
 		return results, err
 	}
@@ -689,7 +690,7 @@ func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 		}
 	}
 
-	imageNames, err := dbImagesGet(d.db, false)
+	imageNames, err := db.ImagesGet(d.db, false)
 	if err != nil {
 		return results, err
 	}

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/shared"
 )
@@ -91,7 +92,7 @@ func rsyncMigrationSource(c container, containerOnly bool) (MigrationStorageSour
 	return rsyncStorageSourceDriver{c, snapshots}, nil
 }
 
-func snapshotProtobufToContainerArgs(containerName string, snap *Snapshot) containerArgs {
+func snapshotProtobufToContainerArgs(containerName string, snap *Snapshot) db.ContainerArgs {
 	config := map[string]string{}
 
 	for _, ent := range snap.LocalConfig {
@@ -109,9 +110,9 @@ func snapshotProtobufToContainerArgs(containerName string, snap *Snapshot) conta
 	}
 
 	name := containerName + shared.SnapshotDelimiter + snap.GetName()
-	return containerArgs{
+	return db.ContainerArgs{
 		Name:         name,
-		Ctype:        cTypeSnapshot,
+		Ctype:        db.CTypeSnapshot,
 		Config:       config,
 		Profiles:     snap.Profiles,
 		Ephemeral:    snap.GetEphemeral(),

--- a/lxd/storage_shared.go
+++ b/lxd/storage_shared.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -106,7 +107,7 @@ func (s *storageShared) createImageDbPoolVolume(fingerprint string) error {
 	}
 
 	// Create a db entry for the storage volume of the image.
-	_, err = dbStoragePoolVolumeCreate(s.d.db, fingerprint, "", storagePoolVolumeTypeImage, s.poolID, volumeConfig)
+	_, err = db.StoragePoolVolumeCreate(s.d.db, fingerprint, "", storagePoolVolumeTypeImage, s.poolID, volumeConfig)
 	if err != nil {
 		// Try to delete the db entry on error.
 		s.deleteImageDbPoolVolume(fingerprint)
@@ -117,7 +118,7 @@ func (s *storageShared) createImageDbPoolVolume(fingerprint string) error {
 }
 
 func (s *storageShared) deleteImageDbPoolVolume(fingerprint string) error {
-	err := dbStoragePoolVolumeDelete(s.d.db, fingerprint, storagePoolVolumeTypeImage, s.poolID)
+	err := db.StoragePoolVolumeDelete(s.d.db, fingerprint, storagePoolVolumeTypeImage, s.poolID)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_utils.go
+++ b/lxd/storage_utils.go
@@ -7,6 +7,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -156,14 +157,14 @@ const imagesDirMode os.FileMode = 0700
 const snapshotsDirMode os.FileMode = 0700
 
 // Detect whether LXD already uses the given storage pool.
-func lxdUsesPool(db *sql.DB, onDiskPoolName string, driver string, onDiskProperty string) (bool, string, error) {
-	pools, err := dbStoragePools(db)
-	if err != nil && err != NoSuchObjectError {
+func lxdUsesPool(dbObj *sql.DB, onDiskPoolName string, driver string, onDiskProperty string) (bool, string, error) {
+	pools, err := db.StoragePools(dbObj)
+	if err != nil && err != db.NoSuchObjectError {
 		return false, "", err
 	}
 
 	for _, pool := range pools {
-		_, pl, err := dbStoragePoolGet(db, pool)
+		_, pl, err := db.StoragePoolGet(dbObj, pool)
 		if err != nil {
 			continue
 		}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/gorilla/mux"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
@@ -25,15 +26,15 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) Response {
 
 	// Retrieve ID of the storage pool (and check if the storage pool
 	// exists).
-	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	poolID, err := db.StoragePoolGetID(d.db, poolName)
 	if err != nil {
 		return SmartError(err)
 	}
 
 	// Get all volumes currently attached to the storage pool by ID of the
 	// pool.
-	volumes, err := dbStoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
-	if err != nil && err != NoSuchObjectError {
+	volumes, err := db.StoragePoolVolumesGet(d.db, poolID, supportedVolumeTypes)
+	if err != nil && err != db.NoSuchObjectError {
 		return SmartError(err)
 	}
 
@@ -92,14 +93,14 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
 
 	// Retrieve ID of the storage pool (and check if the storage pool
 	// exists).
-	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	poolID, err := db.StoragePoolGetID(d.db, poolName)
 	if err != nil {
 		return SmartError(err)
 	}
 
 	// Get the names of all storage volumes of a given volume type currently
 	// attached to the storage pool.
-	volumes, err := dbStoragePoolVolumesGetType(d.db, volumeType, poolID)
+	volumes, err := db.StoragePoolVolumesGetType(d.db, volumeType, poolID)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -114,7 +115,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
 			}
 			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, apiEndpoint, volume))
 		} else {
-			_, vol, err := dbStoragePoolVolumeGetType(d.db, volume, volumeType, poolID)
+			_, vol, err := db.StoragePoolVolumeGetType(d.db, volume, volumeType, poolID)
 			if err != nil {
 				continue
 			}
@@ -202,13 +203,13 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request) Response {
 
 	// Get the ID of the storage pool the storage volume is supposed to be
 	// attached to.
-	poolID, err := dbStoragePoolGetID(d.db, poolName)
+	poolID, err := db.StoragePoolGetID(d.db, poolName)
 	if err != nil {
 		return SmartError(err)
 	}
 
 	// Get the storage volume.
-	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	_, volume, err := db.StoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -246,13 +247,13 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("invalid storage volume type %s", volumeTypeName))
 	}
 
-	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	poolID, pool, err := db.StoragePoolGet(d.db, poolName)
 	if err != nil {
 		return SmartError(err)
 	}
 
 	// Get the existing storage volume.
-	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	_, volume, err := db.StoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -308,13 +309,13 @@ func storagePoolVolumeTypePatch(d *Daemon, r *http.Request) Response {
 
 	// Get the ID of the storage pool the storage volume is supposed to be
 	// attached to.
-	poolID, pool, err := dbStoragePoolGet(d.db, poolName)
+	poolID, pool, err := db.StoragePoolGet(d.db, poolName)
 	if err != nil {
 		return SmartError(err)
 	}
 
 	// Get the existing storage volume.
-	_, volume, err := dbStoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
+	_, volume, err := db.StoragePoolVolumeGetType(d.db, volumeName, volumeType, poolID)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -409,7 +410,7 @@ func (s *storageZfs) StoragePoolVolumeDelete() error {
 		}
 	}
 
-	err = dbStoragePoolVolumeDelete(
+	err = db.StoragePoolVolumeDelete(
 		s.d.db,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,


### PR DESCRIPTION
This branch is very large but almost completely mechanical. It moves
all db-related code into a standalone subpackage (db). This
facilitates testing and makes further refactoring easier to reason
about.

The only point worth mentioning is that containerArgs and
storagePoolVolumeTypeToName had to be moved to the db package, to
avoid circular dependencies. We will probably want to clean that up
down the road.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>