### PR TITLE
Split Daemon functionality into more decoupled components

### DIFF
--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -174,7 +174,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		kernelArchitecture += string(byte(c))
 	}
 
-	addresses, err := d.ListenAddresses()
+	addresses, err := util.ListenAddresses(daemonConfig["core.https_address"].Get())
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -132,7 +132,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 	}
 
 	// If untrusted, return now
-	if !d.isTrustedClient(r) {
+	if !util.IsTrustedClient(r, d.clientCerts) {
 		return SyncResponseETag(true, srv, nil)
 	}
 

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/lxc/go-lxc.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -248,7 +249,7 @@ func api10Put(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = etagCheck(r, daemonConfigRender())
+	err = util.EtagCheck(r, daemonConfigRender())
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -267,7 +268,7 @@ func api10Patch(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = etagCheck(r, daemonConfigRender())
+	err = util.EtagCheck(r, daemonConfigRender())
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -191,7 +191,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 
 	architectures := []string{}
 
-	for _, architecture := range d.architectures {
+	for _, architecture := range d.os.Architectures {
 		architectureName, err := osarch.ArchitectureName(architecture)
 		if err != nil {
 			return InternalError(err)

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -97,7 +97,8 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Access check
-	if !util.IsTrustedClient(r, d.clientCerts) && d.PasswordCheck(req.Password) != nil {
+	secret := daemonConfig["core.trust_password"].Get()
+	if !util.IsTrustedClient(r, d.clientCerts) && util.PasswordCheck(secret, req.Password) != nil {
 		return Forbidden
 	}
 

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -20,7 +20,7 @@ import (
 )
 
 func certificatesGet(d *Daemon, r *http.Request) Response {
-	recursion := d.isRecursionRequest(r)
+	recursion := util.IsRecursionRequest(r)
 
 	if recursion {
 		certResponses := []api.Certificate{}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -193,7 +194,7 @@ func certificateFingerprintPut(d *Daemon, r *http.Request) Response {
 	}
 	fingerprint = oldEntry.Fingerprint
 
-	err = etagCheck(r, oldEntry)
+	err = util.EtagCheck(r, oldEntry)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -215,7 +216,7 @@ func certificateFingerprintPatch(d *Daemon, r *http.Request) Response {
 	}
 	fingerprint = oldEntry.Fingerprint
 
-	err = etagCheck(r, oldEntry)
+	err = util.EtagCheck(r, oldEntry)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"crypto/x509"
+	"database/sql"
 	"encoding/base64"
 	"encoding/json"
 	"encoding/pem"
@@ -77,7 +78,7 @@ func readSavedClientCAList(d *Daemon) {
 	}
 }
 
-func saveCert(d *Daemon, host string, cert *x509.Certificate) error {
+func saveCert(dbObj *sql.DB, host string, cert *x509.Certificate) error {
 	baseCert := new(db.CertInfo)
 	baseCert.Fingerprint = shared.CertFingerprint(cert)
 	baseCert.Type = 1
@@ -86,7 +87,7 @@ func saveCert(d *Daemon, host string, cert *x509.Certificate) error {
 		pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw}),
 	)
 
-	return db.CertSave(d.db, baseCert)
+	return db.CertSave(dbObj, baseCert)
 }
 
 func certificatesPost(d *Daemon, r *http.Request) Response {
@@ -143,7 +144,7 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 		}
 	}
 
-	err := saveCert(d, name, cert)
+	err := saveCert(d.db, name, cert)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -158,7 +159,7 @@ var certificatesCmd = Command{name: "certificates", untrustedPost: true, get: ce
 func certificateFingerprintGet(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	cert, err := doCertificateGet(d, fingerprint)
+	cert, err := doCertificateGet(d.db, fingerprint)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -166,10 +167,10 @@ func certificateFingerprintGet(d *Daemon, r *http.Request) Response {
 	return SyncResponseETag(true, cert, cert)
 }
 
-func doCertificateGet(d *Daemon, fingerprint string) (api.Certificate, error) {
+func doCertificateGet(dbObj *sql.DB, fingerprint string) (api.Certificate, error) {
 	resp := api.Certificate{}
 
-	dbCertInfo, err := db.CertGet(d.db, fingerprint)
+	dbCertInfo, err := db.CertGet(dbObj, fingerprint)
 	if err != nil {
 		return resp, err
 	}
@@ -189,7 +190,7 @@ func doCertificateGet(d *Daemon, fingerprint string) (api.Certificate, error) {
 func certificateFingerprintPut(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	oldEntry, err := doCertificateGet(d, fingerprint)
+	oldEntry, err := doCertificateGet(d.db, fingerprint)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -211,7 +212,7 @@ func certificateFingerprintPut(d *Daemon, r *http.Request) Response {
 func certificateFingerprintPatch(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	oldEntry, err := doCertificateGet(d, fingerprint)
+	oldEntry, err := doCertificateGet(d.db, fingerprint)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/certificates.go
+++ b/lxd/certificates.go
@@ -97,7 +97,7 @@ func certificatesPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Access check
-	if !d.isTrustedClient(r) && d.PasswordCheck(req.Password) != nil {
+	if !util.IsTrustedClient(r, d.clientCerts) && d.PasswordCheck(req.Password) != nil {
 		return Forbidden
 	}
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -65,7 +65,7 @@ func containerValidConfigKey(d *Daemon, key string, value string) error {
 		return lxcValidConfig(value)
 	}
 	if key == "security.syscalls.blacklist_compat" {
-		for _, arch := range d.architectures {
+		for _, arch := range d.os.Architectures {
 			if arch == osarch.ARCH_64BIT_INTEL_X86 ||
 				arch == osarch.ARCH_64BIT_ARMV8_LITTLE_ENDIAN ||
 				arch == osarch.ARCH_64BIT_POWERPC_BIG_ENDIAN {
@@ -733,7 +733,7 @@ func containerCreateInternal(d *Daemon, args db.ContainerArgs) (container, error
 	}
 
 	if args.Architecture == 0 {
-		args.Architecture = d.architectures[0]
+		args.Architecture = d.os.Architectures[0]
 	}
 
 	// Validate container name
@@ -762,7 +762,7 @@ func containerCreateInternal(d *Daemon, args db.ContainerArgs) (container, error
 		return nil, err
 	}
 
-	if !shared.IntInSlice(args.Architecture, d.architectures) {
+	if !shared.IntInSlice(args.Architecture, d.os.Architectures) {
 		return nil, fmt.Errorf("Requested architecture isn't supported by this host")
 	}
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -235,7 +235,7 @@ func containerValidConfig(d *Daemon, config map[string]string, profile bool, exp
 		return fmt.Errorf("security.syscalls.whitelist is mutually exclusive with security.syscalls.blacklist*")
 	}
 
-	if expanded && (config["security.privileged"] == "" || !shared.IsTrue(config["security.privileged"])) && d.IdmapSet == nil {
+	if expanded && (config["security.privileged"] == "" || !shared.IsTrue(config["security.privileged"])) && d.os.IdmapSet == nil {
 		return fmt.Errorf("LXD doesn't have a uid/gid allocation. In this mode, only privileged containers are supported.")
 	}
 

--- a/lxd/container_instance_types.go
+++ b/lxd/container_instance_types.go
@@ -9,6 +9,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -67,7 +68,7 @@ func instanceRefreshTypes(d *Daemon) error {
 	downloadParse := func(filename string, target interface{}) error {
 		url := fmt.Sprintf("https://images.linuxcontainers.org/meta/instance-types/%s", filename)
 
-		httpClient, err := d.httpClient("")
+		httpClient, err := util.HTTPClient("", d.proxy)
 		if err != nil {
 			return err
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -785,7 +785,7 @@ func (c *containerLXC) initLXC() error {
 	}
 
 	// Load the go-lxc struct
-	cc, err := lxc.NewContainer(c.Name(), c.daemon.lxcpath)
+	cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
 	if err != nil {
 		return err
 	}
@@ -2073,7 +2073,7 @@ func (c *containerLXC) Start(stateful bool) error {
 		execPath,
 		"forkstart",
 		c.name,
-		c.daemon.lxcpath,
+		c.daemon.os.LxcPath,
 		configPath)
 
 	// Capture debug output
@@ -4427,7 +4427,7 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 			execPath,
 			"forkmigrate",
 			c.name,
-			c.daemon.lxcpath,
+			c.daemon.os.LxcPath,
 			configPath,
 			stateDir,
 			fmt.Sprintf("%v", preservesInodes))
@@ -4965,7 +4965,7 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	args := []string{execPath, "forkexec", c.name, c.daemon.lxcpath, filepath.Join(c.LogPath(), "lxc.conf")}
+	args := []string{execPath, "forkexec", c.name, c.daemon.os.LxcPath, filepath.Join(c.LogPath(), "lxc.conf")}
 
 	args = append(args, "--")
 	args = append(args, "env")
@@ -5935,7 +5935,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 		}
 
 		// Attempt to include all existing interfaces
-		cc, err := lxc.NewContainer(c.Name(), c.daemon.lxcpath)
+		cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
 		if err == nil {
 			interfaces, err := cc.Interfaces()
 			if err == nil {
@@ -6178,7 +6178,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	}
 
 	// For some reason, having network config confuses detach, so get our own go-lxc struct
-	cc, err := lxc.NewContainer(c.Name(), c.daemon.lxcpath)
+	cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
 	if err != nil {
 		return err
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -269,14 +269,14 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	}
 
 	// Validate expanded config
-	err = containerValidConfig(d, c.expandedConfig, false, true)
+	err = containerValidConfig(d.os, c.expandedConfig, false, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
 		return nil, err
 	}
 
-	err = containerValidDevices(d, c.expandedDevices, false, true)
+	err = containerValidDevices(d.db, c.expandedDevices, false, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
@@ -3164,13 +3164,13 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	// Validate the new config
-	err := containerValidConfig(c.daemon, args.Config, false, false)
+	err := containerValidConfig(c.daemon.os, args.Config, false, false)
 	if err != nil {
 		return err
 	}
 
 	// Validate the new devices
-	err = containerValidDevices(c.daemon, args.Devices, false, false)
+	err = containerValidDevices(c.daemon.db, args.Devices, false, false)
 	if err != nil {
 		return err
 	}
@@ -3324,13 +3324,13 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	removeDevices, addDevices, updateDevices := oldExpandedDevices.Update(c.expandedDevices)
 
 	// Do some validation of the config diff
-	err = containerValidConfig(c.daemon, c.expandedConfig, false, true)
+	err = containerValidConfig(c.daemon.os, c.expandedConfig, false, true)
 	if err != nil {
 		return err
 	}
 
 	// Do some validation of the devices diff
-	err = containerValidDevices(c.daemon, c.expandedDevices, false, true)
+	err = containerValidDevices(c.daemon.db, c.expandedDevices, false, true)
 	if err != nil {
 		return err
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -950,7 +950,7 @@ func (c *containerLXC) initLXC() error {
 	// Setup architecture
 	personality, err := osarch.ArchitecturePersonality(c.architecture)
 	if err != nil {
-		personality, err = osarch.ArchitecturePersonality(c.daemon.architectures[0])
+		personality, err = osarch.ArchitecturePersonality(c.daemon.os.Architectures[0])
 		if err != nil {
 			return err
 		}
@@ -4169,7 +4169,7 @@ func (c *containerLXC) Export(w io.Writer, properties map[string]string) error {
 		}
 
 		if arch == "" {
-			arch, err = osarch.ArchitectureName(c.daemon.architectures[0])
+			arch, err = osarch.ArchitectureName(c.daemon.os.Architectures[0])
 			if err != nil {
 				logger.Error("Failed exporting container", ctxMap)
 				return err
@@ -4599,7 +4599,7 @@ func (c *containerLXC) templateApplyNow(trigger string) error {
 		// Figure out the architecture
 		arch, err := osarch.ArchitectureName(c.architecture)
 		if err != nil {
-			arch, err = osarch.ArchitectureName(c.daemon.architectures[0])
+			arch, err = osarch.ArchitectureName(c.daemon.os.Architectures[0])
 			if err != nil {
 				return err
 			}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/types"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -1627,7 +1628,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	if kernelModules != "" {
 		for _, module := range strings.Split(kernelModules, ",") {
 			module = strings.TrimPrefix(module, " ")
-			err := loadModule(module)
+			err := util.LoadModule(module)
 			if err != nil {
 				return "", fmt.Errorf("Failed to load kernel module '%s': %s", module, err)
 			}
@@ -3487,7 +3488,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 			} else if key == "linux.kernel_modules" && value != "" {
 				for _, module := range strings.Split(value, ",") {
 					module = strings.TrimPrefix(module, " ")
-					err := loadModule(module)
+					err := util.LoadModule(module)
 					if err != nil {
 						return fmt.Errorf("Failed to load kernel module '%s': %s", module, err)
 					}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -521,11 +521,11 @@ func idmapSize(daemon *Daemon, isolatedStr string, size string) (int64, error) {
 		if isolated {
 			idMapSize = 65536
 		} else {
-			if len(daemon.IdmapSet.Idmap) != 2 {
-				return 0, fmt.Errorf("bad initial idmap: %v", daemon.IdmapSet)
+			if len(daemon.os.IdmapSet.Idmap) != 2 {
+				return 0, fmt.Errorf("bad initial idmap: %v", daemon.os.IdmapSet)
 			}
 
-			idMapSize = daemon.IdmapSet.Idmap[0].Maprange
+			idMapSize = daemon.os.IdmapSet.Idmap[0].Maprange
 		}
 	} else {
 		size, err := strconv.ParseInt(size, 10, 64)
@@ -639,8 +639,8 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 	}
 
 	if !isolated {
-		newIdmapset := shared.IdmapSet{Idmap: make([]shared.IdmapEntry, len(daemon.IdmapSet.Idmap))}
-		copy(newIdmapset.Idmap, daemon.IdmapSet.Idmap)
+		newIdmapset := shared.IdmapSet{Idmap: make([]shared.IdmapEntry, len(daemon.os.IdmapSet.Idmap))}
+		copy(newIdmapset.Idmap, daemon.os.IdmapSet.Idmap)
 
 		for _, ent := range rawMaps {
 			newIdmapset.AddSafe(ent)
@@ -684,7 +684,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 		return nil, 0, err
 	}
 
-	offset := daemon.IdmapSet.Idmap[0].Hostid + 65536
+	offset := daemon.os.IdmapSet.Idmap[0].Hostid + 65536
 
 	mapentries := shared.ByHostid{}
 	for _, name := range cs {
@@ -746,7 +746,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 		offset = mapentries[i].Hostid + mapentries[i].Maprange
 	}
 
-	if offset+size < daemon.IdmapSet.Idmap[0].Hostid+daemon.IdmapSet.Idmap[0].Maprange {
+	if offset+size < daemon.os.IdmapSet.Idmap[0].Hostid+daemon.os.IdmapSet.Idmap[0].Maprange {
 		return mkIdmap(offset, size), offset, nil
 	}
 
@@ -6900,8 +6900,8 @@ func (c *containerLXC) NextIdmapSet() (*shared.IdmapSet, error) {
 		return c.idmapsetFromConfig("volatile.idmap.next")
 	} else if c.IsPrivileged() {
 		return nil, nil
-	} else if c.daemon.IdmapSet != nil {
-		return c.daemon.IdmapSet, nil
+	} else if c.daemon.os.IdmapSet != nil {
+		return c.daemon.os.IdmapSet, nil
 	}
 
 	return nil, fmt.Errorf("Unable to determine the idmap")

--- a/lxd/container_patch.go
+++ b/lxd/container_patch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -25,7 +26,7 @@ func containerPatch(d *Daemon, r *http.Request) Response {
 
 	// Validate the ETag
 	etag := []interface{}{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.IsEphemeral(), c.Profiles()}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/osarch"
@@ -28,7 +29,7 @@ func containerPut(d *Daemon, r *http.Request) Response {
 
 	// Validate the ETag
 	etag := []interface{}{c.Architecture(), c.LocalConfig(), c.LocalDevices(), c.IsEphemeral(), c.Profiles()}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -258,7 +258,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	map2, err := c2.(*containerLXC).NextIdmapSet()
 	suite.Req.Nil(err)
 
-	host := suite.d.IdmapSet.Idmap[0]
+	host := suite.d.os.IdmapSet.Idmap[0]
 
 	for i := 0; i < 2; i++ {
 		suite.Req.Equal(host.Hostid+65536, map1.Idmap[i].Hostid, "hostids don't match %d", i)
@@ -299,7 +299,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	map2, err := c2.(*containerLXC).NextIdmapSet()
 	suite.Req.Nil(err)
 
-	host := suite.d.IdmapSet.Idmap[0]
+	host := suite.d.os.IdmapSet.Idmap[0]
 
 	for i := 0; i < 2; i++ {
 		suite.Req.Equal(host.Hostid, map1.Idmap[i].Hostid, "hostids don't match %d", i)
@@ -329,7 +329,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 	map1, err := c1.(*containerLXC).NextIdmapSet()
 	suite.Req.Nil(err)
 
-	host := suite.d.IdmapSet.Idmap[0]
+	host := suite.d.os.IdmapSet.Idmap[0]
 
 	for _, i := range []int{0, 3} {
 		suite.Req.Equal(host.Hostid, map1.Idmap[i].Hostid, "hostids don't match")

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -13,7 +14,7 @@ import (
 
 func containersGet(d *Daemon, r *http.Request) Response {
 	for i := 0; i < 100; i++ {
-		result, err := doContainersGet(d, d.isRecursionRequest(r))
+		result, err := doContainersGet(d, util.IsRecursionRequest(r))
 		if err == nil {
 			return SyncResponse(true, result)
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -634,7 +634,7 @@ func (d *Daemon) Init() error {
 		for {
 			logger.Infof("Expiring log files")
 
-			err := d.ExpireLogs()
+			err := ExpireLogs(d.db)
 			if err != nil {
 				logger.Error("Failed to expire logs", log.Ctx{"err": err})
 			}
@@ -998,88 +998,6 @@ func (d *Daemon) Stop() error {
 	}
 
 	return err
-}
-
-func (d *Daemon) ExpireLogs() error {
-	entries, err := ioutil.ReadDir(shared.LogPath())
-	if err != nil {
-		return err
-	}
-
-	result, err := db.ContainersList(d.db, db.CTypeRegular)
-	if err != nil {
-		return err
-	}
-
-	newestFile := func(path string, dir os.FileInfo) time.Time {
-		newest := dir.ModTime()
-
-		entries, err := ioutil.ReadDir(path)
-		if err != nil {
-			return newest
-		}
-
-		for _, entry := range entries {
-			if entry.ModTime().After(newest) {
-				newest = entry.ModTime()
-			}
-		}
-
-		return newest
-	}
-
-	for _, entry := range entries {
-		// Check if the container still exists
-		if shared.StringInSlice(entry.Name(), result) {
-			// Remove any log file which wasn't modified in the past 48 hours
-			logs, err := ioutil.ReadDir(shared.LogPath(entry.Name()))
-			if err != nil {
-				return err
-			}
-
-			for _, logfile := range logs {
-				path := shared.LogPath(entry.Name(), logfile.Name())
-
-				// Always keep the LXC config
-				if logfile.Name() == "lxc.conf" {
-					continue
-				}
-
-				// Deal with directories (snapshots)
-				if logfile.IsDir() {
-					newest := newestFile(path, logfile)
-					if time.Since(newest).Hours() >= 48 {
-						os.RemoveAll(path)
-						if err != nil {
-							return err
-						}
-					}
-
-					continue
-				}
-
-				// Individual files
-				if time.Since(logfile.ModTime()).Hours() >= 48 {
-					err := os.Remove(path)
-					if err != nil {
-						return err
-					}
-				}
-			}
-		} else {
-			// Empty directory if unchanged in the past 24 hours
-			path := shared.LogPath(entry.Name())
-			newest := newestFile(path, entry)
-			if time.Since(newest).Hours() >= 24 {
-				err := os.RemoveAll(path)
-				if err != nil {
-					return err
-				}
-			}
-		}
-	}
-
-	return nil
 }
 
 func (d *Daemon) GetListeners() []net.Listener {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -745,7 +745,7 @@ func (d *Daemon) Init() error {
 	})
 
 	// Prepare the list of listeners
-	listeners := d.GetListeners()
+	listeners := util.GetListeners()
 	if len(listeners) > 0 {
 		logger.Infof("LXD is socket activated")
 
@@ -998,43 +998,6 @@ func (d *Daemon) Stop() error {
 	}
 
 	return err
-}
-
-func (d *Daemon) GetListeners() []net.Listener {
-	defer func() {
-		os.Unsetenv("LISTEN_PID")
-		os.Unsetenv("LISTEN_FDS")
-	}()
-
-	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
-	if err != nil {
-		return nil
-	}
-
-	if pid != os.Getpid() {
-		return nil
-	}
-
-	fds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
-	if err != nil {
-		return nil
-	}
-
-	listeners := []net.Listener{}
-
-	for i := 3; i < 3+fds; i++ {
-		syscall.CloseOnExec(i)
-
-		file := os.NewFile(uintptr(i), fmt.Sprintf("inherited-fd%d", i))
-		listener, err := net.FileListener(file)
-		if err != nil {
-			continue
-		}
-
-		listeners = append(listeners, listener)
-	}
-
-	return listeners
 }
 
 type lxdHttpServer struct {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -71,7 +71,6 @@ type Daemon struct {
 	db                  *sql.DB
 	group               string
 	IdmapSet            *shared.IdmapSet
-	lxcpath             string
 	mux                 *mux.Router
 	tomb                tomb.Tomb
 	readyChan           chan bool
@@ -476,14 +475,11 @@ func (d *Daemon) Init() error {
 	}
 
 	/* Initialize the operating system facade */
-	d.os = &sys.OS{}
+	d.os = sys.NewOS()
 	err = d.os.Init()
 	if err != nil {
 		return err
 	}
-
-	/* Set container path */
-	d.lxcpath = shared.VarPath("containers")
 
 	/* Make sure all our directories are available */
 	if err := os.MkdirAll(shared.VarPath(), 0711); err != nil {
@@ -527,7 +523,7 @@ func (d *Daemon) Init() error {
 	}
 
 	/* Detect the filesystem */
-	d.BackingFs, err = util.FilesystemDetect(d.lxcpath)
+	d.BackingFs, err = util.FilesystemDetect(d.os.LxcPath)
 	if err != nil {
 		logger.Error("Error detecting backing fs", log.Ctx{"err": err})
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"database/sql"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -20,8 +19,6 @@ import (
 	"sync"
 	"syscall"
 	"time"
-
-	"golang.org/x/crypto/scrypt"
 
 	"github.com/gorilla/mux"
 	_ "github.com/mattn/go-sqlite3"
@@ -1001,33 +998,6 @@ func (d *Daemon) Stop() error {
 	}
 
 	return err
-}
-
-func (d *Daemon) PasswordCheck(password string) error {
-	value := daemonConfig["core.trust_password"].Get()
-
-	// No password set
-	if value == "" {
-		return fmt.Errorf("No password is set")
-	}
-
-	// Compare the password
-	buff, err := hex.DecodeString(value)
-	if err != nil {
-		return err
-	}
-
-	salt := buff[0:32]
-	hash, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, 64)
-	if err != nil {
-		return err
-	}
-
-	if !bytes.Equal(hash, buff[32:]) {
-		return fmt.Errorf("Bad password provided")
-	}
-
-	return nil
 }
 
 func (d *Daemon) ExpireLogs() error {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
@@ -115,25 +116,6 @@ func readMyCert() (string, string, error) {
 	return certf, keyf, err
 }
 
-func (d *Daemon) isTrustedClient(r *http.Request) bool {
-	if r.RemoteAddr == "@" {
-		// Unix socket
-		return true
-	}
-
-	if r.TLS == nil {
-		return false
-	}
-
-	for i := range r.TLS.PeerCertificates {
-		if d.CheckTrustState(*r.TLS.PeerCertificates[i]) {
-			return true
-		}
-	}
-
-	return false
-}
-
 func isJSONRequest(r *http.Request) bool {
 	for k, vs := range r.Header {
 		if strings.ToLower(k) == "content-type" &&
@@ -167,7 +149,7 @@ func (d *Daemon) createCmd(version string, c Command) {
 	d.mux.HandleFunc(uri, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
-		if d.isTrustedClient(r) {
+		if util.IsTrustedClient(r, d.clientCerts) {
 			logger.Debug(
 				"handling",
 				log.Ctx{"method": r.Method, "url": r.URL.RequestURI(), "ip": r.RemoteAddr})
@@ -1082,23 +1064,6 @@ func (d *Daemon) Ready() error {
 	close(d.readyChan)
 
 	return nil
-}
-
-// CheckTrustState returns True if the client is trusted else false.
-func (d *Daemon) CheckTrustState(cert x509.Certificate) bool {
-	// Extra validity check (should have been caught by TLS stack)
-	if time.Now().Before(cert.NotBefore) || time.Now().After(cert.NotAfter) {
-		return false
-	}
-
-	for k, v := range d.clientCerts {
-		if bytes.Compare(cert.Raw, v.Raw) == 0 {
-			logger.Debug("Found cert", log.Ctx{"k": k})
-			return true
-		}
-	}
-
-	return false
 }
 
 func (d *Daemon) numRunningContainers() (int, error) {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -220,75 +220,6 @@ func (d *Daemon) createCmd(version string, c Command) {
 	})
 }
 
-func (d *Daemon) SetupStorageDriver(forceCheck bool) error {
-	pools, err := db.StoragePools(d.db)
-	if err != nil {
-		if err == db.NoSuchObjectError {
-			logger.Debugf("No existing storage pools detected.")
-			return nil
-		}
-		logger.Debugf("Failed to retrieve existing storage pools.")
-		return err
-	}
-
-	// In case the daemon got killed during upgrade we will already have a
-	// valid storage pool entry but it might have gotten messed up and so we
-	// cannot perform StoragePoolCheck(). This case can be detected by
-	// looking at the patches db: If we already have a storage pool defined
-	// but the upgrade somehow got messed up then there will be no
-	// "storage_api" entry in the db.
-	if len(pools) > 0 && !forceCheck {
-		appliedPatches, err := db.Patches(d.db)
-		if err != nil {
-			return err
-		}
-
-		if !shared.StringInSlice("storage_api", appliedPatches) {
-			logger.Warnf("Incorrectly applied \"storage_api\" patch. Skipping storage pool initialization as it might be corrupt.")
-			return nil
-		}
-
-	}
-
-	for _, pool := range pools {
-		logger.Debugf("Initializing and checking storage pool \"%s\".", pool)
-		s, err := storagePoolInit(d, pool)
-		if err != nil {
-			logger.Errorf("Error initializing storage pool \"%s\": %s. Correct functionality of the storage pool cannot be guaranteed.", pool, err)
-			continue
-		}
-
-		err = s.StoragePoolCheck()
-		if err != nil {
-			return err
-		}
-	}
-
-	// Get a list of all storage drivers currently in use
-	// on this LXD instance. Only do this when we do not already have done
-	// this once to avoid unnecessarily querying the db. All subsequent
-	// updates of the cache will be done when we create or delete storage
-	// pools in the db. Since this is a rare event, this cache
-	// implementation is a classic frequent-read, rare-update case so
-	// copy-on-write semantics without locking in the read case seems
-	// appropriate. (Should be cheaper then querying the db all the time,
-	// especially if we keep adding more storage drivers.)
-	if !storagePoolDriversCacheInitialized {
-		tmp, err := db.StoragePoolsGetDrivers(d.db)
-		if err != nil && err != db.NoSuchObjectError {
-			return nil
-		}
-
-		storagePoolDriversCacheLock.Lock()
-		storagePoolDriversCacheVal.Store(tmp)
-		storagePoolDriversCacheLock.Unlock()
-
-		storagePoolDriversCacheInitialized = true
-	}
-
-	return nil
-}
-
 // have we setup shared mounts?
 var sharedMounted bool
 var sharedMountsLock sync.Mutex
@@ -736,7 +667,7 @@ func (d *Daemon) Init() error {
 
 	if !d.MockMode {
 		/* Read the storage pools */
-		err = d.SetupStorageDriver(false)
+		err = SetupStorageDriver(d, false)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -256,66 +256,6 @@ func setupSharedMounts() error {
 	return nil
 }
 
-func (d *Daemon) ListenAddresses() ([]string, error) {
-	addresses := make([]string, 0)
-
-	value := daemonConfig["core.https_address"].Get()
-	if value == "" {
-		return addresses, nil
-	}
-
-	localHost, localPort, err := net.SplitHostPort(value)
-	if err != nil {
-		localHost = value
-		localPort = shared.DefaultPort
-	}
-
-	if localHost == "0.0.0.0" || localHost == "::" || localHost == "[::]" {
-		ifaces, err := net.Interfaces()
-		if err != nil {
-			return addresses, err
-		}
-
-		for _, i := range ifaces {
-			addrs, err := i.Addrs()
-			if err != nil {
-				continue
-			}
-
-			for _, addr := range addrs {
-				var ip net.IP
-				switch v := addr.(type) {
-				case *net.IPNet:
-					ip = v.IP
-				case *net.IPAddr:
-					ip = v.IP
-				}
-
-				if !ip.IsGlobalUnicast() {
-					continue
-				}
-
-				if ip.To4() == nil {
-					if localHost == "0.0.0.0" {
-						continue
-					}
-					addresses = append(addresses, fmt.Sprintf("[%s]:%s", ip, localPort))
-				} else {
-					addresses = append(addresses, fmt.Sprintf("%s:%s", ip, localPort))
-				}
-			}
-		}
-	} else {
-		if strings.Contains(localHost, ":") {
-			addresses = append(addresses, fmt.Sprintf("[%s]:%s", localHost, localPort))
-		} else {
-			addresses = append(addresses, fmt.Sprintf("%s:%s", localHost, localPort))
-		}
-	}
-
-	return addresses, nil
-}
-
 func (d *Daemon) UpdateHTTPsPort(newAddress string) error {
 	oldAddress := daemonConfig["core.https_address"].Get()
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -27,11 +27,11 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
-	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -65,9 +65,9 @@ type Socket struct {
 
 // A Daemon can respond to requests from a shared client.
 type Daemon struct {
-	architectures       []int
 	BackingFs           string
 	clientCerts         []x509.Certificate
+	os                  *sys.OS
 	db                  *sql.DB
 	group               string
 	IdmapSet            *shared.IdmapSet
@@ -475,28 +475,12 @@ func (d *Daemon) Init() error {
 		logger.Warnf("CGroup memory swap accounting is disabled, swap limits will be ignored.")
 	}
 
-	/* Get the list of supported architectures */
-	var architectures = []int{}
-
-	architectureName, err := osarch.ArchitectureGetLocal()
+	/* Initialize the operating system facade */
+	d.os = &sys.OS{}
+	err = d.os.Init()
 	if err != nil {
 		return err
 	}
-
-	architecture, err := osarch.ArchitectureId(architectureName)
-	if err != nil {
-		return err
-	}
-	architectures = append(architectures, architecture)
-
-	personalities, err := osarch.ArchitecturePersonalities(architecture)
-	if err != nil {
-		return err
-	}
-	for _, personality := range personalities {
-		architectures = append(architectures, personality)
-	}
-	d.architectures = architectures
 
 	/* Set container path */
 	d.lxcpath = shared.VarPath("containers")

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -127,17 +127,6 @@ func isJSONRequest(r *http.Request) bool {
 	return false
 }
 
-func (d *Daemon) isRecursionRequest(r *http.Request) bool {
-	recursionStr := r.FormValue("recursion")
-
-	recursion, err := strconv.Atoi(recursionStr)
-	if err != nil {
-		return false
-	}
-
-	return recursion == 1
-}
-
 func (d *Daemon) createCmd(version string, c Command) {
 	var uri string
 	if c.name == "" {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -65,7 +65,6 @@ type Socket struct {
 
 // A Daemon can respond to requests from a shared client.
 type Daemon struct {
-	BackingFs           string
 	clientCerts         []x509.Certificate
 	os                  *sys.OS
 	db                  *sql.DB
@@ -520,12 +519,6 @@ func (d *Daemon) Init() error {
 	}
 	if err := os.MkdirAll(shared.VarPath("storage-pools"), 0711); err != nil {
 		return err
-	}
-
-	/* Detect the filesystem */
-	d.BackingFs, err = util.FilesystemDetect(d.os.LxcPath)
-	if err != nil {
-		logger.Error("Error detecting backing fs", log.Ctx{"err": err})
 	}
 
 	/* Read the uid/gid allocation */

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -527,7 +527,7 @@ func (d *Daemon) Init() error {
 	}
 
 	/* Detect the filesystem */
-	d.BackingFs, err = filesystemDetect(d.lxcpath)
+	d.BackingFs, err = util.FilesystemDetect(d.lxcpath)
 	if err != nil {
 		logger.Error("Error detecting backing fs", log.Ctx{"err": err})
 	}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
@@ -431,7 +432,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		}
 	} else if protocol == "direct" {
 		// Setup HTTP client
-		httpClient, err := d.httpClient(certificate)
+		httpClient, err := util.HTTPClient(certificate, d.proxy)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -834,7 +834,7 @@ func deviceEventListener(d *Daemon) {
 
 			logger.Debugf("Scheduler: network: %s has been added: updating network priorities", e[0])
 			deviceNetworkPriority(d, e[0])
-			networkAutoAttach(d, e[0])
+			networkAutoAttach(d.db, e[0])
 		case e := <-chUSB:
 			deviceUSBEvent(d, e)
 		case e := <-deviceSchedRebalance:

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -1140,7 +1141,7 @@ func deviceGetParentBlocks(path string) ([]string, error) {
 
 	// Deal with per-filesystem oddities. We don't care about failures here
 	// because any non-special filesystem => directory backend.
-	fs, _ := filesystemDetect(expPath)
+	fs, _ := util.FilesystemDetect(expPath)
 
 	if fs == "zfs" && shared.PathExists("/dev/zfs") {
 		// Accessible zfs filesystems

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/version"
@@ -119,7 +120,7 @@ func hoistReq(f func(container, *http.Request) *devLxdResponse, d *Daemon) func(
 			http.Error(w, fmt.Sprintf("%s", resp.content), resp.code)
 		} else if resp.ctype == "json" {
 			w.Header().Set("Content-Type", "application/json")
-			WriteJSON(w, resp.content)
+			util.WriteJSON(w, resp.content, debug)
 		} else {
 			w.Header().Set("Content-Type", "application/octet-stream")
 			fmt.Fprintf(w, resp.content.(string))

--- a/lxd/devlxd_test.go
+++ b/lxd/devlxd_test.go
@@ -120,7 +120,7 @@ func TestHttpRequest(t *testing.T) {
 	}
 	defer os.RemoveAll(testDir)
 
-	d := &Daemon{}
+	d := NewDaemon()
 	err := d.Init()
 	if err != nil {
 		t.Fatal(err)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -23,6 +23,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -1207,7 +1208,7 @@ func imagePut(d *Daemon, r *http.Request) Response {
 
 	// Validate ETag
 	etag := []interface{}{info.Public, info.AutoUpdate, info.Properties}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -1235,7 +1236,7 @@ func imagePatch(d *Daemon, r *http.Request) Response {
 
 	// Validate ETag
 	etag := []interface{}{info.Public, info.AutoUpdate, info.Properties}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -1392,7 +1393,7 @@ func aliasPut(d *Daemon, r *http.Request) Response {
 	}
 
 	// Validate ETag
-	err = etagCheck(r, alias)
+	err = util.EtagCheck(r, alias)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -1428,7 +1429,7 @@ func aliasPatch(d *Daemon, r *http.Request) Response {
 	}
 
 	// Validate ETag
-	err = etagCheck(r, alias)
+	err = util.EtagCheck(r, alias)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -838,7 +838,7 @@ func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 }
 
 func imagesGet(d *Daemon, r *http.Request) Response {
-	public := !d.isTrustedClient(r)
+	public := !util.IsTrustedClient(r, d.clientCerts)
 
 	result, err := doImagesGet(d, d.isRecursionRequest(r), public)
 	if err != nil {
@@ -1182,7 +1182,7 @@ func imageValidSecret(fingerprint string, secret string) bool {
 
 func imageGet(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
-	public := !d.isTrustedClient(r)
+	public := !util.IsTrustedClient(r, d.clientCerts)
 	secret := r.FormValue("secret")
 
 	info, response := doImageGet(d, fingerprint, false)
@@ -1343,7 +1343,8 @@ func aliasesGet(d *Daemon, r *http.Request) Response {
 			responseStr = append(responseStr, url)
 
 		} else {
-			_, alias, err := db.ImageAliasGet(d.db, name, d.isTrustedClient(r))
+			isTrustedClient := util.IsTrustedClient(r, d.clientCerts)
+			_, alias, err := db.ImageAliasGet(d.db, name, isTrustedClient)
 			if err != nil {
 				continue
 			}
@@ -1361,7 +1362,7 @@ func aliasesGet(d *Daemon, r *http.Request) Response {
 func aliasGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 
-	_, alias, err := db.ImageAliasGet(d.db, name, d.isTrustedClient(r))
+	_, alias, err := db.ImageAliasGet(d.db, name, util.IsTrustedClient(r, d.clientCerts))
 	if err != nil {
 		return SmartError(err)
 	}
@@ -1502,7 +1503,7 @@ func aliasPost(d *Daemon, r *http.Request) Response {
 func imageExport(d *Daemon, r *http.Request) Response {
 	fingerprint := mux.Vars(r)["fingerprint"]
 
-	public := !d.isTrustedClient(r)
+	public := !util.IsTrustedClient(r, d.clientCerts)
 	secret := r.FormValue("secret")
 
 	_, imgInfo, err := db.ImageGet(d.db, fingerprint, false, false)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -359,7 +359,7 @@ func imgPostURLInfo(d *Daemon, req api.ImagesPost, op *operation) (*api.Image, e
 		return nil, fmt.Errorf("Missing URL")
 	}
 
-	myhttp, err := d.httpClient("")
+	myhttp, err := util.HTTPClient("", d.proxy)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -371,7 +371,7 @@ func imgPostURLInfo(d *Daemon, req api.ImagesPost, op *operation) (*api.Image, e
 	}
 
 	architecturesStr := []string{}
-	for _, arch := range d.architectures {
+	for _, arch := range d.os.Architectures {
 		architecturesStr = append(architecturesStr, fmt.Sprintf("%d", arch))
 	}
 

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -840,7 +840,7 @@ func doImagesGet(d *Daemon, recursion bool, public bool) (interface{}, error) {
 func imagesGet(d *Daemon, r *http.Request) Response {
 	public := !util.IsTrustedClient(r, d.clientCerts)
 
-	result, err := doImagesGet(d, d.isRecursionRequest(r), public)
+	result, err := doImagesGet(d, util.IsRecursionRequest(r), public)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -1324,7 +1324,7 @@ func aliasesPost(d *Daemon, r *http.Request) Response {
 }
 
 func aliasesGet(d *Daemon, r *http.Request) Response {
-	recursion := d.isRecursionRequest(r)
+	recursion := util.IsRecursionRequest(r)
 
 	q := "SELECT name FROM images_aliases"
 	var name string

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -1,0 +1,93 @@
+package main
+
+import (
+	"database/sql"
+	"io/ioutil"
+	"os"
+	"time"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/shared"
+)
+
+func ExpireLogs(dbObj *sql.DB) error {
+	entries, err := ioutil.ReadDir(shared.LogPath())
+	if err != nil {
+		return err
+	}
+
+	result, err := db.ContainersList(dbObj, db.CTypeRegular)
+	if err != nil {
+		return err
+	}
+
+	newestFile := func(path string, dir os.FileInfo) time.Time {
+		newest := dir.ModTime()
+
+		entries, err := ioutil.ReadDir(path)
+		if err != nil {
+			return newest
+		}
+
+		for _, entry := range entries {
+			if entry.ModTime().After(newest) {
+				newest = entry.ModTime()
+			}
+		}
+
+		return newest
+	}
+
+	for _, entry := range entries {
+		// Check if the container still exists
+		if shared.StringInSlice(entry.Name(), result) {
+			// Remove any log file which wasn't modified in the past 48 hours
+			logs, err := ioutil.ReadDir(shared.LogPath(entry.Name()))
+			if err != nil {
+				return err
+			}
+
+			for _, logfile := range logs {
+				path := shared.LogPath(entry.Name(), logfile.Name())
+
+				// Always keep the LXC config
+				if logfile.Name() == "lxc.conf" {
+					continue
+				}
+
+				// Deal with directories (snapshots)
+				if logfile.IsDir() {
+					newest := newestFile(path, logfile)
+					if time.Since(newest).Hours() >= 48 {
+						os.RemoveAll(path)
+						if err != nil {
+							return err
+						}
+					}
+
+					continue
+				}
+
+				// Individual files
+				if time.Since(logfile.ModTime()).Hours() >= 48 {
+					err := os.Remove(path)
+					if err != nil {
+						return err
+					}
+				}
+			}
+		} else {
+			// Empty directory if unchanged in the past 24 hours
+			path := shared.LogPath(entry.Name())
+			newest := newestFile(path, entry)
+			if time.Since(newest).Hours() >= 24 {
+				err := os.RemoveAll(path)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -18,8 +19,9 @@ func cmdActivateIfNeeded() error {
 
 	// Don't start a full daemon, we just need DB access
 	d := &Daemon{
-		lxcpath: shared.VarPath("containers"),
+		os: sys.NewOS(),
 	}
+	d.os.LxcPath = shared.VarPath("containers")
 
 	if !shared.PathExists(shared.VarPath("lxd.db")) {
 		logger.Debugf("No DB, so no need to start the daemon now.")

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -18,9 +17,7 @@ func cmdActivateIfNeeded() error {
 	}
 
 	// Don't start a full daemon, we just need DB access
-	d := &Daemon{
-		os: sys.NewOS(),
-	}
+	d := NewDaemon()
 	d.os.LxcPath = shared.VarPath("containers")
 
 	if !shared.PathExists(shared.VarPath("lxd.db")) {

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -48,7 +48,7 @@ func cmdActivateIfNeeded() error {
 	}
 
 	// Load the idmap for unprivileged containers
-	d.IdmapSet, err = shared.DefaultIdmapSet()
+	d.os.IdmapSet, err = shared.DefaultIdmapSet()
 	if err != nil {
 		return err
 	}

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -50,9 +50,9 @@ func cmdDaemon() error {
 		}()
 	}
 
-	d := &Daemon{
-		group:     *argGroup,
-		SetupMode: shared.PathExists(shared.VarPath(".setup_mode"))}
+	d := NewDaemon()
+	d.group = *argGroup
+	d.SetupMode = shared.PathExists(shared.VarPath(".setup_mode"))
 	err := d.Init()
 	if err != nil {
 		if d != nil && d.db != nil {

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/crypto/ssh/terminal"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cmd"
@@ -745,7 +746,7 @@ func (cmd *CmdInit) askStorage(client lxd.ContainerServer, existingPools []strin
 				}
 				storage.Device = cmd.Context.AskString("Path to the existing block device: ", "", deviceExists)
 			} else {
-				backingFs, err := filesystemDetect(shared.VarPath())
+				backingFs, err := util.FilesystemDetect(shared.VarPath())
 				if err == nil && storage.Backend == "btrfs" && backingFs == "btrfs" {
 					if cmd.Context.AskBool("Would you like to create a new subvolume for the BTRFS storage pool (yes/no) [default=yes]: ", "yes") {
 						storage.Dataset = shared.VarPath("storage-pools", storage.Pool)

--- a/lxd/main_init_test.go
+++ b/lxd/main_init_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cmd"
@@ -86,7 +87,8 @@ func (suite *cmdInitTestSuite) TestCmdInit_PreseedHTTPSAddressAndTrustPassword()
 
 	key, _ := daemonConfig["core.https_address"]
 	suite.Req.Equal(fmt.Sprintf("127.0.0.1:%d", port), key.Get())
-	suite.Req.Nil(suite.d.PasswordCheck("sekret"))
+	secret := daemonConfig["core.trust_password"].Get()
+	suite.Req.Nil(util.PasswordCheck(secret, "sekret"))
 }
 
 // Input network address and trust password interactively.
@@ -107,7 +109,8 @@ func (suite *cmdInitTestSuite) TestCmdInit_InteractiveHTTPSAddressAndTrustPasswo
 
 	key, _ := daemonConfig["core.https_address"]
 	suite.Req.Equal(fmt.Sprintf("127.0.0.1:%d", port), key.Get())
-	suite.Req.Nil(suite.d.PasswordCheck("sekret"))
+	secret := daemonConfig["core.trust_password"].Get()
+	suite.Req.Nil(util.PasswordCheck(secret, "sekret"))
 }
 
 // Pass network address and trust password via command line arguments.
@@ -124,7 +127,8 @@ func (suite *cmdInitTestSuite) TestCmdInit_AutoHTTPSAddressAndTrustPassword() {
 
 	key, _ := daemonConfig["core.https_address"]
 	suite.Req.Equal(fmt.Sprintf("127.0.0.1:%d", port), key.Get())
-	suite.Req.Nil(suite.d.PasswordCheck("sekret"))
+	secret := daemonConfig["core.trust_password"].Get()
+	suite.Req.Nil(util.PasswordCheck(secret, "sekret"))
 }
 
 // The images auto-update interval can be interactively set by simply accepting

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -23,11 +23,10 @@ func mockStartDaemon() (*Daemon, error) {
 		return nil, err
 	}
 
-	d := &Daemon{
-		MockMode: true,
-		tlsConfig: &tls.Config{
-			Certificates: []tls.Certificate{cert},
-		},
+	d := NewDaemon()
+	d.os.MockMode = true
+	d.tlsConfig = &tls.Config{
+		Certificates: []tls.Certificate{cert},
 	}
 
 	if err := d.Init(); err != nil {

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -34,7 +34,7 @@ func mockStartDaemon() (*Daemon, error) {
 		return nil, err
 	}
 
-	d.IdmapSet = &shared.IdmapSet{Idmap: []shared.IdmapEntry{
+	d.os.IdmapSet = &shared.IdmapSet{Idmap: []shared.IdmapEntry{
 		{Isuid: true, Hostid: 100000, Nsid: 0, Maprange: 500000},
 		{Isgid: true, Hostid: 100000, Nsid: 0, Maprange: 500000},
 	}}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -16,6 +16,7 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -306,7 +307,7 @@ func networkPut(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{dbInfo.Name, dbInfo.Managed, dbInfo.Type, dbInfo.Description, dbInfo.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -331,7 +332,7 @@ func networkPatch(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{dbInfo.Name, dbInfo.Managed, dbInfo.Type, dbInfo.Description, dbInfo.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -31,7 +31,7 @@ func networksGet(d *Daemon, r *http.Request) Response {
 		recursion = 0
 	}
 
-	ifs, err := networkGetInterfaces(d)
+	ifs, err := networkGetInterfaces(d.db)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -80,7 +80,7 @@ func networksPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Only 'bridge' type networks can be created"))
 	}
 
-	networks, err := networkGetInterfaces(d)
+	networks, err := networkGetInterfaces(d.db)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -277,7 +277,7 @@ func networkPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Check that the name isn't already in use
-	networks, err := networkGetInterfaces(d)
+	networks, err := networkGetInterfaces(d.db)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -556,7 +556,7 @@ func (n *network) Rename(name string) error {
 
 func (n *network) Start() error {
 	// If we are in mock mode, just no-op.
-	if n.daemon.MockMode {
+	if n.daemon.os.MockMode {
 		return nil
 	}
 

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"database/sql"
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
@@ -23,8 +24,8 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func networkAutoAttach(d *Daemon, devName string) error {
-	_, dbInfo, err := db.NetworkGetInterface(d.db, devName)
+func networkAutoAttach(dbObj *sql.DB, devName string) error {
+	_, dbInfo, err := db.NetworkGetInterface(dbObj, devName)
 	if err != nil {
 		// No match found, move on
 		return nil
@@ -71,8 +72,8 @@ func networkDetachInterface(netName string, devName string) error {
 	return nil
 }
 
-func networkGetInterfaces(d *Daemon) ([]string, error) {
-	networks, err := db.Networks(d.db)
+func networkGetInterfaces(dbObj *sql.DB) ([]string, error) {
+	networks, err := db.Networks(dbObj)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/pborman/uuid"
 
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/cancel"
@@ -476,7 +477,7 @@ var operationCmd = Command{name: "operations/{id}", get: operationAPIGet, delete
 func operationsAPIGet(d *Daemon, r *http.Request) Response {
 	var md shared.Jmap
 
-	recursion := d.isRecursionRequest(r)
+	recursion := util.IsRecursionRequest(r)
 
 	md = shared.Jmap{}
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -179,7 +179,7 @@ func patchStorageApi(name string, d *Daemon) error {
 	} else if zfsPoolName != "" {
 		preStorageApiStorageType = storageTypeZfs
 		defaultPoolName = zfsPoolName
-	} else if d.BackingFs == "btrfs" {
+	} else if d.os.BackingFS == "btrfs" {
 		preStorageApiStorageType = storageTypeBtrfs
 	} else {
 		// Dir storage pool.
@@ -2129,7 +2129,7 @@ func patchStorageApiLxdOnBtrfs(name string, d *Daemon) error {
 			}
 		}
 
-		if d.BackingFs != "btrfs" {
+		if d.os.BackingFS != "btrfs" {
 			continue
 		}
 

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -282,7 +282,7 @@ func patchStorageApi(name string, d *Daemon) error {
 	daemonConfig["storage.zfs_remove_snapshots"].Set(d, "")
 	daemonConfig["storage.zfs_use_refquota"].Set(d, "")
 
-	return d.SetupStorageDriver(true)
+	return SetupStorageDriver(d, true)
 }
 
 func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -79,12 +79,12 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Invalid profile name '%s'", req.Name))
 	}
 
-	err := containerValidConfig(d, req.Config, true, false)
+	err := containerValidConfig(d.os, req.Config, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}
 
-	err = containerValidDevices(d, req.Devices, true, false)
+	err = containerValidDevices(d.db, req.Devices, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -165,7 +166,7 @@ func profilePut(d *Daemon, r *http.Request) Response {
 
 	// Validate the ETag
 	etag := []interface{}{profile.Config, profile.Description, profile.Devices}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -188,7 +189,7 @@ func profilePatch(d *Daemon, r *http.Request) Response {
 
 	// Validate the ETag
 	etag := []interface{}{profile.Config, profile.Description, profile.Devices}
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -28,7 +28,7 @@ func profilesGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	recursion := d.isRecursionRequest(r)
+	recursion := util.IsRecursionRequest(r)
 
 	resultString := make([]string, len(results))
 	resultMap := make([]*api.Profile, len(results))

--- a/lxd/profiles_test.go
+++ b/lxd/profiles_test.go
@@ -11,7 +11,7 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
 	var db *sql.DB
 	var err error
 
-	d := &Daemon{}
+	d := NewDaemon()
 	err = initializeDbObject(d, ":memory:")
 	db = d.db
 

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -10,12 +10,12 @@ import (
 
 func doProfileUpdate(d *Daemon, name string, id int64, profile *api.Profile, req api.ProfilePut) Response {
 	// Sanity checks
-	err := containerValidConfig(d, req.Config, true, false)
+	err := containerValidConfig(d.os, req.Config, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}
 
-	err = containerValidDevices(d, req.Devices, true, false)
+	err = containerValidDevices(d.db, req.Devices, true, false)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -14,6 +14,7 @@ import (
 	"github.com/mattn/go-sqlite3"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -35,7 +36,7 @@ type syncResponse struct {
 func (r *syncResponse) Render(w http.ResponseWriter) error {
 	// Set an appropriate ETag header
 	if r.etag != nil {
-		etag, err := etagHash(r.etag)
+		etag, err := util.EtagHash(r.etag)
 		if err == nil {
 			w.Header().Set("ETag", etag)
 		}
@@ -66,7 +67,7 @@ func (r *syncResponse) Render(w http.ResponseWriter) error {
 		Metadata: r.metadata,
 	}
 
-	return WriteJSON(w, resp)
+	return util.WriteJSON(w, resp, debug)
 }
 
 func (r *syncResponse) String() string {
@@ -237,7 +238,7 @@ func (r *operationResponse) Render(w http.ResponseWriter) error {
 	w.Header().Set("Location", url)
 	w.WriteHeader(202)
 
-	return WriteJSON(w, body)
+	return util.WriteJSON(w, body, debug)
 }
 
 func (r *operationResponse) String() string {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -8,7 +8,6 @@ import (
 	"reflect"
 	"sync"
 	"sync/atomic"
-	"syscall"
 
 	"github.com/gorilla/websocket"
 
@@ -73,43 +72,6 @@ func readStoragePoolDriversCache() []string {
 	}
 
 	return drivers.([]string)
-}
-
-// Filesystem magic numbers
-const (
-	filesystemSuperMagicTmpfs = 0x01021994
-	filesystemSuperMagicExt4  = 0xEF53
-	filesystemSuperMagicXfs   = 0x58465342
-	filesystemSuperMagicNfs   = 0x6969
-	filesystemSuperMagicZfs   = 0x2fc12fc1
-)
-
-// filesystemDetect returns the filesystem on which the passed-in path sits.
-func filesystemDetect(path string) (string, error) {
-	fs := syscall.Statfs_t{}
-
-	err := syscall.Statfs(path, &fs)
-	if err != nil {
-		return "", err
-	}
-
-	switch fs.Type {
-	case filesystemSuperMagicBtrfs:
-		return "btrfs", nil
-	case filesystemSuperMagicZfs:
-		return "zfs", nil
-	case filesystemSuperMagicTmpfs:
-		return "tmpfs", nil
-	case filesystemSuperMagicExt4:
-		return "ext4", nil
-	case filesystemSuperMagicXfs:
-		return "xfs", nil
-	case filesystemSuperMagicNfs:
-		return "nfs", nil
-	default:
-		logger.Debugf("Unknown backing filesystem type: 0x%x", fs.Type)
-		return string(fs.Type), nil
-	}
 }
 
 // storageType defines the type of a storage

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -837,3 +837,72 @@ func StorageProgressWriter(op *operation, key string, description string) func(i
 		return writePipe
 	}
 }
+
+func SetupStorageDriver(d *Daemon, forceCheck bool) error {
+	pools, err := db.StoragePools(d.db)
+	if err != nil {
+		if err == db.NoSuchObjectError {
+			logger.Debugf("No existing storage pools detected.")
+			return nil
+		}
+		logger.Debugf("Failed to retrieve existing storage pools.")
+		return err
+	}
+
+	// In case the daemon got killed during upgrade we will already have a
+	// valid storage pool entry but it might have gotten messed up and so we
+	// cannot perform StoragePoolCheck(). This case can be detected by
+	// looking at the patches db: If we already have a storage pool defined
+	// but the upgrade somehow got messed up then there will be no
+	// "storage_api" entry in the db.
+	if len(pools) > 0 && !forceCheck {
+		appliedPatches, err := db.Patches(d.db)
+		if err != nil {
+			return err
+		}
+
+		if !shared.StringInSlice("storage_api", appliedPatches) {
+			logger.Warnf("Incorrectly applied \"storage_api\" patch. Skipping storage pool initialization as it might be corrupt.")
+			return nil
+		}
+
+	}
+
+	for _, pool := range pools {
+		logger.Debugf("Initializing and checking storage pool \"%s\".", pool)
+		s, err := storagePoolInit(d, pool)
+		if err != nil {
+			logger.Errorf("Error initializing storage pool \"%s\": %s. Correct functionality of the storage pool cannot be guaranteed.", pool, err)
+			continue
+		}
+
+		err = s.StoragePoolCheck()
+		if err != nil {
+			return err
+		}
+	}
+
+	// Get a list of all storage drivers currently in use
+	// on this LXD instance. Only do this when we do not already have done
+	// this once to avoid unnecessarily querying the db. All subsequent
+	// updates of the cache will be done when we create or delete storage
+	// pools in the db. Since this is a rare event, this cache
+	// implementation is a classic frequent-read, rare-update case so
+	// copy-on-write semantics without locking in the read case seems
+	// appropriate. (Should be cheaper then querying the db all the time,
+	// especially if we keep adding more storage drivers.)
+	if !storagePoolDriversCacheInitialized {
+		tmp, err := db.StoragePoolsGetDrivers(d.db)
+		if err != nil && err != db.NoSuchObjectError {
+			return nil
+		}
+
+		storagePoolDriversCacheLock.Lock()
+		storagePoolDriversCacheVal.Store(tmp)
+		storagePoolDriversCacheLock.Unlock()
+
+		storagePoolDriversCacheInitialized = true
+	}
+
+	return nil
+}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -169,7 +169,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 					} else if strings.HasPrefix(cleanSource, lxdDir) {
 						if cleanSource != poolMntPoint {
 							return fmt.Errorf("BTRFS subvolumes requests in LXD directory \"%s\" are only valid under \"%s\"\n(e.g. source=%s)", shared.VarPath(), shared.VarPath("storage-pools"), poolMntPoint)
-						} else if s.d.BackingFs != "btrfs" {
+						} else if s.d.os.BackingFS != "btrfs" {
 							return fmt.Errorf("creation of BTRFS subvolume requested but \"%s\" does not reside on BTRFS filesystem", source)
 						}
 					}
@@ -394,7 +394,7 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 		} else if !isBlockDev && cleanSource != poolMntPoint {
 			mountSource = source
 			mountFlags |= syscall.MS_BIND
-		} else if !isBlockDev && cleanSource == poolMntPoint && s.d.BackingFs == "btrfs" {
+		} else if !isBlockDev && cleanSource == poolMntPoint && s.d.os.BackingFS == "btrfs" {
 			return false, nil
 		}
 		// User is using block device path.

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -16,6 +16,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -1683,7 +1684,7 @@ func isOnBtrfs(path string) bool {
 		return false
 	}
 
-	if fs.Type != filesystemSuperMagicBtrfs {
+	if fs.Type != util.FilesystemSuperMagicBtrfs {
 		return false
 	}
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1352,7 +1352,7 @@ func (s *storageBtrfs) ImageCreate(fingerprint string) error {
 
 	// Unpack the image in imageMntPoint.
 	imagePath := shared.VarPath("images", fingerprint)
-	err = unpackImage(s.d, imagePath, tmpImageSubvolumeName, storageTypeBtrfs)
+	err = unpackImage(imagePath, tmpImageSubvolumeName, storageTypeBtrfs)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -2167,7 +2167,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 
 		// rsync contents into image
 		imagePath := shared.VarPath("images", fingerprint)
-		err = unpackImage(s.d, imagePath, imageMntPoint, storageTypeCeph)
+		err = unpackImage(imagePath, imageMntPoint, storageTypeCeph)
 		if err != nil {
 			logger.Errorf(`Failed to unpack image for RBD storage `+
 				`volume for image "%s" on storage pool "%s": %s`,

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -295,7 +295,7 @@ func (s *storageDir) ContainerCreateFromImage(container container, imageFingerpr
 	}()
 
 	imagePath := shared.VarPath("images", imageFingerprint)
-	err = unpackImage(s.d, imagePath, containerMntPoint, storageTypeDir)
+	err = unpackImage(imagePath, containerMntPoint, storageTypeDir)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1548,7 +1548,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 		}
 
 		imagePath := shared.VarPath("images", fingerprint)
-		err = unpackImage(s.d, imagePath, imageMntPoint, storageTypeLvm)
+		err = unpackImage(imagePath, imageMntPoint, storageTypeLvm)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -464,7 +464,7 @@ func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
 
 	imagePath := shared.VarPath("images", fp)
 	containerMntPoint := getContainerMountPoint(s.pool.Name, containerName)
-	err = unpackImage(s.d, imagePath, containerMntPoint, storageTypeLvm)
+	err = unpackImage(imagePath, containerMntPoint, storageTypeLvm)
 	if err != nil {
 		logger.Errorf(`Failed to unpack image "%s" into non-thinpool `+
 			`LVM storage volume "%s" for container "%s" on `+

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
 )
@@ -123,7 +124,7 @@ func storagePoolPut(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{dbInfo.Name, dbInfo.Driver, dbInfo.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -161,7 +162,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{dbInfo.Name, dbInfo.Driver, dbInfo.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
@@ -261,7 +262,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{volume.Name, volume.Type, volume.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}
@@ -323,7 +324,7 @@ func storagePoolVolumeTypePatch(d *Daemon, r *http.Request) Response {
 	// Validate the ETag
 	etag := []interface{}{volume.Name, volume.Type, volume.Config}
 
-	err = etagCheck(r, etag)
+	err = util.EtagCheck(r, etag)
 	if err != nil {
 		return PreconditionFailed(err)
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1841,7 +1841,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 	}
 
 	// Unpack the image into the temporary mountpoint.
-	err = unpackImage(s.d, imagePath, tmpImageDir, storageTypeZfs)
+	err = unpackImage(imagePath, tmpImageDir, storageTypeZfs)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -46,7 +47,7 @@ func (s *storageZfs) StorageCoreInit() error {
 	}
 	s.sTypeName = typeName
 
-	loadModule("zfs")
+	util.LoadModule("zfs")
 
 	if !zfsIsEnabled() {
 		return fmt.Errorf("the \"zfs\" tool is not enabled")

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -1,0 +1,23 @@
+package sys
+
+import (
+	"github.com/lxc/lxd/lxd/util"
+)
+
+// OS is a high-level facade for accessing all operating-system
+// level functionality that LXD uses.
+type OS struct {
+	Architectures []int // Cache of detected system architectures
+}
+
+// Init our internal data structures.
+func (s *OS) Init() error {
+	var err error
+
+	s.Architectures, err = util.GetArchitectures()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -2,12 +2,21 @@ package sys
 
 import (
 	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
 )
 
 // OS is a high-level facade for accessing all operating-system
 // level functionality that LXD uses.
 type OS struct {
-	Architectures []int // Cache of detected system architectures
+
+	// Caches of system characteristics detected at Init() time.
+	Architectures []int  // Cache of detected system architectures
+	LxcPath       string // Path to the $LXD_DIR/containers directory
+}
+
+// NewOS returns a fresh uninitialized OS instance.
+func NewOS() *OS {
+	return &OS{}
 }
 
 // Init our internal data structures.
@@ -19,5 +28,6 @@ func (s *OS) Init() error {
 		return err
 	}
 
+	s.LxcPath = shared.VarPath("containers")
 	return nil
 }

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -17,6 +17,8 @@ type OS struct {
 	LxcPath       string // Path to the $LXD_DIR/containers directory
 	BackingFS     string // Backing filesystem of $LXD_DIR/containers
 	IdmapSet      *shared.IdmapSet
+
+	MockMode bool // If true some APIs will be mocked (for testing)
 }
 
 // NewOS returns a fresh uninitialized OS instance.

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -16,6 +16,7 @@ type OS struct {
 	Architectures []int  // Cache of detected system architectures
 	LxcPath       string // Path to the $LXD_DIR/containers directory
 	BackingFS     string // Backing filesystem of $LXD_DIR/containers
+	IdmapSet      *shared.IdmapSet
 }
 
 // NewOS returns a fresh uninitialized OS instance.
@@ -38,6 +39,8 @@ func (s *OS) Init() error {
 	if err != nil {
 		logger.Error("Error detecting backing fs", log.Ctx{"err": err})
 	}
+
+	s.IdmapSet = util.GetIdmapSet()
 
 	return nil
 }

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -1,8 +1,11 @@
 package sys
 
 import (
+	log "gopkg.in/inconshreveable/log15.v2"
+
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 // OS is a high-level facade for accessing all operating-system
@@ -12,6 +15,7 @@ type OS struct {
 	// Caches of system characteristics detected at Init() time.
 	Architectures []int  // Cache of detected system architectures
 	LxcPath       string // Path to the $LXD_DIR/containers directory
+	BackingFS     string // Backing filesystem of $LXD_DIR/containers
 }
 
 // NewOS returns a fresh uninitialized OS instance.
@@ -29,5 +33,11 @@ func (s *OS) Init() error {
 	}
 
 	s.LxcPath = shared.VarPath("containers")
+
+	s.BackingFS, err = util.FilesystemDetect(s.LxcPath)
+	if err != nil {
+		logger.Error("Error detecting backing fs", log.Ctx{"err": err})
+	}
+
 	return nil
 }

--- a/lxd/util/encryption.go
+++ b/lxd/util/encryption.go
@@ -1,0 +1,34 @@
+package util
+
+import (
+	"bytes"
+	"encoding/hex"
+	"fmt"
+
+	"golang.org/x/crypto/scrypt"
+)
+
+func PasswordCheck(secret, password string) error {
+	// No password set
+	if secret == "" {
+		return fmt.Errorf("No password is set")
+	}
+
+	// Compare the password
+	buff, err := hex.DecodeString(secret)
+	if err != nil {
+		return err
+	}
+
+	salt := buff[0:32]
+	hash, err := scrypt.Key([]byte(password), salt, 1<<14, 8, 1, 64)
+	if err != nil {
+		return err
+	}
+
+	if !bytes.Equal(hash, buff[32:]) {
+		return fmt.Errorf("Bad password provided")
+	}
+
+	return nil
+}

--- a/lxd/util/fs.go
+++ b/lxd/util/fs.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"syscall"
+
+	"github.com/lxc/lxd/shared/logger"
+)
+
+// Filesystem magic numbers
+const (
+	FilesystemSuperMagicTmpfs = 0x01021994
+	FilesystemSuperMagicExt4  = 0xEF53
+	FilesystemSuperMagicXfs   = 0x58465342
+	FilesystemSuperMagicNfs   = 0x6969
+	FilesystemSuperMagicZfs   = 0x2fc12fc1
+)
+
+// FilesystemDetect returns the filesystem on which the passed-in path sits.
+func FilesystemDetect(path string) (string, error) {
+	fs := syscall.Statfs_t{}
+
+	err := syscall.Statfs(path, &fs)
+	if err != nil {
+		return "", err
+	}
+
+	switch fs.Type {
+	case FilesystemSuperMagicBtrfs:
+		return "btrfs", nil
+	case FilesystemSuperMagicZfs:
+		return "zfs", nil
+	case FilesystemSuperMagicTmpfs:
+		return "tmpfs", nil
+	case FilesystemSuperMagicExt4:
+		return "ext4", nil
+	case FilesystemSuperMagicXfs:
+		return "xfs", nil
+	case FilesystemSuperMagicNfs:
+		return "nfs", nil
+	default:
+		logger.Debugf("Unknown backing filesystem type: 0x%x", fs.Type)
+		return string(fs.Type), nil
+	}
+}

--- a/lxd/util/fs_32bit.go
+++ b/lxd/util/fs_32bit.go
@@ -1,9 +1,9 @@
 // +build 386 arm ppc s390
 
-package main
+package util
 
 const (
 	/* This is really 0x9123683E, go wants us to give it in signed form
 	 * since we use it as a signed constant. */
-	filesystemSuperMagicBtrfs = -1859950530
+	FilesystemSuperMagicBtrfs = -1859950530
 )

--- a/lxd/util/fs_64bit.go
+++ b/lxd/util/fs_64bit.go
@@ -1,7 +1,7 @@
 // +build amd64 ppc64 ppc64le arm64 s390x
 
-package main
+package util
 
 const (
-	filesystemSuperMagicBtrfs = 0x9123683E
+	FilesystemSuperMagicBtrfs = 0x9123683E
 )

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -11,8 +11,10 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -225,4 +227,41 @@ func ListenAddresses(value string) ([]string, error) {
 	}
 
 	return addresses, nil
+}
+
+func GetListeners() []net.Listener {
+	defer func() {
+		os.Unsetenv("LISTEN_PID")
+		os.Unsetenv("LISTEN_FDS")
+	}()
+
+	pid, err := strconv.Atoi(os.Getenv("LISTEN_PID"))
+	if err != nil {
+		return nil
+	}
+
+	if pid != os.Getpid() {
+		return nil
+	}
+
+	fds, err := strconv.Atoi(os.Getenv("LISTEN_FDS"))
+	if err != nil {
+		return nil
+	}
+
+	listeners := []net.Listener{}
+
+	for i := 3; i < 3+fds; i++ {
+		syscall.CloseOnExec(i)
+
+		file := os.NewFile(uintptr(i), fmt.Sprintf("inherited-fd%d", i))
+		listener, err := net.FileListener(file)
+		if err != nil {
+			continue
+		}
+
+		listeners = append(listeners, listener)
+	}
+
+	return listeners
 }

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -1,4 +1,4 @@
-package main
+package util
 
 import (
 	"bytes"
@@ -11,7 +11,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func WriteJSON(w http.ResponseWriter, body interface{}) error {
+func WriteJSON(w http.ResponseWriter, body interface{}, debug bool) error {
 	var output io.Writer
 	var captured *bytes.Buffer
 
@@ -30,7 +30,7 @@ func WriteJSON(w http.ResponseWriter, body interface{}) error {
 	return err
 }
 
-func etagHash(data interface{}) (string, error) {
+func EtagHash(data interface{}) (string, error) {
 	etag := sha256.New()
 	err := json.NewEncoder(etag).Encode(data)
 	if err != nil {
@@ -40,13 +40,13 @@ func etagHash(data interface{}) (string, error) {
 	return fmt.Sprintf("%x", etag.Sum(nil)), nil
 }
 
-func etagCheck(r *http.Request, data interface{}) error {
+func EtagCheck(r *http.Request, data interface{}) error {
 	match := r.Header.Get("If-Match")
 	if match == "" {
 		return nil
 	}
 
-	hash, err := etagHash(data)
+	hash, err := EtagHash(data)
 	if err != nil {
 		return err
 	}
@@ -56,13 +56,4 @@ func etagCheck(r *http.Request, data interface{}) error {
 	}
 
 	return nil
-}
-
-func loadModule(module string) error {
-	if shared.PathExists(fmt.Sprintf("/sys/module/%s", module)) {
-		return nil
-	}
-
-	_, err := shared.RunCommand("modprobe", module)
-	return err
 }

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"time"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -150,4 +151,17 @@ func checkTrustState(cert x509.Certificate, trustedCerts []x509.Certificate) boo
 	}
 
 	return false
+}
+
+// IsRecursionRequest checks whether the given HTTP request is marked with the
+// "recursion" flag in its form values.
+func IsRecursionRequest(r *http.Request) bool {
+	recursionStr := r.FormValue("recursion")
+
+	recursion, err := strconv.Atoi(recursionStr)
+	if err != nil {
+		return false
+	}
+
+	return recursion == 1
 }

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -8,9 +8,11 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	log "gopkg.in/inconshreveable/log15.v2"
@@ -164,4 +166,63 @@ func IsRecursionRequest(r *http.Request) bool {
 	}
 
 	return recursion == 1
+}
+
+func ListenAddresses(value string) ([]string, error) {
+	addresses := make([]string, 0)
+
+	if value == "" {
+		return addresses, nil
+	}
+
+	localHost, localPort, err := net.SplitHostPort(value)
+	if err != nil {
+		localHost = value
+		localPort = shared.DefaultPort
+	}
+
+	if localHost == "0.0.0.0" || localHost == "::" || localHost == "[::]" {
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			return addresses, err
+		}
+
+		for _, i := range ifaces {
+			addrs, err := i.Addrs()
+			if err != nil {
+				continue
+			}
+
+			for _, addr := range addrs {
+				var ip net.IP
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+
+				if !ip.IsGlobalUnicast() {
+					continue
+				}
+
+				if ip.To4() == nil {
+					if localHost == "0.0.0.0" {
+						continue
+					}
+					addresses = append(addresses, fmt.Sprintf("[%s]:%s", ip, localPort))
+				} else {
+					addresses = append(addresses, fmt.Sprintf("%s:%s", ip, localPort))
+				}
+			}
+		}
+	} else {
+		if strings.Contains(localHost, ":") {
+			addresses = append(addresses, fmt.Sprintf("[%s]:%s", localHost, localPort))
+		} else {
+			addresses = append(addresses, fmt.Sprintf("%s:%s", localHost, localPort))
+		}
+	}
+
+	return addresses, nil
 }

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -10,8 +10,12 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"time"
+
+	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 func WriteJSON(w http.ResponseWriter, body interface{}, debug bool) error {
@@ -107,3 +111,43 @@ func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
 
 // A function capable of proxing an HTTP request.
 type proxyFunc func(req *http.Request) (*url.URL, error)
+
+// IsTrustedClient checks if the given HTTP request comes from a trusted client
+// (i.e. either it's received via Unix socket, or via TLS with a trusted
+// certificate).
+func IsTrustedClient(r *http.Request, trustedCerts []x509.Certificate) bool {
+	if r.RemoteAddr == "@" {
+		// Unix socket
+		return true
+	}
+
+	if r.TLS == nil {
+		return false
+	}
+
+	for i := range r.TLS.PeerCertificates {
+		if checkTrustState(*r.TLS.PeerCertificates[i], trustedCerts) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Check whether the given client certificate is trusted (i.e. it has a valid
+// time span and it belongs to the given list of trusted certificates).
+func checkTrustState(cert x509.Certificate, trustedCerts []x509.Certificate) bool {
+	// Extra validity check (should have been caught by TLS stack)
+	if time.Now().Before(cert.NotBefore) || time.Now().After(cert.NotAfter) {
+		return false
+	}
+
+	for k, v := range trustedCerts {
+		if bytes.Compare(cert.Raw, v.Raw) == 0 {
+			logger.Debug("Found cert", log.Ctx{"k": k})
+			return true
+		}
+	}
+
+	return false
+}

--- a/lxd/util/http.go
+++ b/lxd/util/http.go
@@ -3,10 +3,13 @@ package util
 import (
 	"bytes"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 
 	"github.com/lxc/lxd/shared"
 )
@@ -57,3 +60,50 @@ func EtagCheck(r *http.Request, data interface{}) error {
 
 	return nil
 }
+
+// HTTPClient returns an http.Client using the given certificate and proxy.
+func HTTPClient(certificate string, proxy proxyFunc) (*http.Client, error) {
+	var err error
+	var cert *x509.Certificate
+
+	if certificate != "" {
+		certBlock, _ := pem.Decode([]byte(certificate))
+		if certBlock == nil {
+			return nil, fmt.Errorf("Invalid certificate")
+		}
+
+		cert, err = x509.ParseCertificate(certBlock.Bytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	tlsConfig, err := shared.GetTLSConfig("", "", "", cert)
+	if err != nil {
+		return nil, err
+	}
+
+	tr := &http.Transport{
+		TLSClientConfig:   tlsConfig,
+		Dial:              shared.RFC3493Dialer,
+		Proxy:             proxy,
+		DisableKeepAlives: true,
+	}
+
+	myhttp := http.Client{
+		Transport: tr,
+	}
+
+	// Setup redirect policy
+	myhttp.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		// Replicate the headers
+		req.Header = via[len(via)-1].Header
+
+		return nil
+	}
+
+	return &myhttp, nil
+}
+
+// A function capable of proxing an HTTP request.
+type proxyFunc func(req *http.Request) (*url.URL, error)

--- a/lxd/util/kernel.go
+++ b/lxd/util/kernel.go
@@ -1,0 +1,18 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/lxc/lxd/shared"
+)
+
+// LoadModule loads the kernel module with the given name, by invoking
+// modprobe.
+func LoadModule(module string) error {
+	if shared.PathExists(fmt.Sprintf("/sys/module/%s", module)) {
+		return nil
+	}
+
+	_, err := shared.RunCommand("modprobe", module)
+	return err
+}

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -1,6 +1,12 @@
 package util
 
 import (
+	"strings"
+
+	log "gopkg.in/inconshreveable/log15.v2"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
 )
 
@@ -27,4 +33,49 @@ func GetArchitectures() ([]int, error) {
 		architectures = append(architectures, personality)
 	}
 	return architectures, nil
+}
+
+// GetIdmapSet reads the uid/gid allocation.
+func GetIdmapSet() *shared.IdmapSet {
+	idmapSet, err := shared.DefaultIdmapSet()
+	if err != nil {
+		logger.Warn("Error reading default uid/gid map", log.Ctx{"err": err.Error()})
+		logger.Warnf("Only privileged containers will be able to run")
+		idmapSet = nil
+	} else {
+		kernelIdmapSet, err := shared.CurrentIdmapSet()
+		if err == nil {
+			logger.Infof("Kernel uid/gid map:")
+			for _, lxcmap := range kernelIdmapSet.ToLxcString() {
+				logger.Infof(strings.TrimRight(" - "+lxcmap, "\n"))
+			}
+		}
+
+		if len(idmapSet.Idmap) == 0 {
+			logger.Warnf("No available uid/gid map could be found")
+			logger.Warnf("Only privileged containers will be able to run")
+			idmapSet = nil
+		} else {
+			logger.Infof("Configured LXD uid/gid map:")
+			for _, lxcmap := range idmapSet.Idmap {
+				suffix := ""
+
+				if lxcmap.Usable() != nil {
+					suffix = " (unusable)"
+				}
+
+				for _, lxcEntry := range lxcmap.ToLxcString() {
+					logger.Infof(" - %s%s", strings.TrimRight(lxcEntry, "\n"), suffix)
+				}
+			}
+
+			err = idmapSet.Usable()
+			if err != nil {
+				logger.Warnf("One or more uid/gid map entry isn't usable (typically due to nesting)")
+				logger.Warnf("Only privileged containers will be able to run")
+				idmapSet = nil
+			}
+		}
+	}
+	return idmapSet
 }

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"github.com/lxc/lxd/shared/osarch"
+)
+
+// GetArchitectures returns the list of supported architectures.
+func GetArchitectures() ([]int, error) {
+	architectures := []int{}
+
+	architectureName, err := osarch.ArchitectureGetLocal()
+	if err != nil {
+		return nil, err
+	}
+
+	architecture, err := osarch.ArchitectureId(architectureName)
+	if err != nil {
+		return nil, err
+	}
+	architectures = append(architectures, architecture)
+
+	personalities, err := osarch.ArchitecturePersonalities(architecture)
+	if err != nil {
+		return nil, err
+	}
+	for _, personality := range personalities {
+		architectures = append(architectures, personality)
+	}
+	return architectures, nil
+}


### PR DESCRIPTION
This is mainly a RFC, which needs some more work to complete.

Essentially the effort here is to split the code currently in Daemon into more decoupled components, which have more narrow responsibility. The goal is to help readability/understandability, but more importantly to unlock better unit-testing options.

The Daemon struct seems to have broadly three responsibilities:

- Start/stop the whole LXD server process, with everything it entails, including synchronization of various tasks etc.

- Interface with the operating system to provide several abstractions and functionality.

- Act as gateway to the SQLite storage, via the various API accessible with the Daemon.db handle.

I'd like Daemon to focus on the first responsibility only, and have the last two be handled by separate sub-packages (lxd/sys and lxd/db respectively). This should pave the ground for the possibility of unit-testing application code that is fairly independent from the OS (whose functionality is mostly covered by integration tests already).

Each commit in this series should be reasonably small and self-contained. All of them are basically mechanical changes that move code around without changing actual logic.