### PR TITLE
Replace Daemon with State in all model entities

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -62,7 +62,7 @@ func internalContainerOnStart(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	c, err := containerLoadById(d, id)
+	c, err := containerLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -87,7 +87,7 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 		target = "unknown"
 	}
 
-	c, err := containerLoadById(d, id)
+	c, err := containerLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -351,7 +351,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 	if err != nil {
 		return SmartError(err)
 	}
-	_, err = containerCreateInternal(d, db.ContainerArgs{
+	_, err = containerCreateInternal(d.State(), db.ContainerArgs{
 		Architecture: arch,
 		BaseImage:    baseImage,
 		Config:       backup.Container.Config,
@@ -432,7 +432,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 			return SmartError(err)
 		}
 
-		_, err = containerCreateInternal(d, db.ContainerArgs{
+		_, err = containerCreateInternal(d.State(), db.ContainerArgs{
 			Architecture: arch,
 			BaseImage:    baseImage,
 			Config:       snap.Config,

--- a/lxd/container_delete.go
+++ b/lxd/container_delete.go
@@ -9,7 +9,7 @@ import (
 
 func containerDelete(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -328,7 +328,7 @@ func (s *execWs) Do(op *operation) error {
 
 func containerExecPost(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_file.go
+++ b/lxd/container_file.go
@@ -15,7 +15,7 @@ import (
 
 func containerFileHandler(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_get.go
+++ b/lxd/container_get.go
@@ -8,7 +8,7 @@ import (
 
 func containerGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -25,6 +25,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/types"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -239,10 +240,10 @@ func lxcStatusCode(state lxc.State) api.StatusCode {
 }
 
 // Loader functions
-func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
+func containerLXCCreate(s *state.State, args db.ContainerArgs) (container, error) {
 	// Create the container struct
 	c := &containerLXC{
-		daemon:       d,
+		state:        s,
 		id:           args.Id,
 		name:         args.Name,
 		description:  args.Description,
@@ -271,14 +272,14 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	}
 
 	// Validate expanded config
-	err = containerValidConfig(d.os, c.expandedConfig, false, true)
+	err = containerValidConfig(s.OS, c.expandedConfig, false, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
 		return nil, err
 	}
 
-	err = containerValidDevices(d.db, c.expandedDevices, false, true)
+	err = containerValidDevices(s.DB, c.expandedDevices, false, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
@@ -300,7 +301,7 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	storagePool := rootDiskDevice["pool"]
 
 	// Get the storage pool ID for the container
-	poolID, pool, err := db.StoragePoolGet(d.db, storagePool)
+	poolID, pool, err := db.StoragePoolGet(s.DB, storagePool)
 	if err != nil {
 		c.Delete()
 		return nil, err
@@ -314,14 +315,14 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	}
 
 	// Create a new database entry for the container's storage volume
-	_, err = db.StoragePoolVolumeCreate(d.db, args.Name, "", storagePoolVolumeTypeContainer, poolID, volumeConfig)
+	_, err = db.StoragePoolVolumeCreate(s.DB, args.Name, "", storagePoolVolumeTypeContainer, poolID, volumeConfig)
 	if err != nil {
 		c.Delete()
 		return nil, err
 	}
 
 	// Initialize the container storage
-	cStorage, err := storagePoolVolumeContainerCreateInit(d, storagePool, args.Name)
+	cStorage, err := storagePoolVolumeContainerCreateInit(s, storagePool, args.Name)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed to initialize container storage", ctxMap)
@@ -334,7 +335,7 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	base := int64(0)
 	if !c.IsPrivileged() {
 		idmap, base, err = findIdmap(
-			d,
+			s,
 			args.Name,
 			c.expandedConfig["security.idmap.isolated"],
 			c.expandedConfig["security.idmap.base"],
@@ -398,17 +399,17 @@ func containerLXCCreate(d *Daemon, args db.ContainerArgs) (container, error) {
 	}
 
 	// Update lease files
-	networkUpdateStatic(d, "")
+	networkUpdateStatic(s, "")
 
 	logger.Info("Created container", ctxMap)
 
 	return c, nil
 }
 
-func containerLXCLoad(d *Daemon, args db.ContainerArgs) (container, error) {
+func containerLXCLoad(s *state.State, args db.ContainerArgs) (container, error) {
 	// Create the container struct
 	c := &containerLXC{
-		daemon:       d,
+		state:        s,
 		id:           args.Id,
 		name:         args.Name,
 		description:  args.Description,
@@ -455,7 +456,7 @@ type containerLXC struct {
 
 	// Cache
 	c        *lxc.Container
-	daemon   *Daemon
+	state    *state.State
 	idmapset *shared.IdmapSet
 
 	// Storage
@@ -512,7 +513,7 @@ func (c *containerLXC) waitOperation() error {
 	return nil
 }
 
-func idmapSize(daemon *Daemon, isolatedStr string, size string) (int64, error) {
+func idmapSize(state *state.State, isolatedStr string, size string) (int64, error) {
 	isolated := false
 	if shared.IsTrue(isolatedStr) {
 		isolated = true
@@ -523,11 +524,11 @@ func idmapSize(daemon *Daemon, isolatedStr string, size string) (int64, error) {
 		if isolated {
 			idMapSize = 65536
 		} else {
-			if len(daemon.os.IdmapSet.Idmap) != 2 {
-				return 0, fmt.Errorf("bad initial idmap: %v", daemon.os.IdmapSet)
+			if len(state.OS.IdmapSet.Idmap) != 2 {
+				return 0, fmt.Errorf("bad initial idmap: %v", state.OS.IdmapSet)
 			}
 
-			idMapSize = daemon.os.IdmapSet.Idmap[0].Maprange
+			idMapSize = state.OS.IdmapSet.Idmap[0].Maprange
 		}
 	} else {
 		size, err := strconv.ParseInt(size, 10, 64)
@@ -629,7 +630,7 @@ func parseRawIdmap(value string) ([]shared.IdmapEntry, error) {
 	return ret.Idmap, nil
 }
 
-func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase string, configSize string, rawIdmap string) (*shared.IdmapSet, int64, error) {
+func findIdmap(state *state.State, cName string, isolatedStr string, configBase string, configSize string, rawIdmap string) (*shared.IdmapSet, int64, error) {
 	isolated := false
 	if shared.IsTrue(isolatedStr) {
 		isolated = true
@@ -641,8 +642,8 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 	}
 
 	if !isolated {
-		newIdmapset := shared.IdmapSet{Idmap: make([]shared.IdmapEntry, len(daemon.os.IdmapSet.Idmap))}
-		copy(newIdmapset.Idmap, daemon.os.IdmapSet.Idmap)
+		newIdmapset := shared.IdmapSet{Idmap: make([]shared.IdmapEntry, len(state.OS.IdmapSet.Idmap))}
+		copy(newIdmapset.Idmap, state.OS.IdmapSet.Idmap)
 
 		for _, ent := range rawMaps {
 			newIdmapset.AddSafe(ent)
@@ -651,7 +652,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 		return &newIdmapset, 0, nil
 	}
 
-	size, err := idmapSize(daemon, isolatedStr, configSize)
+	size, err := idmapSize(state, isolatedStr, configSize)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -681,12 +682,12 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 	idmapLock.Lock()
 	defer idmapLock.Unlock()
 
-	cs, err := db.ContainersList(daemon.db, db.CTypeRegular)
+	cs, err := db.ContainersList(state.DB, db.CTypeRegular)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	offset := daemon.os.IdmapSet.Idmap[0].Hostid + 65536
+	offset := state.OS.IdmapSet.Idmap[0].Hostid + 65536
 
 	mapentries := shared.ByHostid{}
 	for _, name := range cs {
@@ -695,7 +696,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 			continue
 		}
 
-		container, err := containerLoadByName(daemon, name)
+		container, err := containerLoadByName(state, name)
 		if err != nil {
 			return nil, 0, err
 		}
@@ -716,7 +717,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 			}
 		}
 
-		cSize, err := idmapSize(daemon, container.ExpandedConfig()["security.idmap.isolated"], container.ExpandedConfig()["security.idmap.size"])
+		cSize, err := idmapSize(state, container.ExpandedConfig()["security.idmap.isolated"], container.ExpandedConfig()["security.idmap.size"])
 		if err != nil {
 			return nil, 0, err
 		}
@@ -748,7 +749,7 @@ func findIdmap(daemon *Daemon, cName string, isolatedStr string, configBase stri
 		offset = mapentries[i].Hostid + mapentries[i].Maprange
 	}
 
-	if offset+size < daemon.os.IdmapSet.Idmap[0].Hostid+daemon.os.IdmapSet.Idmap[0].Maprange {
+	if offset+size < state.OS.IdmapSet.Idmap[0].Hostid+state.OS.IdmapSet.Idmap[0].Maprange {
 		return mkIdmap(offset, size), offset, nil
 	}
 
@@ -787,7 +788,7 @@ func (c *containerLXC) initLXC() error {
 	}
 
 	// Load the go-lxc struct
-	cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
+	cc, err := lxc.NewContainer(c.Name(), c.state.OS.LxcPath)
 	if err != nil {
 		return err
 	}
@@ -952,7 +953,7 @@ func (c *containerLXC) initLXC() error {
 	// Setup architecture
 	personality, err := osarch.ArchitecturePersonality(c.architecture)
 	if err != nil {
-		personality, err = osarch.ArchitecturePersonality(c.daemon.os.Architectures[0])
+		personality, err = osarch.ArchitecturePersonality(c.state.OS.Architectures[0])
 		if err != nil {
 			return err
 		}
@@ -1489,7 +1490,7 @@ func (c *containerLXC) initStorage() error {
 		return nil
 	}
 
-	s, err := storagePoolVolumeContainerLoadInit(c.daemon, c.Name())
+	s, err := storagePoolVolumeContainerLoadInit(c.state, c.Name())
 	if err != nil {
 		return err
 	}
@@ -1505,7 +1506,7 @@ func (c *containerLXC) expandConfig() error {
 
 	// Apply all the profiles
 	for _, name := range c.profiles {
-		profileConfig, err := db.ProfileConfig(c.daemon.db, name)
+		profileConfig, err := db.ProfileConfig(c.state.DB, name)
 		if err != nil {
 			return err
 		}
@@ -1529,7 +1530,7 @@ func (c *containerLXC) expandDevices() error {
 
 	// Apply all the profiles
 	for _, p := range c.profiles {
-		profileDevices, err := db.Devices(c.daemon.db, p, true)
+		profileDevices, err := db.Devices(c.state.DB, p, true)
 		if err != nil {
 			return err
 		}
@@ -1655,7 +1656,7 @@ func (c *containerLXC) startCommon() (string, error) {
 		}
 
 		// Remove the volatile key from the DB
-		err = db.ContainerConfigRemove(c.daemon.db, c.id, "volatile.apply_quota")
+		err = db.ContainerConfigRemove(c.state.DB, c.id, "volatile.apply_quota")
 		if err != nil {
 			return "", err
 		}
@@ -1989,7 +1990,7 @@ func (c *containerLXC) startCommon() (string, error) {
 	}
 
 	// Update time container was last started
-	err = db.ContainerLastUsedUpdate(c.daemon.db, c.id, time.Now().UTC())
+	err = db.ContainerLastUsedUpdate(c.state.DB, c.id, time.Now().UTC())
 	if err != nil {
 		return "", fmt.Errorf("Error updating last used: %v", err)
 	}
@@ -2047,7 +2048,7 @@ func (c *containerLXC) Start(stateful bool) error {
 		os.RemoveAll(c.StatePath())
 		c.stateful = false
 
-		err = db.ContainerSetStateful(c.daemon.db, c.id, false)
+		err = db.ContainerSetStateful(c.state.DB, c.id, false)
 		if err != nil {
 			logger.Error("Failed starting container", ctxMap)
 			return err
@@ -2064,7 +2065,7 @@ func (c *containerLXC) Start(stateful bool) error {
 		}
 
 		c.stateful = false
-		err = db.ContainerSetStateful(c.daemon.db, c.id, false)
+		err = db.ContainerSetStateful(c.state.DB, c.id, false)
 		if err != nil {
 			return err
 		}
@@ -2075,7 +2076,7 @@ func (c *containerLXC) Start(stateful bool) error {
 		execPath,
 		"forkstart",
 		c.name,
-		c.daemon.os.LxcPath,
+		c.state.OS.LxcPath,
 		configPath)
 
 	// Capture debug output
@@ -2157,7 +2158,7 @@ func (c *containerLXC) OnStart() error {
 		}
 
 		// Remove the volatile key from the DB
-		err := db.ContainerConfigRemove(c.daemon.db, c.id, key)
+		err := db.ContainerConfigRemove(c.state.DB, c.id, key)
 		if err != nil {
 			AADestroy(c)
 			if ourStart {
@@ -2211,7 +2212,7 @@ func (c *containerLXC) OnStart() error {
 	}
 
 	// Record current state
-	err = db.ContainerSetState(c.daemon.db, c.id, "RUNNING")
+	err = db.ContainerSetState(c.state.DB, c.id, "RUNNING")
 	if err != nil {
 		return err
 	}
@@ -2265,7 +2266,7 @@ func (c *containerLXC) Stop(stateful bool) error {
 		}
 
 		c.stateful = true
-		err = db.ContainerSetStateful(c.daemon.db, c.id, true)
+		err = db.ContainerSetStateful(c.state.DB, c.id, true)
 		if err != nil {
 			op.Done(err)
 			logger.Error("Failed stopping container", ctxMap)
@@ -2449,7 +2450,7 @@ func (c *containerLXC) OnStop(target string) error {
 		deviceTaskSchedulerTrigger("container", c.name, "stopped")
 
 		// Record current state
-		err = db.ContainerSetState(c.daemon.db, c.id, "STOPPED")
+		err = db.ContainerSetState(c.state.DB, c.id, "STOPPED")
 		if err != nil {
 			logger.Error("Failed to set container state", log.Ctx{"container": c.Name(), "err": err})
 		}
@@ -2649,7 +2650,7 @@ func (c *containerLXC) RenderState() (*api.ContainerState, error) {
 
 func (c *containerLXC) Snapshots() ([]container, error) {
 	// Get all the snapshots
-	snaps, err := db.ContainerGetSnapshots(c.daemon.db, c.name)
+	snaps, err := db.ContainerGetSnapshots(c.state.DB, c.name)
 	if err != nil {
 		return nil, err
 	}
@@ -2657,7 +2658,7 @@ func (c *containerLXC) Snapshots() ([]container, error) {
 	// Build the snapshot list
 	containers := []container{}
 	for _, snapName := range snaps {
-		snap, err := containerLoadByName(c.daemon, snapName)
+		snap, err := containerLoadByName(c.state, snapName)
 		if err != nil {
 			return nil, err
 		}
@@ -2840,7 +2841,7 @@ func (c *containerLXC) Delete() error {
 		}
 	} else {
 		// Remove all snapshot
-		if err := containerDeleteSnapshots(c.daemon, c.Name()); err != nil {
+		if err := containerDeleteSnapshots(c.state, c.Name()); err != nil {
 			logger.Warn("Failed to delete snapshots", log.Ctx{"name": c.Name(), "err": err})
 			return err
 		}
@@ -2858,7 +2859,7 @@ func (c *containerLXC) Delete() error {
 	}
 
 	// Remove the database record
-	if err := db.ContainerRemove(c.daemon.db, c.Name()); err != nil {
+	if err := db.ContainerRemove(c.state.DB, c.Name()); err != nil {
 		logger.Error("Failed deleting container entry", log.Ctx{"name": c.Name(), "err": err})
 		return err
 	}
@@ -2871,14 +2872,14 @@ func (c *containerLXC) Delete() error {
 		poolID, _ := c.storage.GetContainerPoolInfo()
 
 		// Remove volume from storage pool.
-		err := db.StoragePoolVolumeDelete(c.daemon.db, c.Name(), storagePoolVolumeTypeContainer, poolID)
+		err := db.StoragePoolVolumeDelete(c.state.DB, c.Name(), storagePoolVolumeTypeContainer, poolID)
 		if err != nil {
 			return err
 		}
 	}
 
 	// Update network files
-	networkUpdateStatic(c.daemon, "")
+	networkUpdateStatic(c.state, "")
 	for k, m := range c.expandedDevices {
 		if m["type"] != "nic" || m["nictype"] != "bridged" || (m["ipv4.address"] == "" && m["ipv6.address"] == "") {
 			continue
@@ -2889,7 +2890,7 @@ func (c *containerLXC) Delete() error {
 			continue
 		}
 
-		networkClearLease(c.daemon, m["parent"], m["hwaddr"])
+		networkClearLease(c.state, m["parent"], m["hwaddr"])
 	}
 
 	logger.Info("Deleted container", ctxMap)
@@ -2951,7 +2952,7 @@ func (c *containerLXC) Rename(newName string) error {
 	}
 
 	// Rename the database entry
-	err = db.ContainerRename(c.daemon.db, oldName, newName)
+	err = db.ContainerRename(c.state.DB, oldName, newName)
 	if err != nil {
 		logger.Error("Failed renaming container", ctxMap)
 		return err
@@ -2959,7 +2960,7 @@ func (c *containerLXC) Rename(newName string) error {
 
 	// Rename storage volume for the container.
 	poolID, _ := c.storage.GetContainerPoolInfo()
-	err = db.StoragePoolVolumeRename(c.daemon.db, oldName, newName, storagePoolVolumeTypeContainer, poolID)
+	err = db.StoragePoolVolumeRename(c.state.DB, oldName, newName, storagePoolVolumeTypeContainer, poolID)
 	if err != nil {
 		logger.Error("Failed renaming storage volume", ctxMap)
 		return err
@@ -2967,7 +2968,7 @@ func (c *containerLXC) Rename(newName string) error {
 
 	if !c.IsSnapshot() {
 		// Rename all the snapshots
-		results, err := db.ContainerGetSnapshots(c.daemon.db, oldName)
+		results, err := db.ContainerGetSnapshots(c.state.DB, oldName)
 		if err != nil {
 			logger.Error("Failed renaming container", ctxMap)
 			return err
@@ -2977,14 +2978,14 @@ func (c *containerLXC) Rename(newName string) error {
 			// Rename the snapshot
 			baseSnapName := filepath.Base(sname)
 			newSnapshotName := newName + shared.SnapshotDelimiter + baseSnapName
-			err := db.ContainerRename(c.daemon.db, sname, newSnapshotName)
+			err := db.ContainerRename(c.state.DB, sname, newSnapshotName)
 			if err != nil {
 				logger.Error("Failed renaming container", ctxMap)
 				return err
 			}
 
 			// Rename storage volume for the snapshot.
-			err = db.StoragePoolVolumeRename(c.daemon.db, sname, newSnapshotName, storagePoolVolumeTypeContainer, poolID)
+			err = db.StoragePoolVolumeRename(c.state.DB, sname, newSnapshotName, storagePoolVolumeTypeContainer, poolID)
 			if err != nil {
 				logger.Error("Failed renaming storage volume", ctxMap)
 				return err
@@ -3107,13 +3108,13 @@ func writeBackupFile(c container) error {
 		return err
 	}
 
-	d := c.Daemon()
-	poolID, pool, err := db.StoragePoolGet(d.db, poolName)
+	s := c.StateObject()
+	poolID, pool, err := db.StoragePoolGet(s.DB, poolName)
 	if err != nil {
 		return err
 	}
 
-	_, volume, err := db.StoragePoolVolumeGetType(d.db, c.Name(), storagePoolVolumeTypeContainer, poolID)
+	_, volume, err := db.StoragePoolVolumeGetType(s.DB, c.Name(), storagePoolVolumeTypeContainer, poolID)
 	if err != nil {
 		return err
 	}
@@ -3166,19 +3167,19 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	// Validate the new config
-	err := containerValidConfig(c.daemon.os, args.Config, false, false)
+	err := containerValidConfig(c.state.OS, args.Config, false, false)
 	if err != nil {
 		return err
 	}
 
 	// Validate the new devices
-	err = containerValidDevices(c.daemon.db, args.Devices, false, false)
+	err = containerValidDevices(c.state.DB, args.Devices, false, false)
 	if err != nil {
 		return err
 	}
 
 	// Validate the new profiles
-	profiles, err := db.Profiles(c.daemon.db)
+	profiles, err := db.Profiles(c.state.DB)
 	if err != nil {
 		return err
 	}
@@ -3326,13 +3327,13 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	removeDevices, addDevices, updateDevices := oldExpandedDevices.Update(c.expandedDevices)
 
 	// Do some validation of the config diff
-	err = containerValidConfig(c.daemon.os, c.expandedConfig, false, true)
+	err = containerValidConfig(c.state.OS, c.expandedConfig, false, true)
 	if err != nil {
 		return err
 	}
 
 	// Do some validation of the devices diff
-	err = containerValidDevices(c.daemon.db, c.expandedDevices, false, true)
+	err = containerValidDevices(c.state.DB, c.expandedDevices, false, true)
 	if err != nil {
 		return err
 	}
@@ -3364,7 +3365,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 		if !c.IsPrivileged() {
 			// update the idmap
 			idmap, base, err = findIdmap(
-				c.daemon,
+				c.state,
 				c.Name(),
 				c.expandedConfig["security.idmap.isolated"],
 				c.expandedConfig["security.idmap.base"],
@@ -4012,7 +4013,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	// Finally, apply the changes to the database
-	tx, err := db.Begin(c.daemon.db)
+	tx, err := db.Begin(c.state.DB)
 	if err != nil {
 		return err
 	}
@@ -4072,7 +4073,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	if needsUpdate {
-		networkUpdateStatic(c.daemon, "")
+		networkUpdateStatic(c.state, "")
 	}
 
 	// Success, update the closure to mark that the changes should be kept.
@@ -4158,7 +4159,7 @@ func (c *containerLXC) Export(w io.Writer, properties map[string]string) error {
 		var arch string
 		if c.IsSnapshot() {
 			parentName, _, _ := containerGetParentAndSnapshotName(c.name)
-			parent, err := containerLoadByName(c.daemon, parentName)
+			parent, err := containerLoadByName(c.state, parentName)
 			if err != nil {
 				tw.Close()
 				logger.Error("Failed exporting container", ctxMap)
@@ -4171,7 +4172,7 @@ func (c *containerLXC) Export(w io.Writer, properties map[string]string) error {
 		}
 
 		if arch == "" {
-			arch, err = osarch.ArchitectureName(c.daemon.os.Architectures[0])
+			arch, err = osarch.ArchitectureName(c.state.OS.Architectures[0])
 			if err != nil {
 				logger.Error("Failed exporting container", ctxMap)
 				return err
@@ -4429,7 +4430,7 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 			execPath,
 			"forkmigrate",
 			c.name,
-			c.daemon.os.LxcPath,
+			c.state.OS.LxcPath,
 			configPath,
 			stateDir,
 			fmt.Sprintf("%v", preservesInodes))
@@ -4601,7 +4602,7 @@ func (c *containerLXC) templateApplyNow(trigger string) error {
 		// Figure out the architecture
 		arch, err := osarch.ArchitectureName(c.architecture)
 		if err != nil {
-			arch, err = osarch.ArchitectureName(c.daemon.os.Architectures[0])
+			arch, err = osarch.ArchitectureName(c.state.OS.Architectures[0])
 			if err != nil {
 				return err
 			}
@@ -4967,7 +4968,7 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 		envSlice = append(envSlice, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	args := []string{execPath, "forkexec", c.name, c.daemon.os.LxcPath, filepath.Join(c.LogPath(), "lxc.conf")}
+	args := []string{execPath, "forkexec", c.name, c.state.OS.LxcPath, filepath.Join(c.LogPath(), "lxc.conf")}
 
 	args = append(args, "--")
 	args = append(args, "env")
@@ -5937,7 +5938,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 		}
 
 		// Attempt to include all existing interfaces
-		cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
+		cc, err := lxc.NewContainer(c.Name(), c.state.OS.LxcPath)
 		if err == nil {
 			interfaces, err := cc.Interfaces()
 			if err == nil {
@@ -5964,7 +5965,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 	}
 
 	updateKey := func(key string, value string) error {
-		tx, err := db.Begin(c.daemon.db)
+		tx, err := db.Begin(c.state.DB)
 		if err != nil {
 			return err
 		}
@@ -5998,7 +5999,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 			err = updateKey(configKey, volatileHwaddr)
 			if err != nil {
 				// Check if something else filled it in behind our back
-				value, err1 := db.ContainerConfigGet(c.daemon.db, c.id, configKey)
+				value, err1 := db.ContainerConfigGet(c.state.DB, c.id, configKey)
 				if err1 != nil || value == "" {
 					return nil, err
 				}
@@ -6028,7 +6029,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 			err = updateKey(configKey, volatileName)
 			if err != nil {
 				// Check if something else filled it in behind our back
-				value, err1 := db.ContainerConfigGet(c.daemon.db, c.id, configKey)
+				value, err1 := db.ContainerConfigGet(c.state.DB, c.id, configKey)
 				if err1 != nil || value == "" {
 					return nil, err
 				}
@@ -6180,7 +6181,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	}
 
 	// For some reason, having network config confuses detach, so get our own go-lxc struct
-	cc, err := lxc.NewContainer(c.Name(), c.daemon.os.LxcPath)
+	cc, err := lxc.NewContainer(c.Name(), c.state.OS.LxcPath)
 	if err != nil {
 		return err
 	}
@@ -6265,7 +6266,7 @@ func (c *containerLXC) createDiskDevice(name string, m types.Device) (string, er
 		// Initialize a new storage interface and check if the
 		// pool/volume is mounted. If it is not, mount it.
 		volumeType, _ := storagePoolVolumeTypeNameToType(volumeTypeName)
-		s, err := storagePoolVolumeAttachInit(c.daemon, m["pool"], volumeName, volumeType, c)
+		s, err := storagePoolVolumeAttachInit(c.state, m["pool"], volumeName, volumeType, c)
 		if err != nil && !isOptional {
 			return "", fmt.Errorf("Failed to initialize storage volume \"%s\" of type \"%s\" on storage pool \"%s\": %s.",
 				volumeName,
@@ -6902,8 +6903,8 @@ func (c *containerLXC) NextIdmapSet() (*shared.IdmapSet, error) {
 		return c.idmapsetFromConfig("volatile.idmap.next")
 	} else if c.IsPrivileged() {
 		return nil, nil
-	} else if c.daemon.os.IdmapSet != nil {
-		return c.daemon.os.IdmapSet, nil
+	} else if c.state.OS.IdmapSet != nil {
+		return c.state.OS.IdmapSet, nil
 	}
 
 	return nil, fmt.Errorf("Unable to determine the idmap")
@@ -6913,9 +6914,9 @@ func (c *containerLXC) LastIdmapSet() (*shared.IdmapSet, error) {
 	return c.idmapsetFromConfig("volatile.last_state.idmap")
 }
 
-func (c *containerLXC) Daemon() *Daemon {
+func (c *containerLXC) StateObject() *state.State {
 	// FIXME: This function should go away
-	return c.daemon
+	return c.state
 }
 
 func (c *containerLXC) Name() string {
@@ -6982,7 +6983,7 @@ func (c *containerLXC) StatePath() string {
 }
 
 func (c *containerLXC) StoragePool() (string, error) {
-	poolName, err := db.ContainerPool(c.daemon.db, c.Name())
+	poolName, err := db.ContainerPool(c.state.DB, c.Name())
 	if err != nil {
 		return "", err
 	}

--- a/lxd/container_metadata.go
+++ b/lxd/container_metadata.go
@@ -20,7 +20,7 @@ import (
 
 func containerMetadataGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -53,7 +53,7 @@ func containerMetadataGet(d *Daemon, r *http.Request) Response {
 
 func containerMetadataPut(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -87,7 +87,7 @@ func containerMetadataPut(d *Daemon, r *http.Request) Response {
 // Return a list of templates used in a container or the content of a template
 func containerMetadataTemplatesGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -154,7 +154,7 @@ func containerMetadataTemplatesGet(d *Daemon, r *http.Request) Response {
 // Add a container template file
 func containerMetadataTemplatesPostPut(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -197,7 +197,7 @@ func containerMetadataTemplatesPostPut(d *Daemon, r *http.Request) Response {
 // Delete a container template
 func containerMetadataTemplatesDelete(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_patch.go
+++ b/lxd/container_patch.go
@@ -19,7 +19,7 @@ import (
 func containerPatch(d *Daemon, r *http.Request) Response {
 	// Get the container
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return NotFound
 	}

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -15,7 +15,7 @@ import (
 
 func containerPost(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -22,7 +22,7 @@ import (
 func containerPut(d *Daemon, r *http.Request) Response {
 	// Get the container
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return NotFound
 	}
@@ -89,12 +89,12 @@ func containerSnapRestore(d *Daemon, name string, snap string, stateful bool) er
 		snap = name + shared.SnapshotDelimiter + snap
 	}
 
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return err
 	}
 
-	source, err := containerLoadByName(d, snap)
+	source, err := containerLoadByName(d.State(), snap)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -24,7 +24,7 @@ func containerSnapshotsGet(d *Daemon, r *http.Request) Response {
 	}
 
 	cname := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, cname)
+	c, err := containerLoadByName(d.State(), cname)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -104,7 +104,7 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 	 * 2. copy the database info over
 	 * 3. copy over the rootfs
 	 */
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -145,7 +145,7 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 			Stateful:     req.Stateful,
 		}
 
-		_, err := containerCreateAsSnapshot(d, args, c)
+		_, err := containerCreateAsSnapshot(d.State(), args, c)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func snapshotHandler(d *Daemon, r *http.Request) Response {
 	snapshotName := mux.Vars(r)["snapshotName"]
 
 	sc, err := containerLoadByName(
-		d,
+		d.State(),
 		containerName+
 			shared.SnapshotDelimiter+
 			snapshotName)

--- a/lxd/container_state.go
+++ b/lxd/container_state.go
@@ -15,7 +15,7 @@ import (
 
 func containerState(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -44,7 +44,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 	// Don't mess with containers while in setup mode
 	<-d.readyChan
 
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -22,7 +22,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesDefault() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -59,7 +59,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesMulti() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -87,7 +87,7 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 		Name: "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 
 	suite.True(c.IsPrivileged(), "This container should be privileged.")
@@ -118,12 +118,12 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	}
 
 	// Create the container
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
 	// Load the container and trigger initLXC()
-	c2, err := containerLoadByName(suite.d, "testFoo")
+	c2, err := containerLoadByName(suite.d.State(), "testFoo")
 	c2.IsRunning()
 	suite.Req.Nil(err)
 	_, err = c2.StorageStart()
@@ -143,7 +143,7 @@ func (suite *containerTestSuite) TestContainer_Path_Regular() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -160,7 +160,7 @@ func (suite *containerTestSuite) TestContainer_Path_Snapshot() {
 		Name:      "test/snap0",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -180,7 +180,7 @@ func (suite *containerTestSuite) TestContainer_LogPath() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -195,7 +195,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Privileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 
 	suite.Req.True(c.IsPrivileged(), "This container should be privileged.")
@@ -210,7 +210,7 @@ func (suite *containerTestSuite) TestContainer_IsPrivileged_Unprivileged() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 
 	suite.Req.False(c.IsPrivileged(), "This container should be unprivileged.")
@@ -224,7 +224,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 		Name:      "testFoo",
 	}
 
-	c, err := containerCreateInternal(suite.d, args)
+	c, err := containerCreateInternal(suite.d.State(), args)
 	suite.Req.Nil(err)
 	defer c.Delete()
 
@@ -233,7 +233,7 @@ func (suite *containerTestSuite) TestContainer_Rename() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
-	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+	c1, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
@@ -243,7 +243,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	suite.Req.Nil(err)
 	defer c1.Delete()
 
-	c2, err := containerCreateInternal(suite.d, db.ContainerArgs{
+	c2, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 		Ctype: db.CTypeRegular,
 		Name:  "isol-2",
 		Config: map[string]string{
@@ -274,7 +274,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
-	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+	c1, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
@@ -284,7 +284,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	suite.Req.Nil(err)
 	defer c1.Delete()
 
-	c2, err := containerCreateInternal(suite.d, db.ContainerArgs{
+	c2, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 		Ctype: db.CTypeRegular,
 		Name:  "isol-2",
 		Config: map[string]string{
@@ -315,7 +315,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 }
 
 func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
-	c1, err := containerCreateInternal(suite.d, db.ContainerArgs{
+	c1, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 		Ctype: db.CTypeRegular,
 		Name:  "isol-1",
 		Config: map[string]string{
@@ -354,7 +354,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 	maps := []*shared.IdmapSet{}
 
 	for i := 0; i < 7; i++ {
-		c, err := containerCreateInternal(suite.d, db.ContainerArgs{
+		c, err := containerCreateInternal(suite.d.State(), db.ContainerArgs{
 			Ctype: db.CTypeRegular,
 			Name:  fmt.Sprintf("isol-%d", i),
 			Config: map[string]string{

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 
@@ -106,7 +107,7 @@ func containersRestart(d *Daemon) error {
 	containers := []container{}
 
 	for _, name := range result {
-		c, err := containerLoadByName(d, name)
+		c, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			return err
 		}
@@ -158,7 +159,7 @@ func containersShutdown(d *Daemon) error {
 
 	for _, r := range results {
 		// Load the container
-		c, err := containerLoadByName(d, r)
+		c, err := containerLoadByName(d.State(), r)
 		if err != nil {
 			return err
 		}
@@ -195,17 +196,17 @@ func containersShutdown(d *Daemon) error {
 	return nil
 }
 
-func containerDeleteSnapshots(d *Daemon, cname string) error {
+func containerDeleteSnapshots(s *state.State, cname string) error {
 	logger.Debug("containerDeleteSnapshots",
 		log.Ctx{"container": cname})
 
-	results, err := db.ContainerGetSnapshots(d.db, cname)
+	results, err := db.ContainerGetSnapshots(s.DB, cname)
 	if err != nil {
 		return err
 	}
 
 	for _, sname := range results {
-		sc, err := containerLoadByName(d, sname)
+		sc, err := containerLoadByName(s, sname)
 		if err != nil {
 			logger.Error(
 				"containerDeleteSnapshots: Failed to load the snapshotcontainer",

--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -68,7 +68,7 @@ func doContainersGet(d *Daemon, recursion bool) (interface{}, error) {
 }
 
 func doContainerGet(d *Daemon, cname string) (*api.Container, error) {
-	c, err := containerLoadByName(d, cname)
+	c, err := containerLoadByName(d.State(), cname)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -295,7 +295,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 		}
 	} else {
 		// Retrieve the future storage pool
-		cM, err := containerLXCLoad(d, args)
+		cM, err := containerLXCLoad(d.State(), args)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -415,7 +415,7 @@ func createFromCopy(d *Daemon, req *api.ContainersPost) Response {
 		return BadRequest(fmt.Errorf("must specify a source container"))
 	}
 
-	source, err := containerLoadByName(d, req.Source.Source)
+	source, err := containerLoadByName(d.State(), req.Source.Source)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -125,6 +126,11 @@ func isJSONRequest(r *http.Request) bool {
 	}
 
 	return false
+}
+
+// State creates a new State instance liked to our internal db and os.
+func (d *Daemon) State() *state.State {
+	return state.NewState(d.db, d.os)
 }
 
 func (d *Daemon) createCmd(version string, c Command) {
@@ -866,7 +872,7 @@ func (d *Daemon) numRunningContainers() (int, error) {
 
 	count := 0
 	for _, r := range results {
-		container, err := containerLoadByName(d, r)
+		container, err := containerLoadByName(d.State(), r)
 		if err != nil {
 			continue
 		}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -599,7 +599,7 @@ func deviceTaskBalance(d *Daemon) {
 	fixedContainers := map[int][]container{}
 	balancedContainers := map[container]int{}
 	for _, name := range containers {
-		c, err := containerLoadByName(d, name)
+		c, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			continue
 		}
@@ -724,7 +724,7 @@ func deviceNetworkPriority(d *Daemon, netif string) {
 
 	for _, name := range containers {
 		// Get the container struct
-		c, err := containerLoadByName(d, name)
+		c, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			continue
 		}
@@ -755,7 +755,7 @@ func deviceUSBEvent(d *Daemon, usb usbDevice) {
 	}
 
 	for _, name := range containers {
-		containerIf, err := containerLoadByName(d, name)
+		containerIf, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			continue
 		}

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -345,7 +345,7 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 			parts := strings.Split(string(cmdline), " ")
 			name := strings.TrimSuffix(parts[len(parts)-1], "\x00")
 
-			return containerLoadByName(d, name)
+			return containerLoadByName(d.State(), name)
 		}
 
 		status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
@@ -379,7 +379,7 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 	}
 
 	for _, container := range containers {
-		c, err := containerLoadByName(d, container)
+		c, err := containerLoadByName(d.State(), container)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -240,7 +240,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, builddir st
 		info.Public = false
 	}
 
-	c, err := containerLoadByName(d, name)
+	c, err := containerLoadByName(d.State(), name)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -57,7 +57,7 @@ func cmdActivateIfNeeded() error {
 	}
 
 	for _, name := range result {
-		c, err := containerLoadByName(d, name)
+		c, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			return err
 		}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -16,6 +16,7 @@ import (
 	log "gopkg.in/inconshreveable/log15.v2"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -136,7 +137,7 @@ func networksPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Start the network
-	n, err := networkLoadByName(d, req.Name)
+	n, err := networkLoadByName(d.State(), req.Name)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -188,7 +189,7 @@ func doNetworkGet(d *Daemon, name string) (api.Network, error) {
 	}
 
 	for _, ct := range cts {
-		c, err := containerLoadByName(d, ct)
+		c, err := containerLoadByName(d.State(), ct)
 		if err != nil {
 			return api.Network{}, err
 		}
@@ -229,9 +230,10 @@ func doNetworkGet(d *Daemon, name string) (api.Network, error) {
 
 func networkDelete(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
+	state := d.State()
 
 	// Get the existing network
-	n, err := networkLoadByName(d, name)
+	n, err := networkLoadByName(state, name)
 	if err != nil {
 		return NotFound
 	}
@@ -253,6 +255,7 @@ func networkDelete(d *Daemon, r *http.Request) Response {
 func networkPost(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
 	req := api.NetworkPost{}
+	state := d.State()
 
 	// Parse the request
 	err := json.NewDecoder(r.Body).Decode(&req)
@@ -261,7 +264,7 @@ func networkPost(d *Daemon, r *http.Request) Response {
 	}
 
 	// Get the existing network
-	n, err := networkLoadByName(d, name)
+	n, err := networkLoadByName(state, name)
 	if err != nil {
 		return NotFound
 	}
@@ -372,7 +375,7 @@ func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req ap
 	}
 
 	// Load the network
-	n, err := networkLoadByName(d, name)
+	n, err := networkLoadByName(d.State(), name)
 	if err != nil {
 		return NotFound
 	}
@@ -388,13 +391,13 @@ func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req ap
 var networkCmd = Command{name: "networks/{name}", get: networkGet, delete: networkDelete, post: networkPost, put: networkPut, patch: networkPatch}
 
 // The network structs and functions
-func networkLoadByName(d *Daemon, name string) (*network, error) {
-	id, dbInfo, err := db.NetworkGet(d.db, name)
+func networkLoadByName(s *state.State, name string) (*network, error) {
+	id, dbInfo, err := db.NetworkGet(s.DB, name)
 	if err != nil {
 		return nil, err
 	}
 
-	n := network{daemon: d, id: id, name: name, description: dbInfo.Description, config: dbInfo.Config}
+	n := network{state: s, id: id, name: name, description: dbInfo.Description, config: dbInfo.Config}
 
 	return &n, nil
 }
@@ -408,7 +411,7 @@ func networkStartup(d *Daemon) error {
 
 	// Bring them all up
 	for _, name := range networks {
-		n, err := networkLoadByName(d, name)
+		n, err := networkLoadByName(d.State(), name)
 		if err != nil {
 			return err
 		}
@@ -432,7 +435,7 @@ func networkShutdown(d *Daemon) error {
 
 	// Bring them all up
 	for _, name := range networks {
-		n, err := networkLoadByName(d, name)
+		n, err := networkLoadByName(d.State(), name)
 		if err != nil {
 			return err
 		}
@@ -452,7 +455,7 @@ func networkShutdown(d *Daemon) error {
 
 type network struct {
 	// Properties
-	daemon      *Daemon
+	state       *state.State
 	id          int64
 	name        string
 	description string
@@ -471,13 +474,13 @@ func (n *network) IsRunning() bool {
 
 func (n *network) IsUsed() bool {
 	// Look for containers using the interface
-	cts, err := db.ContainersList(n.daemon.db, db.CTypeRegular)
+	cts, err := db.ContainersList(n.state.DB, db.CTypeRegular)
 	if err != nil {
 		return true
 	}
 
 	for _, ct := range cts {
-		c, err := containerLoadByName(n.daemon, ct)
+		c, err := containerLoadByName(n.state, ct)
 		if err != nil {
 			return true
 		}
@@ -505,7 +508,7 @@ func (n *network) Delete() error {
 	}
 
 	// Remove the network from the database
-	err := db.NetworkDelete(n.daemon.db, n.name)
+	err := db.NetworkDelete(n.state.DB, n.name)
 	if err != nil {
 		return err
 	}
@@ -540,7 +543,7 @@ func (n *network) Rename(name string) error {
 	}
 
 	// Rename the database entry
-	err := db.NetworkRename(n.daemon.db, n.name, name)
+	err := db.NetworkRename(n.state.DB, n.name, name)
 	if err != nil {
 		return err
 	}
@@ -556,7 +559,7 @@ func (n *network) Rename(name string) error {
 
 func (n *network) Start() error {
 	// If we are in mock mode, just no-op.
-	if n.daemon.os.MockMode {
+	if n.state.OS.MockMode {
 		return nil
 	}
 
@@ -1228,7 +1231,7 @@ func (n *network) Start() error {
 		}
 
 		// Update the static leases
-		err = networkUpdateStatic(n.daemon, n.name)
+		err = networkUpdateStatic(n.state, n.name)
 		if err != nil {
 			return err
 		}
@@ -1402,7 +1405,7 @@ func (n *network) Update(newNetwork api.NetworkPut) error {
 	n.description = newNetwork.Description
 
 	// Update the database
-	err = db.NetworkUpdate(n.daemon.db, n.name, n.description, n.config)
+	err = db.NetworkUpdate(n.state.DB, n.name, n.description, n.config)
 	if err != nil {
 		return err
 	}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -723,9 +724,9 @@ func networkKillDnsmasq(name string, reload bool) error {
 	return nil
 }
 
-func networkUpdateStatic(d *Daemon, name string) error {
+func networkUpdateStatic(s *state.State, name string) error {
 	// Get all the containers
-	containers, err := db.ContainersList(d.db, db.CTypeRegular)
+	containers, err := db.ContainersList(s.DB, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -733,7 +734,7 @@ func networkUpdateStatic(d *Daemon, name string) error {
 	networks := []string{}
 	if name == "" {
 		// Get all the networks
-		networks, err = db.Networks(d.db)
+		networks, err = db.Networks(s.DB)
 		if err != nil {
 			return err
 		}
@@ -745,7 +746,7 @@ func networkUpdateStatic(d *Daemon, name string) error {
 	entries := map[string][][]string{}
 	for _, cName := range containers {
 		// Load the container
-		c, err := containerLoadByName(d, cName)
+		c, err := containerLoadByName(s, cName)
 		if err != nil {
 			continue
 		}
@@ -782,7 +783,7 @@ func networkUpdateStatic(d *Daemon, name string) error {
 			continue
 		}
 
-		n, err := networkLoadByName(d, network)
+		n, err := networkLoadByName(s, network)
 		if err != nil {
 			return err
 		}
@@ -874,7 +875,7 @@ func networkGetMacSlice(hwaddr string) []string {
 	return buf
 }
 
-func networkClearLease(d *Daemon, network string, hwaddr string) error {
+func networkClearLease(s *state.State, network string, hwaddr string) error {
 	leaseFile := shared.VarPath("networks", network, "dnsmasq.leases")
 
 	// Check that we are in fact running a dnsmasq for the network
@@ -883,7 +884,7 @@ func networkClearLease(d *Daemon, network string, hwaddr string) error {
 	}
 
 	// Restart the network when we're done here
-	n, err := networkLoadByName(d, network)
+	n, err := networkLoadByName(s, network)
 	if err != nil {
 		return err
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1039,14 +1039,14 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 				// Initialize storage interface for the new
 				// container.
-				ctStorage, err := storagePoolVolumeContainerLoadInit(d, ct)
+				ctStorage, err := storagePoolVolumeContainerLoadInit(d.State(), ct)
 				if err != nil {
 					logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s.", ct, err)
 					return err
 				}
 
 				// Load the container from the database.
-				ctStruct, err := containerLoadByName(d, ct)
+				ctStruct, err := containerLoadByName(d.State(), ct)
 				if err != nil {
 					logger.Errorf("Failed to load LVM container %s: %s.", ct, err)
 					return err
@@ -1192,14 +1192,14 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 					// Initialize storage interface for the new
 					// snapshot.
-					csStorage, err := storagePoolVolumeContainerLoadInit(d, cs)
+					csStorage, err := storagePoolVolumeContainerLoadInit(d.State(), cs)
 					if err != nil {
 						logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s.", cs, err)
 						return err
 					}
 
 					// Load the snapshot from the database.
-					csStruct, err := containerLoadByName(d, cs)
+					csStruct, err := containerLoadByName(d.State(), cs)
 					if err != nil {
 						logger.Errorf("Failed to load LVM container %s: %s.", cs, err)
 						return err
@@ -1773,7 +1773,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 	// Make sure all containers and snapshots have a valid disk configuration
 	for _, ct := range allcontainers {
-		c, err := containerLoadByName(d, ct)
+		c, err := containerLoadByName(d.State(), ct)
 		if err != nil {
 			continue
 		}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -145,7 +145,7 @@ func getContainersWithProfile(d *Daemon, profile string) []container {
 	}
 
 	for _, name := range output {
-		c, err := containerLoadByName(d, name)
+		c, err := containerLoadByName(d.State(), name)
 		if err != nil {
 			logger.Error("Failed opening container", log.Ctx{"container": name})
 			continue

--- a/lxd/state/state.go
+++ b/lxd/state/state.go
@@ -1,0 +1,24 @@
+package state
+
+import (
+	"database/sql"
+
+	"github.com/lxc/lxd/lxd/sys"
+)
+
+// State is a gateway to the two main stateful components of LXD, the database
+// and the operating system. It's typically used by model entities such as
+// containers, volumes, etc. in order to perform changes.
+type State struct {
+	DB *sql.DB
+	OS *sys.OS
+}
+
+// NewState returns a new State object with the given database and operating
+// system components.
+func NewState(db *sql.DB, os *sys.OS) *State {
+	return &State{
+		DB: db,
+		OS: os,
+	}
+}

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -489,7 +489,7 @@ func (s *storageCeph) StoragePoolVolumeDelete() error {
 		s.volume.Name, s.pool.Name)
 
 	err = db.StoragePoolVolumeDelete(
-		s.d.db,
+		s.s.DB,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
 		s.poolID)

--- a/lxd/storage_ceph_migration.go
+++ b/lxd/storage_ceph_migration.go
@@ -178,7 +178,7 @@ func (s *storageCeph) MigrationSource(c container, containerOnly bool) (Migratio
 		}
 
 		lxdName := fmt.Sprintf("%s%s%s", containerName, shared.SnapshotDelimiter, snap[len("snapshot_"):])
-		snapshot, err := containerLoadByName(s.d, lxdName)
+		snapshot, err := containerLoadByName(s.s, lxdName)
 		if err != nil {
 			logger.Errorf(`Failed to load snapshot "%s" for RBD storage volume "%s" on storage pool "%s": %s`, lxdName, containerName, s.pool.Name, err)
 			return nil, err
@@ -267,7 +267,7 @@ func (s *storageCeph) MigrationSink(live bool, c container, snapshots []*Snapsho
 				args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 			}
 		}
-		_, err := containerCreateEmptySnapshot(c.Daemon(), args)
+		_, err := containerCreateEmptySnapshot(c.StateObject(), args)
 		if err != nil {
 			logger.Errorf(`Failed to create empty RBD storage `+
 				`volume for container "%s" on storage pool "%s: %s`,

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -216,7 +216,7 @@ func (s *storageDir) StoragePoolVolumeDelete() error {
 	}
 
 	err = db.StoragePoolVolumeDelete(
-		s.d.db,
+		s.s.DB,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
 		s.poolID)
@@ -475,14 +475,14 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 	}
 
 	for _, snap := range snapshots {
-		sourceSnapshot, err := containerLoadByName(s.d, snap.Name())
+		sourceSnapshot, err := containerLoadByName(s.s, snap.Name())
 		if err != nil {
 			return err
 		}
 
 		_, snapOnlyName, _ := containerGetParentAndSnapshotName(snap.Name())
 		newSnapName := fmt.Sprintf("%s/%s", target.Name(), snapOnlyName)
-		targetSnapshot, err := containerLoadByName(s.d, newSnapName)
+		targetSnapshot, err := containerLoadByName(s.s, newSnapName)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -283,7 +283,7 @@ func (s *storageLvm) StoragePoolCreate() error {
 		}
 
 		// Check that we don't already use this volume group.
-		inUse, user, err := lxdUsesPool(s.d.db, poolName, s.pool.Driver, "lvm.vg_name")
+		inUse, user, err := lxdUsesPool(s.s.DB, poolName, s.pool.Driver, "lvm.vg_name")
 		if err != nil {
 			return err
 		}
@@ -471,7 +471,7 @@ func (s *storageLvm) StoragePoolVolumeCreate() error {
 	}
 
 	if s.useThinpool {
-		err = lvmCreateThinpool(s.d, s.sTypeVersion, poolName, thinPoolName, lvFsType)
+		err = lvmCreateThinpool(s.s, s.sTypeVersion, poolName, thinPoolName, lvFsType)
 		if err != nil {
 			return err
 		}
@@ -545,7 +545,7 @@ func (s *storageLvm) StoragePoolVolumeDelete() error {
 	}
 
 	err = db.StoragePoolVolumeDelete(
-		s.d.db,
+		s.s.DB,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
 		s.poolID)
@@ -837,7 +837,7 @@ func (s *storageLvm) ContainerCreate(container container) error {
 
 	poolName := s.getOnDiskPoolName()
 	if s.useThinpool {
-		err = lvmCreateThinpool(s.d, s.sTypeVersion, poolName, thinPoolName, lvFsType)
+		err = lvmCreateThinpool(s.s, s.sTypeVersion, poolName, thinPoolName, lvFsType)
 		if err != nil {
 			return err
 		}
@@ -1064,12 +1064,12 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 
 		logger.Debugf("Copying LVM container storage for snapshot %s -> %s.", snap.Name(), newSnapName)
 
-		sourceSnapshot, err := containerLoadByName(s.d, snap.Name())
+		sourceSnapshot, err := containerLoadByName(s.s, snap.Name())
 		if err != nil {
 			return err
 		}
 
-		targetSnapshot, err := containerLoadByName(s.d, newSnapName)
+		targetSnapshot, err := containerLoadByName(s.s, newSnapName)
 		if err != nil {
 			return err
 		}
@@ -1514,7 +1514,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 	}()
 
 	if s.useThinpool {
-		err = lvmCreateThinpool(s.d, s.sTypeVersion, poolName, thinPoolName, lvFsType)
+		err = lvmCreateThinpool(s.s, s.sTypeVersion, poolName, thinPoolName, lvFsType)
 		if err != nil {
 			return err
 		}
@@ -1710,7 +1710,7 @@ func (s *storageLvm) StorageEntitySetQuota(volumeType int, size int64, data inte
 	// Update the database
 	s.volume.Config["size"] = shared.GetByteSizeString(size, 0)
 	err = db.StoragePoolVolumeUpdate(
-		s.d.db,
+		s.s.DB,
 		s.volume.Name,
 		volumeType,
 		s.poolID,

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -669,10 +670,10 @@ func storageLVMThinpoolExists(vgName string, poolName string) (bool, error) {
 	return false, fmt.Errorf("pool named \"%s\" exists but is not a thin pool", poolName)
 }
 
-func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
+func storageLVMGetThinPoolUsers(s *state.State) ([]string, error) {
 	results := []string{}
 
-	cNames, err := db.ContainersList(d.db, db.CTypeRegular)
+	cNames, err := db.ContainersList(s.DB, db.CTypeRegular)
 	if err != nil {
 		return results, err
 	}
@@ -690,7 +691,7 @@ func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 		}
 	}
 
-	imageNames, err := db.ImagesGet(d.db, false)
+	imageNames, err := db.ImagesGet(s.DB, false)
 	if err != nil {
 		return results, err
 	}
@@ -705,8 +706,8 @@ func storageLVMGetThinPoolUsers(d *Daemon) ([]string, error) {
 	return results, nil
 }
 
-func storageLVMValidateThinPoolName(d *Daemon, vgName string, value string) error {
-	users, err := storageLVMGetThinPoolUsers(d)
+func storageLVMValidateThinPoolName(s *state.State, vgName string, value string) error {
+	users, err := storageLVMGetThinPoolUsers(s)
 	if err != nil {
 		return fmt.Errorf("error checking if a pool is already in use: %v", err)
 	}
@@ -818,7 +819,7 @@ func lvmCreateLv(vgName string, thinPoolName string, lvName string, lvFsType str
 	return nil
 }
 
-func lvmCreateThinpool(d *Daemon, sTypeVersion string, vgName string, thinPoolName string, lvFsType string) error {
+func lvmCreateThinpool(s *state.State, sTypeVersion string, vgName string, thinPoolName string, lvFsType string) error {
 	exists, err := storageLVMThinpoolExists(vgName, thinPoolName)
 	if err != nil {
 		return err
@@ -833,7 +834,7 @@ func lvmCreateThinpool(d *Daemon, sTypeVersion string, vgName string, thinPoolNa
 		return err
 	}
 
-	err = storageLVMValidateThinPoolName(d, vgName, thinPoolName)
+	err = storageLVMValidateThinPoolName(s, vgName, thinPoolName)
 	if err != nil {
 		logger.Errorf("Setting thin pool name: %s.", err)
 		return fmt.Errorf("Error setting LVM thin pool config: %v", err)

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -163,7 +163,7 @@ func rsyncMigrationSink(live bool, container container, snapshots []*Snapshot, c
 					}
 				}
 
-				s, err := containerCreateEmptySnapshot(container.Daemon(), args)
+				s, err := containerCreateEmptySnapshot(container.StateObject(), args)
 				if err != nil {
 					return err
 				}
@@ -213,7 +213,7 @@ func rsyncMigrationSink(live bool, container container, snapshots []*Snapshot, c
 					return err
 				}
 
-				_, err = containerCreateAsSnapshot(container.Daemon(), args, container)
+				_, err = containerCreateAsSnapshot(container.StateObject(), args, container)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage_shared.go
+++ b/lxd/storage_shared.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -14,7 +15,7 @@ type storageShared struct {
 	sTypeName    string
 	sTypeVersion string
 
-	d *Daemon
+	s *state.State
 
 	poolID int64
 	pool   *api.StoragePool
@@ -107,7 +108,7 @@ func (s *storageShared) createImageDbPoolVolume(fingerprint string) error {
 	}
 
 	// Create a db entry for the storage volume of the image.
-	_, err = db.StoragePoolVolumeCreate(s.d.db, fingerprint, "", storagePoolVolumeTypeImage, s.poolID, volumeConfig)
+	_, err = db.StoragePoolVolumeCreate(s.s.DB, fingerprint, "", storagePoolVolumeTypeImage, s.poolID, volumeConfig)
 	if err != nil {
 		// Try to delete the db entry on error.
 		s.deleteImageDbPoolVolume(fingerprint)
@@ -118,7 +119,7 @@ func (s *storageShared) createImageDbPoolVolume(fingerprint string) error {
 }
 
 func (s *storageShared) deleteImageDbPoolVolume(fingerprint string) error {
-	err := db.StoragePoolVolumeDelete(s.d.db, fingerprint, storagePoolVolumeTypeImage, s.poolID)
+	err := db.StoragePoolVolumeDelete(s.s.DB, fingerprint, storagePoolVolumeTypeImage, s.poolID)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -407,7 +407,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 		}
 	}
 
-	s, err := storagePoolVolumeInit(d, poolName, volumeName, volumeType)
+	s, err := storagePoolVolumeInit(d.State(), poolName, volumeName, volumeType)
 	if err != nil {
 		return NotFound
 	}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -415,7 +415,7 @@ func (s *storageZfs) StoragePoolVolumeDelete() error {
 	}
 
 	err = db.StoragePoolVolumeDelete(
-		s.d.db,
+		s.s.DB,
 		s.volume.Name,
 		storagePoolVolumeTypeCustom,
 		s.poolID)
@@ -1265,7 +1265,7 @@ func (s *storageZfs) ContainerCopy(target container, source container, container
 				prev = snapshots[i-1].Name()
 			}
 
-			sourceSnapshot, err := containerLoadByName(s.d, snap.Name())
+			sourceSnapshot, err := containerLoadByName(s.s, snap.Name())
 			if err != nil {
 				return err
 			}
@@ -1273,7 +1273,7 @@ func (s *storageZfs) ContainerCopy(target container, source container, container
 			_, snapOnlyName, _ := containerGetParentAndSnapshotName(snap.Name())
 			prevSnapOnlyName = snapOnlyName
 			newSnapName := fmt.Sprintf("%s/%s", target.Name(), snapOnlyName)
-			targetSnapshot, err := containerLoadByName(s.d, newSnapName)
+			targetSnapshot, err := containerLoadByName(s.s, newSnapName)
 			if err != nil {
 				return err
 			}
@@ -2102,7 +2102,7 @@ func (s *storageZfs) MigrationSource(ct container, containerOnly bool) (Migratio
 		}
 
 		lxdName := fmt.Sprintf("%s%s%s", ct.Name(), shared.SnapshotDelimiter, snap[len("snapshot-"):])
-		snapshot, err := containerLoadByName(s.d, lxdName)
+		snapshot, err := containerLoadByName(s.s, lxdName)
 		if err != nil {
 			return nil, err
 		}
@@ -2209,7 +2209,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 				args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 			}
 		}
-		_, err := containerCreateEmptySnapshot(container.Daemon(), args)
+		_, err := containerCreateEmptySnapshot(container.StateObject(), args)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This branch adds a new State struct which is a more focused version of
Daemon, only containing handles to the two components that model
entities need: sql.DB and sys.OS.

Then, update all model entities and associated functions to use State
instead of Daemon.

It's not possible to split this commit in smaller chunks since
everything is interdependent (e.g. replacing the containerLXD.daemon
with containerLXD.state cascades down to everything else).

Later down the road, State will be used as handle also in higher-level
HTTP-related APIs.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>