### PR TITLE
Fix sorting order of devices

### DIFF
--- a/lxd/types/devices.go
+++ b/lxd/types/devices.go
@@ -132,14 +132,19 @@ func (devices sortableDevices) Less(i, j int) bool {
 	a := devices[i]
 	b := devices[j]
 
-	if a.device["type"] == "disk" && b.device["type"] == "disk" {
-		if a.device["path"] == b.device["path"] {
-			return a.name < b.name
-		}
-
-		return a.device["path"] < b.device["path"]
+	// First sort by types
+	if a.device["type"] != b.device["type"] {
+		return a.device["type"] < b.device["type"]
 	}
 
+	// Special case disk paths
+	if a.device["type"] == "disk" && b.device["type"] == "disk" {
+		if a.device["path"] != b.device["path"] {
+			return a.device["path"] < b.device["path"]
+		}
+	}
+
+	// Fallback to sorting by names
 	return a.name < b.name
 }
 

--- a/lxd/types/devices_test.go
+++ b/lxd/types/devices_test.go
@@ -13,7 +13,7 @@ func TestSortableDevices(t *testing.T) {
 		"2": Device{"type": "nic"},
 	}
 
-	expected := []string{"1", "2", "4", "3"}
+	expected := []string{"4", "3", "1", "2"}
 
 	result := devices.DeviceNames()
 	if !reflect.DeepEqual(result, expected) {


### PR DESCRIPTION
Make sure we always get the exact same order.

Closes #2895

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>