### PR TITLE
Finish replacing Daemon with State also in higher-level entity APIs

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -205,7 +205,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 
 	if poolErr == db.NoSuchObjectError {
 		// Create the storage pool db entry if it doesn't exist.
-		err := storagePoolDBCreate(d, containerPoolName, "", backup.Pool.Driver, backup.Pool.Config)
+		err := storagePoolDBCreate(d.State(), containerPoolName, "", backup.Pool.Driver, backup.Pool.Config)
 		if err != nil {
 			return SmartError(err)
 		}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -540,9 +540,9 @@ func containerCreateEmptySnapshot(s *state.State, args db.ContainerArgs) (contai
 	return c, nil
 }
 
-func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (container, error) {
+func containerCreateFromImage(s *state.State, args db.ContainerArgs, hash string) (container, error) {
 	// Get the image properties
-	_, img, err := db.ImageGet(d.db, hash, false, false)
+	_, img, err := db.ImageGet(s.DB, hash, false, false)
 	if err != nil {
 		return nil, err
 	}
@@ -558,12 +558,12 @@ func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (co
 	args.BaseImage = hash
 
 	// Create the container
-	c, err := containerCreateInternal(d.State(), args)
+	c, err := containerCreateInternal(s, args)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := db.ImageLastAccessUpdate(d.db, hash, time.Now().UTC()); err != nil {
+	if err := db.ImageLastAccessUpdate(s.DB, hash, time.Now().UTC()); err != nil {
 		return nil, fmt.Errorf("Error updating image last use date: %s", err)
 	}
 
@@ -583,9 +583,9 @@ func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (co
 	return c, nil
 }
 
-func containerCreateAsCopy(d *Daemon, args db.ContainerArgs, sourceContainer container, containerOnly bool) (container, error) {
+func containerCreateAsCopy(s *state.State, args db.ContainerArgs, sourceContainer container, containerOnly bool) (container, error) {
 	// Create the container.
-	ct, err := containerCreateInternal(d.State(), args)
+	ct, err := containerCreateInternal(s, args)
 	if err != nil {
 		return nil, err
 	}
@@ -612,7 +612,7 @@ func containerCreateAsCopy(d *Daemon, args db.ContainerArgs, sourceContainer con
 			}
 
 			// Create the snapshots.
-			cs, err := containerCreateInternal(d.State(), csArgs)
+			cs, err := containerCreateInternal(s, csArgs)
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gorilla/mux"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -68,7 +69,7 @@ func containerPut(d *Daemon, r *http.Request) Response {
 	} else {
 		// Snapshot Restore
 		do = func(op *operation) error {
-			return containerSnapRestore(d, name, configRaw.Restore, configRaw.Stateful)
+			return containerSnapRestore(d.State(), name, configRaw.Restore, configRaw.Stateful)
 		}
 	}
 
@@ -83,18 +84,18 @@ func containerPut(d *Daemon, r *http.Request) Response {
 	return OperationResponse(op)
 }
 
-func containerSnapRestore(d *Daemon, name string, snap string, stateful bool) error {
+func containerSnapRestore(s *state.State, name string, snap string, stateful bool) error {
 	// normalize snapshot name
 	if !shared.IsSnapshot(snap) {
 		snap = name + shared.SnapshotDelimiter + snap
 	}
 
-	c, err := containerLoadByName(d.State(), name)
+	c, err := containerLoadByName(s, name)
 	if err != nil {
 		return err
 	}
 
-	source, err := containerLoadByName(d.State(), snap)
+	source, err := containerLoadByName(s, snap)
 	if err != nil {
 		switch err {
 		case sql.ErrNoRows:

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -97,9 +97,9 @@ func (slice containerAutostartList) Swap(i, j int) {
 	slice[i], slice[j] = slice[j], slice[i]
 }
 
-func containersRestart(d *Daemon) error {
+func containersRestart(s *state.State) error {
 	// Get all the containers
-	result, err := db.ContainersList(d.db, db.CTypeRegular)
+	result, err := db.ContainersList(s.DB, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -107,7 +107,7 @@ func containersRestart(d *Daemon) error {
 	containers := []container{}
 
 	for _, name := range result {
-		c, err := containerLoadByName(d.State(), name)
+		c, err := containerLoadByName(s, name)
 		if err != nil {
 			return err
 		}
@@ -142,24 +142,24 @@ func containersRestart(d *Daemon) error {
 	return nil
 }
 
-func containersShutdown(d *Daemon) error {
+func containersShutdown(s *state.State) error {
 	var wg sync.WaitGroup
 
 	// Get all the containers
-	results, err := db.ContainersList(d.db, db.CTypeRegular)
+	results, err := db.ContainersList(s.DB, db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Reset all container states
-	_, err = db.Exec(d.db, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
+	_, err = db.Exec(s.DB, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
 	if err != nil {
 		return err
 	}
 
 	for _, r := range results {
 		// Load the container
-		c, err := containerLoadByName(d.State(), r)
+		c, err := containerLoadByName(s, r)
 		if err != nil {
 			return err
 		}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -114,7 +114,7 @@ func createFromImage(d *Daemon, req *api.ContainersPost) Response {
 			return err
 		}
 
-		_, err = containerCreateFromImage(d, args, info.Fingerprint)
+		_, err = containerCreateFromImage(d.State(), args, info.Fingerprint)
 		return err
 	}
 
@@ -311,13 +311,13 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 
 		storagePool = rootDiskDevice["pool"]
 
-		ps, err := storagePoolInit(d, storagePool)
+		ps, err := storagePoolInit(d.State(), storagePool)
 		if err != nil {
 			return InternalError(err)
 		}
 
 		if ps.MigrationType() == MigrationFSType_RSYNC {
-			c, err = containerCreateFromImage(d, args, req.Source.BaseImage)
+			c, err = containerCreateFromImage(d.State(), args, req.Source.BaseImage)
 			if err != nil {
 				return InternalError(err)
 			}
@@ -486,7 +486,7 @@ func createFromCopy(d *Daemon, req *api.ContainersPost) Response {
 	}
 
 	run := func(op *operation) error {
-		_, err := containerCreateAsCopy(d, args, source, req.Source.ContainerOnly)
+		_, err := containerCreateAsCopy(d.State(), args, source, req.Source.ContainerOnly)
 		if err != nil {
 			return err
 		}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -545,7 +545,7 @@ func (d *Daemon) Init() error {
 
 	if !d.os.MockMode {
 		/* Read the storage pools */
-		err = SetupStorageDriver(d, false)
+		err = SetupStorageDriver(d.State(), false)
 		if err != nil {
 			return err
 		}
@@ -557,7 +557,7 @@ func (d *Daemon) Init() error {
 		}
 
 		/* Setup the networks */
-		err = networkStartup(d)
+		err = networkStartup(d.State())
 		if err != nil {
 			return err
 		}
@@ -617,7 +617,7 @@ func (d *Daemon) Init() error {
 
 	if !d.os.MockMode {
 		/* Start the scheduler */
-		go deviceEventListener(d)
+		go deviceEventListener(d.State())
 
 		/* Setup the TLS authentication */
 		certf, keyf, err := readMyCert()
@@ -853,11 +853,13 @@ func (d *Daemon) Ready() error {
 		}
 	}()
 
+	s := d.State()
+
 	/* Restore containers */
-	containersRestart(d)
+	containersRestart(s)
 
 	/* Re-balance in case things changed while LXD was down */
-	deviceTaskBalance(d)
+	deviceTaskBalance(s)
 
 	close(d.readyChan)
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -67,21 +67,22 @@ func cmdDaemon() error {
 	signal.Notify(ch, syscall.SIGQUIT)
 	signal.Notify(ch, syscall.SIGTERM)
 
+	s := d.State()
 	select {
 	case sig := <-ch:
 
 		if sig == syscall.SIGPWR {
 			logger.Infof("Received '%s signal', shutting down containers.", sig)
-			containersShutdown(d)
-			networkShutdown(d)
+			containersShutdown(s)
+			networkShutdown(s)
 		} else {
 			logger.Infof("Received '%s signal', exiting.", sig)
 		}
 
 	case <-d.shutdownChan:
 		logger.Infof("Asked to shutdown by API, shutting down containers.")
-		containersShutdown(d)
-		networkShutdown(d)
+		containersShutdown(s)
+		networkShutdown(s)
 	}
 
 	return d.Stop()

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -402,16 +402,16 @@ func networkLoadByName(s *state.State, name string) (*network, error) {
 	return &n, nil
 }
 
-func networkStartup(d *Daemon) error {
+func networkStartup(s *state.State) error {
 	// Get a list of managed networks
-	networks, err := db.Networks(d.db)
+	networks, err := db.Networks(s.DB)
 	if err != nil {
 		return err
 	}
 
 	// Bring them all up
 	for _, name := range networks {
-		n, err := networkLoadByName(d.State(), name)
+		n, err := networkLoadByName(s, name)
 		if err != nil {
 			return err
 		}
@@ -426,16 +426,16 @@ func networkStartup(d *Daemon) error {
 	return nil
 }
 
-func networkShutdown(d *Daemon) error {
+func networkShutdown(s *state.State) error {
 	// Get a list of managed networks
-	networks, err := db.Networks(d.db)
+	networks, err := db.Networks(s.DB)
 	if err != nil {
 		return err
 	}
 
 	// Bring them all up
 	for _, name := range networks {
-		n, err := networkLoadByName(d.State(), name)
+		n, err := networkLoadByName(s, name)
 		if err != nil {
 			return err
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -283,7 +283,7 @@ func patchStorageApi(name string, d *Daemon) error {
 	daemonConfig["storage.zfs_remove_snapshots"].Set(d, "")
 	daemonConfig["storage.zfs_use_refquota"].Set(d, "")
 
-	return SetupStorageDriver(d, true)
+	return SetupStorageDriver(d.State(), true)
 }
 
 func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {
@@ -335,7 +335,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		}
 		poolID = tmp
 
-		s, err := storagePoolInit(d, defaultPoolName)
+		s, err := storagePoolInit(d.State(), defaultPoolName)
 		if err != nil {
 			return err
 		}
@@ -632,7 +632,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		}
 		poolID = tmp
 
-		s, err := storagePoolInit(d, defaultPoolName)
+		s, err := storagePoolInit(d.State(), defaultPoolName)
 		if err != nil {
 			return err
 		}
@@ -2416,8 +2416,9 @@ func patchUpdateFromV10(d *Daemon) error {
 		}
 
 		logger.Debugf("Restarting all the containers following directory rename")
-		containersShutdown(d)
-		containersRestart(d)
+		s := d.State()
+		containersShutdown(s)
+		containersRestart(s)
 	}
 
 	return nil

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -20,7 +20,7 @@ func doProfileUpdate(d *Daemon, name string, id int64, profile *api.Profile, req
 		return BadRequest(err)
 	}
 
-	containers := getContainersWithProfile(d, name)
+	containers := getContainersWithProfile(d.State(), name)
 
 	// Check if the root device is supposed to be changed or removed.
 	oldProfileRootDiskDeviceKey, oldProfileRootDiskDevice, _ := containerGetRootDiskDevice(profile.Devices)

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -77,7 +77,7 @@ func storagePoolsPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("No driver provided"))
 	}
 
-	err = storagePoolCreateInternal(d, req.Name, req.Description, req.Driver, req.Config)
+	err = storagePoolCreateInternal(d.State(), req.Name, req.Description, req.Driver, req.Config)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -140,7 +140,7 @@ func storagePoolPut(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = storagePoolUpdate(d, poolName, req.Description, req.Config)
+	err = storagePoolUpdate(d.State(), poolName, req.Description, req.Config)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -190,7 +190,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = storagePoolUpdate(d, poolName, req.Description, req.Config)
+	err = storagePoolUpdate(d.State(), poolName, req.Description, req.Config)
 	if err != nil {
 		return InternalError(fmt.Errorf("failed to update the storage pool configuration"))
 	}
@@ -224,7 +224,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("Storage pool \"%s\" has profiles using it:\n%s", poolName, strings.Join(profiles, "\n")))
 	}
 
-	s, err := storagePoolInit(d, poolName)
+	s, err := storagePoolInit(d.State(), poolName)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -49,7 +49,7 @@ func storagePoolVolumesGet(d *Daemon, r *http.Request) Response {
 		if recursion == 0 {
 			resultString = append(resultString, fmt.Sprintf("/%s/storage-pools/%s/volumes/%s/%s", version.APIVersion, poolName, apiEndpoint, volume.Name))
 		} else {
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volume.Name, volume.Type)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), volume.Name, volume.Type)
 			if err != nil {
 				return InternalError(err)
 			}
@@ -121,7 +121,7 @@ func storagePoolVolumesTypeGet(d *Daemon, r *http.Request) Response {
 				continue
 			}
 
-			volumeUsedBy, err := storagePoolVolumeUsedByGet(d, vol.Name, vol.Type)
+			volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), vol.Name, vol.Type)
 			if err != nil {
 				return SmartError(err)
 			}
@@ -164,7 +164,7 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) Response {
 	// volume is supposed to be created.
 	poolName := mux.Vars(r)["name"]
 
-	err = storagePoolVolumeCreateInternal(d, poolName, req.Name, req.Description, req.Type, req.Config)
+	err = storagePoolVolumeCreateInternal(d.State(), poolName, req.Name, req.Description, req.Type, req.Config)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -215,7 +215,7 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volume.Name, volume.Type)
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), volume.Name, volume.Type)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -278,7 +278,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = storagePoolVolumeUpdate(d, poolName, volumeName, volumeType, req.Description, req.Config)
+	err = storagePoolVolumeUpdate(d.State(), poolName, volumeName, volumeType, req.Description, req.Config)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -351,7 +351,7 @@ func storagePoolVolumeTypePatch(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = storagePoolVolumeUpdate(d, poolName, volumeName, volumeType, req.Description, req.Config)
+	err = storagePoolVolumeUpdate(d.State(), poolName, volumeName, volumeType, req.Description, req.Config)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -390,7 +390,7 @@ func storagePoolVolumeTypeDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("storage volumes of type \"%s\" cannot be deleted with the storage api", volumeTypeName))
 	}
 
-	volumeUsedBy, err := storagePoolVolumeUsedByGet(d, volumeName, volumeTypeName)
+	volumeUsedBy, err := storagePoolVolumeUsedByGet(d.State(), volumeName, volumeTypeName)
 	if err != nil {
 		return SmartError(err)
 	}


### PR DESCRIPTION
All higher-level entry points to entity-related functionality now
takes a State parameter as opposed to Daemon. With this commit, only
the REST-API layer is still depending direcly on Daemon, and that will
be squashed too in coming branches, effectively paving the ground for
new unit-testing possibilities.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>