### PR TITLE
Fix handling of major and minor numbers in device IDs

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -243,8 +243,8 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 					return nil, nil, err
 				}
 				tmpGpu.nvidia.path = nvidiaPath
-				tmpGpu.nvidia.major = int(stat.Rdev / 256)
-				tmpGpu.nvidia.minor = int(stat.Rdev % 256)
+				tmpGpu.nvidia.major = shared.Major(stat.Rdev)
+				tmpGpu.nvidia.minor = shared.Minor(stat.Rdev)
 				tmpGpu.nvidia.id = strconv.Itoa(tmpGpu.nvidia.minor)
 			}
 			gpus = append(gpus, tmpGpu)
@@ -276,8 +276,8 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 			}
 			tmpNividiaGpu := nvidiaGpuDevices{
 				path:  nvidiaPath,
-				major: int(stat.Rdev / 256),
-				minor: int(stat.Rdev % 256),
+				major: shared.Major(stat.Rdev),
+				minor: shared.Minor(stat.Rdev),
 			}
 			nvidiaDevices = append(nvidiaDevices, tmpNividiaGpu)
 		}
@@ -914,8 +914,8 @@ func deviceGetAttributes(path string) (string, int, int, error) {
 	}
 
 	// Return the device information
-	major := int(stat.Rdev / 256)
-	minor := int(stat.Rdev % 256)
+	major := shared.Major(stat.Rdev)
+	minor := shared.Minor(stat.Rdev)
 	return dType, major, minor, nil
 }
 

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -448,6 +448,14 @@ again:
 
 // --- pure Go functions ---
 
+func Major(dev uint64) int {
+	return int(((dev >> 8) & 0xfff) | ((dev >> 32) & (0xfffff000)))
+}
+
+func Minor(dev uint64) int {
+	return int((dev & 0xff) | ((dev >> 12) & (0xfff00)))
+}
+
 func GetFileStat(p string) (uid int, gid int, major int, minor int,
 	inode uint64, nlink int, err error) {
 	var stat syscall.Stat_t
@@ -462,8 +470,8 @@ func GetFileStat(p string) (uid int, gid int, major int, minor int,
 	major = -1
 	minor = -1
 	if stat.Mode&syscall.S_IFBLK != 0 || stat.Mode&syscall.S_IFCHR != 0 {
-		major = int(stat.Rdev / 256)
-		minor = int(stat.Rdev % 256)
+		major = Major(stat.Rdev)
+		minor = Minor(stat.Rdev)
 	}
 
 	return

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -453,7 +453,7 @@ func Major(dev uint64) int {
 }
 
 func Minor(dev uint64) int {
-	return int((dev & 0xff) | ((dev >> 12) & (0xfff00)))
+	return int((dev & 0xff) | ((dev >> 12) & (0xffffff00)))
 }
 
 func GetFileStat(p string) (uid int, gid int, major int, minor int,


### PR DESCRIPTION
LXD was copying only the lowest 8 bits of the minor device number when adding a device to a container. This caused a wrong device node to be created when adding a device with minor number above 255. Here is a fix to the problem.