### PR TITLE
Make the log cmdInit unit-testable

### DIFF
--- a/lxd/main_init_test.go
+++ b/lxd/main_init_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/lxc/lxd/shared/cmd"
+	"github.com/stretchr/testify/suite"
+)
+
+type cmdInitTestSuite struct {
+	lxdTestSuite
+	context *cmd.Context
+	args    *CmdInitArgs
+	command *CmdInit
+}
+
+func (suite *cmdInitTestSuite) SetupSuite() {
+	suite.lxdTestSuite.SetupSuite()
+	suite.context = cmd.NewMemoryContext(cmd.NewMemoryStreams(""))
+	suite.args = &CmdInitArgs{
+		NetworkPort:       -1,
+		StorageCreateLoop: -1,
+	}
+	suite.command = &CmdInit{
+		Context:         suite.context,
+		Args:            suite.args,
+		RunningInUserns: false,
+		SocketPath:      suite.d.UnixSocket.Socket.Addr().String(),
+	}
+}
+
+// If any argument intended for --auto is passed in interactive mode, an
+// error is returned.
+func (suite *cmdInitTestSuite) TestCmdInit_InteractiveWithAutoArgs() {
+	suite.args.NetworkPort = 9999
+	err := suite.command.Run()
+	suite.Req.Equal(err.Error(), "Init configuration is only valid with --auto")
+}
+
+func TestCmdInitTestSuite(t *testing.T) {
+	suite.Run(t, new(cmdInitTestSuite))
+}

--- a/lxd/main_test.go
+++ b/lxd/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"io/ioutil"
 	"os"
 
@@ -12,7 +13,8 @@ import (
 
 func mockStartDaemon() (*Daemon, error) {
 	d := &Daemon{
-		MockMode: true,
+		MockMode:  true,
+		tlsConfig: &tls.Config{},
 	}
 
 	if err := d.Init(); err != nil {
@@ -71,6 +73,7 @@ func (suite *lxdTestSuite) TearDownSuite() {
 func (suite *lxdTestSuite) SetupTest() {
 	initializeDbObject(suite.d, shared.VarPath("lxd.db"))
 	daemonConfigInit(suite.d.db)
+	suite.Req = require.New(suite.T())
 }
 
 func (suite *lxdTestSuite) TearDownTest() {


### PR DESCRIPTION
This branch essentially wires into cmdInit the logic previously
introduced in the shared/cmd package.

In order to be able to run the underlying logic in isolation a few
globals (such as command line arguments) have been replaced with
explicit parameters, that get passed to the CmdInit structure.

An initial unit test has been added, mostly for exemplification, and I
plan to keep working on the logic and on the tests in order to
implement #2834.

Signed-off-by: Free Ekanayaka <free@ekanayaka.io>