### PR TITLE
Reset the images auto-update loop when configuration changes

### DIFF
--- a/lxd/daemon_config.go
+++ b/lxd/daemon_config.go
@@ -186,7 +186,7 @@ func daemonConfigInit(db *sql.DB) error {
 		"core.trust_password":            {valueType: "string", hiddenValue: true, setter: daemonConfigSetPassword},
 
 		"images.auto_update_cached":    {valueType: "bool", defaultValue: "true"},
-		"images.auto_update_interval":  {valueType: "int", defaultValue: "6"},
+		"images.auto_update_interval":  {valueType: "int", defaultValue: "6", trigger: daemonConfigTriggerAutoUpdateInterval},
 		"images.compression_algorithm": {valueType: "string", validator: daemonConfigValidateCompression, defaultValue: "gzip"},
 		"images.remote_cache_expiry":   {valueType: "int", defaultValue: "10", trigger: daemonConfigTriggerExpiry},
 
@@ -304,6 +304,11 @@ func daemonConfigSetProxy(d *Daemon, key string, value string) (string, error) {
 func daemonConfigTriggerExpiry(d *Daemon, key string, value string) {
 	// Trigger an image pruning run
 	d.pruneChan <- true
+}
+
+func daemonConfigTriggerAutoUpdateInterval(d *Daemon, key string, value string) {
+	// Reset the auto-update interval loop
+	d.resetAutoUpdateChan <- true
 }
 
 func daemonConfigValidateCompression(d *Daemon, key string, value string) error {


### PR DESCRIPTION
This fixes a bug where changing the auto-update images interval with
the API would not take effect unless the daemon is restarted.

See also the comments to:

https://github.com/stgraber/lxd/commit/28e7d344175097877af7747fd5f2926e9965b17

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>