### PR TITLE
More lxd-benchmark refactors

### DIFF
--- a/lxd-benchmark/benchmark/batch.go
+++ b/lxd-benchmark/benchmark/batch.go
@@ -1,0 +1,61 @@
+package benchmark
+
+import (
+	"io/ioutil"
+	"sync"
+	"time"
+)
+
+func getBatchSize(parallel int) (int, error) {
+	batchSize := parallel
+	if batchSize < 1 {
+		// Detect the number of parallel actions
+		cpus, err := ioutil.ReadDir("/sys/bus/cpu/devices")
+		if err != nil {
+			return -1, err
+		}
+
+		batchSize = len(cpus)
+	}
+
+	return batchSize, nil
+}
+
+func processBatch(count int, batchSize int, process func(index int, wg *sync.WaitGroup)) time.Duration {
+	batches := count / batchSize
+	remainder := count % batchSize
+	processed := 0
+	wg := sync.WaitGroup{}
+	nextStat := batchSize
+
+	logf("Batch processing start")
+	timeStart := time.Now()
+
+	for i := 0; i < batches; i++ {
+		for j := 0; j < batchSize; j++ {
+			wg.Add(1)
+			go process(processed, &wg)
+			processed++
+		}
+		wg.Wait()
+
+		if processed >= nextStat {
+			interval := time.Since(timeStart).Seconds()
+			logf("Processed %d containers in %.3fs (%.3f/s)", processed, interval, float64(processed)/interval)
+			nextStat = nextStat * 2
+		}
+
+	}
+
+	for k := 0; k < remainder; k++ {
+		wg.Add(1)
+		go process(processed, &wg)
+		processed++
+	}
+	wg.Wait()
+
+	timeEnd := time.Now()
+	duration := timeEnd.Sub(timeStart)
+	logf("Batch processing completed in %.3fs", duration.Seconds())
+	return duration
+}

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -67,17 +67,9 @@ func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image strin
 			return
 		}
 
-		// Freeze
 		if freeze {
-			op, err := c.UpdateContainerState(name, api.ContainerStatePut{Action: "freeze", Timeout: -1}, "")
-			if err != nil {
-				logf("Failed to spawn container '%s': %s", name, err)
-				return
-			}
-
-			err = op.Wait()
-			if err != nil {
-				logf("Failed to spawn container '%s': %s", name, err)
+			if freezeContainer(c, name) != nil {
+				logf("Failed to freeze container '%s': %s", name, err)
 				return
 			}
 		}

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -2,7 +2,6 @@ package benchmark
 
 import (
 	"fmt"
-	"io/ioutil"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +11,8 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/version"
 )
+
+const userConfigKey = "user.lxd-benchmark"
 
 // PrintServerInfo prints out information about the server.
 func PrintServerInfo(c lxd.ContainerServer) error {
@@ -35,7 +36,7 @@ func PrintServerInfo(c lxd.ContainerServer) error {
 }
 
 // SpawnContainers launches a set of containers.
-func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image string, privileged bool, freeze bool) (time.Duration, error) {
+func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image string, privileged bool, start bool, freeze bool) (time.Duration, error) {
 	var duration time.Duration
 
 	batchSize, err := getBatchSize(parallel)
@@ -61,16 +62,19 @@ func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image strin
 			return
 		}
 
-		err = startContainer(c, name)
-		if err != nil {
-			logf("Failed to start container '%s': %s", name, err)
-			return
-		}
-
-		if freeze {
-			if freezeContainer(c, name) != nil {
-				logf("Failed to freeze container '%s': %s", name, err)
+		if start {
+			err := startContainer(c, name)
+			if err != nil {
+				logf("Failed to start container '%s': %s", name, err)
 				return
+			}
+
+			if freeze {
+				err := freezeContainer(c, name)
+				if err != nil {
+					logf("Failed to freeze container '%s': %s", name, err)
+					return
+				}
 			}
 		}
 	}
@@ -115,11 +119,9 @@ func GetContainers(c lxd.ContainerServer) ([]api.Container, error) {
 	}
 
 	for _, container := range allContainers {
-		if container.Config["user.lxd-benchmark"] != "true" {
-			continue
+		if container.Config[userConfigKey] == "true" {
+			containers = append(containers, container)
 		}
-
-		containers = append(containers, container)
 	}
 
 	return containers, nil
@@ -226,26 +228,6 @@ func DeleteContainers(c lxd.ContainerServer, containers []api.Container, paralle
 	return duration, nil
 }
 
-func getBatchSize(parallel int) (int, error) {
-	batchSize := parallel
-	if batchSize < 1 {
-		// Detect the number of parallel actions
-		cpus, err := ioutil.ReadDir("/sys/bus/cpu/devices")
-		if err != nil {
-			return -1, err
-		}
-
-		batchSize = len(cpus)
-	}
-
-	return batchSize, nil
-}
-
-func getContainerName(count int, index int) string {
-	nameFormat := "benchmark-%." + fmt.Sprintf("%d", len(fmt.Sprintf("%d", count))) + "d"
-	return fmt.Sprintf(nameFormat, index+1)
-}
-
 func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 	var fingerprint string
 
@@ -301,70 +283,4 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 		logf("Found image in local store: %s", fingerprint)
 	}
 	return fingerprint, nil
-}
-
-func processBatch(count int, batchSize int, process func(index int, wg *sync.WaitGroup)) time.Duration {
-	batches := count / batchSize
-	remainder := count % batchSize
-	processed := 0
-	wg := sync.WaitGroup{}
-	nextStat := batchSize
-
-	logf("Batch processing start")
-	timeStart := time.Now()
-
-	for i := 0; i < batches; i++ {
-		for j := 0; j < batchSize; j++ {
-			wg.Add(1)
-			go process(processed, &wg)
-			processed++
-		}
-		wg.Wait()
-
-		if processed >= nextStat {
-			interval := time.Since(timeStart).Seconds()
-			logf("Processed %d containers in %.3fs (%.3f/s)", processed, interval, float64(processed)/interval)
-			nextStat = nextStat * 2
-		}
-
-	}
-
-	for k := 0; k < remainder; k++ {
-		wg.Add(1)
-		go process(processed, &wg)
-		processed++
-	}
-	wg.Wait()
-
-	timeEnd := time.Now()
-	duration := timeEnd.Sub(timeStart)
-	logf("Batch processing completed in %.3fs", duration.Seconds())
-	return duration
-}
-
-func logf(format string, args ...interface{}) {
-	fmt.Printf(fmt.Sprintf("[%s] %s\n", time.Now().Format(time.StampMilli), format), args...)
-}
-
-func printTestConfig(count int, batchSize int, image string, privileged bool, freeze bool) {
-	privilegedStr := "unprivileged"
-	if privileged {
-		privilegedStr = "privileged"
-	}
-	mode := "normal startup"
-	if freeze {
-		mode = "start and freeze"
-	}
-
-	batches := count / batchSize
-	remainder := count % batchSize
-	fmt.Printf("Test variables:\n")
-	fmt.Printf("  Container count: %d\n", count)
-	fmt.Printf("  Container mode: %s\n", privilegedStr)
-	fmt.Printf("  Startup mode: %s\n", mode)
-	fmt.Printf("  Image: %s\n", image)
-	fmt.Printf("  Batches: %d\n", batches)
-	fmt.Printf("  Batch size: %d\n", batchSize)
-	fmt.Printf("  Remainder: %d\n", remainder)
-	fmt.Printf("\n")
 }

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -48,3 +48,13 @@ func stopContainer(c lxd.ContainerServer, name string) error {
 
 	return op.Wait()
 }
+
+func freezeContainer(c lxd.ContainerServer, name string) error {
+	op, err := c.UpdateContainerState(
+		name, api.ContainerStatePut{Action: "freeze", Timeout: -1}, "")
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -10,7 +10,7 @@ func createContainer(c lxd.ContainerServer, fingerprint string, name string, pri
 	if privileged {
 		config["security.privileged"] = "true"
 	}
-	config["user.lxd-benchmark"] = "true"
+	config[userConfigKey] = "true"
 
 	req := api.ContainersPost{
 		Name: name,

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -5,6 +5,30 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
+func createContainer(c lxd.ContainerServer, fingerprint string, name string, privileged bool) error {
+	config := map[string]string{}
+	if privileged {
+		config["security.privileged"] = "true"
+	}
+	config["user.lxd-benchmark"] = "true"
+
+	req := api.ContainersPost{
+		Name: name,
+		Source: api.ContainerSource{
+			Type:        "image",
+			Fingerprint: fingerprint,
+		},
+	}
+	req.Config = config
+
+	op, err := c.CreateContainer(req)
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}
+
 func stopContainer(c lxd.ContainerServer, name string) error {
 	op, err := c.UpdateContainerState(
 		name, api.ContainerStatePut{Action: "stop", Timeout: -1, Force: true}, "")

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -29,6 +29,16 @@ func createContainer(c lxd.ContainerServer, fingerprint string, name string, pri
 	return op.Wait()
 }
 
+func startContainer(c lxd.ContainerServer, name string) error {
+	op, err := c.UpdateContainerState(
+		name, api.ContainerStatePut{Action: "start", Timeout: -1}, "")
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}
+
 func stopContainer(c lxd.ContainerServer, name string) error {
 	op, err := c.UpdateContainerState(
 		name, api.ContainerStatePut{Action: "stop", Timeout: -1, Force: true}, "")

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -1,0 +1,16 @@
+package benchmark
+
+import (
+	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/shared/api"
+)
+
+func stopContainer(c lxd.ContainerServer, name string) error {
+	op, err := c.UpdateContainerState(
+		name, api.ContainerStatePut{Action: "stop", Timeout: -1, Force: true}, "")
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}

--- a/lxd-benchmark/benchmark/util.go
+++ b/lxd-benchmark/benchmark/util.go
@@ -1,0 +1,38 @@
+package benchmark
+
+import (
+	"fmt"
+	"time"
+)
+
+func getContainerName(count int, index int) string {
+	nameFormat := "benchmark-%." + fmt.Sprintf("%d", len(fmt.Sprintf("%d", count))) + "d"
+	return fmt.Sprintf(nameFormat, index+1)
+}
+
+func logf(format string, args ...interface{}) {
+	fmt.Printf(fmt.Sprintf("[%s] %s\n", time.Now().Format(time.StampMilli), format), args...)
+}
+
+func printTestConfig(count int, batchSize int, image string, privileged bool, freeze bool) {
+	privilegedStr := "unprivileged"
+	if privileged {
+		privilegedStr = "privileged"
+	}
+	mode := "normal startup"
+	if freeze {
+		mode = "start and freeze"
+	}
+
+	batches := count / batchSize
+	remainder := count % batchSize
+	fmt.Printf("Test variables:\n")
+	fmt.Printf("  Container count: %d\n", count)
+	fmt.Printf("  Container mode: %s\n", privilegedStr)
+	fmt.Printf("  Startup mode: %s\n", mode)
+	fmt.Printf("  Image: %s\n", image)
+	fmt.Printf("  Batches: %d\n", batches)
+	fmt.Printf("  Batch size: %d\n", batchSize)
+	fmt.Printf("  Remainder: %d\n", remainder)
+	fmt.Printf("\n")
+}

--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -30,7 +30,7 @@ func main() {
 
 func run(args []string) error {
 	// Parse command line
-	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"spawn", "delete"}) {
+	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"spawn", "start", "stop", "delete"}) {
 		if len(os.Args) > 1 && os.Args[1] == "--version" {
 			fmt.Println(version.Version)
 			return nil
@@ -43,6 +43,8 @@ func run(args []string) error {
 		gnuflag.SetOut(out)
 
 		fmt.Fprintf(out, "Usage: %s spawn [--count=COUNT] [--image=IMAGE] [--privileged=BOOL] [--start=BOOL] [--freeze=BOOL] [--parallel=COUNT]\n", os.Args[0])
+		fmt.Fprintf(out, "       %s start [--parallel=COUNT]\n", os.Args[0])
+		fmt.Fprintf(out, "       %s stop [--parallel=COUNT]\n", os.Args[0])
 		fmt.Fprintf(out, "       %s delete [--parallel=COUNT]\n\n", os.Args[0])
 		gnuflag.PrintDefaults()
 		fmt.Fprintf(out, "\n")
@@ -51,7 +53,7 @@ func run(args []string) error {
 			return nil
 		}
 
-		return fmt.Errorf("A valid action (spawn or delete) must be passed.")
+		return fmt.Errorf("A valid action (spawn, start, stop, delete) must be passed.")
 	}
 
 	gnuflag.Parse(true)
@@ -67,6 +69,20 @@ func run(args []string) error {
 	switch os.Args[1] {
 	case "spawn":
 		_, err = benchmark.SpawnContainers(c, *argCount, *argParallel, *argImage, *argPrivileged, *argStart, *argFreeze)
+		return err
+	case "start":
+		containers, err := benchmark.GetContainers(c)
+		if err != nil {
+			return err
+		}
+		_, err = benchmark.StartContainers(c, containers, *argParallel)
+		return err
+	case "stop":
+		containers, err := benchmark.GetContainers(c)
+		if err != nil {
+			return err
+		}
+		_, err = benchmark.StopContainers(c, containers, *argParallel)
 		return err
 	case "delete":
 		containers, err := benchmark.GetContainers(c)

--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -65,13 +65,15 @@ func run(args []string) error {
 
 	switch os.Args[1] {
 	case "spawn":
-		return benchmark.SpawnContainers(c, *argCount, *argParallel, *argImage, *argPrivileged, *argFreeze)
+		_, err = benchmark.SpawnContainers(c, *argCount, *argParallel, *argImage, *argPrivileged, *argFreeze)
+		return err
 	case "delete":
 		containers, err := benchmark.GetContainers(c)
 		if err != nil {
 			return err
 		}
-		return benchmark.DeleteContainers(c, containers, *argParallel)
+		_, err = benchmark.DeleteContainers(c, containers, *argParallel)
+		return err
 	}
 
 	return nil

--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -15,6 +15,7 @@ var argCount = gnuflag.Int("count", 100, "Number of containers to create")
 var argParallel = gnuflag.Int("parallel", -1, "Number of threads to use")
 var argImage = gnuflag.String("image", "ubuntu:", "Image to use for the test")
 var argPrivileged = gnuflag.Bool("privileged", false, "Use privileged containers")
+var argStart = gnuflag.Bool("start", true, "Start the container after creation")
 var argFreeze = gnuflag.Bool("freeze", false, "Freeze the container right after start")
 
 func main() {
@@ -41,7 +42,7 @@ func run(args []string) error {
 		}
 		gnuflag.SetOut(out)
 
-		fmt.Fprintf(out, "Usage: %s spawn [--count=COUNT] [--image=IMAGE] [--privileged=BOOL] [--parallel=COUNT]\n", os.Args[0])
+		fmt.Fprintf(out, "Usage: %s spawn [--count=COUNT] [--image=IMAGE] [--privileged=BOOL] [--start=BOOL] [--freeze=BOOL] [--parallel=COUNT]\n", os.Args[0])
 		fmt.Fprintf(out, "       %s delete [--parallel=COUNT]\n\n", os.Args[0])
 		gnuflag.PrintDefaults()
 		fmt.Fprintf(out, "\n")
@@ -50,7 +51,7 @@ func run(args []string) error {
 			return nil
 		}
 
-		return fmt.Errorf("An valid action (spawn or delete) must be passed.")
+		return fmt.Errorf("A valid action (spawn or delete) must be passed.")
 	}
 
 	gnuflag.Parse(true)
@@ -65,7 +66,7 @@ func run(args []string) error {
 
 	switch os.Args[1] {
 	case "spawn":
-		_, err = benchmark.SpawnContainers(c, *argCount, *argParallel, *argImage, *argPrivileged, *argFreeze)
+		_, err = benchmark.SpawnContainers(c, *argCount, *argParallel, *argImage, *argPrivileged, *argStart, *argFreeze)
 		return err
 	case "delete":
 		containers, err := benchmark.GetContainers(c)


### PR DESCRIPTION
This does the folliwing:

- extract more code from the main `SpawnContainers` and `DeleteContainers` functions to reusable helper methods
- add `start` and `stop` commands to `lxd-benchmark`