### PR TITLE
test: Don't copy running lvm/ceph containers

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -293,7 +293,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 	poolSubvolumePath := getStoragePoolMountPoint(defaultPoolName)
 	poolConfig["source"] = poolSubvolumePath
 
-	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig)
+	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig, nil)
 	if err != nil {
 		return err
 	}
@@ -590,7 +590,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 	poolConfig := map[string]string{}
 	poolConfig["source"] = shared.VarPath("storage-pools", defaultPoolName)
 
-	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig)
+	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig, nil)
 	if err != nil {
 		return err
 	}
@@ -873,7 +873,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	// "volume.size", so unset it.
 	poolConfig["size"] = ""
 
-	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig)
+	err := storagePoolValidateConfig(defaultPoolName, defaultStorageTypeName, poolConfig, nil)
 	if err != nil {
 		return err
 	}
@@ -1380,7 +1380,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 	// run into problems. For example, the "zfs.img" file might have already
 	// been moved into ${LXD_DIR}/disks and we might therefore falsely
 	// conclude that we're using an existing storage pool.
-	err := storagePoolValidateConfig(poolName, defaultStorageTypeName, poolConfig)
+	err := storagePoolValidateConfig(poolName, defaultStorageTypeName, poolConfig, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -192,7 +192,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) Response {
 
 	err = storagePoolUpdate(d.State(), poolName, req.Description, req.Config)
 	if err != nil {
-		return InternalError(fmt.Errorf("failed to update the storage pool configuration"))
+		return InternalError(err)
 	}
 
 	return EmptySyncResponse

--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -135,7 +135,7 @@ func storagePoolPut(d *Daemon, r *http.Request) Response {
 	}
 
 	// Validate the configuration
-	err = storagePoolValidateConfig(poolName, dbInfo.Driver, req.Config)
+	err = storagePoolValidateConfig(poolName, dbInfo.Driver, req.Config, dbInfo.Config)
 	if err != nil {
 		return BadRequest(err)
 	}
@@ -185,7 +185,7 @@ func storagePoolPatch(d *Daemon, r *http.Request) Response {
 	}
 
 	// Validate the configuration
-	err = storagePoolValidateConfig(poolName, dbInfo.Driver, req.Config)
+	err = storagePoolValidateConfig(poolName, dbInfo.Driver, req.Config, dbInfo.Config)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -84,7 +84,7 @@ var storagePoolConfigKeys = map[string]func(value string) error{
 	"rsync.bwlimit":  shared.IsAny,
 }
 
-func storagePoolValidateConfig(name string, driver string, config map[string]string) error {
+func storagePoolValidateConfig(name string, driver string, config map[string]string, oldConfig map[string]string) error {
 	err := func(value string) error {
 		return shared.IsOneOf(value, supportedStoragePoolDrivers)
 	}(driver)
@@ -110,6 +110,11 @@ func storagePoolValidateConfig(name string, driver string, config map[string]str
 	// Check whether the config properties for the driver container sane
 	// values.
 	for key, val := range config {
+		// Skip unchanged keys
+		if oldConfig != nil && oldConfig[key] == val {
+			continue
+		}
+
 		// User keys are not validated.
 		if strings.HasPrefix(key, "user.") {
 			continue

--- a/lxd/storage_pools_utils.go
+++ b/lxd/storage_pools_utils.go
@@ -176,7 +176,7 @@ func storagePoolDBCreate(s *state.State, poolName, poolDescription string, drive
 	}
 
 	// Validate the requested storage pool configuration.
-	err = storagePoolValidateConfig(poolName, driver, config)
+	err = storagePoolValidateConfig(poolName, driver, config, nil)
 	if err != nil {
 		return err
 	}

--- a/test/backends/ceph.sh
+++ b/test/backends/ceph.sh
@@ -15,7 +15,7 @@ ceph_configure() {
 
   echo "==> Configuring CEPH backend in ${LXD_DIR}"
 
-  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" ceph
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" ceph volume.size=25MB
   lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 }
 

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -46,7 +46,7 @@ test_image_auto_update() {
   #
   # XXX: Since the auto-update logic runs asynchronously we need to wait
   #      a little bit before it actually completes.
-  retries=10
+  retries=60
   while [ "${retries}" != "0" ]; do
     if lxc image info "${fp1}" > /dev/null 2>&1; then
         sleep 2

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -15,11 +15,11 @@ test_storage_driver_ceph() {
     LXD_DIR="${LXD_STORAGE_DIR}"
 
     if [ "$lxd_backend" != "ceph" ]; then
-	    exit 0
+        exit 0
     fi
 
     # shellcheck disable=SC1009
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" ceph
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" ceph volume.size=25MB
 
     # Set default storage pool for image import.
     lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")-pool1"
@@ -31,7 +31,7 @@ test_storage_driver_ceph() {
     ceph --cluster "${LXD_CEPH_CLUSTER}" osd pool create "lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" 32
 
     # Let LXD use an already existing osd pool.
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" ceph source="lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool"
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" ceph source="lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" volume.size=25MB
 
     # Test that no invalid ceph storage pool configuration keys can be set.
     ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-invalid-ceph-pool-config" ceph lvm.thinpool_name=bla

--- a/test/suites/template.sh
+++ b/test/suites/template.sh
@@ -1,4 +1,8 @@
 test_template() {
+  # shellcheck disable=2039
+  local lxd_backend
+  lxd_backend=$(storage_backend "$LXD_DIR")
+
   # Import a template which only triggers on create
   deps/import-busybox --alias template-test --template create
   lxc init template-test template
@@ -9,6 +13,10 @@ test_template() {
   # Validate that the template is applied
   lxc start template
   lxc file pull template/template - | grep "^name: template$"
+
+  if [ "$lxd_backend" = "lvm" ] || [ "$lxd_backend" = "ceph" ]; then
+    lxc stop template --force
+  fi
 
   # Confirm it's not applied on copies
   lxc copy template template1
@@ -25,6 +33,9 @@ test_template() {
 
   # Confirm that the template doesn't trigger on create
   ! lxc file pull template/template -
+  if [ "$lxd_backend" = "lvm" ] || [ "$lxd_backend" = "ceph" ]; then
+    lxc stop template --force
+  fi
 
   # Copy the container
   lxc copy template template1


### PR DESCRIPTION
Running containers when backed by LVM or Ceph may be in an inconsistent
state during copy.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>