### PR TITLE
Add performance tests for regression testing

### DIFF
--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -275,12 +275,22 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 				logf("Failed to import image: %s", err)
 				return "", err
 			}
-		} else {
-			logf("Found image in local store: %s", fingerprint)
 		}
 	} else {
+		alias, _, err := c.GetImageAlias(image)
+		if err == nil {
+			fingerprint = alias.Target
+		} else {
+			_, _, err = c.GetImage(image)
+		}
+
+		if err != nil {
+			logf("Image not found in local store: %s", image)
+			return "", err
+		}
 		fingerprint = image
-		logf("Found image in local store: %s", fingerprint)
 	}
+
+	logf("Found image in local store: %s", fingerprint)
 	return fingerprint, nil
 }

--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -200,26 +200,19 @@ func DeleteContainers(c lxd.ContainerServer, containers []api.Container, paralle
 	deleteContainer := func(index int, wg *sync.WaitGroup) {
 		defer wg.Done()
 
-		ct := containers[index]
-
-		if ct.IsActive() {
-			err := stopContainer(c, ct.Name)
+		container := containers[index]
+		name := container.Name
+		if container.IsActive() {
+			err := stopContainer(c, name)
 			if err != nil {
-				logf("Failed to stop container '%s': %s", ct.Name, err)
+				logf("Failed to stop container '%s': %s", name, err)
 				return
 			}
 		}
 
-		// Delete
-		op, err := c.DeleteContainer(ct.Name)
+		err = deleteContainer(c, name)
 		if err != nil {
-			logf("Failed to delete container: %s", ct.Name)
-			return
-		}
-
-		err = op.Wait()
-		if err != nil {
-			logf("Failed to delete container: %s", ct.Name)
+			logf("Failed to delete container: %s", name)
 			return
 		}
 	}
@@ -264,13 +257,7 @@ func ensureImage(c lxd.ContainerServer, image string) (string, error) {
 				return "", err
 			}
 
-			op, err := c.CopyImage(imageServer, *image, nil)
-			if err != nil {
-				logf("Failed to import image: %s", err)
-				return "", err
-			}
-
-			err = op.Wait()
+			err = copyImage(c, imageServer, *image)
 			if err != nil {
 				logf("Failed to import image: %s", err)
 				return "", err

--- a/lxd-benchmark/benchmark/operation.go
+++ b/lxd-benchmark/benchmark/operation.go
@@ -58,3 +58,21 @@ func freezeContainer(c lxd.ContainerServer, name string) error {
 
 	return op.Wait()
 }
+
+func deleteContainer(c lxd.ContainerServer, name string) error {
+	op, err := c.DeleteContainer(name)
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}
+
+func copyImage(c lxd.ContainerServer, s lxd.ImageServer, image api.Image) error {
+	op, err := c.CopyImage(s, image, nil)
+	if err != nil {
+		return err
+	}
+
+	return op.Wait()
+}

--- a/lxd-benchmark/benchmark/report.go
+++ b/lxd-benchmark/benchmark/report.go
@@ -1,0 +1,95 @@
+package benchmark
+
+import (
+	"encoding/csv"
+	"fmt"
+	"io"
+	"os"
+	"time"
+)
+
+// Subset of JMeter CSV log format that are required by Jenkins performance
+// plugin
+// (see http://jmeter.apache.org/usermanual/listeners.html#csvlogformat)
+var csvFields = []string{
+	"timeStamp", // in milliseconds since 1/1/1970
+	"elapsed",   // in milliseconds
+	"label",
+	"responseCode",
+	"success", // "true" or "false"
+}
+
+// CSVReport reads/writes a CSV report file.
+type CSVReport struct {
+	Filename string
+
+	records [][]string
+}
+
+// Load reads current content of the filename and loads records.
+func (r *CSVReport) Load() error {
+	file, err := os.Open(r.Filename)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	reader := csv.NewReader(file)
+	for line := 1; err != io.EOF; line++ {
+		record, err := reader.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		err = r.addRecord(record)
+		if err != nil {
+			return err
+		}
+	}
+	logf("Loaded report file %s", r.Filename)
+	return nil
+}
+
+// Write writes current records to file.
+func (r *CSVReport) Write() error {
+	file, err := os.OpenFile(r.Filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	writer := csv.NewWriter(file)
+	err = writer.WriteAll(r.records)
+	if err != nil {
+		return err
+	}
+
+	logf("Written report file %s", r.Filename)
+	return nil
+}
+
+// AddRecord adds a record to the report.
+func (r *CSVReport) AddRecord(label string, elapsed time.Duration) error {
+	if len(r.records) == 0 {
+		r.addRecord(csvFields)
+	}
+
+	record := []string{
+		fmt.Sprintf("%d", time.Now().UnixNano()/int64(time.Millisecond)), // timestamp
+		fmt.Sprintf("%d", elapsed/time.Millisecond),
+		label,
+		"",     // responseCode is not used
+		"true", // success"
+	}
+	return r.addRecord(record)
+}
+
+func (r *CSVReport) addRecord(record []string) error {
+	if len(record) != len(csvFields) {
+		return fmt.Errorf("Invalid number of fields : %q", record)
+	}
+	r.records = append(r.records, record)
+	return nil
+}

--- a/test/perf.sh
+++ b/test/perf.sh
@@ -1,0 +1,82 @@
+#!/bin/sh -eu
+#
+# Performance tests runner
+#
+
+[ -n "${GOPATH:-}" ] && export "PATH=${GOPATH}/bin:${PATH}"
+
+PERF_LOG_CSV="perf.csv"
+
+import_subdir_files() {
+    test  "$1"
+    # shellcheck disable=SC2039
+    local file
+    for file in "$1"/*.sh; do
+        # shellcheck disable=SC1090
+        . "$file"
+    done
+}
+
+import_subdir_files includes
+
+log_message() {
+    echo "==>" "$@"
+}
+
+run_benchmark() {
+    # shellcheck disable=SC2039
+    local label description opts
+    label="$1"
+    description="$2"
+    shift 2
+
+    log_message "Benchmark start: $label - $description"
+    lxd_benchmark "$@" --report-file "$PERF_LOG_CSV" --report-label "$label"
+    log_message "Benchmark completed: $label"
+}
+
+lxd_benchmark() {
+    # shellcheck disable=SC2039
+    local opts
+    [ "${LXD_TEST_IMAGE:-}" ] && opts="--image $LXD_TEST_IMAGE" || opts=""
+    lxd-benchmark "$@" $opts
+}
+
+cleanup() {
+    if [ "$TEST_RESULT" != "success" ]; then
+        rm -f "$PERF_LOG_CSV"
+    fi
+    lxd_benchmark delete  # ensure all test containers have been deleted
+    kill_lxd "$LXD_DIR"
+    cleanup_lxds "$TEST_DIR"
+    log_message "Performance tests result: $TEST_RESULT"
+}
+
+trap cleanup EXIT HUP INT TERM
+
+# Setup test directories
+TEST_DIR=$(mktemp -d -p "$(pwd)" tmp.XXX)
+LXD_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+export LXD_DIR
+chmod +x "${TEST_DIR}" "${LXD_DIR}"
+
+if [ -z "${LXD_BACKEND:-}" ]; then
+    LXD_BACKEND="dir"
+fi
+
+import_storage_backends
+
+spawn_lxd "${LXD_DIR}" true
+
+# shellcheck disable=SC2034
+TEST_RESULT=failure
+
+run_benchmark "create-one" "create 1 container" spawn --count 1 --start=false
+run_benchmark "start-one" "start 1 container" start
+run_benchmark "stop-one" "stop 1 container" stop
+run_benchmark "delete-one" "delete 1 container" delete
+run_benchmark "create-128" "create 128 containers" spawn --count 128 --start=false
+run_benchmark "delete-128" "delete 128 containers" delete
+
+# shellcheck disable=SC2034
+TEST_RESULT=success


### PR DESCRIPTION
- add support for CSV reporting in `lxd-benchmark`, conforming to the JMeter CSV format (understood by the Jenkins performance plugin)
- add a `perf.sh` script that runs performance tests (create/start/stop/delete containers)
- fix the `--image` parameter in `lxd-benchmark` to correctly fail when a local image fingerprint/alias is passed (without `remote:`) and is not found.

To test, run something like
```
sudo -E LXD_TMPFS=1 LXD_TEST_IMAGE=images:alpine/3.6 ./perf.sh
```

The script also supports setting `LXD_BACKEND` so that matrix testing can be done for different storage backends.

Closes #3670 