### PR TITLE
ceph: use uuid when creating zombie storage volumes

### DIFF
--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -2354,8 +2354,8 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 			}
 
 			err := cephRBDVolumeMarkDeleted(s.ClusterName,
-				s.OSDPoolName, fingerprint,
-				storagePoolVolumeTypeNameImage, s.UserName)
+				s.OSDPoolName, storagePoolVolumeTypeNameImage,
+				fingerprint, fingerprint, s.UserName)
 			if err != nil {
 				logger.Warnf(`Failed to mark RBD storage `+
 					`volume for image "%s" on storage `+
@@ -2472,7 +2472,8 @@ func (s *storageCeph) ImageDelete(fingerprint string) error {
 
 		// mark deleted
 		err := cephRBDVolumeMarkDeleted(s.ClusterName, s.OSDPoolName,
-			fingerprint, storagePoolVolumeTypeNameImage, s.UserName)
+			storagePoolVolumeTypeNameImage, fingerprint,
+			fingerprint, s.UserName)
 		if err != nil {
 			logger.Errorf(`Failed to mark RBD storage volume for `+
 				`image "%s" on storage pool "%s" as zombie: %s`,

--- a/test/backends/ceph.sh
+++ b/test/backends/ceph.sh
@@ -15,7 +15,7 @@ ceph_configure() {
 
   echo "==> Configuring CEPH backend in ${LXD_DIR}"
 
-  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" ceph volume.size=25MB
+  lxc storage create "lxdtest-$(basename "${LXD_DIR}")" ceph volume.size=25MB ceph.osd.pg_num=8
   lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")"
 }
 

--- a/test/suites/backup.sh
+++ b/test/suites/backup.sh
@@ -1,10 +1,13 @@
 test_container_import() {
-  ensure_import_testimage
-
   LXD_IMPORT_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_IMPORT_DIR}"
   spawn_lxd "${LXD_IMPORT_DIR}" true
   (
+    # shellcheck disable=SC2030
+    LXD_DIR=${LXD_IMPORT_DIR}
+
+    ensure_import_testimage
+
     lxc init testimage ctImport
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
@@ -31,10 +34,8 @@ test_container_import() {
     lxc snapshot ctImport
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
-    shutdown_lxd "${LXD_IMPORT_DIR}"
     kill -9 "${pid}"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport'"
-    respawn_lxd "${LXD_IMPORT_DIR}"
     ! lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
@@ -44,10 +45,8 @@ test_container_import() {
     lxc snapshot ctImport
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
-    shutdown_lxd "${LXD_IMPORT_DIR}"
     kill -9 "${pid}"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport/snap0'"
-    respawn_lxd "${LXD_IMPORT_DIR}"
     ! lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
@@ -57,12 +56,10 @@ test_container_import() {
     lxc snapshot ctImport
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
-    shutdown_lxd "${LXD_IMPORT_DIR}"
     kill -9 "${pid}"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport/snap0'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport'"
-    respawn_lxd "${LXD_IMPORT_DIR}"
     ! lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
@@ -72,13 +69,11 @@ test_container_import() {
     lxc snapshot ctImport
     lxc start ctImport
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
-    shutdown_lxd "${LXD_IMPORT_DIR}"
     kill -9 "${pid}"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport/snap0'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
-    respawn_lxd "${LXD_IMPORT_DIR}"
     lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
@@ -89,12 +84,10 @@ test_container_import() {
     lxc start ctImport
     rm "${LXD_DIR}/containers/ctImport"
     pid=$(lxc info ctImport | grep ^Pid | awk '{print $2}')
-    shutdown_lxd "${LXD_IMPORT_DIR}"
     kill -9 "${pid}"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM containers WHERE name='ctImport/snap0'"
     sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport'"
-    respawn_lxd "${LXD_IMPORT_DIR}"
     ! lxd import ctImport
     lxd import ctImport --force
     lxc info ctImport | grep snap0
@@ -106,9 +99,7 @@ test_container_import() {
     if [ "$(storage_backend "$LXD_DIR")" = "dir" ]; then
       lxc init testimage ctImport
       lxc snapshot ctImport
-      shutdown_lxd "${LXD_IMPORT_DIR}"
       sqlite3 "${LXD_DIR}/lxd.db" "PRAGMA foreign_keys=ON; DELETE FROM storage_volumes WHERE name='ctImport/snap0'"
-      respawn_lxd "${LXD_IMPORT_DIR}"
       ! lxd import ctImport
       lxd import ctImport --force
       lxc info ctImport | grep snap0
@@ -116,5 +107,6 @@ test_container_import() {
     fi
   )
   # shellcheck disable=SC2031
+  LXD_DIR=${LXD_DIR}
   kill_lxd "${LXD_IMPORT_DIR}"
 }

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -120,7 +120,7 @@ test_basic_usage() {
   lxc launch testimage baz
   # change the container filesystem so the resulting image is different
   lxc exec baz touch /somefile
-  lxc stop baz
+  lxc stop baz --force
   # publishing another image with same alias doesn't fail
   lxc publish baz --alias=foo-image
   lxc delete baz

--- a/test/suites/image_auto_update.sh
+++ b/test/suites/image_auto_update.sh
@@ -46,7 +46,7 @@ test_image_auto_update() {
   #
   # XXX: Since the auto-update logic runs asynchronously we need to wait
   #      a little bit before it actually completes.
-  retries=60
+  retries=600
   while [ "${retries}" != "0" ]; do
     if lxc image info "${fp1}" > /dev/null 2>&1; then
         sleep 2

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -15,7 +15,7 @@ test_storage_driver_ceph() {
     LXD_DIR="${LXD_STORAGE_DIR}"
 
     if [ "$lxd_backend" != "ceph" ]; then
-        exit 0
+      exit 0
     fi
 
     # shellcheck disable=SC1009

--- a/test/suites/storage_driver_ceph.sh
+++ b/test/suites/storage_driver_ceph.sh
@@ -19,7 +19,7 @@ test_storage_driver_ceph() {
     fi
 
     # shellcheck disable=SC1009
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" ceph volume.size=25MB
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool1" ceph volume.size=25MB ceph.osd.pg_num=8
 
     # Set default storage pool for image import.
     lxc profile device add default root disk path="/" pool="lxdtest-$(basename "${LXD_DIR}")-pool1"
@@ -31,7 +31,7 @@ test_storage_driver_ceph() {
     ceph --cluster "${LXD_CEPH_CLUSTER}" osd pool create "lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" 32
 
     # Let LXD use an already existing osd pool.
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" ceph source="lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" volume.size=25MB
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-pool2" ceph source="lxdtest-$(basename "${LXD_DIR}")-existing-osd-pool" volume.size=25MB ceph.osd.pg_num=8
 
     # Test that no invalid ceph storage pool configuration keys can be set.
     ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-invalid-ceph-pool-config" ceph lvm.thinpool_name=bla
@@ -39,7 +39,7 @@ test_storage_driver_ceph() {
     ! lxc storage create "lxdtest-$(basename "${LXD_DIR}")-invalid-ceph-pool-config" ceph lvm.vg_name=bla
 
     # Test that all valid ceph storage pool configuration keys can be set.
-    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-valid-ceph-pool-config" ceph volume.block.filesystem=ext4 volume.block.mount_options=discard volume.size=2GB ceph.rbd.clone_copy=true ceph.osd.pg_num=32
+    lxc storage create "lxdtest-$(basename "${LXD_DIR}")-valid-ceph-pool-config" ceph volume.block.filesystem=ext4 volume.block.mount_options=discard volume.size=2GB ceph.rbd.clone_copy=true ceph.osd.pg_num=8
     lxc storage delete "lxdtest-$(basename "${LXD_DIR}")-valid-ceph-pool-config"
 
     # Muck around with some containers on various pools.


### PR DESCRIPTION
Ceph is similar to zfs in that storage volumes need to be kept around in case they have dependent snapshots. That is:

```
- <storage-volume-1>
- snapshot(<storage-volume-1) = <snap1>
- protect(<snap1>)            = <snap1_protected>
- delete(<storage-volume-1>)
```

will fail since \<snap1_protected\> is dependent. Because of this the way I implemented the ceph driver it will map the delete() operation onto a rename() operation:

```
- delete(<storage-volume-1>) -> rename(<storage-volume-1>) = zombie_<storage-volume-1>
```

But consider the following:

```
lxc init images:alpine/edge a = <storage-volume-a>                                  /* succeeds */
lxc copy a b                  = <storage-volume-b> depends <storage-volume-a>       /* succeeds */
lxc delete a                  = <storage-volume-a> rename zombie_<storage-volume-a> /* succeeds */
lxc init images:alpine/edge a = <storage-volume-a>                                  /* succeeds */
lxc copy a c                  = <storage-volume-c> depends <storage-volume-a>       /* succeeds */
lxc delete a                  = <storage-volume-a> rename zombie_<storage-volume-a> /* fails    */
```

To avoid this we suffix each storage volume with a UUID so the sequence above becomes:

```
lxc init images:alpine/edge a = <storage-volume-a>                                         /* succeeds */
lxc copy a b                  = <storage-volume-b> depends <storage-volume-a>              /* succeeds */
lxc delete a                  = <storage-volume-a> rename zombie_<storage-volume-a>_<uuid> /* succeeds */
lxc init images:alpine/edge a = <storage-volume-a>                                         /* succeeds */
lxc copy a c                  = <storage-volume-c> depends <storage-volume-a>              /* succeeds */
lxc delete a                  = <storage-volume-a> rename zombie_<storage-volume-a>-<uuid> /* succeeds */
```