### PR TITLE
idmapping: disallow hostids intersecting subids

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -647,7 +647,10 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 		copy(newIdmapset.Idmap, state.OS.IdmapSet.Idmap)
 
 		for _, ent := range rawMaps {
-			newIdmapset.AddSafe(ent)
+			err := newIdmapset.AddSafe(ent)
+			if err != nil && err == idmap.ErrHostIdIsSubId {
+				return nil, 0, err
+			}
 		}
 
 		return &newIdmapset, 0, nil
@@ -658,17 +661,20 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 		return nil, 0, err
 	}
 
-	mkIdmap := func(offset int64, size int64) *idmap.IdmapSet {
+	mkIdmap := func(offset int64, size int64) (*idmap.IdmapSet, error) {
 		set := &idmap.IdmapSet{Idmap: []idmap.IdmapEntry{
 			{Isuid: true, Nsid: 0, Hostid: offset, Maprange: size},
 			{Isgid: true, Nsid: 0, Hostid: offset, Maprange: size},
 		}}
 
 		for _, ent := range rawMaps {
-			set.AddSafe(ent)
+			err := set.AddSafe(ent)
+			if err != nil && err == idmap.ErrHostIdIsSubId {
+				return nil, err
+			}
 		}
 
-		return set
+		return set, nil
 	}
 
 	if configBase != "" {
@@ -677,7 +683,12 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 			return nil, 0, err
 		}
 
-		return mkIdmap(offset, size), offset, nil
+		set, err := mkIdmap(offset, size)
+		if err != nil && err == idmap.ErrHostIdIsSubId {
+			return nil, 0, err
+		}
+
+		return set, offset, nil
 	}
 
 	idmapLock.Lock()
@@ -735,7 +746,12 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 				continue
 			}
 
-			return mkIdmap(offset, size), offset, nil
+			set, err := mkIdmap(offset, size)
+			if err != nil && err == idmap.ErrHostIdIsSubId {
+				return nil, 0, err
+			}
+
+			return set, offset, nil
 		}
 
 		if mapentries[i-1].Hostid+mapentries[i-1].Maprange > offset {
@@ -745,13 +761,23 @@ func findIdmap(state *state.State, cName string, isolatedStr string, configBase 
 
 		offset = mapentries[i-1].Hostid + mapentries[i-1].Maprange
 		if offset+size < mapentries[i].Hostid {
-			return mkIdmap(offset, size), offset, nil
+			set, err := mkIdmap(offset, size)
+			if err != nil && err == idmap.ErrHostIdIsSubId {
+				return nil, 0, err
+			}
+
+			return set, offset, nil
 		}
 		offset = mapentries[i].Hostid + mapentries[i].Maprange
 	}
 
 	if offset+size < state.OS.IdmapSet.Idmap[0].Hostid+state.OS.IdmapSet.Idmap[0].Maprange {
-		return mkIdmap(offset, size), offset, nil
+		set, err := mkIdmap(offset, size)
+		if err != nil && err == idmap.ErrHostIdIsSubId {
+			return nil, 0, err
+		}
+
+		return set, offset, nil
 	}
 
 	return nil, 0, fmt.Errorf("Not enough uid/gid available for the container.")

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -344,6 +344,8 @@ func (m IdmapSet) ValidRanges() ([]*IdRange, error) {
 	return ranges, nil
 }
 
+var ErrHostIdIsSubId = fmt.Errorf("Host id is in the range of subids")
+
 /* AddSafe adds an entry to the idmap set, breaking apart any ranges that the
  * new idmap intersects with in the process.
  */
@@ -357,7 +359,7 @@ func (m *IdmapSet) AddSafe(i IdmapEntry) error {
 		}
 
 		if e.HostidsIntersect(i) {
-			return fmt.Errorf("can't map the same host ID twice")
+			return ErrHostIdIsSubId
 		}
 
 		added = true

--- a/test/suites/idmap.sh
+++ b/test/suites/idmap.sh
@@ -51,6 +51,10 @@ test_idmap() {
   [ "$(lxc exec idmap -- cat /proc/self/uid_map | awk '{print $3}')" = "${UIDs}" ]
   [ "$(lxc exec idmap -- cat /proc/self/gid_map | awk '{print $3}')" = "${GIDs}" ]
 
+  # Confirm that we don't allow double mappings
+  ! echo "uid $((UID_BASE+1)) 1000" | lxc config set idmap raw.idmap - || false
+  ! echo "gid $((GID_BASE+1)) 1000" | lxc config set idmap raw.idmap - || false
+
   # Convert container to isolated and confirm it's not using the first range
   lxc config set idmap security.idmap.isolated true
   lxc restart idmap --force


### PR DESCRIPTION
Our code has explicitly disallowed this for a long time but somehow we have
never correctly errored out in these cases like we should.
After having discussed this with Eric at Plumbers I think this should be
considered a security liability. The problem I see with this is that it
accidently allows users to escalate a container that is unprivileged to a
privileged container without their knowledge. The most obvious case is when
the allocated range of subids is accidently 0-65536 which is rare but basically
runs afoul of creating an unprivileged container but there are more subtle
problems when using "{uid,gid,both} \<id\> \<id\>" directly so I prefer to disallow
this for now. Especially since this feature is currently not very useful since
the maximum number of allowed idmappings is currently capped at five so this
would overflow quite easy.

Closes #3416.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>