### PR TITLE
storage/zfs: use "referenced" property when zfs.use_refquota=true

### DIFF
--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1493,7 +1493,7 @@ func (s *storageZfs) ContainerGetUsage(container container) (int64, error) {
 	}
 
 	if shared.IsTrue(zfsUseRefquota) {
-		property = "usedbydataset"
+		property = "referenced"
 	}
 
 	value, err := zfsFilesystemEntityPropertyGet(s.getOnDiskPoolName(), fs, property)


### PR DESCRIPTION
Fixes #3795 