### PR TITLE
migration: restore state when moving container 

### DIFF
--- a/lxc/move.go
+++ b/lxc/move.go
@@ -98,12 +98,16 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 
 	cpy := copyCmd{}
 
+	stateful := !c.stateless
+
 	// A move is just a copy followed by a delete; however, we want to
 	// keep the volatile entries around since we are moving the container.
-	err = cpy.copyContainer(conf, args[0], args[1], true, -1, true, c.containerOnly, mode)
+	err = cpy.copyContainer(conf, args[0], args[1], true, -1, stateful, c.containerOnly, mode)
 	if err != nil {
 		return err
 	}
 
-	return commands["delete"].run(conf, args[:1])
+	del := deleteCmd{}
+	del.force = true
+	return del.run(conf, args[:1])
 }

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -388,6 +388,12 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 			return err
 		}
 
+		if !migrationArgs.Live {
+			if req.Config["volatile.last_state.power"] == "RUNNING" {
+				return c.Start(false)
+			}
+		}
+
 		return nil
 	}
 


### PR DESCRIPTION
When a container is running users can pass "--stateful" to the lxd command line
tool "lxc move". This will move the container and restore the state of the
container on the target.
My original implementation of this feature only applied to stateless container
copies but not to requests to move a container. The only thing we need to do is
pass the stateless argument along in the move codepath for the "lxc move"
command line tool and then restore state on the receiving side based on the
container's config. This is trivial since we know the source container's state
because we preserve volatile keys when moving containers.

Closes #3798.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>