### PR TITLE
Added InsecureSkipVerify flag the ConnectionArgs struct

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -32,6 +32,9 @@ type ConnectionArgs struct {
 
 	// Custom HTTP Client (used as base for the connection)
 	HTTPClient *http.Client
+
+	// Controls whether a client verifies the server's certificate chain and host name.
+	InsecureSkipVerify bool
 }
 
 // ConnectLXD lets you connect to a remote LXD daemon over HTTPs.
@@ -123,7 +126,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.Proxy)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy)
 	if err != nil {
 		return nil, err
 	}
@@ -152,7 +155,7 @@ func httpsLXD(url string, args *ConnectionArgs) (ContainerServer, error) {
 	}
 
 	// Setup the HTTP client
-	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.Proxy)
+	httpClient, err := tlsHTTPClient(args.HTTPClient, args.TLSClientCert, args.TLSClientKey, args.TLSCA, args.TLSServerCert, args.InsecureSkipVerify, args.Proxy)
 	if err != nil {
 		return nil, err
 	}

--- a/client/util.go
+++ b/client/util.go
@@ -13,9 +13,9 @@ import (
 	"github.com/lxc/lxd/shared/ioprogress"
 )
 
-func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, proxy func(req *http.Request) (*url.URL, error)) (*http.Client, error) {
+func tlsHTTPClient(client *http.Client, tlsClientCert string, tlsClientKey string, tlsCA string, tlsServerCert string, insecureSkipVerify bool, proxy func(req *http.Request) (*url.URL, error)) (*http.Client, error) {
 	// Get the TLS configuration
-	tlsConfig, err := shared.GetTLSConfigMem(tlsClientCert, tlsClientKey, tlsCA, tlsServerCert)
+	tlsConfig, err := shared.GetTLSConfigMem(tlsClientCert, tlsClientKey, tlsCA, tlsServerCert, insecureSkipVerify)
 	if err != nil {
 		return nil, err
 	}

--- a/shared/network.go
+++ b/shared/network.go
@@ -103,9 +103,9 @@ func GetTLSConfig(tlsClientCertFile string, tlsClientKeyFile string, tlsClientCA
 	return tlsConfig, nil
 }
 
-func GetTLSConfigMem(tlsClientCert string, tlsClientKey string, tlsClientCA string, tlsRemoteCertPEM string) (*tls.Config, error) {
+func GetTLSConfigMem(tlsClientCert string, tlsClientKey string, tlsClientCA string, tlsRemoteCertPEM string, insecureSkipVerify bool) (*tls.Config, error) {
 	tlsConfig := initTLSConfig()
-
+	tlsConfig.InsecureSkipVerify = insecureSkipVerify
 	// Client authentication
 	if tlsClientCert != "" && tlsClientKey != "" {
 		cert, err := tls.X509KeyPair([]byte(tlsClientCert), []byte(tlsClientKey))


### PR DESCRIPTION
Added a flag in ConnectionArgs struct that controls whether a client verifies the certificate chain and host name. This allows users to use self signed certificates when connecting to remote host through https. Of course the default value is false, but if you need that you can set it to true when connecting.

Signed-off-by: Ivan Georgiev <vanko.georgiev@gmail.com>