### PR TITLE
lvm: mount xfs snapshots with "nouuid"

### DIFF
--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1435,6 +1435,14 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 	if !shared.IsMountPoint(containerMntPoint) {
 		mntOptString := s.getLvmMountOptions()
 		mountFlags, mountOptions := lxdResolveMountoptions(mntOptString)
+
+		if lvFsType == "xfs" {
+			idx := strings.Index(mountOptions, "nouuid")
+			if idx < 0 {
+				mountOptions += ",nouuid"
+			}
+		}
+
 		err = tryMount(containerLvmPath, containerMntPoint, lvFsType, mountFlags, mountOptions)
 		if err != nil {
 			logger.Errorf(`Failed to mount LVM snapshot "%s" with `+

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1409,7 +1409,8 @@ func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newCon
 }
 
 func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
-	logger.Debugf("Initializing LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf(`Initializing LVM storage volume for snapshot "%s" on `+
+		`storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	containerName := container.Name()
@@ -1432,14 +1433,20 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 	lvFsType := s.getLvmFilesystem()
 	containerMntPoint := getSnapshotMountPoint(s.pool.Name, containerName)
 	if !shared.IsMountPoint(containerMntPoint) {
-		mountFlags, mountOptions := lxdResolveMountoptions(s.getLvmMountOptions())
+		mntOptString := s.getLvmMountOptions()
+		mountFlags, mountOptions := lxdResolveMountoptions(mntOptString)
 		err = tryMount(containerLvmPath, containerMntPoint, lvFsType, mountFlags, mountOptions)
 		if err != nil {
-			return false, fmt.Errorf("Error mounting snapshot LV path='%s': %s", containerMntPoint, err)
+			logger.Errorf(`Failed to mount LVM snapshot "%s" with `+
+				`filesystem "%s" options "%s" onto "%s": %s`,
+				s.volume.Name, lvFsType, mntOptString,
+				containerMntPoint, err)
+			return false, err
 		}
 	}
 
-	logger.Debugf("Initialized LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf(`Initialized LVM storage volume for snapshot "%s" on `+
+		`storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	if wasWritableAtCheck {
 		return false, nil


### PR DESCRIPTION
xfs explicitly mentions:

"nouuid Don't check for double mounted file systems using the file system uuid.
	This is useful to mount LVM snapshot volumes, and often  used  in
	combination with "norecovery" for mounting read-only snapshots."

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>