### PR TITLE
btrfs: workaround btrfs bug 

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1766,10 +1766,11 @@ func (s *btrfsMigrationSourceDriver) Snapshots() []container {
 }
 
 func (s *btrfsMigrationSourceDriver) send(conn *websocket.Conn, btrfsPath string, btrfsParent string, readWrapper func(io.ReadCloser) io.ReadCloser) error {
-	args := []string{"send", btrfsPath}
+	args := []string{"send"}
 	if btrfsParent != "" {
 		args = append(args, "-p", btrfsParent)
 	}
+	args = append(args, btrfsPath)
 
 	cmd := exec.Command("btrfs", args...)
 


### PR DESCRIPTION
It seems that btrfs v4.12.1 allows:

        (1) btrfs send -p <ro-snap-1> <ro-snap-0>

but disallows

        (2) btrfs send <ro-snap-0> -p <ro-snap-1>

Code-wise it assumes that <ro-snap-1> is always found at optind == 1. I
reported upstream and might patch this once they told me which direction they
want to go with this. Until then, work around it.

Closes #3843.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>