### PR TITLE
storage: rework container volume properties 

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -624,6 +624,10 @@ func (s *storageBtrfs) StoragePoolVolumeUpdate(writable *api.StorageVolumePut, c
 	}
 
 	if shared.StringInSlice("size", changedConfig) {
+		if s.volume.Type != storagePoolVolumeTypeNameCustom {
+			return updateStoragePoolVolumeError([]string{"size"}, "btrfs")
+		}
+
 		if s.volume.Config["size"] != writable.Config["size"] {
 			size, err := shared.ParseByteSizeString(writable.Config["size"])
 			if err != nil {

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -684,6 +684,10 @@ func (s *storageCeph) StoragePoolVolumeUpdate(writable *api.StorageVolumePut, ch
 	}
 
 	if shared.StringInSlice("size", changedConfig) {
+		if s.volume.Type != storagePoolVolumeTypeNameCustom {
+			return updateStoragePoolVolumeError([]string{"size"}, "ceph")
+		}
+
 		if s.volume.Config["size"] != writable.Config["size"] {
 			size, err := shared.ParseByteSizeString(writable.Config["size"])
 			if err != nil {

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -804,6 +804,10 @@ func (s *storageLvm) StoragePoolVolumeUpdate(writable *api.StorageVolumePut,
 	}
 
 	if shared.StringInSlice("size", changedConfig) {
+		if s.volume.Type != storagePoolVolumeTypeNameCustom {
+			return updateStoragePoolVolumeError([]string{"size"}, "lvm")
+		}
+
 		if s.volume.Config["size"] != writable.Config["size"] {
 			size, err := shared.ParseByteSizeString(writable.Config["size"])
 			if err != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -164,6 +164,15 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) Response {
 	// volume is supposed to be created.
 	poolName := mux.Vars(r)["name"]
 
+
+	// We currently only allow to create storage volumes of type
+	// storagePoolVolumeTypeCustom. So check, that nothing else was
+	// requested.
+	if req.Type != storagePoolVolumeTypeNameCustom {
+		return BadRequest(fmt.Errorf(`Currently not allowed to create `+
+			`storage volumes of type %s`, req.Type))
+	}
+
 	err = storagePoolVolumeCreateInternal(d.State(), poolName, req.Name, req.Description, req.Type, req.Config)
 	if err != nil {
 		return InternalError(err)

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -164,7 +164,6 @@ func storagePoolVolumesTypePost(d *Daemon, r *http.Request) Response {
 	// volume is supposed to be created.
 	poolName := mux.Vars(r)["name"]
 
-
 	// We currently only allow to create storage volumes of type
 	// storagePoolVolumeTypeCustom. So check, that nothing else was
 	// requested.

--- a/lxd/storage_volumes_config.go
+++ b/lxd/storage_volumes_config.go
@@ -13,6 +13,11 @@ func updateStoragePoolVolumeError(unchangeable []string, driverName string) erro
 		`storage volumes`, unchangeable, driverName)
 }
 
+// For storage volumes of type storagePoolVolumeTypeContainer We only allow to
+// change properties directly on the storage volume if there's not
+// corresponding way to change it by other means. A good example is the "size"
+// property which can be manipulated by setting a root disk device "size"
+// property.
 var changeableStoragePoolVolumeProperties = map[string][]string{
 	"btrfs": {"size"},
 

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -302,13 +302,6 @@ func storagePoolVolumeDBCreate(s *state.State, poolName string, volumeName, volu
 		return err
 	}
 
-	// We currently only allow to create storage volumes of type
-	// storagePoolVolumeTypeCustom. So check, that nothing else was
-	// requested.
-	if volumeType != storagePoolVolumeTypeCustom {
-		return fmt.Errorf("currently not allowed to create storage volumes of type %s", volumeTypeName)
-	}
-
 	// Load storage pool the volume will be attached to.
 	poolID, poolStruct, err := db.StoragePoolGet(s.DB, poolName)
 	if err != nil {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -581,6 +581,10 @@ func (s *storageZfs) StoragePoolVolumeUpdate(writable *api.StorageVolumePut, cha
 	}
 
 	if shared.StringInSlice("size", changedConfig) {
+		if s.volume.Type != storagePoolVolumeTypeNameCustom {
+			return updateStoragePoolVolumeError([]string{"size"}, "zfs")
+		}
+
 		if s.volume.Config["size"] != writable.Config["size"] {
 			size, err := shared.ParseByteSizeString(writable.Config["size"])
 			if err != nil {

--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -19,11 +19,9 @@ test_storage() {
   lxc storage show "$storage_pool" | grep -q 'description: foo'
 
   lxc storage volume create "$storage_pool" "$storage_volume"
-  if [ "$lxd_backend" != "dir" ] && [ "$lxd_backend" != "ceph" ]; then
-    # Test resizing/applying quota to a storage volume.
-    lxc storage volume set "$storage_pool" "$storage_volume" size 200MB
-    lxc storage volume unset "$storage_pool" "$storage_volume" size
-  fi
+  # Test resizing/applying quota to a storage volume's of type container fails.
+  ! lxc storage volume set "$storage_pool" "$storage_volume" size 200MB
+
   # Test setting description on a storage volume
   lxc storage volume show "$storage_pool" "$storage_volume" | sed 's/^description:.*/description: bar/' | lxc storage volume edit "$storage_pool" "$storage_volume"
   lxc storage volume show "$storage_pool" "$storage_volume" | grep -q 'description: bar'


### PR DESCRIPTION
For storage volumes of type storagePoolVolumeTypeContainer We only allow to
change properties directly on the storage volume if there's not corresponding
way to change it by other means. A good example is the "size" property which
can be manipulated by setting a root disk device "size" property.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>