### PR TITLE
lxd-benchmark: Change the default number of containers from 100 to 3

### DIFF
--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-var argCount = gnuflag.Int("count", 100, "Number of containers to create")
+var argCount = gnuflag.Int("count", 3, "Number of containers to create")
 var argParallel = gnuflag.Int("parallel", -1, "Number of threads to use")
 var argImage = gnuflag.String("image", "ubuntu:", "Image to use for the test")
 var argPrivileged = gnuflag.Bool("privileged", false, "Use privileged containers")


### PR DESCRIPTION
By default, lxd-benchmark will create 100 containers.
This can crash systems with less than 16GB of RAM.
A value of 3 should be sufficient for systems with 1GB RAM,
even when the storage backend is `dir`.