### PR TITLE
lxd-benchmark: Change name of `spawn` command to `launch`

### DIFF
--- a/lxd-benchmark/benchmark/benchmark.go
+++ b/lxd-benchmark/benchmark/benchmark.go
@@ -35,8 +35,8 @@ func PrintServerInfo(c lxd.ContainerServer) error {
 	return nil
 }
 
-// SpawnContainers launches a set of containers.
-func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image string, privileged bool, start bool, freeze bool) (time.Duration, error) {
+// LaunchContainers launches a set of containers.
+func LaunchContainers(c lxd.ContainerServer, count int, parallel int, image string, privileged bool, start bool, freeze bool) (time.Duration, error) {
 	var duration time.Duration
 
 	batchSize, err := getBatchSize(parallel)
@@ -58,7 +58,7 @@ func SpawnContainers(c lxd.ContainerServer, count int, parallel int, image strin
 
 		err := createContainer(c, fingerprint, name, privileged)
 		if err != nil {
-			logf("Failed to spawn container '%s': %s", name, err)
+			logf("Failed to launch container '%s': %s", name, err)
 			return
 		}
 
@@ -99,7 +99,7 @@ func CreateContainers(c lxd.ContainerServer, count int, parallel int, fingerprin
 
 		err := createContainer(c, fingerprint, name, privileged)
 		if err != nil {
-			logf("Failed to spawn container '%s': %s", name, err)
+			logf("Failed to launch container '%s': %s", name, err)
 			return
 		}
 	}

--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-var argCount = gnuflag.Int("count", 100, "Number of containers to create")
+var argCount = gnuflag.Int("count", 3, "Number of containers to create")
 var argParallel = gnuflag.Int("parallel", -1, "Number of threads to use")
 var argImage = gnuflag.String("image", "ubuntu:", "Image to use for the test")
 var argPrivileged = gnuflag.Bool("privileged", false, "Use privileged containers")
@@ -33,7 +33,7 @@ func main() {
 
 func run(args []string) error {
 	// Parse command line
-	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"spawn", "start", "stop", "delete"}) {
+	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"launch", "start", "stop", "delete"}) {
 		if len(os.Args) > 1 && os.Args[1] == "--version" {
 			fmt.Println(version.Version)
 			return nil
@@ -45,7 +45,7 @@ func run(args []string) error {
 		}
 		gnuflag.SetOut(out)
 
-		fmt.Fprintf(out, "Usage: %s spawn [--count=COUNT] [--image=IMAGE] [--privileged=BOOL] [--start=BOOL] [--freeze=BOOL] [--parallel=COUNT]\n", os.Args[0])
+		fmt.Fprintf(out, "Usage: %s launch [--count=COUNT] [--image=IMAGE] [--privileged=BOOL] [--start=BOOL] [--freeze=BOOL] [--parallel=COUNT]\n", os.Args[0])
 		fmt.Fprintf(out, "       %s start [--parallel=COUNT]\n", os.Args[0])
 		fmt.Fprintf(out, "       %s stop [--parallel=COUNT]\n", os.Args[0])
 		fmt.Fprintf(out, "       %s delete [--parallel=COUNT]\n\n", os.Args[0])
@@ -56,7 +56,7 @@ func run(args []string) error {
 			return nil
 		}
 
-		return fmt.Errorf("A valid action (spawn, start, stop, delete) must be passed.")
+		return fmt.Errorf("A valid action (launch, start, stop, delete) must be passed.")
 	}
 
 	gnuflag.Parse(true)
@@ -83,8 +83,8 @@ func run(args []string) error {
 	action := os.Args[1]
 	var duration time.Duration
 	switch action {
-	case "spawn":
-		duration, err = benchmark.SpawnContainers(
+	case "launch":
+		duration, err = benchmark.LaunchContainers(
 			c, *argCount, *argParallel, *argImage, *argPrivileged, *argStart, *argFreeze)
 		if err != nil {
 			return err

--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -33,7 +33,8 @@ func main() {
 
 func run(args []string) error {
 	// Parse command line
-	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"launch", "start", "stop", "delete"}) {
+	// "spawn" is being deprecated, use "launch" instead.
+	if len(os.Args) == 1 || !shared.StringInSlice(os.Args[1], []string{"launch", "spawn", "start", "stop", "delete"}) {
 		if len(os.Args) > 1 && os.Args[1] == "--version" {
 			fmt.Println(version.Version)
 			return nil
@@ -83,7 +84,8 @@ func run(args []string) error {
 	action := os.Args[1]
 	var duration time.Duration
 	switch action {
-	case "launch":
+	// "spawn" is being deprecated.
+	case "launch", "spawn":
 		duration, err = benchmark.LaunchContainers(
 			c, *argCount, *argParallel, *argImage, *argPrivileged, *argStart, *argFreeze)
 		if err != nil {


### PR DESCRIPTION
LXD supports the four commands launch, start, stop, delete.
lxd-benchmark performs equivalent actions over a number of containers.
lxd-benchmark has the four commands spawn, start, stop, delete.
The `spawn` command should be renamed to `launch`.