### PR TITLE
Document that squashfs images can also be used.

### DIFF
--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -80,6 +80,10 @@ rootfs.tar contains a Linux root filesystem at its root.
 In this mode the image identifier is the SHA-256 of the concatenation of
 the metadata and rootfs tarball (in that order).
 
+## Supported compression
+The tarball(s) can be compressed using bz2, gz, xz, lzma, tar (uncompressed) or
+it can also be a squashfs image.
+
 ## Content
 The rootfs directory (or tarball) contains a full file system tree of what will become the container's /.
 


### PR DESCRIPTION
I had to look in the code to figure out all supported image formats. https://github.com/lxc/lxd/blob/master/lxd/images.go#L67

#3355 made me ^^