### PR TITLE
Temporary workaround for log15 API breakage

### DIFF
--- a/shared/logging/log_posix.go
+++ b/shared/logging/log_posix.go
@@ -3,6 +3,8 @@
 package logging
 
 import (
+	slog "log/syslog"
+
 	log "gopkg.in/inconshreveable/log15.v2"
 )
 
@@ -13,11 +15,11 @@ func getSystemHandler(syslog string, debug bool, format log.Format) log.Handler 
 		if !debug {
 			return log.LvlFilterHandler(
 				log.LvlInfo,
-				log.Must.SyslogHandler(syslog, format),
+				log.Must.SyslogHandler(slog.LOG_INFO, syslog, format),
 			)
 		}
 
-		return log.Must.SyslogHandler(syslog, format)
+		return log.Must.SyslogHandler(slog.LOG_INFO, syslog, format)
 	}
 
 	return nil


### PR DESCRIPTION
log15 broke their v2 API earlier today, this change should get things
building again until upstream log15 fixes the API breakage.

Related: https://github.com/inconshreveable/log15/issues/139

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>