### PR TITLE
drop useless apparmor denies

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -80,8 +80,6 @@ const AA_PROFILE_BASE = `
 
   # block some other dangerous paths
   deny @{PROC}/kcore rwklx,
-  deny @{PROC}/kmem rwklx,
-  deny @{PROC}/mem rwklx,
   deny @{PROC}/sysrq-trigger rwklx,
 
   # deny writes in /sys except for /sys/fs/cgroup, also allow


### PR DESCRIPTION
mem and kmem are really in /dev, and they're not propagated into lxd
containers, privileged or otherwise anyways, so these are useless.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>