### PR TITLE
add resource api

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -43,6 +43,7 @@ type ContainerServer interface {
 
 	// Server functions
 	GetServer() (server *api.Server, ETag string, err error)
+	GetServerResources() (*api.Resources, error)
 	UpdateServer(server api.ServerPut, ETag string) (err error)
 	HasExtension(extension string) bool
 

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -140,6 +140,7 @@ type ContainerServer interface {
 	GetStoragePoolNames() (names []string, err error)
 	GetStoragePools() (pools []api.StoragePool, err error)
 	GetStoragePool(name string) (pool *api.StoragePool, ETag string, err error)
+	GetStoragePoolResources(name string) (resources *api.ResourcesStoragePool, err error)
 	CreateStoragePool(pool api.StoragePoolsPost) (err error)
 	UpdateStoragePool(name string, pool api.StoragePoolPut, ETag string) (err error)
 	DeleteStoragePool(name string) (err error)

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -1,6 +1,8 @@
 package lxd
 
 import (
+	"fmt"
+
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -52,4 +54,21 @@ func (r *ProtocolLXD) HasExtension(extension string) bool {
 	}
 
 	return false
+}
+
+// GetServerResources returns the resources available to a given LXD server
+func (r *ProtocolLXD) GetServerResources() (*api.Resources, error) {
+	if !r.HasExtension("resources") {
+		return nil, fmt.Errorf("The server is missing the required \"resources\" API extension")
+	}
+
+	resources := api.Resources{}
+
+	// Fetch the raw value
+	_, err := r.queryStruct("GET", "/resources", nil, "", &resources)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resources, nil
 }

--- a/client/lxd_storage_pools.go
+++ b/client/lxd_storage_pools.go
@@ -99,3 +99,20 @@ func (r *ProtocolLXD) DeleteStoragePool(name string) error {
 
 	return nil
 }
+
+// GetStoragePoolResources gets the resources available to a given storage pool
+func (r *ProtocolLXD) GetStoragePoolResources(name string) (*api.ResourcesStoragePool, error) {
+	if !r.HasExtension("resources") {
+		return nil, fmt.Errorf("The server is missing the required \"resources\" API extension")
+	}
+
+	res := api.ResourcesStoragePool{}
+
+	// Fetch the raw value
+	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/resources", name), nil, "", &res)
+	if err != nil {
+		return nil, err
+	}
+
+	return &res, nil
+}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -339,3 +339,7 @@ use by another LXD instance.
 ## storage\_block\_filesystem\_btrfs
 This adds support for btrfs as a storage volume filesystem, in addition to ext4
 and xfs.
+
+## resources
+This adds support for querying an LXD daemon for the system resources it has
+available.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -209,6 +209,7 @@ won't work and PUT needs to be used instead.
          * `/1.0/operations/<uuid>/websocket`
      * `/1.0/profiles`
        * `/1.0/profiles/<name>`
+     * `/1.0/resources`
 
 # API details
 ## `/`
@@ -2162,6 +2163,34 @@ Input (none at present):
     {
     }
 
+## `/1.0/storage-pools/<name>/resources`
+### GET
+ * Description: information about the resources available to the storage pool
+ * Introduced: with API extension `resources`
+ * Authentication: trusted
+ * Operation: sync
+ * Return: dict representing the storage pool resources
+
+    {
+        "type": "sync",
+        "status": "Success",
+        "status_code": 200,
+        "operation": "",
+        "error_code": 0,
+        "error": "",
+        "metadata": {
+            "space": {
+                "used": 207111192576,
+                "total": 306027577344
+            },
+            "inodes": {
+                "used": 3275333,
+                "total": 18989056
+            }
+        }
+    }
+
+
 ## `/1.0/storage-pools/<name>/volumes`
 ### GET
  * Description: list of storage volumes
@@ -2336,4 +2365,40 @@ l    }
 Input (none at present):
 
     {
+    }
+
+## `/1.0/resources`
+### GET
+ * Description: information about the resources available to the LXD server
+ * Introduced: with API extension `resources`
+ * Authentication: guest, untrusted or trusted
+ * Operation: sync
+ * Return: dict representing the system resources
+
+    {
+        "type": "sync",
+        "status": "Success",
+        "status_code": 200,
+        "operation": "",
+        "error_code": 0,
+        "error": "",
+        "metadata": {
+            "cpu": {
+                "sockets": [
+                   {
+                       "cores": 2,
+                       "frequency": 2691,
+                       "frequency_turbo": 3400,
+                       "name": "GenuineIntel",
+                       "vendor": "Intel(R) Core(TM) i5-3340M CPU @ 2.70GHz",
+                       "threads": 4
+                   }
+                ],
+                "total": 4
+            },
+            "memory": {
+                "used": 4454240256,
+                "total": 8271765504
+            }
+        }
     }

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -51,6 +51,7 @@ var api10 = []Command{
 	serverResourceCmd,
 	storagePoolsCmd,
 	storagePoolCmd,
+	storagePoolResourcesCmd,
 	storagePoolVolumesCmd,
 	storagePoolVolumesTypeCmd,
 	storagePoolVolumeTypeCmd,

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -48,6 +48,7 @@ var api10 = []Command{
 	certificateFingerprintCmd,
 	profilesCmd,
 	profileCmd,
+	serverResourceCmd,
 	storagePoolsCmd,
 	storagePoolCmd,
 	storagePoolVolumesCmd,

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -55,6 +55,7 @@ var api10 = []Command{
 	storagePoolVolumesCmd,
 	storagePoolVolumesTypeCmd,
 	storagePoolVolumeTypeCmd,
+	serverResourceCmd,
 }
 
 func api10Get(d *Daemon, r *http.Request) Response {
@@ -127,6 +128,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"storage_volatile_initial_source",
 			"storage_ceph_force_osd_reuse",
 			"storage_block_filesystem_btrfs",
+			"resources",
 		},
 		APIStatus:  "stable",
 		APIVersion: version.APIVersion,

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -3,6 +3,8 @@ package main
 import (
 	"net/http"
 
+	"github.com/gorilla/mux"
+
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -22,10 +24,36 @@ func serverResourcesGet(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	res.CPU = cpu
-	res.Memory = mem
+	res.CPU = *cpu
+	res.Memory = *mem
 
 	return SyncResponse(true, res)
 }
 
 var serverResourceCmd = Command{name: "resources", get: serverResourcesGet}
+
+// /1.0/storage-pools/{name}/resources
+// Get resources for a specific storage pool
+func storagePoolResourcesGet(d *Daemon, r *http.Request) Response {
+	poolName := mux.Vars(r)["name"]
+
+	// Get the existing storage pool.
+	s, err := storagePoolInit(d.State(), poolName)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	err = s.StoragePoolCheck()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	res, err := s.StoragePoolResources()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return SyncResponse(true, &res)
+}
+
+var storagePoolResourcesCmd = Command{name: "storage-pools/{name}/resources", get: storagePoolResourcesGet}

--- a/lxd/resources.go
+++ b/lxd/resources.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/http"
+
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// /1.0/resources
+// Get system resources
+func serverResourcesGet(d *Daemon, r *http.Request) Response {
+	res := api.Resources{}
+
+	cpu, err := util.CpuResource()
+	if err != nil {
+		return SmartError(err)
+	}
+
+	mem, err := util.MemoryResource()
+	if err != nil {
+		return SmartError(err)
+	}
+
+	res.CPU = cpu
+	res.Memory = mem
+
+	return SyncResponse(true, res)
+}
+
+var serverResourceCmd = Command{name: "resources", get: serverResourcesGet}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -144,6 +144,7 @@ type storage interface {
 	StoragePoolDelete() error
 	StoragePoolMount() (bool, error)
 	StoragePoolUmount() (bool, error)
+	StoragePoolResources() (*api.ResourcesStoragePool, error)
 	StoragePoolUpdate(writable *api.StoragePoolPut, changedConfig []string) error
 	GetStoragePoolWritable() api.StoragePoolPut
 	SetStoragePoolWritable(writable *api.StoragePoolPut)

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -2229,3 +2229,19 @@ func (s *storageBtrfs) StorageEntitySetQuota(volumeType int, size int64, data in
 	logger.Debugf(`Set BTRFS quota for "%s"`, s.volume.Name)
 	return nil
 }
+
+func (s *storageBtrfs) StoragePoolResources() (*api.ResourcesStoragePool, error) {
+	ourMount, err := s.StoragePoolMount()
+	if err != nil {
+		return nil, err
+	}
+	if ourMount {
+		defer s.StoragePoolUmount()
+	}
+
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+
+	// Inode allocation is dynamic so no use in reporting them.
+
+	return storageResource(poolMntPoint)
+}

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -1647,3 +1647,32 @@ func (s *storageCeph) rbdGrow(path string, size int64, fsType string,
 
 	return growFileSystem(fsType, path, fsMntPoint)
 }
+
+func parseCephSize(numStr string) (uint64, error) {
+	if numStr == "" {
+		return 0, fmt.Errorf("Empty string is not valid input")
+	}
+
+	lxdSuffix := "GB"
+	cephSuffix := numStr[(len(numStr) - 1):]
+	switch cephSuffix {
+	case "M":
+		lxdSuffix = "MB"
+	case "K":
+		lxdSuffix = "KB"
+	}
+
+	_, err := strconv.Atoi(cephSuffix)
+	if err != nil {
+		numStr = numStr[:(len(numStr) - 1)]
+		numStr = strings.TrimSpace(numStr)
+	}
+	numStr = fmt.Sprintf("%s%s", numStr, lxdSuffix)
+
+	size, err := shared.ParseByteSizeString(numStr)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint64(size), nil
+}

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -948,3 +948,17 @@ func (s *storageDir) MigrationSink(live bool, container container, snapshots []*
 func (s *storageDir) StorageEntitySetQuota(volumeType int, size int64, data interface{}) error {
 	return fmt.Errorf("the directory container backend doesn't support quotas")
 }
+
+func (s *storageDir) StoragePoolResources() (*api.ResourcesStoragePool, error) {
+	ourMount, err := s.StoragePoolMount()
+	if err != nil {
+		return nil, err
+	}
+	if ourMount {
+		defer s.StoragePoolUmount()
+	}
+
+	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
+
+	return storageResource(poolMntPoint)
+}

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -218,3 +218,7 @@ func (s *storageMock) MigrationSink(live bool, container container, snapshots []
 func (s *storageMock) StorageEntitySetQuota(volumeType int, size int64, data interface{}) error {
 	return nil
 }
+
+func (s *storageMock) StoragePoolResources() (*api.ResourcesStoragePool, error) {
+	return &api.ResourcesStoragePool{}, nil
+}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -250,6 +250,10 @@ func zfsPoolVolumeCleanup(pool string, path string) error {
 }
 
 func zfsFilesystemEntityPropertyGet(pool string, path string, key string) (string, error) {
+	entity := pool
+	if path != "" {
+		entity = fmt.Sprintf("%s/%s", pool, path)
+	}
 	output, err := shared.RunCommand(
 		"zfs",
 		"get",
@@ -257,7 +261,7 @@ func zfsFilesystemEntityPropertyGet(pool string, path string, key string) (strin
 		"-p",
 		"-o", "value",
 		key,
-		fmt.Sprintf("%s/%s", pool, path))
+		entity)
 	if err != nil {
 		return "", fmt.Errorf("Failed to get ZFS config: %s", output)
 	}

--- a/lxd/util/resources.go
+++ b/lxd/util/resources.go
@@ -234,12 +234,12 @@ func getThreads() ([]thread, error) {
 	return threads, nil
 }
 
-func CpuResource() (api.ResourcesCPU, error) {
+func CpuResource() (*api.ResourcesCPU, error) {
 	c := api.ResourcesCPU{}
 
 	threads, err := getThreads()
 	if err != nil {
-		return c, err
+		return nil, err
 	}
 
 	var cur *api.ResourcesCPUSocket
@@ -264,19 +264,18 @@ func CpuResource() (api.ResourcesCPU, error) {
 		cur.FrequencyTurbo = v.frequencyTurbo
 	}
 
-	return c, nil
+	return &c, nil
 }
 
-func MemoryResource() (api.ResourcesMemory, error) {
+func MemoryResource() (*api.ResourcesMemory, error) {
 	var buffers uint64
 	var cached uint64
 	var free uint64
 	var total uint64
 
-	mem := api.ResourcesMemory{}
 	f, err := os.Open("/proc/meminfo")
 	if err != nil {
-		return mem, err
+		return nil, err
 	}
 	defer f.Close()
 
@@ -290,6 +289,7 @@ func MemoryResource() (api.ResourcesMemory, error) {
 		return strings.TrimSpace(l[:idx]), nil
 	}
 
+	mem := api.ResourcesMemory{}
 	scanner := bufio.NewScanner(f)
 	found := 0
 	for scanner.Scan() {
@@ -299,48 +299,48 @@ func MemoryResource() (api.ResourcesMemory, error) {
 		if strings.HasPrefix(line, "MemTotal:") {
 			line, err = cleanLine(line[len("MemTotal:"):])
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			total, err = strconv.ParseUint(line, 10, 64)
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			found++
 		} else if strings.HasPrefix(line, "MemFree:") {
 			line, err = cleanLine(line[len("MemFree:"):])
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			free, err = strconv.ParseUint(line, 10, 64)
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			found++
 		} else if strings.HasPrefix(line, "Cached:") {
 			line, err = cleanLine(line[len("Cached:"):])
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			cached, err = strconv.ParseUint(line, 10, 64)
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			found++
 		} else if strings.HasPrefix(line, "Buffers:") {
 			line, err = cleanLine(line[len("Buffers:"):])
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			buffers, err = strconv.ParseUint(line, 10, 64)
 			if err != nil {
-				return mem, err
+				return nil, err
 			}
 
 			found++
@@ -354,5 +354,5 @@ func MemoryResource() (api.ResourcesMemory, error) {
 	mem.Total = total * 1024
 	mem.Used = (total - free - cached - buffers) * 1024
 
-	return mem, err
+	return &mem, err
 }

--- a/lxd/util/resources.go
+++ b/lxd/util/resources.go
@@ -1,0 +1,358 @@
+package util
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+type thread struct {
+	ID             uint64
+	vendor         string
+	name           string
+	coreID         uint64
+	socketID       uint64
+	frequency      uint64
+	frequencyTurbo uint64
+}
+
+func parseNumberFromFile(file string) (int64, error) {
+	buf, err := ioutil.ReadFile(file)
+	if err != nil {
+		return int64(0), err
+	}
+
+	str := strings.TrimSpace(string(buf))
+	nr, err := strconv.Atoi(str)
+	if err != nil {
+		return int64(0), err
+	}
+
+	return int64(nr), nil
+}
+
+func parseCpuinfo() ([]thread, error) {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	threads := []thread{}
+	scanner := bufio.NewScanner(f)
+	var t *thread
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "processor") {
+			i := strings.Index(line, ":")
+			if i < 0 {
+				return nil, err
+			}
+			i++
+
+			line = line[i:]
+			line = strings.TrimSpace(line)
+
+			id, err := strconv.Atoi(line)
+			if err != nil {
+				return nil, err
+			}
+
+			t = &thread{}
+			t.ID = uint64(id)
+
+			path := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/core_id", t.ID)
+			coreID, err := parseNumberFromFile(path)
+			if err != nil {
+				return nil, err
+			}
+
+			t.coreID = uint64(coreID)
+
+			path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/physical_package_id", t.ID)
+			sockID, err := parseNumberFromFile(path)
+			if err != nil {
+				return nil, err
+			}
+
+			t.socketID = uint64(sockID)
+
+			path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", t.ID)
+			freq, err := parseNumberFromFile(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return nil, err
+				}
+			} else {
+				t.frequency = uint64(freq / 1000)
+			}
+
+			path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", t.ID)
+			freq, err = parseNumberFromFile(path)
+			if err != nil {
+				if !os.IsNotExist(err) {
+					return nil, err
+				}
+			} else {
+				t.frequencyTurbo = uint64(freq / 1000)
+			}
+
+			threads = append(threads, *t)
+		} else if strings.HasPrefix(line, "vendor_id") {
+			i := strings.Index(line, ":")
+			if i < 0 {
+				return nil, err
+			}
+			i++
+
+			line = line[i:]
+			line = strings.TrimSpace(line)
+
+			if t != nil {
+				threads[len(threads)-1].name = line
+			}
+		} else if strings.HasPrefix(line, "model name") {
+			i := strings.Index(line, ":")
+			if i < 0 {
+				return nil, err
+			}
+			i++
+
+			line = line[i:]
+			line = strings.TrimSpace(line)
+
+			if t != nil {
+				threads[len(threads)-1].vendor = line
+			}
+		} else if t != nil && t.frequency == 0 && strings.HasPrefix(line, "cpu MHz") {
+			i := strings.Index(line, ":")
+			if i < 0 {
+				return nil, err
+			}
+			i++
+
+			line = line[i:]
+			line = strings.TrimSpace(line)
+
+			if t != nil {
+				freqFloat, err := strconv.ParseFloat(line, 64)
+				if err != nil {
+					return nil, err
+				}
+
+				threads[len(threads)-1].frequency = uint64(freqFloat)
+			}
+		}
+	}
+
+	if len(threads) == 0 {
+		return nil, os.ErrNotExist
+	}
+
+	return threads, err
+}
+
+func parseSysDevSystemCpu() ([]thread, error) {
+	ents, err := ioutil.ReadDir("/sys/devices/system/cpu/")
+	if err != nil {
+		return nil, err
+	}
+
+	threads := []thread{}
+	for _, ent := range ents {
+		entName := ent.Name()
+		if !strings.HasPrefix(entName, "cpu") {
+			continue
+		}
+
+		entName = entName[len("cpu"):]
+		idx, err := strconv.Atoi(entName)
+		if err != nil {
+			continue
+		}
+
+		t := thread{}
+		t.ID = uint64(idx)
+		path := fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/core_id", t.ID)
+		coreID, err := parseNumberFromFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		t.coreID = uint64(coreID)
+
+		path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/topology/physical_package_id", t.ID)
+		sockID, err := parseNumberFromFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		t.socketID = uint64(sockID)
+
+		path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/scaling_cur_freq", t.ID)
+		freq, err := parseNumberFromFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		t.frequency = uint64(freq / 1000)
+
+		path = fmt.Sprintf("/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", t.ID)
+		freq, err = parseNumberFromFile(path)
+		if err != nil {
+			return nil, err
+		}
+
+		t.frequencyTurbo = uint64(freq / 1000)
+
+		threads = append(threads, t)
+	}
+
+	if len(threads) == 0 {
+		return nil, os.ErrNotExist
+	}
+
+	return threads, err
+}
+
+func getThreads() ([]thread, error) {
+	threads, err := parseCpuinfo()
+	if err == nil {
+		return threads, nil
+	}
+
+	threads, err = parseSysDevSystemCpu()
+	if err != nil {
+		return nil, err
+	}
+
+	return threads, nil
+}
+
+func CpuResource() (api.ResourcesCPU, error) {
+	c := api.ResourcesCPU{}
+
+	threads, err := getThreads()
+	if err != nil {
+		return c, err
+	}
+
+	var cur *api.ResourcesCPUSocket
+	c.Total = uint64(len(threads))
+	c.Sockets = append(c.Sockets, api.ResourcesCPUSocket{})
+	for _, v := range threads {
+		if uint64(len(c.Sockets)) <= v.socketID {
+			c.Sockets = append(c.Sockets, api.ResourcesCPUSocket{})
+			cur = &c.Sockets[v.socketID]
+		} else {
+			cur = &c.Sockets[v.socketID]
+		}
+
+		if v.coreID+1 > cur.Cores {
+			cur.Cores++
+		}
+
+		cur.Threads++
+		cur.Name = v.name
+		cur.Vendor = v.vendor
+		cur.Frequency = v.frequency
+		cur.FrequencyTurbo = v.frequencyTurbo
+	}
+
+	return c, nil
+}
+
+func MemoryResource() (api.ResourcesMemory, error) {
+	var buffers uint64
+	var cached uint64
+	var free uint64
+	var total uint64
+
+	mem := api.ResourcesMemory{}
+	f, err := os.Open("/proc/meminfo")
+	if err != nil {
+		return mem, err
+	}
+	defer f.Close()
+
+	cleanLine := func(l string) (string, error) {
+		l = strings.TrimSpace(l)
+		idx := strings.LastIndex(l, "kB")
+		if idx < 0 {
+			return "", fmt.Errorf(`Failed to detect "kB" suffix`)
+		}
+
+		return strings.TrimSpace(l[:idx]), nil
+	}
+
+	scanner := bufio.NewScanner(f)
+	found := 0
+	for scanner.Scan() {
+		var err error
+		line := scanner.Text()
+
+		if strings.HasPrefix(line, "MemTotal:") {
+			line, err = cleanLine(line[len("MemTotal:"):])
+			if err != nil {
+				return mem, err
+			}
+
+			total, err = strconv.ParseUint(line, 10, 64)
+			if err != nil {
+				return mem, err
+			}
+
+			found++
+		} else if strings.HasPrefix(line, "MemFree:") {
+			line, err = cleanLine(line[len("MemFree:"):])
+			if err != nil {
+				return mem, err
+			}
+
+			free, err = strconv.ParseUint(line, 10, 64)
+			if err != nil {
+				return mem, err
+			}
+
+			found++
+		} else if strings.HasPrefix(line, "Cached:") {
+			line, err = cleanLine(line[len("Cached:"):])
+			if err != nil {
+				return mem, err
+			}
+
+			cached, err = strconv.ParseUint(line, 10, 64)
+			if err != nil {
+				return mem, err
+			}
+
+			found++
+		} else if strings.HasPrefix(line, "Buffers:") {
+			line, err = cleanLine(line[len("Buffers:"):])
+			if err != nil {
+				return mem, err
+			}
+
+			buffers, err = strconv.ParseUint(line, 10, 64)
+			if err != nil {
+				return mem, err
+			}
+
+			found++
+		}
+
+		if found == 4 {
+			break
+		}
+	}
+
+	mem.Total = total * 1024
+	mem.Used = (total - free - cached - buffers) * 1024
+
+	return mem, err
+}

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.14-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
@@ -279,7 +279,7 @@ msgstr "'/' ist kein gültiges Zeichen im Namen eines Sicherungspunktes\n"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -313,7 +313,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -328,11 +328,11 @@ msgstr "automatisches Update: %s"
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -340,11 +340,11 @@ msgstr "Bytes gesendet"
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
@@ -381,7 +381,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -407,8 +407,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -457,7 +457,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -472,12 +472,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -500,7 +500,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
@@ -565,7 +565,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -574,7 +574,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -676,11 +676,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, fuzzy, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
@@ -726,7 +726,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -751,7 +751,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -768,15 +768,15 @@ msgstr "Veröffentliche Abbild"
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -816,7 +816,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -835,7 +835,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -854,7 +854,7 @@ msgstr "Kein Zertifikat zum hinzufügen bereitgestellt"
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 #, fuzzy
 msgid "No device found for this storage volume."
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -863,7 +863,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "No fingerprint specified."
 msgstr "Kein Fingerabdruck angegeben."
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -907,11 +907,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -934,17 +934,17 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -964,7 +964,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -999,7 +999,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, fuzzy, c-format
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
@@ -1036,7 +1036,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remote operation canceled by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -1050,7 +1050,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -1072,7 +1072,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -1121,7 +1121,7 @@ msgstr "Zeigt alle Befehle (nicht nur die interessanten)"
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
@@ -1129,12 +1129,20 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, fuzzy, c-format
 msgid "Size: %.2fMB"
 msgstr "Größe: %.2vMB\n"
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1157,7 +1165,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1180,12 +1188,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Stopping the container failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -1195,12 +1203,12 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -1210,15 +1218,15 @@ msgstr "Profil %s gelöscht\n"
 msgid "Store the container state (only for stop)"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1256,7 +1264,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -1309,7 +1317,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1319,11 +1327,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1335,7 +1343,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1711,16 +1719,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -2195,7 +2203,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -2205,7 +2213,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2419,15 +2427,15 @@ msgstr "entfernte Instanz %s existiert als <%s>"
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -36,7 +36,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -174,7 +174,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -207,7 +207,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -222,11 +222,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -234,11 +234,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
@@ -271,7 +271,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -296,8 +296,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -359,12 +359,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -399,7 +399,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -459,7 +459,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -557,11 +557,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -606,7 +606,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -631,7 +631,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -647,15 +647,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
@@ -664,7 +664,7 @@ msgstr "  Χρήση μνήμης:"
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -693,7 +693,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -712,7 +712,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -729,7 +729,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -781,11 +781,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -805,17 +805,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -835,7 +835,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -869,7 +869,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -939,7 +939,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -987,7 +987,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -995,12 +995,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1022,7 +1030,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1044,12 +1052,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1058,12 +1066,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1072,15 +1080,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1116,7 +1124,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1165,7 +1173,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1175,11 +1183,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1191,7 +1199,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1506,16 +1514,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1896,7 +1904,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1906,7 +1914,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2111,15 +2119,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 2.15-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -50,7 +50,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
@@ -269,7 +269,7 @@ msgstr "'/' n'est pas autorisé dans le nom d'un instantané"
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -303,7 +303,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -318,11 +318,11 @@ msgstr "Mise à jour auto. : %s"
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -330,11 +330,11 @@ msgstr "Octets émis"
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
@@ -369,7 +369,7 @@ msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr "Impossible de fournir le nom du conteneur à lister"
 
@@ -394,8 +394,8 @@ msgstr "Commandes:"
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -444,7 +444,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -458,12 +458,12 @@ msgstr "Création de %s"
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -486,7 +486,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -498,7 +498,7 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
@@ -549,7 +549,7 @@ msgstr "Expire : %s"
 msgid "Expires: never"
 msgstr "N'expire jamais"
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
@@ -559,7 +559,7 @@ msgstr "Import de l'image : %s"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -663,12 +663,12 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 #, fuzzy
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
@@ -714,7 +714,7 @@ msgstr "Source invalide %s"
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr "IPs :"
 
@@ -739,7 +739,7 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr "Journal : "
 
@@ -755,15 +755,15 @@ msgstr "Rendre l'image publique"
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
@@ -772,7 +772,7 @@ msgstr "  Mémoire utilisée :"
 msgid "Missing summary."
 msgstr "Résumé manquant."
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -795,7 +795,7 @@ msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr "NOM"
 
@@ -803,7 +803,7 @@ msgstr "NOM"
 msgid "NO"
 msgstr "NON"
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -822,7 +822,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -839,7 +839,7 @@ msgstr "Un certificat à ajouter n'a pas été fourni"
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 #, fuzzy
 msgid "No device found for this storage volume."
 msgstr "Aucun périphérique existant pour ce réseau"
@@ -848,7 +848,7 @@ msgstr "Aucun périphérique existant pour ce réseau"
 msgid "No fingerprint specified."
 msgstr "Aucune empreinte n'a été indiquée."
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "Seul les volumes \"personnalisés\" peuvent être attaché aux conteneurs"
 
@@ -892,11 +892,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -917,17 +917,17 @@ msgstr "Création du conteneur"
 msgid "Permission denied, are you in the lxd group?"
 msgstr "Permission refusée, êtes-vous dans le groupe lxd ?"
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid : %d"
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
@@ -947,7 +947,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -981,7 +981,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr "Profils : %s"
@@ -1017,7 +1017,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remote operation canceled by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr "Serveur distant : %s"
@@ -1031,7 +1031,7 @@ msgstr "Supprimer %s (oui/non) : "
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -1053,7 +1053,7 @@ msgstr "TAILLE"
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -1102,7 +1102,7 @@ msgstr "Afficher toutes les comandes (pas seulement les plus intéressantes)"
 msgid "Show client version"
 msgstr "Afficher la version du client"
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
@@ -1110,12 +1110,20 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "Taille : %.2f Mo"
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -1138,7 +1146,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -1161,12 +1169,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Stopping the container failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -1175,12 +1183,12 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, fuzzy, c-format
 msgid "Storage volume %s created"
 msgstr "Profil %s créé"
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, fuzzy, c-format
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
@@ -1189,15 +1197,15 @@ msgstr "Profil %s supprimé"
 msgid "Store the container state (only for stop)"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -1239,7 +1247,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
@@ -1294,7 +1302,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
@@ -1304,11 +1312,11 @@ msgstr "Transfert de l'image : %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr "Type : éphémère"
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr "Type : persistant"
 
@@ -1320,7 +1328,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
 
@@ -1819,16 +1827,17 @@ msgstr ""
 "    Lister les alias.  Les filtres peuvent être une partie de l'empreinte\n"
 "    de l'image ou une partie de l'alias de l'image."
 
-#: lxc/info.go:26
+#: lxc/info.go:27
+#, fuzzy
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 "Utilisation: lxc info [<serveur distant>:][<conteneur>] [--show-log]\n"
@@ -2473,7 +2482,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -2483,7 +2492,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2698,15 +2707,15 @@ msgstr "le serveur distant %s existe en tant que <%s>"
 msgid "remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr "sans suivi d'état"
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr "pris à %s"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.17-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -50,7 +50,7 @@ msgstr ""
 "###   source: /home/chb/mnt/lxd_test/default.img\n"
 "###   zfs.pool_name: default"
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,7 +195,7 @@ msgstr "'/' non è permesso nel nome di uno snapshot"
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -228,7 +228,7 @@ msgstr "Password amministratore per %s: "
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -243,11 +243,11 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -255,11 +255,11 @@ msgstr "Byte inviati"
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -316,8 +316,8 @@ msgstr "Comandi:"
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -379,12 +379,12 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -407,7 +407,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
@@ -419,7 +419,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
@@ -469,7 +469,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -478,7 +478,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -576,11 +576,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -625,7 +625,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -666,15 +666,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -682,7 +682,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -694,7 +694,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -703,7 +703,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -746,7 +746,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -754,7 +754,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -798,11 +798,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -822,17 +822,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -852,7 +852,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -886,7 +886,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -921,7 +921,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -956,7 +956,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -1004,7 +1004,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -1012,12 +1012,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1039,7 +1047,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1061,12 +1069,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1075,12 +1083,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1089,15 +1097,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1133,7 +1141,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1182,7 +1190,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1192,11 +1200,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1208,7 +1216,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1523,16 +1531,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1913,7 +1921,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1923,7 +1931,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2128,15 +2136,15 @@ msgstr "il remote %s esiste come %s"
 msgid "remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr "senza stato"
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr "salvato alle %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-08-03 05:16+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 2.16-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -36,7 +36,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -175,7 +175,7 @@ msgstr "'/' はスナップショットの名前には使用できません"
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr "%s の管理者パスワード: "
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -223,11 +223,11 @@ msgstr "自動更新: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -235,11 +235,11 @@ msgstr "送信バイト数"
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
@@ -273,7 +273,7 @@ msgstr "キー '%s' が設定されていないので削除できません"
 msgid "Can't unset key '%s', it's not currently set."
 msgstr "キー '%s' が指定されていないので削除できません。"
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr "コンテナ名を取得できません"
 
@@ -298,8 +298,8 @@ msgstr "コマンド:"
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -347,7 +347,7 @@ msgstr "サーバ証明書格納用のディレクトリを作成できません
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -361,12 +361,12 @@ msgstr "%s を作成中"
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -389,7 +389,7 @@ msgstr "デバイス %s が %s から削除されました"
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
@@ -401,7 +401,7 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
@@ -451,7 +451,7 @@ msgstr "失効日時: %s"
 msgid "Expires: never"
 msgstr "失効日時: 失効しない"
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
@@ -460,7 +460,7 @@ msgstr "イメージのエクスポート中: %s"
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -560,11 +560,11 @@ msgstr "イメージは更新済みです。"
 msgid "Image copied successfully!"
 msgstr "イメージのコピーが成功しました!"
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
@@ -609,7 +609,7 @@ msgstr "不正なソース %s"
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr "IPアドレス:"
 
@@ -634,7 +634,7 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr "ログ:"
 
@@ -650,15 +650,15 @@ msgstr "イメージを public にする"
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
@@ -666,7 +666,7 @@ msgstr "メモリ消費量:"
 msgid "Missing summary."
 msgstr "サマリーはありません。"
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください。"
 
@@ -680,7 +680,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr "コンテナを移動します (スナップショットは移動しません)"
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
@@ -689,7 +689,7 @@ msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -697,7 +697,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr "コンテナ名: %s"
@@ -716,7 +716,7 @@ msgstr "ネットワーク %s を削除しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -732,7 +732,7 @@ msgstr "追加すべき証明書が提供されていません"
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr "このストレージボリュームに対するデバイスがありません。"
 
@@ -740,7 +740,7 @@ msgstr "このストレージボリュームに対するデバイスがありま
 msgid "No fingerprint specified."
 msgstr "フィンガープリントが指定されていません。"
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチできます。"
 
@@ -784,11 +784,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -808,17 +808,17 @@ msgstr "コンテナを一時停止します。"
 msgid "Permission denied, are you in the lxd group?"
 msgstr "アクセスが拒否されました。lxd グループに所属していますか?"
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid: %d"
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
 
@@ -838,7 +838,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr "詳細情報を表示します"
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -872,7 +872,7 @@ msgstr "新しいコンテナに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
@@ -907,7 +907,7 @@ msgstr "リモートの管理者パスワード"
 msgid "Remote operation canceled by user"
 msgstr "リモート操作がユーザによってキャンセルされました"
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr "リモート名: %s"
@@ -921,7 +921,7 @@ msgstr "%s を消去しますか (yes/no): "
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -942,7 +942,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -990,7 +990,7 @@ msgstr "全てコマンドを表示します (主なコマンドだけではな�
 msgid "Show client version"
 msgstr "クライアントのバージョンを表示します"
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "コンテナログの最後の 100 行を表示しますか?"
 
@@ -998,12 +998,20 @@ msgstr "コンテナログの最後の 100 行を表示しますか?"
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr "サイズ: %.2fMB"
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -1025,7 +1033,7 @@ msgstr "コンテナを起動します。"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -1047,12 +1055,12 @@ msgstr "コンテナの停止に失敗しました！"
 msgid "Stopping the container failed: %s"
 msgstr "コンテナの停止に失敗しました: %s"
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
@@ -1061,12 +1069,12 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr "ストレージボリューム %s を作成しました"
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
@@ -1075,15 +1083,15 @@ msgstr "ストレージボリューム %s を削除しました"
 msgid "Store the container state (only for stop)"
 msgstr "コンテナの状態を保存します (stopのみ)"
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1122,7 +1130,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
@@ -1181,7 +1189,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transferring container: %s"
 msgstr "コンテナを転送中: %s"
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
@@ -1191,11 +1199,11 @@ msgstr "イメージを転送中: %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr "タイプ: ephemeral"
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr "タイプ: persistent"
 
@@ -1207,7 +1215,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1777,16 +1785,17 @@ msgstr ""
 "ス\n"
 "    名の一部をフィルタとして指定できます。"
 
-#: lxc/info.go:26
+#: lxc/info.go:27
+#, fuzzy
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 "使い方: lxc info [<remote>:][<container>] [--show-log]\n"
@@ -2493,7 +2502,8 @@ msgstr ""
 "lxc snapshot u1 snap0\n"
 "    \"u1\" のスナップショットを \"snap0\" という名前で作成します。"
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
+#, fuzzy
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -2503,7 +2513,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2806,15 +2816,15 @@ msgstr "リモート %s は <%s> として存在します"
 msgid "remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr "ステートレス"
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr "%s に取得しました"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-09-05 18:15+0200\n"
+        "POT-Creation-Date: 2017-10-06 13:51+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid   "### This is a yaml representation of a storage pool.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -32,7 +32,7 @@ msgid   "### This is a yaml representation of a storage pool.\n"
         "###   zfs.pool_name: default"
 msgstr  ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid   "### This is a yaml representation of a storage volume.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -164,7 +164,7 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid   "ALIAS"
 msgstr  ""
 
@@ -197,7 +197,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -212,11 +212,11 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -224,11 +224,11 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid   "CPU usage:"
 msgstr  ""
 
@@ -260,7 +260,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set."
 msgstr  ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid   "Cannot provide container name to list"
 msgstr  ""
 
@@ -285,7 +285,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169 lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -333,7 +333,7 @@ msgstr  ""
 msgid   "Create any directories necessary"
 msgstr  ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -347,11 +347,11 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507 lxc/storage.go:658 lxc/storage.go:769
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid   "DRIVER"
 msgstr  ""
 
@@ -374,7 +374,7 @@ msgstr  ""
 msgid   "Device already exists: %s"
 msgstr  ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
@@ -386,7 +386,7 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid   "Disk usage:"
 msgstr  ""
 
@@ -436,7 +436,7 @@ msgstr  ""
 msgid   "Expires: never"
 msgstr  ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid   "Exporting the image: %s"
 msgstr  ""
@@ -445,7 +445,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -543,11 +543,11 @@ msgstr  ""
 msgid   "Image copied successfully!"
 msgstr  ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
@@ -592,7 +592,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid   "Ips:"
 msgstr  ""
 
@@ -617,7 +617,7 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid   "Log:"
 msgstr  ""
 
@@ -633,15 +633,15 @@ msgstr  ""
 msgid   "Make the image public"
 msgstr  ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid   "Memory usage:"
 msgstr  ""
 
@@ -649,7 +649,7 @@ msgstr  ""
 msgid   "Missing summary."
 msgstr  ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid   "More than one device matches, specify the device name."
 msgstr  ""
 
@@ -661,7 +661,7 @@ msgstr  ""
 msgid   "Move the container without its snapshots"
 msgstr  ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
@@ -669,7 +669,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381 lxc/storage.go:653 lxc/storage.go:748
+#: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381 lxc/storage.go:657 lxc/storage.go:768
 msgid   "NAME"
 msgstr  ""
 
@@ -677,7 +677,7 @@ msgstr  ""
 msgid   "NO"
 msgstr  ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -696,7 +696,7 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid   "Network usage:"
 msgstr  ""
 
@@ -712,7 +712,7 @@ msgstr  ""
 msgid   "No device found for this network"
 msgstr  ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid   "No device found for this storage volume."
 msgstr  ""
 
@@ -720,7 +720,7 @@ msgstr  ""
 msgid   "No fingerprint specified."
 msgstr  ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid   "Only \"custom\" volumes can be attached to containers."
 msgstr  ""
 
@@ -764,11 +764,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid   "Packets sent"
 msgstr  ""
 
@@ -788,16 +788,16 @@ msgstr  ""
 msgid   "Permission denied, are you in the lxd group?"
 msgstr  ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid   "Pid: %d"
 msgstr  ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382 lxc/image.go:1156
+#: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382 lxc/image.go:1170
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -817,7 +817,7 @@ msgstr  ""
 msgid   "Print verbose information"
 msgstr  ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -851,7 +851,7 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid   "Profiles: %s"
 msgstr  ""
@@ -886,7 +886,7 @@ msgstr  ""
 msgid   "Remote operation canceled by user"
 msgstr  ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid   "Remote: %s"
 msgstr  ""
@@ -900,7 +900,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid   "Resources:"
 msgstr  ""
 
@@ -921,7 +921,7 @@ msgstr  ""
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid   "SOURCE"
 msgstr  ""
 
@@ -969,7 +969,7 @@ msgstr  ""
 msgid   "Show client version"
 msgstr  ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
@@ -977,12 +977,20 @@ msgstr  ""
 msgid   "Show the expanded configuration"
 msgstr  ""
 
+#: lxc/info.go:41
+msgid   "Show the resources available to the server"
+msgstr  ""
+
+#: lxc/storage.go:148
+msgid   "Show the resources available to the storage pool"
+msgstr  ""
+
 #: lxc/image.go:580
 #, c-format
 msgid   "Size: %.2fMB"
 msgstr  ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -1004,7 +1012,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -1026,12 +1034,12 @@ msgstr  ""
 msgid   "Stopping the container failed: %s"
 msgstr  ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
@@ -1040,12 +1048,12 @@ msgstr  ""
 msgid   "Storage pool name"
 msgstr  ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid   "Storage volume %s created"
 msgstr  ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid   "Storage volume %s deleted"
 msgstr  ""
@@ -1054,15 +1062,15 @@ msgstr  ""
 msgid   "Store the container state (only for stop)"
 msgstr  ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid   "TYPE"
 msgstr  ""
 
@@ -1095,7 +1103,7 @@ msgstr  ""
 msgid   "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
@@ -1143,7 +1151,7 @@ msgstr  ""
 msgid   "Transferring container: %s"
 msgstr  ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid   "Transferring image: %s"
 msgstr  ""
@@ -1153,11 +1161,11 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid   "Type: ephemeral"
 msgstr  ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid   "Type: persistent"
 msgstr  ""
 
@@ -1169,7 +1177,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid   "USED BY"
 msgstr  ""
 
@@ -1453,15 +1461,15 @@ msgid   "Usage: lxc image <subcommand> [options]\n"
         "    List the aliases. Filters may be part of the image hash or part of the image alias name."
 msgstr  ""
 
-#: lxc/info.go:26
-msgid   "Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+#: lxc/info.go:27
+msgid   "Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
         "\n"
         "Show container or server information.\n"
         "\n"
         "lxc info [<remote>:]<container> [--show-log]\n"
         "    For container information.\n"
         "\n"
-        "lxc info [<remote>:]\n"
+        "lxc info [<remote>:] [--resources]\n"
         "    For LXD server information."
 msgstr  ""
 
@@ -1803,7 +1811,7 @@ msgid   "Usage: lxc snapshot [<remote>:]<container> <snapshot name> [--stateful]
         "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr  ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid   "Usage: lxc storage <subcommand> [options]\n"
         "\n"
         "Manage storage pools and volumes.\n"
@@ -1812,7 +1820,7 @@ msgid   "Usage: lxc storage <subcommand> [options]\n"
         "lxc storage list [<remote>:]\n"
         "    List available storage pools.\n"
         "\n"
-        "lxc storage show [<remote>:]<pool>\n"
+        "lxc storage show [<remote>:]<pool> [--resources]\n"
         "    Show details of a storage pool.\n"
         "\n"
         "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2003,15 +2011,15 @@ msgstr  ""
 msgid   "remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid   "stateful"
 msgstr  ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid   "stateless"
 msgstr  ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid   "taken at %s"
 msgstr  ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: 2017-06-06 13:55+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 2.15-dev\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
@@ -54,7 +54,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -260,7 +260,7 @@ msgstr "Нельзя использовать '/' в имени снимка"
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -294,7 +294,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -309,11 +309,11 @@ msgstr "Авто-обновление: %s"
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -321,11 +321,11 @@ msgstr "Отправлено байтов"
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
@@ -358,7 +358,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr "Невозможно добавить имя контейнера в список"
 
@@ -383,8 +383,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -432,7 +432,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -446,12 +446,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -474,7 +474,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -486,7 +486,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
@@ -537,7 +537,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, fuzzy, c-format
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
@@ -546,7 +546,7 @@ msgstr "Копирование образа: %s"
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -644,11 +644,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -693,7 +693,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -734,15 +734,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
@@ -751,7 +751,7 @@ msgstr " Использование памяти:"
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -763,7 +763,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -772,7 +772,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -780,7 +780,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -799,7 +799,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -816,7 +816,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -824,7 +824,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -868,11 +868,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -892,17 +892,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -956,7 +956,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -991,7 +991,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -1005,7 +1005,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -1082,12 +1082,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1131,12 +1139,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1145,12 +1153,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1159,15 +1167,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1203,7 +1211,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1252,7 +1260,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1262,11 +1270,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1278,7 +1286,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1601,16 +1609,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1991,7 +1999,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -2001,7 +2009,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2206,15 +2214,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-09-05 18:15+0200\n"
+"POT-Creation-Date: 2017-10-06 13:51+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:31
+#: lxc/storage.go:33
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -33,7 +33,7 @@ msgid ""
 "###   zfs.pool_name: default"
 msgstr ""
 
-#: lxc/storage.go:48
+#: lxc/storage.go:50
 msgid ""
 "### This is a yaml representation of a storage volume.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/image.go:227 lxc/image.go:1100
+#: lxc/image.go:227 lxc/image.go:1114
 msgid "ALIAS"
 msgstr ""
 
@@ -204,7 +204,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:581 lxc/info.go:104
+#: lxc/image.go:581 lxc/info.go:122
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -219,11 +219,11 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/info.go:197
+#: lxc/info.go:215
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:198
+#: lxc/info.go:216
 msgid "Bytes sent"
 msgstr ""
 
@@ -231,11 +231,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:161
+#: lxc/info.go:179
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:165
+#: lxc/info.go:183
 msgid "CPU usage:"
 msgstr ""
 
@@ -267,7 +267,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set."
 msgstr ""
 
-#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:625
+#: lxc/network.go:468 lxc/profile.go:528 lxc/storage.go:629
 msgid "Cannot provide container name to list"
 msgstr ""
 
@@ -292,8 +292,8 @@ msgstr ""
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1155
-#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:576 lxc/storage.go:935
+#: lxc/config.go:816 lxc/config.go:881 lxc/config.go:1331 lxc/image.go:1169
+#: lxc/network.go:418 lxc/profile.go:267 lxc/storage.go:580 lxc/storage.go:955
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Create any directories necessary"
 msgstr ""
 
-#: lxc/image.go:586 lxc/info.go:106
+#: lxc/image.go:586 lxc/info.go:124
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -355,12 +355,12 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:231 lxc/image.go:1102 lxc/list.go:463 lxc/network.go:507
-#: lxc/storage.go:654 lxc/storage.go:749
+#: lxc/image.go:231 lxc/image.go:1116 lxc/list.go:463 lxc/network.go:507
+#: lxc/storage.go:658 lxc/storage.go:769
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:655
+#: lxc/storage.go:659
 msgid "DRIVER"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Device already exists: %s"
 msgstr ""
 
-#: lxc/image.go:1254
+#: lxc/image.go:1268
 msgid "Directory import is not available on this platform"
 msgstr ""
 
@@ -395,7 +395,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:154
+#: lxc/info.go:172
 msgid "Disk usage:"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Expires: never"
 msgstr ""
 
-#: lxc/image.go:896
+#: lxc/image.go:900
 #, c-format
 msgid "Exporting the image: %s"
 msgstr ""
@@ -454,7 +454,7 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1101
+#: lxc/config.go:399 lxc/image.go:229 lxc/image.go:1115
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -552,11 +552,11 @@ msgstr ""
 msgid "Image copied successfully!"
 msgstr ""
 
-#: lxc/image.go:946
+#: lxc/image.go:960
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:753
+#: lxc/image.go:757
 #, c-format
 msgid "Image imported with fingerprint: %s"
 msgstr ""
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:135
+#: lxc/info.go:153
 msgid "Ips:"
 msgstr ""
 
@@ -626,7 +626,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/info.go:250
+#: lxc/info.go:268
 msgid "Log:"
 msgstr ""
 
@@ -642,15 +642,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/info.go:172
+#: lxc/info.go:190
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:176
+#: lxc/info.go:194
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:188
+#: lxc/info.go:206
 msgid "Memory usage:"
 msgstr ""
 
@@ -658,7 +658,7 @@ msgstr ""
 msgid "Missing summary."
 msgstr ""
 
-#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:374 lxc/storage.go:494
+#: lxc/network.go:276 lxc/network.go:329 lxc/storage.go:378 lxc/storage.go:498
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
@@ -670,7 +670,7 @@ msgstr ""
 msgid "Move the container without its snapshots"
 msgstr ""
 
-#: lxc/image.go:1256
+#: lxc/image.go:1270
 msgid "Must run as root to import from directory"
 msgstr ""
 
@@ -679,7 +679,7 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/list.go:465 lxc/network.go:504 lxc/profile.go:555 lxc/remote.go:381
-#: lxc/storage.go:653 lxc/storage.go:748
+#: lxc/storage.go:657 lxc/storage.go:768
 msgid "NAME"
 msgstr ""
 
@@ -687,7 +687,7 @@ msgstr ""
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:99
+#: lxc/info.go:117
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:223
 msgid "Network usage:"
 msgstr ""
 
@@ -722,7 +722,7 @@ msgstr ""
 msgid "No device found for this network"
 msgstr ""
 
-#: lxc/storage.go:383 lxc/storage.go:503
+#: lxc/storage.go:387 lxc/storage.go:507
 msgid "No device found for this storage volume."
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "No fingerprint specified."
 msgstr ""
 
-#: lxc/storage.go:327 lxc/storage.go:420
+#: lxc/storage.go:331 lxc/storage.go:424
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
@@ -774,11 +774,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:199
+#: lxc/info.go:217
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:200
+#: lxc/info.go:218
 msgid "Packets sent"
 msgstr ""
 
@@ -798,17 +798,17 @@ msgstr ""
 msgid "Permission denied, are you in the lxd group?"
 msgstr ""
 
-#: lxc/info.go:117
+#: lxc/info.go:135
 #, c-format
 msgid "Pid: %d"
 msgstr ""
 
-#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:577 lxc/storage.go:936
+#: lxc/network.go:419 lxc/profile.go:268 lxc/storage.go:581 lxc/storage.go:956
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:817 lxc/config.go:882 lxc/config.go:1332 lxc/config.go:1382
-#: lxc/image.go:1156
+#: lxc/image.go:1170
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -828,7 +828,7 @@ msgstr ""
 msgid "Print verbose information"
 msgstr ""
 
-#: lxc/info.go:141
+#: lxc/info.go:159
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:115
+#: lxc/info.go:133
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -897,7 +897,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:101
+#: lxc/info.go:119
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -911,7 +911,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:156
 msgid "Resources:"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:656
+#: lxc/storage.go:660
 msgid "SOURCE"
 msgstr ""
 
@@ -980,7 +980,7 @@ msgstr ""
 msgid "Show client version"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -988,12 +988,20 @@ msgstr ""
 msgid "Show the expanded configuration"
 msgstr ""
 
+#: lxc/info.go:41
+msgid "Show the resources available to the server"
+msgstr ""
+
+#: lxc/storage.go:148
+msgid "Show the resources available to the storage pool"
+msgstr ""
+
 #: lxc/image.go:580
 #, c-format
 msgid "Size: %.2fMB"
 msgstr ""
 
-#: lxc/info.go:219
+#: lxc/info.go:237
 msgid "Snapshots:"
 msgstr ""
 
@@ -1015,7 +1023,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/info.go:109
+#: lxc/info.go:127
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -1037,12 +1045,12 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:468
+#: lxc/storage.go:472
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:527
+#: lxc/storage.go:531
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
@@ -1051,12 +1059,12 @@ msgstr ""
 msgid "Storage pool name"
 msgstr ""
 
-#: lxc/storage.go:782
+#: lxc/storage.go:802
 #, c-format
 msgid "Storage volume %s created"
 msgstr ""
 
-#: lxc/storage.go:797
+#: lxc/storage.go:817
 #, c-format
 msgid "Storage volume %s deleted"
 msgstr ""
@@ -1065,15 +1073,15 @@ msgstr ""
 msgid "Store the container state (only for stop)"
 msgstr ""
 
-#: lxc/info.go:180
+#: lxc/info.go:198
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:184
+#: lxc/info.go:202
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:747
+#: lxc/list.go:470 lxc/network.go:505 lxc/storage.go:767
 msgid "TYPE"
 msgstr ""
 
@@ -1109,7 +1117,7 @@ msgstr ""
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
-#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:388 lxc/storage.go:508
+#: lxc/network.go:290 lxc/network.go:343 lxc/storage.go:392 lxc/storage.go:512
 msgid "The specified device doesn't exist"
 msgstr ""
 
@@ -1158,7 +1166,7 @@ msgstr ""
 msgid "Transferring container: %s"
 msgstr ""
 
-#: lxc/image.go:692
+#: lxc/image.go:696
 #, c-format
 msgid "Transferring image: %s"
 msgstr ""
@@ -1168,11 +1176,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:111
+#: lxc/info.go:129
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:113
+#: lxc/info.go:131
 msgid "Type: persistent"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:657 lxc/storage.go:750
+#: lxc/network.go:508 lxc/profile.go:556 lxc/storage.go:661 lxc/storage.go:770
 msgid "USED BY"
 msgstr ""
 
@@ -1499,16 +1507,16 @@ msgid ""
 "image alias name."
 msgstr ""
 
-#: lxc/info.go:26
+#: lxc/info.go:27
 msgid ""
-"Usage: lxc info [<remote>:][<container>] [--show-log]\n"
+"Usage: lxc info [<remote>:][<container>] [--show-log] [--resources]\n"
 "\n"
 "Show container or server information.\n"
 "\n"
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
 "\n"
-"lxc info [<remote>:]\n"
+"lxc info [<remote>:] [--resources]\n"
 "    For LXD server information."
 msgstr ""
 
@@ -1889,7 +1897,7 @@ msgid ""
 "    Create a snapshot of \"u1\" called \"snap0\"."
 msgstr ""
 
-#: lxc/storage.go:62
+#: lxc/storage.go:64
 msgid ""
 "Usage: lxc storage <subcommand> [options]\n"
 "\n"
@@ -1899,7 +1907,7 @@ msgid ""
 "lxc storage list [<remote>:]\n"
 "    List available storage pools.\n"
 "\n"
-"lxc storage show [<remote>:]<pool>\n"
+"lxc storage show [<remote>:]<pool> [--resources]\n"
 "    Show details of a storage pool.\n"
 "\n"
 "lxc storage create [<remote>:]<pool> <driver> [key=value]...\n"
@@ -2104,15 +2112,15 @@ msgstr ""
 msgid "remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/info.go:230
+#: lxc/info.go:248
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:232
+#: lxc/info.go:250
 msgid "stateless"
 msgstr ""
 
-#: lxc/info.go:226
+#: lxc/info.go:244
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -1,0 +1,33 @@
+package api
+
+// Resources represents the system resources avaible for LXD
+// API extension: resources
+type Resources struct {
+	CPU    ResourcesCPU    `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	Memory ResourcesMemory `json:"memory,omitempty" yaml:"memory,omitempty"`
+}
+
+// ResourcesCPUSocket represents a cpu socket on the system
+// API extension: resources
+type ResourcesCPUSocket struct {
+	Cores          uint64 `json:"cores" yaml:"cores"`
+	Frequency      uint64 `json:"frequency,omitempty" yaml:"frequency,omitempty"`
+	FrequencyTurbo uint64 `json:"frequency_turbo,omitempty" yaml:"frequency_turbo,omitempty"`
+	Name           string `json:"name,omitempty" yaml:"name,omitempty"`
+	Vendor         string `json:"vendor,omitempty" yaml:"vendor,omitempty"`
+	Threads        uint64 `json:"threads" yaml:"threads"`
+}
+
+// ResourcesCPU represents the cpu resources available on the system
+// API extension: resources
+type ResourcesCPU struct {
+	Sockets []ResourcesCPUSocket `json:"sockets" yaml:"sockets"`
+	Total   uint64               `json:"total" yaml:"total"`
+}
+
+// ResourcesMemory represents the memory resources available on the system
+// API extension: resources
+type ResourcesMemory struct {
+	Used  uint64 `json:"used" yaml:"used"`
+	Total uint64 `json:"total" yaml:"total"`
+}

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -3,8 +3,9 @@ package api
 // Resources represents the system resources avaible for LXD
 // API extension: resources
 type Resources struct {
-	CPU    ResourcesCPU    `json:"cpu,omitempty" yaml:"cpu,omitempty"`
-	Memory ResourcesMemory `json:"memory,omitempty" yaml:"memory,omitempty"`
+	CPU         ResourcesCPU         `json:"cpu,omitempty" yaml:"cpu,omitempty"`
+	Memory      ResourcesMemory      `json:"memory,omitempty" yaml:"memory,omitempty"`
+	StoragePool ResourcesStoragePool `json:"pool,omitempty" yaml:"pool,omitempty"`
 }
 
 // ResourcesCPUSocket represents a cpu socket on the system
@@ -28,6 +29,27 @@ type ResourcesCPU struct {
 // ResourcesMemory represents the memory resources available on the system
 // API extension: resources
 type ResourcesMemory struct {
+	Used  uint64 `json:"used" yaml:"used"`
+	Total uint64 `json:"total" yaml:"total"`
+}
+
+// ResourcesStoragePool represents the resources available to a given storage pool
+// API extension: resources
+type ResourcesStoragePool struct {
+	Space  ResourcesStoragePoolSpace  `json:"space,omitempty" yaml:"space,omitempty"`
+	Inodes ResourcesStoragePoolInodes `json:"inodes,omitempty" yaml:"inodes,omitempty"`
+}
+
+// ResourcesStoragePoolSpace represents the space available to a given storage pool
+// API extension: resources
+type ResourcesStoragePoolSpace struct {
+	Used  uint64 `json:"used,omitempty" yaml:"used,omitempty"`
+	Total uint64 `json:"total" yaml:"total"`
+}
+
+// ResourcesStoragePoolInodes represents the inodes available to a given storage pool
+// API extension: resources
+type ResourcesStoragePoolInodes struct {
 	Used  uint64 `json:"used" yaml:"used"`
 	Total uint64 `json:"total" yaml:"total"`
 }

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -853,3 +853,14 @@ func intArrayToString(arr interface{}) string {
 
 	return s
 }
+
+func Statvfs(path string) (*syscall.Statfs_t, error) {
+	var st syscall.Statfs_t
+
+	err := syscall.Statfs(path, &st)
+	if err != nil {
+		return nil, err
+	}
+
+	return &st, nil
+}

--- a/test/main.sh
+++ b/test/main.sh
@@ -184,6 +184,7 @@ run_test test_storage_profiles "storage profiles"
 run_test test_container_import "container import"
 run_test test_storage_volume_attach "attaching storage volumes"
 run_test test_storage_driver_ceph "ceph storage driver"
+run_test test_resources "resources"
 
 # shellcheck disable=SC2034
 TEST_RESULT=success

--- a/test/suites/resources.sh
+++ b/test/suites/resources.sh
@@ -1,0 +1,13 @@
+test_resources() {
+  RES=$(lxc storage show --resources "lxdtest-$(basename "${LXD_DIR}")")
+  echo "${RES}" | grep -q "^space:"
+
+  RES=$(lxc info --resources)
+  echo "${RES}" | grep -q "^cpu:"
+  echo "${RES}" | grep -q "sockets:"
+  echo "${RES}" | grep -q "threads:"
+  echo "${RES}" | grep -q "total:"
+  echo "${RES}" | grep -q "memory:"
+  echo "${RES}" | grep -q "used:"
+  echo "${RES}" | grep -q "total:"
+}


### PR DESCRIPTION
This adds a resource API for a LXD server. Sending a request will currently yield cpu and memory information. Further resources for appropriate LXD objects might be added later.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>