### PR TITLE
containers: add limits.kernel.[limit name] support 

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -342,4 +342,7 @@ and xfs.
 
 ## resources
 This adds support for querying an LXD daemon for the system resources it has
-available.
+
+## kernel\_limits
+This adds support for setting process limits such as maximum number of open
+files for the container via `nofile`. The format is `limits.kernel.[limit name]`.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -129,6 +129,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 			"storage_ceph_force_osd_reuse",
 			"storage_block_filesystem_btrfs",
 			"resources",
+			"kernel_limits",
 		},
 		APIStatus:  "stable",
 		APIVersion: version.APIVersion,

--- a/shared/container.go
+++ b/shared/container.go
@@ -231,5 +231,10 @@ func ConfigKeyChecker(key string) (func(value string) error, error) {
 		return IsAny, nil
 	}
 
+	if strings.HasPrefix(key, "limits.kernel.") &&
+		(len(key) > len("limits.kernel.")) {
+		return IsAny, nil
+	}
+
 	return nil, fmt.Errorf("Bad key: %s", key)
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -185,6 +185,7 @@ run_test test_container_import "container import"
 run_test test_storage_volume_attach "attaching storage volumes"
 run_test test_storage_driver_ceph "ceph storage driver"
 run_test test_resources "resources"
+run_test test_kernel_limits "kernel limits"
 
 # shellcheck disable=SC2034
 TEST_RESULT=success

--- a/test/suites/kernel_limits.sh
+++ b/test/suites/kernel_limits.sh
@@ -1,0 +1,17 @@
+test_kernel_limits() {
+  echo "==> API extension kernel_limits"
+
+  ensure_import_testimage
+  lxc init testimage limits
+  # Set it to a limit < 65536 because older systemd's do not have my nofile
+  # limit patch.
+  lxc config set limits limits.kernel.nofile 3000
+  lxc start limits
+  pid=$(lxc info limits | grep ^Pid | awk '{print $2}')
+  soft=$(grep ^"Max open files" /proc/"${pid}"/limits | awk '{print $4}')
+  hard=$(grep ^"Max open files" /proc/"${pid}"/limits | awk '{print $5}')
+
+  lxc delete --force limits 
+
+  [ "${soft}" = "3000" ] && [ "${hard}" = "3000" ]
+}


### PR DESCRIPTION
This adds support for liblxc's lxc.prlimit.[limit name] feature.

Closes #3272.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>