### PR TITLE
ceph: remove size property from osd pools

### DIFF
--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -187,9 +187,10 @@ func storagePoolValidateConfig(name string, driver string, config map[string]str
 }
 
 func storagePoolFillDefault(name string, driver string, config map[string]string) error {
-	if driver == "dir" {
+	if driver == "dir" || driver == "ceph" {
 		if config["size"] != "" {
-			return fmt.Errorf("The \"size\" property does not apply to %s storage pools", driver)
+			return fmt.Errorf(`The "size" property does not apply `+
+				`to %s storage pools`, driver)
 		}
 	} else {
 		if config["size"] == "" {


### PR DESCRIPTION
The size property does not make sense for osd storage pools since the cluster
effectively determines the size.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>