### PR TITLE
network: do not update limits unconditionally

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -81,6 +81,8 @@ func containerValidConfigKey(os *sys.OS, key string, value string) error {
 	return nil
 }
 
+var containerNetworkLimitKeys = []string{"limits.max", "limits.ingress", "limits.egress"}
+
 func containerValidDeviceConfigKey(t, k string) bool {
 	if k == "type" {
 		return true

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3387,7 +3387,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	// Diff the devices
-	removeDevices, addDevices, updateDevices := oldExpandedDevices.Update(c.expandedDevices)
+	removeDevices, addDevices, updateDevices, updateDiff := oldExpandedDevices.Update(c.expandedDevices)
 
 	// Do some validation of the config diff
 	err = containerValidConfig(c.state.OS, c.expandedConfig, false, true)
@@ -3997,10 +3997,20 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 			if m["type"] == "disk" {
 				updateDiskLimit = true
 			} else if m["type"] == "nic" {
-				// Refresh tc limits
-				err = c.setNetworkLimits(k, m)
-				if err != nil {
-					return err
+				needsUpdate := false
+				for _, v := range containerNetworkLimitKeys {
+					needsUpdate = shared.StringInSlice(v, updateDiff)
+					if needsUpdate {
+						break
+					}
+				}
+
+				if needsUpdate {
+					// Refresh tc limits
+					err = c.setNetworkLimits(k, m)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}
@@ -6796,7 +6806,6 @@ func (c *containerLXC) setNetworkLimits(name string, m types.Device) error {
 
 	// Look for the host side interface name
 	veth := c.getHostInterface(m["name"])
-
 	if veth == "" {
 		return fmt.Errorf("LXC doesn't know about this device and the host_name property isn't set, can't find host side veth name")
 	}


### PR DESCRIPTION
In order to determine whether a given device needs to be updated LXD will diff
the keys and values for the old and the new device settings. If LXD determines
a difference it will append the key and the corresponding value to the device.
If it determines they don't differ the key and value won't be in the updated
devices list that is passed to the the container's update method. So we can
simply rely on checking whether the given key exists in the device that is to
be updated if it isn't we don't need to run the actual update.

Closes #3920.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>