### PR TITLE
Prefix paths when lxc is run in a snap

### DIFF
--- a/lxc/file.go
+++ b/lxc/file.go
@@ -260,7 +260,7 @@ func (c *fileCmd) push(conf *config.Config, send_file_perms bool, args []string)
 	var sourcefilenames []string
 	for _, fname := range args[:len(args)-1] {
 		if !strings.HasPrefix(fname, "--") {
-			sourcefilenames = append(sourcefilenames, fname)
+			sourcefilenames = append(sourcefilenames, shared.HostPath(filepath.Clean(fname)))
 		}
 	}
 
@@ -423,7 +423,7 @@ func (c *fileCmd) pull(conf *config.Config, args []string) error {
 		return errArgs
 	}
 
-	target := args[len(args)-1]
+	target := shared.HostPath(filepath.Clean(args[len(args)-1]))
 	targetIsDir := false
 	sb, err := os.Stat(target)
 	if err != nil && !os.IsNotExist(err) {

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -630,7 +630,7 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 
 		for _, arg := range args[1:] {
 			split := strings.Split(arg, "=")
-			if len(split) == 1 || shared.PathExists(arg) {
+			if len(split) == 1 || shared.PathExists(shared.HostPath(arg)) {
 				if strings.HasSuffix(arg, ":") {
 					var err error
 					remote, _, err = conf.ParseRemote(arg)
@@ -657,6 +657,7 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 			imageFile = args[1]
 			properties = properties[1:]
 		}
+		imageFile = shared.HostPath(filepath.Clean(imageFile))
 
 		d, err := conf.GetContainerServer(remote)
 		if err != nil {
@@ -881,6 +882,7 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 				targetMeta = args[2]
 			}
 		}
+		targetMeta = shared.HostPath(targetMeta)
 		targetRootfs := targetMeta + ".root"
 
 		// Prepare the files
@@ -927,7 +929,7 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 		// Rename files
 		if shared.IsDir(target) {
 			if resp.MetaName != "" {
-				err := os.Rename(targetMeta, filepath.Join(target, resp.MetaName))
+				err := os.Rename(targetMeta, shared.HostPath(filepath.Join(target, resp.MetaName)))
 				if err != nil {
 					os.Remove(targetMeta)
 					os.Remove(targetRootfs)
@@ -937,7 +939,7 @@ func (c *imageCmd) run(conf *config.Config, args []string) error {
 			}
 
 			if resp.RootfsSize > 0 && resp.RootfsName != "" {
-				err := os.Rename(targetRootfs, filepath.Join(target, resp.RootfsName))
+				err := os.Rename(targetRootfs, shared.HostPath(filepath.Join(target, resp.RootfsName)))
 				if err != nil {
 					os.Remove(targetMeta)
 					os.Remove(targetRootfs)


### PR DESCRIPTION
Prefix local paths with `/var/lib/snapd/hostfs` when running in the snap.

Closes #3921 