### PR TITLE
Extract common logic from the ContainerExec API backend.

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -79,7 +79,7 @@ func (c *execCmd) sendTermSize(control *websocket.Conn) error {
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.ContainerTTYControl{}
 	msg.Command = "window-resize"
 	msg.Args = make(map[string]string)
 	msg.Args["width"] = strconv.Itoa(width)
@@ -103,7 +103,7 @@ func (c *execCmd) forwardSignal(control *websocket.Conn, sig syscall.Signal) err
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.ContainerTTYControl{}
 	msg.Command = "signal"
 	msg.Signal = int(sig)
 

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -84,13 +84,7 @@ func (s *execWs) Do(op *operation) error {
 						break
 					}
 
-					// If an abnormal closure occurred, kill the attached process.
-					err := syscall.Kill(s.attachedChildPid, syscall.SIGKILL)
-					if err != nil {
-						logger.Debugf("Failed to send SIGKILL to pid %d.", s.attachedChildPid)
-					} else {
-						logger.Debugf("Sent SIGKILL to pid %d.", s.attachedChildPid)
-					}
+					s.handleAbnormalClosure()
 					return
 				}
 
@@ -281,6 +275,16 @@ func (s *execWs) handleSignal(signal int) {
 		return
 	}
 	logger.Debugf("Forwarded signal '%d' to PID %d.", signal, s.attachedChildPid)
+}
+
+func (s *execWs) handleAbnormalClosure() {
+	// If an abnormal closure occurred, kill the attached process.
+	err := syscall.Kill(s.attachedChildPid, syscall.SIGKILL)
+	if err != nil {
+		logger.Debugf("Failed to send SIGKILL to pid %d.", s.attachedChildPid)
+	} else {
+		logger.Debugf("Sent SIGKILL to pid %d.", s.attachedChildPid)
+	}
 }
 
 func containerExecPost(d *Daemon, r *http.Request) Response {

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -53,7 +53,7 @@ func (s *execWs) Do(op *operation) error {
 	if s.interactive {
 		s.wgEOF.Add(1)
 		go func() {
-			s.attachedChildPid = <-s.attachedChildIsBorn
+			s.startup()
 			select {
 			case <-s.controlConnected:
 				break
@@ -134,6 +134,10 @@ func (s *execWs) Do(op *operation) error {
 	}
 	s.finish(op)
 	return op.UpdateMetadata(s.getMetadata())
+}
+
+func (s *execWs) startup() {
+	s.attachedChildPid = <-s.attachedChildIsBorn
 }
 
 func (s *execWs) do(stdin, stdout, stderr *os.File) error {

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -187,7 +187,7 @@ func (s *execWs) Do(op *operation) error {
 					break
 				}
 
-				command := api.ContainerExecControl{}
+				command := api.ContainerTTYControl{}
 
 				if err := json.Unmarshal(buf, &command); err != nil {
 					logger.Debugf("Failed to unmarshal control socket command: %s", err)

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -25,74 +25,13 @@ import (
 )
 
 type execWs struct {
-	command   []string
-	container container
-	env       map[string]string
+	ttyWs
 
-	rootUid          int64
-	rootGid          int64
-	conns            map[int]*websocket.Conn
-	connsLock        sync.Mutex
-	allConnected     chan bool
-	controlConnected chan bool
-	interactive      bool
-	fds              map[int]string
-	width            int
-	height           int
-}
-
-func (s *execWs) Metadata() interface{} {
-	fds := shared.Jmap{}
-	for fd, secret := range s.fds {
-		if fd == -1 {
-			fds["control"] = secret
-		} else {
-			fds[strconv.Itoa(fd)] = secret
-		}
-	}
-
-	return shared.Jmap{"fds": fds}
-}
-
-func (s *execWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) error {
-	secret := r.FormValue("secret")
-	if secret == "" {
-		return fmt.Errorf("missing secret")
-	}
-
-	for fd, fdSecret := range s.fds {
-		if secret == fdSecret {
-			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
-			if err != nil {
-				return err
-			}
-
-			s.connsLock.Lock()
-			s.conns[fd] = conn
-			s.connsLock.Unlock()
-
-			if fd == -1 {
-				s.controlConnected <- true
-				return nil
-			}
-
-			s.connsLock.Lock()
-			for i, c := range s.conns {
-				if i != -1 && c == nil {
-					s.connsLock.Unlock()
-					return nil
-				}
-			}
-			s.connsLock.Unlock()
-
-			s.allConnected <- true
-			return nil
-		}
-	}
-
-	/* If we didn't find the right secret, the user provided a bad one,
-	 * which 403, not 404, since this operation actually exists */
-	return os.ErrPermission
+	command     []string
+	env         map[string]string
+	rootUid     int64
+	rootGid     int64
+	interactive bool
 }
 
 func (s *execWs) Do(op *operation) error {

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -128,6 +128,15 @@ func (s *execWs) Do(op *operation) error {
 		s.connectNotInteractiveStreams()
 	}
 
+	err = s.do(stdin, stdout, stderr)
+	if err != nil {
+		return err
+	}
+	s.finish(op)
+	return op.UpdateMetadata(s.getMetadata())
+}
+
+func (s *execWs) do(stdin, stdout, stderr *os.File) error {
 	cmd, _, attachedPid, err := s.container.Exec(s.command, s.env, stdin, stdout, stderr, false)
 	if err != nil {
 		return err
@@ -153,8 +162,7 @@ func (s *execWs) Do(op *operation) error {
 			}
 		}
 	}
-	s.finish(op)
-	return op.UpdateMetadata(s.getMetadata())
+	return nil
 }
 
 // Open TTYs. Retruns stdin, stdout, stderr descriptors.

--- a/lxd/container_tty.go
+++ b/lxd/container_tty.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/shared"
+)
+
+type ttyWs struct {
+	container        container
+	conns            map[int]*websocket.Conn
+	connsLock        sync.Mutex
+	allConnected     chan bool
+	controlConnected chan bool
+	fds              map[int]string
+	width            int
+	height           int
+}
+
+func (s *ttyWs) Metadata() interface{} {
+	fds := shared.Jmap{}
+	for fd, secret := range s.fds {
+		if fd == -1 {
+			fds["control"] = secret
+		} else {
+			fds[strconv.Itoa(fd)] = secret
+		}
+	}
+
+	return shared.Jmap{"fds": fds}
+}
+
+func (s *ttyWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) error {
+	secret := r.FormValue("secret")
+	if secret == "" {
+		return fmt.Errorf("missing secret")
+	}
+
+	for fd, fdSecret := range s.fds {
+		if secret == fdSecret {
+			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return err
+			}
+
+			s.connsLock.Lock()
+			s.conns[fd] = conn
+			s.connsLock.Unlock()
+
+			if fd == -1 {
+				s.controlConnected <- true
+				return nil
+			}
+
+			s.connsLock.Lock()
+			for i, c := range s.conns {
+				if i != -1 && c == nil {
+					s.connsLock.Unlock()
+					return nil
+				}
+			}
+			s.connsLock.Unlock()
+
+			s.allConnected <- true
+			return nil
+		}
+	}
+
+	/* If we didn't find the right secret, the user provided a bad one,
+	 * which 403, not 404, since this operation actually exists */
+	return os.ErrPermission
+}

--- a/lxd/container_tty.go
+++ b/lxd/container_tty.go
@@ -1,7 +1,9 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"strconv"
@@ -10,7 +12,18 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
 )
+
+type ttyWsOps interface {
+	openTTYs(s *ttyWs) (*os.File, *os.File, *os.File, error)
+	startup(s *ttyWs)
+	do(s *ttyWs, stdin, stdout, stderr *os.File) error
+	handleSignal(s *ttyWs, signal int)
+	handleAbnormalClosure(s *ttyWs)
+	getMetadata(s *ttyWs) shared.Jmap
+}
 
 type ttyWs struct {
 	container        container
@@ -18,13 +31,20 @@ type ttyWs struct {
 	connsLock        sync.Mutex
 	allConnected     chan bool
 	controlConnected chan bool
-	fds              map[int]string
+	controlExit      chan bool
+	doneCh           chan bool
+	wgEOF            sync.WaitGroup
 	interactive      bool
+	fds              map[int]string
+	ttys             []*os.File
+	ptys             []*os.File
 	width            int
 	height           int
+
+	ops ttyWsOps
 }
 
-func newttyWs(c container, interactive bool, width int, height int) (*ttyWs, error) {
+func newttyWs(ops ttyWsOps, c container, interactive bool, width int, height int) (*ttyWs, error) {
 	fds := map[int]string{}
 	conns := map[int]*websocket.Conn{
 		-1: nil,
@@ -48,9 +68,12 @@ func newttyWs(c container, interactive bool, width int, height int) (*ttyWs, err
 		conns:            conns,
 		allConnected:     make(chan bool, 1),
 		controlConnected: make(chan bool, 1),
+		controlExit:      make(chan bool),
+		doneCh:           make(chan bool, 1),
 		interactive:      interactive,
 		width:            width,
 		height:           height,
+		ops:              ops,
 	}, nil
 }
 
@@ -106,4 +129,165 @@ func (s *ttyWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) e
 	/* If we didn't find the right secret, the user provided a bad one,
 	 * which 403, not 404, since this operation actually exists */
 	return os.ErrPermission
+}
+
+func (s *ttyWs) Do(op *operation) error {
+	<-s.allConnected
+
+	stdin, stdout, stderr, err := s.ops.openTTYs(s)
+	if err != nil {
+		return err
+	}
+
+	if s.interactive {
+		s.wgEOF.Add(1)
+		go func() {
+			s.ops.startup(s)
+			select {
+			case <-s.controlConnected:
+				break
+
+			case <-s.controlExit:
+				return
+			}
+
+			for {
+				s.connsLock.Lock()
+				conn := s.conns[-1]
+				s.connsLock.Unlock()
+
+				mt, r, err := conn.NextReader()
+				if mt == websocket.CloseMessage {
+					break
+				}
+
+				if err != nil {
+					logger.Debugf("Got error getting next reader %s", err)
+					er, ok := err.(*websocket.CloseError)
+					if !ok {
+						break
+					}
+
+					if er.Code != websocket.CloseAbnormalClosure {
+						break
+					}
+
+					s.ops.handleAbnormalClosure(s)
+					return
+				}
+
+				buf, err := ioutil.ReadAll(r)
+				if err != nil {
+					logger.Debugf("Failed to read message %s", err)
+					break
+				}
+
+				command := api.ContainerTTYControl{}
+
+				if err := json.Unmarshal(buf, &command); err != nil {
+					logger.Debugf("Failed to unmarshal control socket command: %s", err)
+					continue
+				}
+
+				if command.Command == "window-resize" {
+					winchWidth, err := strconv.Atoi(command.Args["width"])
+					if err != nil {
+						logger.Debugf("Unable to extract window width: %s", err)
+						continue
+					}
+
+					winchHeight, err := strconv.Atoi(command.Args["height"])
+					if err != nil {
+						logger.Debugf("Unable to extract window height: %s", err)
+						continue
+					}
+
+					err = shared.SetSize(int(s.ptys[0].Fd()), winchWidth, winchHeight)
+					if err != nil {
+						logger.Debugf("Failed to set window size to: %dx%d", winchWidth, winchHeight)
+						continue
+					}
+				} else if command.Command == "signal" {
+					s.ops.handleSignal(s, command.Signal)
+				}
+			}
+		}()
+		s.connectInteractiveStreams()
+	} else {
+		s.connectNotInteractiveStreams()
+	}
+
+	err = s.ops.do(s, stdin, stdout, stderr)
+	if err != nil {
+		return err
+	}
+	s.finish(op)
+	return op.UpdateMetadata(s.ops.getMetadata(s))
+}
+
+func (s *ttyWs) connectInteractiveStreams() {
+	go func() {
+		s.connsLock.Lock()
+		conn := s.conns[0]
+		s.connsLock.Unlock()
+
+		logger.Debugf("Starting to mirror websocket")
+		readDone, writeDone := shared.WebsocketExecMirror(conn, s.ptys[0], s.ptys[0], s.doneCh, int(s.ptys[0].Fd()))
+
+		<-readDone
+		<-writeDone
+		logger.Debugf("Finished to mirror websocket")
+
+		conn.Close()
+		s.wgEOF.Done()
+	}()
+}
+
+func (s *ttyWs) connectNotInteractiveStreams() {
+	s.wgEOF.Add(len(s.ttys) - 1)
+	for i := 0; i < len(s.ttys); i++ {
+		go func(i int) {
+			if i == 0 {
+				s.connsLock.Lock()
+				conn := s.conns[0]
+				s.connsLock.Unlock()
+
+				<-shared.WebsocketRecvStream(s.ttys[0], conn)
+				s.ttys[0].Close()
+			} else {
+				s.connsLock.Lock()
+				conn := s.conns[i]
+				s.connsLock.Unlock()
+
+				<-shared.WebsocketSendStream(conn, s.ptys[i], -1)
+				s.ptys[i].Close()
+				s.wgEOF.Done()
+			}
+		}(i)
+	}
+}
+
+func (s *ttyWs) finish(op *operation) {
+	for _, tty := range s.ttys {
+		tty.Close()
+	}
+
+	s.connsLock.Lock()
+	conn := s.conns[-1]
+	s.connsLock.Unlock()
+
+	if conn == nil {
+		if s.interactive {
+			s.controlExit <- true
+		}
+	} else {
+		conn.Close()
+	}
+
+	s.doneCh <- true
+	s.wgEOF.Wait()
+
+	for _, pty := range s.ptys {
+		pty.Close()
+	}
 }

--- a/lxd/container_tty.go
+++ b/lxd/container_tty.go
@@ -19,8 +19,39 @@ type ttyWs struct {
 	allConnected     chan bool
 	controlConnected chan bool
 	fds              map[int]string
+	interactive      bool
 	width            int
 	height           int
+}
+
+func newttyWs(c container, interactive bool, width int, height int) (*ttyWs, error) {
+	fds := map[int]string{}
+	conns := map[int]*websocket.Conn{
+		-1: nil,
+		0:  nil,
+	}
+	if !interactive {
+		conns[1] = nil
+		conns[2] = nil
+	}
+	for i := -1; i < len(conns)-1; i++ {
+		var err error
+		fds[i], err = shared.RandomCryptoString()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return &ttyWs{
+		container:        c,
+		fds:              fds,
+		conns:            conns,
+		allConnected:     make(chan bool, 1),
+		controlConnected: make(chan bool, 1),
+		interactive:      interactive,
+		width:            width,
+		height:           height,
+	}, nil
 }
 
 func (s *ttyWs) Metadata() interface{} {

--- a/shared/api/container_exec.go
+++ b/shared/api/container_exec.go
@@ -1,12 +1,5 @@
 package api
 
-// ContainerExecControl represents a message on the container exec "control" socket
-type ContainerExecControl struct {
-	Command string            `json:"command" yaml:"command"`
-	Args    map[string]string `json:"args" yaml:"args"`
-	Signal  int               `json:"signal" yaml:"signal"`
-}
-
 // ContainerExecPost represents a LXD container exec request
 type ContainerExecPost struct {
 	Command     []string          `json:"command" yaml:"command"`

--- a/shared/api/container_tty.go
+++ b/shared/api/container_tty.go
@@ -1,0 +1,8 @@
+package api
+
+// ContainerTTYControl represents a message on the container tty "control" socket
+type ContainerTTYControl struct {
+	Command string            `json:"command" yaml:"command"`
+	Args    map[string]string `json:"args" yaml:"args"`
+	Signal  int               `json:"signal" yaml:"signal"`
+}


### PR DESCRIPTION
This is meant as a first step to allow adding a `ContainerConsole` call to connect to the container console, reusing as much as possible of the exec code