### PR TITLE
Fix failure due to bind-mount through /proc

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -137,14 +137,10 @@ func HostPath(path string) string {
 	}
 
 	// Check if the path is already snap-aware
-	for _, prefix := range []string{"/snap", "/var/snap", "/var/lib/snapd"} {
+	for _, prefix := range []string{"/dev", "/snap", "/var/snap", "/var/lib/snapd"} {
 		if strings.HasPrefix(path, prefix) {
 			return path
 		}
-	}
-
-	if os.Geteuid() == 0 {
-		return fmt.Sprintf("/proc/1/root%s", path)
 	}
 
 	return fmt.Sprintf("/var/lib/snapd/hostfs%s", path)


### PR DESCRIPTION
The kernel won't allow us to bind-mount stuff through /proc.
Since the main reason for my previous change was to fix /dev handling,
lets just whitelist /dev as safe to read from within the snap, which
should be fine so long as distros use devtmpfs.

Closes #3968

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>