### PR TITLE
liblxc: detect version at runtime

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -109,7 +109,7 @@ func lxcSetConfigItem(c *lxc.Container, key string, value string) error {
 		return fmt.Errorf("Uninitialized go-lxc struct")
 	}
 
-	if !lxc.VersionAtLeast(2, 1, 0) {
+	if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 		switch key {
 		case "lxc.uts.name":
 			key = "lxc.utsname"
@@ -155,7 +155,7 @@ func lxcSetConfigItem(c *lxc.Container, key string, value string) error {
 	}
 
 	if strings.HasPrefix(key, "lxc.prlimit.") {
-		if !lxc.VersionAtLeast(2, 1, 0) {
+		if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 			return fmt.Errorf(`Process limits require libxc >= 2.1`)
 		}
 	}
@@ -211,7 +211,7 @@ func lxcValidConfig(rawLxc string) error {
 		}
 
 		networkKeyPrefix := "lxc.net."
-		if !lxc.VersionAtLeast(2, 1, 0) {
+		if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 			networkKeyPrefix = "lxc.network."
 		}
 
@@ -219,7 +219,7 @@ func lxcValidConfig(rawLxc string) error {
 			fields := strings.Split(key, ".")
 
 			allowedIPKeys := []string{"ipv4.address", "ipv6.address"}
-			if !lxc.VersionAtLeast(2, 1, 0) {
+			if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 				allowedIPKeys = []string{"ipv4", "ipv6"}
 			}
 
@@ -1340,7 +1340,7 @@ func (c *containerLXC) initLXC() error {
 			}
 
 			networkKeyPrefix := "lxc.net"
-			if !lxc.VersionAtLeast(2, 1, 0) {
+			if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 				networkKeyPrefix = "lxc.network"
 			}
 
@@ -1452,7 +1452,7 @@ func (c *containerLXC) initLXC() error {
 
 			// Deal with a rootfs
 			if tgtPath == "" {
-				if !lxc.VersionAtLeast(2, 1, 0) {
+				if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 					// Set the rootfs backend type if supported (must happen before any other lxc.rootfs)
 					err := lxcSetConfigItem(cc, "lxc.rootfs.backend", "dir")
 					if err == nil {
@@ -1464,7 +1464,7 @@ func (c *containerLXC) initLXC() error {
 				}
 
 				// Set the rootfs path
-				if lxc.VersionAtLeast(2, 1, 0) {
+				if util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 					rootfsPath := fmt.Sprintf("dir:%s", c.RootfsPath())
 					err = lxcSetConfigItem(cc, "lxc.rootfs.path", rootfsPath)
 				} else {
@@ -1922,7 +1922,7 @@ func (c *containerLXC) startCommon() (string, error) {
 			}
 		} else if m["type"] == "nic" {
 			networkKeyPrefix := "lxc.net"
-			if !lxc.VersionAtLeast(2, 1, 0) {
+			if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 				networkKeyPrefix = "lxc.network"
 			}
 
@@ -4487,7 +4487,7 @@ func (c *containerLXC) Migrate(cmd uint, stateDir string, function string, stop 
 	/* This feature was only added in 2.0.1, let's not ask for it
 	 * before then or migrations will fail.
 	 */
-	if !lxc.VersionAtLeast(2, 0, 1) {
+	if !util.RuntimeLiblxcVersionAtLeast(2, 0, 1) {
 		preservesInodes = false
 	}
 
@@ -6922,7 +6922,7 @@ func (c *containerLXC) setNetworkPriority() error {
 func (c *containerLXC) getHostInterface(name string) string {
 	if c.IsRunning() {
 		networkKeyPrefix := "lxc.net"
-		if !lxc.VersionAtLeast(2, 1, 0) {
+		if !util.RuntimeLiblxcVersionAtLeast(2, 1, 0) {
 			networkKeyPrefix = "lxc.network"
 		}
 

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/websocket"
 	"gopkg.in/lxc/go-lxc.v2"
 
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
@@ -486,7 +487,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 			return abort(err)
 		}
 
-		if lxc.VersionAtLeast(2, 0, 4) {
+		if util.RuntimeLiblxcVersionAtLeast(2, 0, 4) {
 			/* What happens below is slightly convoluted. Due to various
 			 * complications with networking, there's no easy way for criu
 			 * to exit and leave the container in a frozen state for us to

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -1,9 +1,11 @@
 package util
 
 import (
+	"strconv"
 	"strings"
 
 	log "gopkg.in/inconshreveable/log15.v2"
+	golxc "gopkg.in/lxc/go-lxc.v2"
 
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/logger"
@@ -78,4 +80,72 @@ func GetIdmapSet() *idmap.IdmapSet {
 		}
 	}
 	return idmapSet
+}
+
+func RuntimeLiblxcVersionAtLeast(major int, minor int, micro int) bool {
+	version := golxc.Version()
+	version = strings.Replace(version, " (devel)", "-devel", 1)
+	parts := strings.Split(version, ".")
+	partsLen := len(parts)
+	if partsLen == 0 {
+		return false
+	}
+
+	develParts := strings.Split(parts[partsLen-1], "-")
+	if len(develParts) == 2 && develParts[1] == "devel" {
+		return true
+	}
+
+	maj := -1
+	min := -1
+	mic := -1
+
+	for i, v := range parts {
+		num, err := strconv.Atoi(v)
+		if err != nil {
+			return false
+		}
+
+		if i > 2 {
+			return false
+		}
+
+		switch i {
+		case 0:
+			maj = num
+		case 1:
+			min = num
+		case 2:
+			mic = num
+		}
+	}
+
+	/* Major version is greater. */
+	if maj > major {
+		return true
+	}
+
+	if maj < major {
+		return false
+	}
+
+	/* Minor number is greater.*/
+	if min > minor {
+		return true
+	}
+
+	if min < minor {
+		return false
+	}
+
+	/* Patch number is greater. */
+	if mic > micro {
+		return true
+	}
+
+	if mic < micro {
+		return false
+	}
+
+	return true
 }


### PR DESCRIPTION
This requires us to link against liblxc.

Closes #3934.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>