### PR TITLE
console attach

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -71,6 +71,7 @@ type ContainerServer interface {
 	ExecContainer(containerName string, exec api.ContainerExecPost, args *ContainerExecArgs) (op *Operation, err error)
 	ConsoleContainer(containerName string, console api.ContainerConsolePost, args *ContainerConsoleArgs) (op *Operation, err error)
 	GetContainerConsoleLog(containerName string, args *ContainerConsoleLogArgs) (content io.ReadCloser, err error)
+	DeleteContainerConsoleLog(containerName string, args *ContainerConsoleLogArgs) (err error)
 
 	GetContainerFile(containerName string, path string) (content io.ReadCloser, resp *ContainerFileResponse, err error)
 	CreateContainerFile(containerName string, path string, args ContainerFileArgs) (err error)

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -290,6 +290,9 @@ type ContainerConsoleArgs struct {
 
 	// Control message handler (window resize)
 	Control func(conn *websocket.Conn)
+
+	// Closing this Channel causes a disconnect from the container's console
+	ConsoleDisconnect chan bool
 }
 
 // The ContainerConsoleLogArgs struct is used to pass additional options during a

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -69,6 +69,7 @@ type ContainerServer interface {
 	DeleteContainer(name string) (op *Operation, err error)
 
 	ExecContainer(containerName string, exec api.ContainerExecPost, args *ContainerExecArgs) (op *Operation, err error)
+	ConsoleContainer(containerName string, console api.ContainerConsolePost, args *ContainerConsoleArgs) (op *Operation, err error)
 
 	GetContainerFile(containerName string, path string) (content io.ReadCloser, resp *ContainerFileResponse, err error)
 	CreateContainerFile(containerName string, path string, args ContainerFileArgs) (err error)
@@ -277,6 +278,16 @@ type ContainerSnapshotCopyArgs struct {
 	// API extension: container_snapshot_stateful_migration
 	// If set, the container running state will be transferred (live migration)
 	Live bool
+}
+
+// The ContainerConsoleArgs struct is used to pass additional options during a
+// container console session
+type ContainerConsoleArgs struct {
+	// Bidirectional fd to pass to the container
+	Terminal io.ReadWriteCloser
+
+	// Control message handler (window resize)
+	Control func(conn *websocket.Conn)
 }
 
 // The ContainerExecArgs struct is used to pass additional options during container exec

--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -70,6 +70,7 @@ type ContainerServer interface {
 
 	ExecContainer(containerName string, exec api.ContainerExecPost, args *ContainerExecArgs) (op *Operation, err error)
 	ConsoleContainer(containerName string, console api.ContainerConsolePost, args *ContainerConsoleArgs) (op *Operation, err error)
+	GetContainerConsoleLog(containerName string, args *ContainerConsoleLogArgs) (content io.ReadCloser, err error)
 
 	GetContainerFile(containerName string, path string) (content io.ReadCloser, resp *ContainerFileResponse, err error)
 	CreateContainerFile(containerName string, path string, args ContainerFileArgs) (err error)
@@ -288,6 +289,11 @@ type ContainerConsoleArgs struct {
 
 	// Control message handler (window resize)
 	Control func(conn *websocket.Conn)
+}
+
+// The ContainerConsoleLogArgs struct is used to pass additional options during a
+// container console log request
+type ContainerConsoleLogArgs struct {
 }
 
 // The ContainerExecArgs struct is used to pass additional options during container exec

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1406,6 +1406,10 @@ func (r *ProtocolLXD) DeleteContainerTemplateFile(name string, templateName stri
 
 // ConsoleContainer requests that LXD attaches to the console device of a container.
 func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.ContainerConsolePost, args *ContainerConsoleArgs) (*Operation, error) {
+	if !r.HasExtension("console") {
+		return nil, fmt.Errorf("The server is missing the required \"console\" API extension")
+	}
+
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", containerName), console, "")
 	if err != nil {

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -1489,3 +1489,18 @@ func (r *ProtocolLXD) GetContainerConsoleLog(containerName string, args *Contain
 
 	return resp.Body, err
 }
+
+// DeleteContainerConsoleLog deletes the requested container's console log
+func (r *ProtocolLXD) DeleteContainerConsoleLog(containerName string, args *ContainerConsoleLogArgs) error {
+	if !r.HasExtension("console") {
+		return fmt.Errorf("The server is missing the required \"console\" API extension")
+	}
+
+	// Send the request
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/console", containerName), nil, "")
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -356,3 +356,6 @@ This adds support for external authentication via Macaroons.
 
 ## network\_sriov
 This adds support for SR-IOV enabled network devices.
+
+## console
+This adds support to interact with the container console device and console log.

--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -185,6 +185,7 @@ won't work and PUT needs to be used instead.
        * `/1.0/certificates/<fingerprint>`
      * `/1.0/containers`
        * `/1.0/containers/<name>`
+         * `/1.0/containers/<name>/console`
          * `/1.0/containers/<name>/exec`
          * `/1.0/containers/<name>/files`
          * `/1.0/containers/<name>/snapshots`
@@ -753,6 +754,45 @@ Input (none at present):
     }
 
 HTTP code for this should be 202 (Accepted).
+
+## `/1.0/containers/<name>/console`
+### GET
+* Description: returns the contents of the container's console  log
+* Authentication: trusted
+* Operation: N/A
+* Return: the contents of the console log
+
+### POST
+ * Description: attach to a container's console devices
+ * Authentication: trusted
+ * Operation: async
+ * Return: standard error
+
+Input (attach to /dev/console):
+
+    {
+        "width": 80,                    # Initial width of the terminal (optional)
+        "height": 25,                   # Initial height of the terminal (optional)
+    }
+
+The control websocket can be used to send out-of-band messages during a console session.
+This is currently used for window size changes.
+
+Control (window size change):
+
+    {
+        "command": "window-resize",
+        "args": {
+            "width": "80",
+            "height": "50"
+        }
+    }
+
+### DELETE
+* Description: empty the container's console log
+* Authentication: trusted
+* Operation: Sync
+* Return: empty response or standard error
 
 ## `/1.0/containers/<name>/exec`
 ### POST

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strconv"
+	"syscall"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxc/config"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/i18n"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/termios"
+)
+
+type consoleCmd struct {
+}
+
+func (c *consoleCmd) showByDefault() bool {
+	return true
+}
+
+func (c *consoleCmd) usage() string {
+	return i18n.G(
+		`Usage: lxc console [<remote>:]<container>
+
+Interact with the container's console device and log.`)
+}
+
+func (c *consoleCmd) flags() {
+}
+
+func (c *consoleCmd) sendTermSize(control *websocket.Conn) error {
+	width, height, err := termios.GetSize(int(syscall.Stdout))
+	if err != nil {
+		return err
+	}
+
+	logger.Debugf("Window size is now: %dx%d", width, height)
+
+	w, err := control.NextWriter(websocket.TextMessage)
+	if err != nil {
+		return err
+	}
+
+	msg := api.ContainerExecControl{}
+	msg.Command = "window-resize"
+	msg.Args = make(map[string]string)
+	msg.Args["width"] = strconv.Itoa(width)
+	msg.Args["height"] = strconv.Itoa(height)
+
+	buf, err := json.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(buf)
+
+	w.Close()
+	return err
+}
+
+type ReadWriteCloser struct {
+	io.Reader
+	io.WriteCloser
+}
+
+func (c *consoleCmd) run(conf *config.Config, args []string) error {
+	if len(args) < 1 {
+		return errArgs
+	}
+
+	remote, name, err := conf.ParseRemote(args[0])
+	if err != nil {
+		return err
+	}
+
+	d, err := conf.GetContainerServer(remote)
+	if err != nil {
+		return err
+	}
+
+	cfd := int(syscall.Stdin)
+
+	var oldttystate *termios.State
+	oldttystate, err = termios.MakeRaw(cfd)
+	if err != nil {
+		return err
+	}
+	defer termios.Restore(cfd, oldttystate)
+
+	handler := c.controlSocketHandler
+
+	var width, height int
+	width, height, err = termios.GetSize(int(syscall.Stdout))
+	if err != nil {
+		return err
+	}
+
+	req := api.ContainerConsolePost{
+		Width:  width,
+		Height: height,
+	}
+
+	consoleArgs := lxd.ContainerConsoleArgs{
+		Terminal: &ReadWriteCloser{os.Stdin, os.Stdout},
+		Control:  handler,
+	}
+
+	// Run the command in the container
+	op, err := d.ConsoleContainer(name, req, &consoleArgs)
+	if err != nil {
+		return err
+	}
+
+	// Wait for the operation to complete
+	err = op.Wait()
+	if err != nil {
+		return err
+	}
+
+	if oldttystate != nil {
+		/* A bit of a special case here: we want to exit with the same code as
+		 * the process inside the container, so we explicitly exit here
+		 * instead of returning an error.
+		 *
+		 * Additionally, since os.Exit() exits without running deferred
+		 * functions, we restore the terminal explicitly.
+		 */
+		termios.Restore(cfd, oldttystate)
+	}
+
+	return nil
+}

--- a/lxc/console_unix.go
+++ b/lxc/console_unix.go
@@ -1,0 +1,36 @@
+// +build !windows
+
+package main
+
+import (
+	"io"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/shared/logger"
+)
+
+func (c *consoleCmd) getStdout() io.WriteCloser {
+	return os.Stdout
+}
+
+func (c *consoleCmd) controlSocketHandler(control *websocket.Conn) {
+	ch := make(chan os.Signal, 10)
+	signal.Notify(ch, syscall.SIGWINCH)
+
+	for {
+		sig := <-ch
+		logger.Debugf("Received '%s signal', updating window geometry.", sig)
+		err := c.sendTermSize(control)
+		if err != nil {
+			logger.Debugf("error setting term size %s", err)
+			break
+		}
+	}
+
+	closeMsg := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+	control.WriteMessage(websocket.CloseMessage, closeMsg)
+}

--- a/lxc/console_windows.go
+++ b/lxc/console_windows.go
@@ -1,0 +1,31 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/gorilla/websocket"
+	"github.com/mattn/go-colorable"
+)
+
+func (c *consoleCmd) getStdout() io.WriteCloser {
+	// Defined in exec_windows.go
+	return &WrappedWriteCloser{os.Stdout, colorable.NewColorableStdout()}
+}
+
+func (c *consoleCmd) getTERM() (string, bool) {
+	return "dumb", true
+}
+
+func (c *consoleCmd) controlSocketHandler(control *websocket.Conn) {
+	// TODO: figure out what the equivalent of signal.SIGWINCH is on
+	// windows and use that; for now if you resize your terminal it just
+	// won't work quite correctly.
+	err := c.sendTermSize(control)
+	if err != nil {
+		fmt.Printf("error setting term size %s\n", err)
+	}
+}

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -214,6 +214,7 @@ type command interface {
 
 var commands = map[string]command{
 	"config":    &configCmd{},
+	"console":   &consoleCmd{},
 	"copy":      &copyCmd{},
 	"delete":    &deleteCmd{},
 	"exec":      &execCmd{},

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -19,6 +19,7 @@ import (
 var api10 = []Command{
 	containersCmd,
 	containerCmd,
+	containerConsoleCmd,
 	containerStateCmd,
 	containerFileCmd,
 	containerLogsCmd,

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -443,7 +443,7 @@ type container interface {
 	//
 	// This function will not return until the console has been exited by
 	// the user.
-	Console(terminal *os.File) error
+	Console(terminal *os.File) *exec.Cmd
 	ConsoleLog(opts lxc.ConsoleLogOptions) (string, error)
 	/* Command execution:
 		 * 1. passing in false for wait

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -437,6 +437,13 @@ type container interface {
 	FilePush(type_ string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error
 	FileRemove(path string) error
 
+	// Console - Allocate and run a console tty.
+	//
+	// terminal  - Bidirectional file descriptor.
+	//
+	// This function will not return until the console has been exited by
+	// the user.
+	Console(terminal *os.File) error
 	/* Command execution:
 		 * 1. passing in false for wait
 		 *    - equivalent to calling cmd.Run()

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -444,6 +444,7 @@ type container interface {
 	// This function will not return until the console has been exited by
 	// the user.
 	Console(terminal *os.File) error
+	ConsoleLog(opts lxc.ConsoleLogOptions) (string, error)
 	/* Command execution:
 		 * 1. passing in false for wait
 		 *    - equivalent to calling cmd.Run()

--- a/lxd/container_console.go
+++ b/lxd/container_console.go
@@ -1,0 +1,296 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"strconv"
+	"sync"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/websocket"
+
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
+)
+
+type consoleWs struct {
+	// container currently worked on
+	container container
+
+	// uid to chown pty to
+	rootUid int64
+
+	// gid to chown pty to
+	rootGid int64
+
+	// websocket connections to bridge pty fds to
+	conns map[int]*websocket.Conn
+
+	// locks needed to access the "conns" member
+	connsLock sync.Mutex
+
+	// channel to wait until all websockets are properly connected
+	allConnected chan bool
+
+	// channel to wait until the control socket is connected
+	controlConnected chan bool
+
+	// map file descriptors -> secret
+	fds map[int]string
+
+	// terminal width
+	width int
+
+	// terminal height
+	height int
+}
+
+func (s *consoleWs) Metadata() interface{} {
+	fds := shared.Jmap{}
+	for fd, secret := range s.fds {
+		if fd == -1 {
+			fds["control"] = secret
+		} else {
+			fds[strconv.Itoa(fd)] = secret
+		}
+	}
+
+	return shared.Jmap{"fds": fds}
+}
+
+func (s *consoleWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) error {
+	secret := r.FormValue("secret")
+	if secret == "" {
+		return fmt.Errorf("missing secret")
+	}
+
+	for fd, fdSecret := range s.fds {
+		if secret == fdSecret {
+			conn, err := shared.WebsocketUpgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return err
+			}
+
+			s.connsLock.Lock()
+			s.conns[fd] = conn
+			s.connsLock.Unlock()
+
+			if fd == -1 {
+				s.controlConnected <- true
+				return nil
+			}
+
+			s.connsLock.Lock()
+			for i, c := range s.conns {
+				if i != -1 && c == nil {
+					s.connsLock.Unlock()
+					return nil
+				}
+			}
+			s.connsLock.Unlock()
+
+			s.allConnected <- true
+			return nil
+		}
+	}
+
+	/* If we didn't find the right secret, the user provided a bad one,
+	 * which 403, not 404, since this operation actually exists */
+	return os.ErrPermission
+}
+
+func (s *consoleWs) Do(op *operation) error {
+	<-s.allConnected
+
+	var err error
+	master := &os.File{}
+	slave := &os.File{}
+	master, slave, err = shared.OpenPty(s.rootUid, s.rootGid)
+	if err != nil {
+		return err
+	}
+
+	if s.width > 0 && s.height > 0 {
+		shared.SetSize(int(master.Fd()), s.width, s.height)
+	}
+
+	controlExit := make(chan bool)
+	var wgEOF sync.WaitGroup
+
+	wgEOF.Add(1)
+	go func() {
+		select {
+		case <-s.controlConnected:
+			break
+
+		case <-controlExit:
+			return
+		}
+
+		for {
+			s.connsLock.Lock()
+			conn := s.conns[-1]
+			s.connsLock.Unlock()
+
+			mt, r, err := conn.NextReader()
+			if mt == websocket.CloseMessage {
+				break
+			}
+
+			if err != nil {
+				logger.Debugf("Got error getting next reader %s", err)
+				break
+			}
+
+			buf, err := ioutil.ReadAll(r)
+			if err != nil {
+				logger.Debugf("Failed to read message %s", err)
+				break
+			}
+
+			command := api.ContainerConsoleControl{}
+
+			err = json.Unmarshal(buf, &command)
+			if err != nil {
+				logger.Debugf("Failed to unmarshal control socket command: %s", err)
+				continue
+			}
+
+			if command.Command == "window-resize" {
+				winchWidth, err := strconv.Atoi(command.Args["width"])
+				if err != nil {
+					logger.Debugf("Unable to extract window width: %s", err)
+					continue
+				}
+
+				winchHeight, err := strconv.Atoi(command.Args["height"])
+				if err != nil {
+					logger.Debugf("Unable to extract window height: %s", err)
+					continue
+				}
+
+				err = shared.SetSize(int(master.Fd()), winchWidth, winchHeight)
+				if err != nil {
+					logger.Debugf("Failed to set window size to: %dx%d", winchWidth, winchHeight)
+					continue
+				}
+
+				logger.Debugf("Set window size to: %dx%d", winchWidth, winchHeight)
+			}
+		}
+	}()
+
+	go func() {
+		s.connsLock.Lock()
+		conn := s.conns[0]
+		s.connsLock.Unlock()
+
+		logger.Debugf("Starting to mirror websocket")
+		readDone, writeDone := shared.WebsocketConsoleMirror(conn, master, master)
+
+		<-readDone
+		<-writeDone
+		logger.Debugf("Finished to mirror websocket")
+
+		conn.Close()
+		wgEOF.Done()
+	}()
+
+	finisher := func(cmdErr error) error {
+		slave.Close()
+
+		s.connsLock.Lock()
+		conn := s.conns[-1]
+		s.connsLock.Unlock()
+
+		if conn == nil {
+			controlExit <- true
+		}
+
+		wgEOF.Wait()
+
+		master.Close()
+
+		return cmdErr
+	}
+
+	err = s.container.Console(slave)
+	if err != nil {
+		return err
+	}
+
+	return finisher(err)
+}
+
+func containerConsolePost(d *Daemon, r *http.Request) Response {
+	name := mux.Vars(r)["name"]
+	c, err := containerLoadByName(d.State(), name)
+	if err != nil {
+		return SmartError(err)
+	}
+
+	err = fmt.Errorf("Container is not running")
+	if !c.IsRunning() {
+		return BadRequest(err)
+	}
+
+	err = fmt.Errorf("Container is frozen")
+	if c.IsFrozen() {
+		return BadRequest(err)
+	}
+
+	post := api.ContainerConsolePost{}
+	buf, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	err = json.Unmarshal(buf, &post)
+	if err != nil {
+		return BadRequest(err)
+	}
+
+	ws := &consoleWs{}
+	ws.fds = map[int]string{}
+
+	idmapset, err := c.IdmapSet()
+	if err != nil {
+		return InternalError(err)
+	}
+
+	if idmapset != nil {
+		ws.rootUid, ws.rootGid = idmapset.ShiftIntoNs(0, 0)
+	}
+
+	ws.conns = map[int]*websocket.Conn{}
+	ws.conns[-1] = nil
+	ws.conns[0] = nil
+	for i := -1; i < len(ws.conns)-1; i++ {
+		ws.fds[i], err = shared.RandomCryptoString()
+		if err != nil {
+			return InternalError(err)
+		}
+	}
+
+	ws.allConnected = make(chan bool, 1)
+	ws.controlConnected = make(chan bool, 1)
+
+	ws.container = c
+	ws.width = post.Width
+	ws.height = post.Height
+
+	resources := map[string][]string{}
+	resources["containers"] = []string{ws.container.Name()}
+
+	op, err := operationCreate(operationClassWebsocket, resources,
+		ws.Metadata(), ws.Do, nil, ws.Connect)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return OperationResponse(op)
+}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -110,6 +110,9 @@ func (s *execWs) Do(op *operation) error {
 		ttys = make([]*os.File, 1)
 		ptys = make([]*os.File, 1)
 		ptys[0], ttys[0], err = shared.OpenPty(s.rootUid, s.rootGid)
+		if err != nil {
+			return err
+		}
 
 		stdin = ttys[0]
 		stdout = ttys[0]

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5105,6 +5105,15 @@ func (c *containerLXC) Console(terminal *os.File) error {
 	return cmd.Run()
 }
 
+func (c *containerLXC) ConsoleLog(opts lxc.ConsoleLogOptions) (string, error) {
+	msg, err := c.c.ConsoleLog(opts)
+	if err != nil {
+		return "", err
+	}
+
+	return string(msg), nil
+}
+
 func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool) (*exec.Cmd, int, int, error) {
 	envSlice := []string{}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5086,7 +5086,7 @@ func (c *containerLXC) FileRemove(path string) error {
 	return nil
 }
 
-func (c *containerLXC) Console(terminal *os.File) error {
+func (c *containerLXC) Console(terminal *os.File) *exec.Cmd {
 	args := []string{
 		c.state.OS.ExecPath,
 		"forkconsole",
@@ -5102,7 +5102,7 @@ func (c *containerLXC) Console(terminal *os.File) error {
 	cmd.Stdin = terminal
 	cmd.Stdout = terminal
 	cmd.Stderr = terminal
-	return cmd.Run()
+	return &cmd
 }
 
 func (c *containerLXC) ConsoleLog(opts lxc.ConsoleLogOptions) (string, error) {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5073,6 +5073,25 @@ func (c *containerLXC) FileRemove(path string) error {
 	return nil
 }
 
+func (c *containerLXC) Console(terminal *os.File) error {
+	args := []string{
+		c.state.OS.ExecPath,
+		"forkconsole",
+		c.name,
+		c.state.OS.LxcPath,
+		filepath.Join(c.LogPath(), "lxc.conf"),
+		"0",
+		"1"}
+
+	cmd := exec.Cmd{}
+	cmd.Path = c.state.OS.ExecPath
+	cmd.Args = args
+	cmd.Stdin = terminal
+	cmd.Stdout = terminal
+	cmd.Stderr = terminal
+	return cmd.Run()
+}
+
 func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool) (*exec.Cmd, int, int, error) {
 	envSlice := []string{}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -168,28 +168,41 @@ func lxcSetConfigItem(c *lxc.Container, key string, value string) error {
 	return nil
 }
 
+func lxcParseRawLXC(line string) (string, string, error) {
+	// Ignore empty lines
+	if len(line) == 0 {
+		return "", "", nil
+	}
+
+	// Skip whitespace {"\t", " "}
+	line = strings.TrimLeft(line, "\t ")
+
+	// Ignore comments
+	if strings.HasPrefix(line, "#") {
+		return "", "", nil
+	}
+
+	// Ensure the format is valid
+	membs := strings.SplitN(line, "=", 2)
+	if len(membs) != 2 {
+		return "", "", fmt.Errorf("Invalid raw.lxc line: %s", line)
+	}
+
+	key := strings.ToLower(strings.Trim(membs[0], " \t"))
+	val := strings.Trim(membs[1], " \t")
+	return key, val, nil
+}
+
 func lxcValidConfig(rawLxc string) error {
 	for _, line := range strings.Split(rawLxc, "\n") {
-		// Ignore empty lines
-		if len(line) == 0 {
+		key, _, err := lxcParseRawLXC(line)
+		if err != nil {
+			return err
+		}
+
+		if key == "" {
 			continue
 		}
-
-		// Skip whitespace {"\t", " "}
-		line = strings.TrimLeft(line, "\t ")
-
-		// Ignore comments
-		if strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		// Ensure the format is valid
-		membs := strings.SplitN(line, "=", 2)
-		if len(membs) != 2 {
-			return fmt.Errorf("Invalid raw.lxc line: %s", line)
-		}
-
-		key := strings.ToLower(strings.Trim(membs[0], " \t"))
 
 		// Blacklist some keys
 		if key == "lxc.logfile" || key == "lxc.log.file" {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5093,8 +5093,8 @@ func (c *containerLXC) Console(terminal *os.File) error {
 		c.name,
 		c.state.OS.LxcPath,
 		filepath.Join(c.LogPath(), "lxc.conf"),
-		"0",
-		"1"}
+		"tty=0",
+		"escape=-1"}
 
 	cmd := exec.Cmd{}
 	cmd.Path = c.state.OS.ExecPath

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -55,6 +55,11 @@ var containerSnapshotCmd = Command{
 	delete: snapshotHandler,
 }
 
+var containerConsoleCmd = Command{
+	name: "containers/{name}/console",
+	post: containerConsolePost,
+}
+
 var containerExecCmd = Command{
 	name: "containers/{name}/exec",
 	post: containerExecPost,

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -57,6 +57,7 @@ var containerSnapshotCmd = Command{
 
 var containerConsoleCmd = Command{
 	name: "containers/{name}/console",
+	get:  containerConsoleLogGet,
 	post: containerConsolePost,
 }
 

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -56,9 +56,10 @@ var containerSnapshotCmd = Command{
 }
 
 var containerConsoleCmd = Command{
-	name: "containers/{name}/console",
-	get:  containerConsoleLogGet,
-	post: containerConsolePost,
+	name:   "containers/{name}/console",
+	get:    containerConsoleLogGet,
+	post:   containerConsolePost,
+	delete: containerConsoleLogDelete,
 }
 
 var containerExecCmd = Command{

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -58,6 +58,7 @@ var subcommands = map[string]SubCommand{
 	"import":           cmdImport,
 
 	// Internal commands
+	"forkconsole":        cmdForkConsole,
 	"forkgetnet":         cmdForkGetNet,
 	"forkmigrate":        cmdForkMigrate,
 	"forkstart":          cmdForkStart,

--- a/lxd/main_args.go
+++ b/lxd/main_args.go
@@ -113,6 +113,8 @@ Waitready options:
 
 
 Internal commands (don't call these directly):
+    forkconsole
+        Attach to the console of a container
     forkexec
         Execute a command in a container
     forkgetnet

--- a/lxd/main_forkconsole.go
+++ b/lxd/main_forkconsole.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"strconv"
+
+	"gopkg.in/lxc/go-lxc.v2"
+)
+
+/*
+ * This is called by lxd when called as "lxd forkconsole <container> <path> <conf> <ttynum> <escape>"
+ */
+func cmdForkConsole(args *Args) error {
+	if len(args.Params) != 5 {
+		return SubCommandErrorf(-1, "Bad params: %q", args.Params)
+	}
+
+	name := args.Params[0]
+	lxcpath := args.Params[1]
+	configPath := args.Params[2]
+	ttynum, err := strconv.Atoi(args.Params[3])
+	if err != nil {
+		return SubCommandErrorf(-1, "Failed to retrieve tty number: %q", err)
+	}
+	escape, err := strconv.Atoi(args.Params[4])
+	if err != nil {
+		return SubCommandErrorf(-1, "Failed to retrieve escape character: %q", err)
+	}
+
+	c, err := lxc.NewContainer(name, lxcpath)
+	if err != nil {
+		return SubCommandErrorf(-1, "Error initializing container: %q", err)
+	}
+
+	err = c.LoadConfigFile(configPath)
+	if err != nil {
+		return SubCommandErrorf(-1, "Error opening config file: %q", err)
+	}
+
+	opts := lxc.ConsoleOptions{}
+	opts.Tty = ttynum
+	opts.StdinFd = uintptr(os.Stdin.Fd())
+	opts.StdoutFd = uintptr(os.Stdout.Fd())
+	opts.StderrFd = uintptr(os.Stderr.Fd())
+	opts.EscapeCharacter = rune(escape)
+
+	err = c.Console(opts)
+	if err != nil {
+		return SubCommandErrorf(-1, "Failed running forkconsole: %q", err)
+	}
+
+	return nil
+}

--- a/lxd/main_forkconsole.go
+++ b/lxd/main_forkconsole.go
@@ -3,12 +3,13 @@ package main
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"gopkg.in/lxc/go-lxc.v2"
 )
 
 /*
- * This is called by lxd when called as "lxd forkconsole <container> <path> <conf> <ttynum> <escape>"
+ * This is called by lxd when called as "lxd forkconsole <container> <path> <conf> <tty=<n>> <escape=<n>>"
  */
 func cmdForkConsole(args *Args) error {
 	if len(args.Params) != 5 {
@@ -18,11 +19,15 @@ func cmdForkConsole(args *Args) error {
 	name := args.Params[0]
 	lxcpath := args.Params[1]
 	configPath := args.Params[2]
-	ttynum, err := strconv.Atoi(args.Params[3])
+
+	ttyNum := strings.TrimPrefix(args.Params[3], "tty=")
+	tty, err := strconv.Atoi(ttyNum)
 	if err != nil {
 		return SubCommandErrorf(-1, "Failed to retrieve tty number: %q", err)
 	}
-	escape, err := strconv.Atoi(args.Params[4])
+
+	escapeNum := strings.TrimPrefix(args.Params[4], "escape=")
+	escape, err := strconv.Atoi(escapeNum)
 	if err != nil {
 		return SubCommandErrorf(-1, "Failed to retrieve escape character: %q", err)
 	}
@@ -38,7 +43,7 @@ func cmdForkConsole(args *Args) error {
 	}
 
 	opts := lxc.ConsoleOptions{}
-	opts.Tty = ttynum
+	opts.Tty = tty
 	opts.StdinFd = uintptr(os.Stdin.Fd())
 	opts.StdoutFd = uintptr(os.Stdout.Fd())
 	opts.StderrFd = uintptr(os.Stderr.Fd())

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -437,6 +437,10 @@ msgstr "YAML Analyse Fehler %v\n"
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -973,7 +977,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Path to an alternate server directory"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 #, fuzzy
 msgid "Pause containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1112,10 +1116,15 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 #, fuzzy
 msgid "Restart containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
+
+#: lxc/console.go:38
+#, fuzzy
+msgid "Retrieve the container's console log"
+msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/init.go:289
 #, c-format
@@ -1222,7 +1231,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 #, fuzzy
 msgid "Start containers."
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1237,7 +1246,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 #, fuzzy
 msgid "Stop containers."
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1583,6 +1592,13 @@ msgstr ""
 "\tlxc config set <container> raw.lxc 'lxc.aa_allow_incomplete = 1'\n"
 "Um das Server Passwort zur authentifizierung zu setzen:\n"
 "\tlxc config set core.trust_password blah\n"
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
+msgstr ""
 
 #: lxc/copy.go:28
 #, fuzzy
@@ -2510,7 +2526,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr "OK (y/n)? "
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2552,7 +2568,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr "falsche Anzahl an Parametern für Unterbefehl"
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -325,6 +325,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -841,7 +845,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -976,8 +980,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1083,7 +1091,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1097,7 +1105,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1394,6 +1402,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2192,7 +2207,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2234,7 +2249,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -426,6 +426,10 @@ msgstr "Erreur lors de la lecture de la configuration : %s"
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "Connexion refusée ; LXD est-il actif ?"
+
+#: lxc/console.go:132
+msgid "Console log:"
+msgstr ""
 
 #: lxc/publish.go:71
 msgid "Container name is mandatory"
@@ -955,7 +959,7 @@ msgstr "Chemin vers un dossier de configuration client alternatif"
 msgid "Path to an alternate server directory"
 msgstr "Chemin vers un dossier de configuration serveur alternatif"
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 #, fuzzy
 msgid "Pause containers."
 msgstr "Création du conteneur"
@@ -1092,10 +1096,15 @@ msgstr "Requérir une confirmation de l'utilisateur"
 msgid "Resources:"
 msgstr "Ressources :"
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 #, fuzzy
 msgid "Restart containers."
 msgstr "Création du conteneur"
+
+#: lxc/console.go:38
+#, fuzzy
+msgid "Retrieve the container's console log"
+msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
 #: lxc/init.go:289
 #, c-format
@@ -1203,7 +1212,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Source:"
 msgstr "Source :"
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 #, fuzzy
 msgid "Start containers."
 msgstr "Création du conteneur"
@@ -1218,7 +1227,7 @@ msgstr "Démarrage de %s"
 msgid "Status: %s"
 msgstr "État : %s"
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 #, fuzzy
 msgid "Stop containers."
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1589,6 +1598,13 @@ msgstr ""
 "\n"
 "Pour positionner le mot de passe de confiance du serveur :\n"
 "    lxc config set core.trust_password blah"
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
+msgstr ""
 
 #: lxc/copy.go:28
 #, fuzzy
@@ -2793,7 +2809,7 @@ msgstr "non"
 msgid "ok (y/n)?"
 msgstr "ok (y/n) ?"
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "l'analyse des alias a échoué %s\n"
@@ -2835,7 +2851,7 @@ msgstr "sans suivi d'état"
 msgid "taken at %s"
 msgstr "pris à %s"
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -346,6 +346,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -860,7 +864,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -995,8 +999,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1102,7 +1110,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1116,7 +1124,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1413,6 +1421,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2211,7 +2226,7 @@ msgstr "no"
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "errore di processamento degli alias %s\n"
@@ -2253,7 +2268,7 @@ msgstr "senza stato"
 msgid "taken at %s"
 msgstr "salvato alle %s"
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr "numero errato di argomenti del sottocomando"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -328,6 +328,10 @@ msgstr "設定の構文エラー: %s"
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "接続が拒否されました。LXDが実行されていますか?"
+
+#: lxc/console.go:132
+msgid "Console log:"
+msgstr ""
 
 #: lxc/publish.go:71
 msgid "Container name is mandatory"
@@ -845,7 +849,7 @@ msgstr "別のクライアント用設定ディレクトリ"
 msgid "Path to an alternate server directory"
 msgstr "別のサーバ用設定ディレクトリ"
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr "コンテナを一時停止します。"
 
@@ -980,9 +984,14 @@ msgstr "ユーザの確認を要求する"
 msgid "Resources:"
 msgstr "リソース:"
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
 msgstr "コンテナを再起動します。"
+
+#: lxc/console.go:38
+#, fuzzy
+msgid "Retrieve the container's console log"
+msgstr "コンテナの状態を保存します (stopのみ)"
 
 #: lxc/init.go:289
 #, c-format
@@ -1088,7 +1097,7 @@ msgstr "一部のコンテナで %s が失敗しました"
 msgid "Source:"
 msgstr "取得元:"
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr "コンテナを起動します。"
 
@@ -1102,7 +1111,7 @@ msgstr "%s を起動中"
 msgid "Status: %s"
 msgstr "状態: %s"
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr "コンテナを停止します。"
 
@@ -1519,6 +1528,13 @@ msgstr ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    サーバのパスワードを blah に設定する。"
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
+msgstr ""
 
 #: lxc/copy.go:28
 msgid ""
@@ -2909,7 +2925,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr "エイリアスの処理が失敗しました %s\n"
@@ -2951,7 +2967,7 @@ msgstr "ステートレス"
 msgid "taken at %s"
 msgstr "%s に取得しました"
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr "サブコマンドの引数の数が正しくありません"
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-11-07 17:09-0500\n"
+        "POT-Creation-Date: 2017-11-14 07:37+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -313,6 +313,10 @@ msgstr  ""
 
 #: lxc/main.go:40
 msgid   "Connection refused; is LXD running?"
+msgstr  ""
+
+#: lxc/console.go:132
+msgid   "Console log:"
 msgstr  ""
 
 #: lxc/publish.go:71
@@ -824,7 +828,7 @@ msgstr  ""
 msgid   "Path to an alternate server directory"
 msgstr  ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid   "Pause containers."
 msgstr  ""
 
@@ -958,8 +962,12 @@ msgstr  ""
 msgid   "Resources:"
 msgstr  ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid   "Restart containers."
+msgstr  ""
+
+#: lxc/console.go:38
+msgid   "Retrieve the container's console log"
 msgstr  ""
 
 #: lxc/init.go:289
@@ -1065,7 +1073,7 @@ msgstr  ""
 msgid   "Source:"
 msgstr  ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid   "Start containers."
 msgstr  ""
 
@@ -1079,7 +1087,7 @@ msgstr  ""
 msgid   "Status: %s"
 msgstr  ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid   "Stop containers."
 msgstr  ""
 
@@ -1366,6 +1374,12 @@ msgid   "Usage: lxc config <subcommand> [options]\n"
         "\n"
         "lxc config set core.trust_password blah\n"
         "    Will set the server's trust password to blah."
+msgstr  ""
+
+#: lxc/console.go:31
+msgid   "Usage: lxc console [<remote>:]<container> [-l]\n"
+        "\n"
+        "Interact with the container's console device and log."
 msgstr  ""
 
 #: lxc/copy.go:28
@@ -2081,7 +2095,7 @@ msgstr  ""
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid   "processing aliases failed %s\n"
 msgstr  ""
@@ -2123,7 +2137,7 @@ msgstr  ""
 msgid   "taken at %s"
 msgstr  ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid   "wrong number of subcommand arguments"
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -410,6 +410,10 @@ msgstr ""
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
 msgstr "В соединении отказано; LXD запущен?"
+
+#: lxc/console.go:132
+msgid "Console log:"
+msgstr ""
 
 #: lxc/publish.go:71
 msgid "Container name is mandatory"
@@ -925,7 +929,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -1060,8 +1064,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1167,7 +1175,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1181,7 +1189,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1481,6 +1489,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2288,7 +2303,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2330,7 +2345,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-07 17:09-0500\n"
+"POT-Creation-Date: 2017-11-14 07:36+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -321,6 +321,10 @@ msgstr ""
 
 #: lxc/main.go:40
 msgid "Connection refused; is LXD running?"
+msgstr ""
+
+#: lxc/console.go:132
+msgid "Console log:"
 msgstr ""
 
 #: lxc/publish.go:71
@@ -834,7 +838,7 @@ msgstr ""
 msgid "Path to an alternate server directory"
 msgstr ""
 
-#: lxc/main.go:237
+#: lxc/main.go:238
 msgid "Pause containers."
 msgstr ""
 
@@ -969,8 +973,12 @@ msgstr ""
 msgid "Resources:"
 msgstr ""
 
-#: lxc/main.go:245
+#: lxc/main.go:246
 msgid "Restart containers."
+msgstr ""
+
+#: lxc/console.go:38
+msgid "Retrieve the container's console log"
 msgstr ""
 
 #: lxc/init.go:289
@@ -1076,7 +1084,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: lxc/main.go:255
+#: lxc/main.go:256
 msgid "Start containers."
 msgstr ""
 
@@ -1090,7 +1098,7 @@ msgstr ""
 msgid "Status: %s"
 msgstr ""
 
-#: lxc/main.go:261
+#: lxc/main.go:262
 msgid "Stop containers."
 msgstr ""
 
@@ -1387,6 +1395,13 @@ msgid ""
 "\n"
 "lxc config set core.trust_password blah\n"
 "    Will set the server's trust password to blah."
+msgstr ""
+
+#: lxc/console.go:31
+msgid ""
+"Usage: lxc console [<remote>:]<container> [-l]\n"
+"\n"
+"Interact with the container's console device and log."
 msgstr ""
 
 #: lxc/copy.go:28
@@ -2185,7 +2200,7 @@ msgstr ""
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/main.go:365 lxc/main.go:369
+#: lxc/main.go:366 lxc/main.go:370
 #, c-format
 msgid "processing aliases failed %s\n"
 msgstr ""
@@ -2227,7 +2242,7 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/main.go:296
+#: lxc/main.go:297
 msgid "wrong number of subcommand arguments"
 msgstr ""
 

--- a/shared/api/container_console.go
+++ b/shared/api/container_console.go
@@ -1,0 +1,17 @@
+package api
+
+// ContainerConsoleControl represents a message on the container console "control" socket
+//
+// API extension: console
+type ContainerConsoleControl struct {
+	Command string            `json:"command" yaml:"command"`
+	Args    map[string]string `json:"args" yaml:"args"`
+}
+
+// ContainerConsolePost represents a LXD container console request
+//
+// API extension: console
+type ContainerConsolePost struct {
+	Width  int `json:"width" yaml:"width"`
+	Height int `json:"height" yaml:"height"`
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -79,4 +79,5 @@ var APIExtensions = []string{
 	"storage_api_volume_rename",
 	"macaroon_authentication",
 	"network_sriov",
+	"console",
 }

--- a/test/main.sh
+++ b/test/main.sh
@@ -189,6 +189,7 @@ run_test test_storage_driver_ceph "ceph storage driver"
 run_test test_resources "resources"
 run_test test_kernel_limits "kernel limits"
 run_test test_macaroon_auth "macaroon authentication"
+run_test test_console "console"
 
 # shellcheck disable=SC2034
 TEST_RESULT=success

--- a/test/suites/console.sh
+++ b/test/suites/console.sh
@@ -1,0 +1,83 @@
+test_console() {
+  ensure_import_testimage
+
+  lxc init testimage cons1
+
+  # 1. Set a console log file but no ringbuffer.
+
+  # Test the console log file requests.
+  lxc start cons1
+
+  # No console log file set so this should return an error.
+  ! lxc console cons1 --show-log
+  lxc stop --force cons1
+
+  # Set a console log file but no ringbuffer.
+  # shellcheck disable=SC2034
+  CONSOLE_LOGFILE="$(mktemp -p "${LXD_DIR}" XXXXXXXXX)"
+  lxc config set cons1 raw.lxc "lxc.console.logfile=${CONSOLE_LOGFILE}"
+  lxc start cons1
+
+  # Let the container come up. Two seconds should be fine.
+  sleep 2
+
+  # Make sure there's something in the console ringbuffer.
+  echo 'some content' | lxc exec cons1 -- tee /dev/console
+
+  # Console log file set so this should return without an error.
+  lxc console cons1 --show-log
+
+  lxc stop --force cons1
+
+  # 2. Set a console ringbuffer but no log file.
+
+  # remove logfile
+  lxc config unset cons1 raw.lxc
+
+  # set console ringbuffer
+  lxc config set cons1 raw.lxc "lxc.console.logsize=auto"
+
+  lxc start cons1
+
+  # Let the container come up. Two seconds should be fine.
+  sleep 2
+
+  # Make sure there's something in the console ringbuffer.
+  echo 'some content' | lxc exec cons1 -- tee /dev/console
+  echo 'some more content' | lxc exec cons1 -- tee /dev/console
+
+  # Retrieve the ringbuffer contents.
+  lxc console cons1 --show-log
+
+  # 3. Set a console ringbuffer and a log file.
+
+  lxc stop --force cons1
+
+  lxc config unset cons1 raw.lxc
+
+  rm -f "${CONSOLE_LOGFILE}"
+  printf "lxc.console.logsize=auto\nlxc.console.logfile=%s" "${CONSOLE_LOGFILE}" | lxc config set cons1 raw.lxc -
+
+  lxc start cons1
+
+  # Let the container come up. Two seconds should be fine.
+  sleep 2
+
+  # Make sure there's something in the console ringbuffer.
+  echo 'Ringbuffer contents and log file contents must match' | lxc exec cons1 -- tee /dev/console
+
+  # Retrieve the ringbuffer contents.
+  RINGBUFFER_CONTENT=$(lxc console cons1 --show-log)
+  # Strip prefix added by the client tool.
+  RINGBUFFER_CONTENT="${RINGBUFFER_CONTENT#
+Console log:
+
+}"
+  # Give kernel time to sync data to disk
+  sleep 2
+  LOGFILE_CONTENT=$(cat "${CONSOLE_LOGFILE}")
+
+  [ "${RINGBUFFER_CONTENT}" = "${LOGFILE_CONTENT}" ]
+
+  lxc delete --force cons1
+}


### PR DESCRIPTION
This is an RFC for attaching to the container's console. @stgraber, it would be cool if you could test this.
Note, the code duplication here in e.g. `container_exec.go` and `container_console.go` is **intentional**. This code will likely grow when we add support for retrieving the container's ringbuffer once this is merged in liblxc at which point the codepaths will diverge a lot more. Also, I want to keep the codepaths separate for a few feature releases in case of bugs. This will make it a lot easier to reason about what is going on. The abstraction level in `container_exec.go` is high enough already. In a few months we can then abstract/merge the codepaths if it makes sense.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>