### PR TITLE
lxd/logs: Don't allow removing lxc.conf or lxc.log

### DIFF
--- a/lxd/container_logs.go
+++ b/lxd/container_logs.go
@@ -93,6 +93,10 @@ func containerLogDelete(d *Daemon, r *http.Request) Response {
 		return BadRequest(fmt.Errorf("log file name %s not valid", file))
 	}
 
+	if file == "lxc.log" || file == "lxc.conf" {
+		return BadRequest(fmt.Errorf("lxc.log and lxc.conf may not be deleted"))
+	}
+
 	return SmartError(os.Remove(shared.LogPath(name, file)))
 }
 


### PR DESCRIPTION
Those files are used by the container runtime.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>