### PR TITLE
shared/api: Add API extension label to AuthMethods

### DIFF
--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -29,8 +29,10 @@ type ServerUntrusted struct {
 	APIStatus     string   `json:"api_status" yaml:"api_status"`
 	APIVersion    string   `json:"api_version" yaml:"api_version"`
 	Auth          string   `json:"auth" yaml:"auth"`
-	AuthMethods   []string `json:"auth_methods" yaml:"auth_methods"`
 	Public        bool     `json:"public" yaml:"public"`
+
+	// API extension: macaroon_authentication
+	AuthMethods []string `json:"auth_methods" yaml:"auth_methods"`
 }
 
 // Server represents a LXD server


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>