### PR TITLE
Print detach message in console and improve lxc file logging

### DIFF
--- a/lxc/console.go
+++ b/lxc/console.go
@@ -170,6 +170,8 @@ func (c *consoleCmd) run(conf *config.Config, args []string) error {
 		close(consoleDisconnect)
 	}()
 
+	fmt.Printf(i18n.G("To detach from the console, press: <ctrl>+a q") + "\n\r")
+
 	// Run the command in the container
 	op, err := d.ConsoleContainer(name, req, &consoleArgs)
 	if err != nil {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -255,7 +255,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -380,7 +380,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -748,7 +748,7 @@ msgstr "Akzeptiere Zertifikat"
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -758,12 +758,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -830,7 +830,7 @@ msgstr "Fehlende Zusammenfassung."
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
@@ -1380,6 +1380,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1427,7 +1431,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -2487,7 +2491,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2531,7 +2535,7 @@ msgstr "OK (y/n)? "
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -161,7 +161,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -269,7 +269,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -634,12 +634,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -706,7 +706,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1230,6 +1230,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1277,7 +1281,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2169,7 +2173,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2212,7 +2216,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-06-07 15:24+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -246,7 +246,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -256,7 +256,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -366,7 +366,7 @@ msgstr "CRÉÉ À"
 msgid "Cached: %s"
 msgstr "Créé : %s"
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -615,7 +615,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -735,7 +735,7 @@ msgstr "Certificat invalide"
 msgid "Invalid configuration key"
 msgstr "Clé de configuration invalide"
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -745,12 +745,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -817,7 +817,7 @@ msgstr "Résumé manquant."
 msgid "More than one device matches, specify the device name."
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
@@ -1364,6 +1364,10 @@ msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1412,7 +1416,7 @@ msgstr "UTILISÉ PAR"
 msgid "Unable to find help2man."
 msgstr "Impossible de trouver help2man"
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2771,7 +2775,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
@@ -2814,7 +2818,7 @@ msgstr "ok (y/n) ?"
 msgid "processing aliases failed %s\n"
 msgstr "l'analyse des alias a échoué %s\n"
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr "l'édition récursive ne fait aucun sens :("
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -172,7 +172,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -182,7 +182,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr "'%s' non è un tipo di file supportato."
@@ -290,7 +290,7 @@ msgstr "CREATO IL"
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -532,7 +532,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -645,7 +645,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -655,12 +655,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -726,7 +726,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1249,6 +1249,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1296,7 +1300,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2188,7 +2192,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2231,7 +2235,7 @@ msgstr "ok (y/n)?"
 msgid "processing aliases failed %s\n"
 msgstr "errore di processamento degli alias %s\n"
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -151,7 +151,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -162,7 +162,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr "'%s' はサポートされないタイプのファイルです。"
@@ -269,7 +269,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr "キャッシュ済: %s"
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr "新しいコンテナ名が取得できません"
 msgid "Failed to remove alias %s"
 msgstr "エイリアス %s の削除に失敗しました"
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -628,7 +628,7 @@ msgstr "不正な証明書です"
 msgid "Invalid configuration key"
 msgstr "正しくない設定項目 (key) です"
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -638,12 +638,12 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なパス %s"
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -709,7 +709,7 @@ msgstr "サマリーはありません。"
 msgid "More than one device matches, specify the device name."
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください。"
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
@@ -1247,6 +1247,10 @@ msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1296,7 +1300,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr "help2man が見つかりません。"
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -2885,7 +2889,7 @@ msgstr "`lxc config profile` は廃止されました。`lxc profile` を使っ�
 msgid "can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -2930,7 +2934,7 @@ msgstr "ok (y/n)?"
 msgid "processing aliases failed %s\n"
 msgstr "エイリアスの処理が失敗しました %s\n"
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr "再帰的な edit は意味がありません :("
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-11-14 07:37+0100\n"
+        "POT-Creation-Date: 2017-11-14 18:03-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -141,7 +141,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -151,7 +151,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid   "'%s' isn't a supported file type."
 msgstr  ""
@@ -258,7 +258,7 @@ msgstr  ""
 msgid   "Cached: %s"
 msgstr  ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -498,7 +498,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s"
 msgstr  ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -610,7 +610,7 @@ msgstr  ""
 msgid   "Invalid configuration key"
 msgstr  ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -620,12 +620,12 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -691,7 +691,7 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name."
 msgstr  ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
@@ -1208,6 +1208,10 @@ msgstr  ""
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
+#: lxc/console.go:173
+msgid   "To detach from the console, press: <ctrl>+a q"
+msgstr  ""
+
 #: lxc/main.go:172
 msgid   "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr  ""
@@ -1255,7 +1259,7 @@ msgstr  ""
 msgid   "Unable to find help2man."
 msgstr  ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -2057,7 +2061,7 @@ msgstr  ""
 msgid   "can't remove the default remote"
 msgstr  ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid   "can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -2100,7 +2104,7 @@ msgstr  ""
 msgid   "processing aliases failed %s\n"
 msgstr  ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid   "recursive edit doesn't make sense :("
 msgstr  ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -233,7 +233,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -243,7 +243,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -353,7 +353,7 @@ msgstr "СОЗДАН"
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -708,7 +708,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -718,12 +718,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -790,7 +790,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1314,6 +1314,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1361,7 +1365,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2265,7 +2269,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2308,7 +2312,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 07:36+0100\n"
+"POT-Creation-Date: 2017-11-14 18:02-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -148,7 +148,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:192
+#: lxc/file.go:195
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -158,7 +158,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:130
+#: lxc/file.go:132
 #, c-format
 msgid "'%s' isn't a supported file type."
 msgstr ""
@@ -265,7 +265,7 @@ msgstr ""
 msgid "Cached: %s"
 msgstr ""
 
-#: lxc/file.go:485
+#: lxc/file.go:491
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:125
+#: lxc/file.go:127
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -619,7 +619,7 @@ msgstr ""
 msgid "Invalid configuration key"
 msgstr ""
 
-#: lxc/file.go:528
+#: lxc/file.go:536
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -629,12 +629,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:457
+#: lxc/file.go:463
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:234
+#: lxc/file.go:240
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -700,7 +700,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name."
 msgstr ""
 
-#: lxc/file.go:444
+#: lxc/file.go:450
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -1223,6 +1223,10 @@ msgstr ""
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
+#: lxc/console.go:173
+msgid "To detach from the console, press: <ctrl>+a q"
+msgstr ""
+
 #: lxc/main.go:172
 msgid "To start your first container, try: lxc launch ubuntu:16.04"
 msgstr ""
@@ -1270,7 +1274,7 @@ msgstr ""
 msgid "Unable to find help2man."
 msgstr ""
 
-#: lxc/file.go:112
+#: lxc/file.go:114
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -2162,7 +2166,7 @@ msgstr ""
 msgid "can't remove the default remote"
 msgstr ""
 
-#: lxc/file.go:282
+#: lxc/file.go:286
 msgid "can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -2205,7 +2209,7 @@ msgstr ""
 msgid "processing aliases failed %s\n"
 msgstr ""
 
-#: lxc/file.go:556
+#: lxc/file.go:564
 msgid "recursive edit doesn't make sense :("
 msgstr ""
 


### PR DESCRIPTION
This will likely show as redundant until we SRU the -1 fix to the various LXC releases, but for recent LXC, this is useful.