### PR TITLE
lxd/dameon: Add LXD_EXEC_PATH to override execPath

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -20,5 +20,6 @@ Name                            | Description
 # Server environment variable
 Name                            | Description
 :---                            | :----
-`LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off
+`LXD_EXEC_PATH`                 | Full path to the LXD binary (used when forking subcommands)
 `LXD_LXC_TEMPLATE_CONFIG`       | Path to the LXC template configuration directory
+`LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -152,6 +152,11 @@ func RuntimeLiblxcVersionAtLeast(major int, minor int, micro int) bool {
 }
 
 func GetExecPath() string {
+	execPath := os.Getenv("LXD_EXEC_PATH")
+	if execPath != "" {
+		return execPath
+	}
+
 	execPath, err := os.Readlink("/proc/self/exe")
 	if err != nil {
 		execPath = "bad-exec-path"


### PR DESCRIPTION
This is needed for the LXD snap.

The pre-start/post-stop container hooks point to the LXD path and are
called when the container shuts down.

As the snapd paths include the revision of the daemon, a system which
got updated would then have a hook path pointing to a non-existing
binary.

This extra env variable allows us to point to the "current" path in the
snap, which is effectively a symlink to whichever is the latest binary.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>