### PR TITLE
Gracefully cancel tasks on daemon shutdown

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -378,7 +378,9 @@ func (d *Daemon) Ready() error {
 	// FIXME: There's no hard reason for which we should not run tasks in
 	//        mock mode. However it requires that we tweak the tasks so
 	//        they exit gracefully without blocking (something we should
-	//        do anyways) and they don't hit the internet or similar.
+	//        do anyways) and they don't hit the internet or similar. Support
+	//        for proper cancellation is something that has been started but
+	//        has not been fully completed.
 	if !d.os.MockMode {
 		d.tasks.Start()
 	}
@@ -430,7 +432,7 @@ func (d *Daemon) Stop() error {
 		trackError(d.endpoints.Down())
 	}
 
-	trackError(d.tasks.Stop(5 * time.Second)) // Give tasks at most five seconds to cleanup.
+	trackError(d.tasks.Stop(time.Second)) // Give tasks at second to cleanup.
 
 	if d.db != nil {
 		if n, err := d.numRunningContainers(); err != nil || n == 0 {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -831,8 +831,8 @@ func imagesGet(d *Daemon, r *http.Request) Response {
 var imagesCmd = Command{name: "images", post: imagesPost, untrustedGet: true, get: imagesGet}
 
 func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
-	f := func(context.Context) {
-		autoUpdateImages(d)
+	f := func(ctx context.Context) {
+		autoUpdateImages(ctx, d)
 	}
 	schedule := func() (time.Duration, error) {
 		interval := daemonConfig["images.auto_update_interval"].GetInt64()
@@ -841,7 +841,7 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, schedule
 }
 
-func autoUpdateImages(d *Daemon) {
+func autoUpdateImages(ctx context.Context, d *Daemon) {
 	logger.Infof("Updating images")
 
 	images, err := d.db.ImagesGet(false)
@@ -861,7 +861,19 @@ func autoUpdateImages(d *Daemon) {
 			continue
 		}
 
-		autoUpdateImage(d, nil, id, info)
+		// FIXME: since our APIs around image downloading don't support
+		//        cancelling, we run the function in a different
+		//        goroutine and simply abort when the context expires.
+		ch := make(chan struct{})
+		go func() {
+			autoUpdateImage(d, nil, id, info)
+			ch <- struct{}{}
+		}()
+		select {
+		case <-ctx.Done():
+			return
+		case <-ch:
+		}
 	}
 
 	logger.Infof("Done updating images")
@@ -938,18 +950,18 @@ func autoUpdateImage(d *Daemon, op *operation, id int, info *api.Image) error {
 }
 
 func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
-	f := func(context.Context) {
-		pruneExpiredImages(d)
+	f := func(ctx context.Context) {
+		pruneExpiredImages(ctx, d)
 	}
 
 	// Skip the first run, and instead run an initial pruning synchronously
 	// before we start updating images later on in the start up process.
-	pruneExpiredImages(d)
+	pruneExpiredImages(context.Background(), d)
 
 	return f, task.Daily(task.SkipFirst)
 }
 
-func pruneExpiredImages(d *Daemon) {
+func pruneExpiredImages(ctx context.Context, d *Daemon) {
 	// Get the list of expired images.
 	expiry := daemonConfig["images.remote_cache_expiry"].GetInt64()
 
@@ -967,6 +979,15 @@ func pruneExpiredImages(d *Daemon) {
 
 	// Delete them
 	for _, fp := range images {
+		// At each iteration we check if we got cancelled in the
+		// meantime. It is safe to abort here since anything not
+		// expired now will be expired at the next run.
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
 		if err := doDeleteImage(d, fp); err != nil {
 			logger.Error("Error deleting image", log.Ctx{"err": err, "fp": fp})
 		}

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -18,9 +18,9 @@ import (
 // This task function expires logs when executed. It's started by the Daemon
 // and will run once every 24h.
 func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
-	f := func(context.Context) {
+	f := func(ctx context.Context) {
 		logger.Infof("Expiring log files")
-		err := expireLogs(state)
+		err := expireLogs(ctx, state)
 		if err != nil {
 			logger.Error("Failed to expire logs", log.Ctx{"err": err})
 		}
@@ -29,13 +29,27 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 	return f, task.Daily()
 }
 
-func expireLogs(state *state.State) error {
+func expireLogs(ctx context.Context, state *state.State) error {
 	entries, err := ioutil.ReadDir(state.OS.LogDir)
 	if err != nil {
 		return err
 	}
 
-	result, err := state.DB.ContainersList(db.CTypeRegular)
+	// FIXME: our DB APIs don't yet support cancellation, se we need to run
+	//        them in a goroutine and abort this task if the context gets
+	//        cancelled.
+	var containers []string
+	ch := make(chan struct{})
+	go func() {
+		containers, err = state.DB.ContainersList(db.CTypeRegular)
+		ch <- struct{}{}
+	}()
+	select {
+	case <-ctx.Done():
+		return nil // Context expired
+	case <-ch:
+	}
+
 	if err != nil {
 		return err
 	}
@@ -58,8 +72,15 @@ func expireLogs(state *state.State) error {
 	}
 
 	for _, entry := range entries {
+		// At each iteration we check if we got cancelled in the meantime.
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		// Check if the container still exists
-		if shared.StringInSlice(entry.Name(), result) {
+		if shared.StringInSlice(entry.Name(), containers) {
 			// Remove any log file which wasn't modified in the past 48 hours
 			logs, err := ioutil.ReadDir(shared.LogPath(entry.Name()))
 			if err != nil {


### PR DESCRIPTION
The various periodic tasks that the Daemon spawns have been changed so
they do their best to gracefully terminate as soon as possible when
the given context gets cancelled (which happens upn daemon
shutdown). Due to some of underlying APIs not supporting cancellation
yet, this should be considered just a starting point.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>