### PR TITLE
Document issue with LXD performance when backed by LVM with a large v…

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -257,6 +257,10 @@ lxc storage create pool1 btrfs source=/dev/sdX
    serious performance impacts for the LVM driver causing it to be close to the
    fallback DIR driver both in speed and storage usage. This option should only
    be chosen if the use-case renders it necessary.
+ - For environments with high container turn over (e.g continuous integration)
+   it may be important to tweak the archival `retain_min` and `retain_days`
+   settings in `/etc/lvm/lvm.conf` to avoid slowdowns when interacting with
+   LXD.
 
 #### The following commands can be used to create LVM storage pools
 


### PR DESCRIPTION
…olume of archive metadata (high container, volume turnover)

Extension of https://github.com/lxc/lxd/issues/3942 which turned out to be a misconfiguration on my side. I consider my issue closed if the documentation is updated to reflect the fact that an external piece of software may be responsible for LXD slowdowns.

There's an argument about whether LXD can/should through some kind of `doctor` command check for this, but it's out of scope.