### PR TITLE
Added documentation about shell env to lxc exec

### DIFF
--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -55,6 +55,12 @@ func (c *execCmd) usage() string {
 
 Execute commands in containers.
 
+The command is executed directly using exec, so there is no shell and shell patterns (variables, file redirects, ...)
+won't be understood. If you need a shell environment you need to execute the shell executeable, passing the shell commands
+as arguments, for example:
+
+    lxc exec <container> -- sh -c "cd /tmp && pwd"
+
 Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored).`)
 }
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -530,11 +530,11 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -561,7 +561,7 @@ msgstr "Aktiviert Debug Modus"
 msgid "Enable verbose mode"
 msgstr "Aktiviert ausführliche Ausgabe"
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Fingerabdruck: %s\n"
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -935,7 +935,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1637,6 +1637,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2469,11 +2477,11 @@ msgstr "Zustand des laufenden Containers sichern oder nicht"
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -416,11 +416,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -445,7 +445,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -530,7 +530,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -805,7 +805,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1438,6 +1438,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2153,11 +2161,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,11 +7,11 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-10-26 15:46+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
-"Language-Team: French <https://hosted.weblate.org/projects/linux-"
-"containers/lxd/fr/>\n"
+"Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
+"lxd/fr/>\n"
 "Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -517,11 +517,11 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr "Désactiver l'allocation pseudo-terminal"
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
@@ -546,7 +546,7 @@ msgstr "Activer le mode de débogage"
 msgid "Enable verbose mode"
 msgstr "Activer le mode verbeux"
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
@@ -634,7 +634,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr "Empreinte : %s"
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation de pseudo-terminal "
 
@@ -919,7 +919,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Options:"
 msgstr "Options :"
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
@@ -1647,6 +1647,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2751,11 +2759,11 @@ msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur
 msgid "YES"
 msgstr "OUI"
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr "Il est impossible de passer -t et -T simultanément"
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 #, fuzzy
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -437,11 +437,11 @@ msgstr "La periferica esiste già: %s"
 msgid "Directory import is not available on this platform"
 msgstr "Import da directory non disponibile su questa piattaforma"
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -465,7 +465,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr "Abilita modalità verbosa"
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -824,7 +824,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1457,6 +1457,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2172,11 +2180,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -418,11 +418,11 @@ msgstr "デバイスは既に存在します: %s"
 msgid "Directory import is not available on this platform"
 msgstr "このプラットフォーム上ではディレクトリのインポートは利用できません"
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr "擬似端末の割り当てを無効にします"
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
@@ -446,7 +446,7 @@ msgstr "デバッグモードを有効にします"
 msgid "Enable verbose mode"
 msgstr "詳細モードを有効にします"
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
@@ -533,7 +533,7 @@ msgstr "リモートの情報表示はまだサポートされていません。
 msgid "Fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
@@ -809,7 +809,7 @@ msgstr "ネットワーク %s を削除しました"
 msgid "Options:"
 msgstr "オプション:"
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
@@ -1566,11 +1566,20 @@ msgstr ""
 "コンテナとコンテナのスナップショットを消去します。"
 
 #: lxc/exec.go:53
+#, fuzzy
 msgid ""
 "Usage: lxc exec [<remote>:]<container> [-t] [-T] [-n] [--mode=auto|"
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2868,11 +2877,11 @@ msgstr "コンテナの稼動状態のスナップショットを取得するか
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr "-t と -T は同時に指定できません"
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-11-14 23:10-0500\n"
+        "POT-Creation-Date: 2017-11-30 21:51-0800\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -403,11 +403,11 @@ msgstr  ""
 msgid   "Directory import is not available on this platform"
 msgstr  ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid   "Disable pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
@@ -431,7 +431,7 @@ msgstr  ""
 msgid   "Enable verbose mode"
 msgstr  ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
@@ -516,7 +516,7 @@ msgstr  ""
 msgid   "Fingerprint: %s"
 msgstr  ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
@@ -788,7 +788,7 @@ msgstr  ""
 msgid   "Options:"
 msgstr  ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
@@ -1402,6 +1402,12 @@ msgstr  ""
 msgid   "Usage: lxc exec [<remote>:]<container> [-t] [-T] [-n] [--mode=auto|interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
         "\n"
         "Execute commands in containers.\n"
+        "\n"
+        "The command is executed directly using exec, so there is no shell and shell patterns (variables, file redirects, ...)\n"
+        "won't be understood. If you need a shell environment you need to execute the shell executeable, passing the shell commands\n"
+        "as arguments, for example:\n"
+        "\n"
+        "    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
         "\n"
         "Mode defaults to non-interactive, interactive mode is selected if both stdin AND stdout are terminals (stderr is ignored)."
 msgstr  ""
@@ -2041,11 +2047,11 @@ msgstr  ""
 msgid   "YES"
 msgstr  ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid   "You can't pass -t and -T at the same time"
 msgstr  ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 23:10-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 23:10-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -500,11 +500,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -529,7 +529,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -614,7 +614,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -889,7 +889,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1530,6 +1530,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2249,11 +2257,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-14 18:02-0500\n"
+"POT-Creation-Date: 2017-11-30 21:51-0800\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -412,11 +412,11 @@ msgstr ""
 msgid "Directory import is not available on this platform"
 msgstr ""
 
-#: lxc/exec.go:65
+#: lxc/exec.go:71
 msgid "Disable pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/exec.go:66
+#: lxc/exec.go:72
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
@@ -440,7 +440,7 @@ msgstr ""
 msgid "Enable verbose mode"
 msgstr ""
 
-#: lxc/exec.go:62
+#: lxc/exec.go:68
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
@@ -525,7 +525,7 @@ msgstr ""
 msgid "Fingerprint: %s"
 msgstr ""
 
-#: lxc/exec.go:64
+#: lxc/exec.go:70
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
@@ -798,7 +798,7 @@ msgstr ""
 msgid "Options:"
 msgstr ""
 
-#: lxc/exec.go:63
+#: lxc/exec.go:69
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
@@ -1431,6 +1431,14 @@ msgid ""
 "interactive|non-interactive] [--env KEY=VALUE...] [--] <command line>\n"
 "\n"
 "Execute commands in containers.\n"
+"\n"
+"The command is executed directly using exec, so there is no shell and shell "
+"patterns (variables, file redirects, ...)\n"
+"won't be understood. If you need a shell environment you need to execute the "
+"shell executeable, passing the shell commands\n"
+"as arguments, for example:\n"
+"\n"
+"    lxc exec <container> -- sh -c \"cd /tmp && pwd\"\n"
 "\n"
 "Mode defaults to non-interactive, interactive mode is selected if both stdin "
 "AND stdout are terminals (stderr is ignored)."
@@ -2146,11 +2154,11 @@ msgstr ""
 msgid "YES"
 msgstr ""
 
-#: lxc/exec.go:126
+#: lxc/exec.go:132
 msgid "You can't pass -t and -T at the same time"
 msgstr ""
 
-#: lxc/exec.go:130
+#: lxc/exec.go:136
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 


### PR DESCRIPTION
See https://github.com/lxc/lxd/issues/3054#issuecomment-347925994

This probably needs to be adjusted in the i18n translation files, but I have no idea how that works.