### PR TITLE
console: adapt to new liblxc changes 

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -495,6 +495,7 @@ type container interface {
 	TemplatesPath() string
 	StatePath() string
 	LogFilePath() string
+	ConsoleBufferLogPath() string
 	LogPath() string
 
 	StoragePool() (string, error)

--- a/test/suites/console.sh
+++ b/test/suites/console.sh
@@ -13,43 +13,9 @@ test_console() {
 
   lxc init testimage cons1
 
-  # 1. Set a console log file but no ringbuffer.
-
-  # Test the console log file requests.
   lxc start cons1
 
-  # No console log file set so this should return an error.
-  ! lxc console cons1 --show-log
-  lxc stop --force cons1
-
-  # Set a console log file but no ringbuffer.
-  # shellcheck disable=SC2034
-  CONSOLE_LOGFILE="$(mktemp -p "${LXD_DIR}" XXXXXXXXX)"
-  lxc config set cons1 raw.lxc "lxc.console.logfile=${CONSOLE_LOGFILE}"
-  lxc start cons1
-
-  # Let the container come up. Two seconds should be fine.
-  sleep 2
-
-  # Make sure there's something in the console ringbuffer.
-  echo 'some content' | lxc exec cons1 -- tee /dev/console
-
-  # Console log file set so this should return without an error.
-  lxc console cons1 --show-log
-
-  lxc stop --force cons1
-
-  # 2. Set a console ringbuffer but no log file.
-
-  # remove logfile
-  lxc config unset cons1 raw.lxc
-
-  # set console ringbuffer
-  lxc config set cons1 raw.lxc "lxc.console.logsize=auto"
-
-  lxc start cons1
-
-  # Let the container come up. Two seconds should be fine.
+  # Let the init system come up.
   sleep 2
 
   # Make sure there's something in the console ringbuffer.
@@ -59,35 +25,10 @@ test_console() {
   # Retrieve the ringbuffer contents.
   lxc console cons1 --show-log
 
-  # 3. Set a console ringbuffer and a log file.
-
   lxc stop --force cons1
 
-  lxc config unset cons1 raw.lxc
-
-  rm -f "${CONSOLE_LOGFILE}"
-  printf "lxc.console.logsize=auto\nlxc.console.logfile=%s" "${CONSOLE_LOGFILE}" | lxc config set cons1 raw.lxc -
-
-  lxc start cons1
-
-  # Let the container come up. Two seconds should be fine.
-  sleep 2
-
-  # Make sure there's something in the console ringbuffer.
-  echo 'Ringbuffer contents and log file contents must match' | lxc exec cons1 -- tee /dev/console
-
-  # Retrieve the ringbuffer contents.
-  RINGBUFFER_CONTENT=$(lxc console cons1 --show-log)
-  # Strip prefix added by the client tool.
-  RINGBUFFER_CONTENT="${RINGBUFFER_CONTENT#
-Console log:
-
-}"
-  # Give kernel time to sync data to disk
-  sleep 2
-  LOGFILE_CONTENT=$(cat "${CONSOLE_LOGFILE}")
-
-  [ "${RINGBUFFER_CONTENT}" = "${LOGFILE_CONTENT}" ]
+  # Retrieve on-disk representation of the console ringbuffer.
+  lxc console cons1 --show-log
 
   lxc delete --force cons1
 }


### PR DESCRIPTION
Not too long ago we merged

lxc/lxc#1925

which adds the new configuration keys

- lxc.console.buffer.size
- lxc.console.buffer.logfile
- lxc.console.rotate

LXD will always set

lxc.console.buffer = auto

which allocates a 128kB ringbuffer for each container and

lxc.console.buffer.logfile=/var/log/lxd/<container-name>/console.log

which is an on-disk representation of the console ringbuffer. liblxc will
always dump the in-memory ringbuffer when a container stops so users can
request the last contents of the ringbuffer if a container fails to start. When
a container is running and a request is sent to the retrieve the current
in-memory ringbuffer contents liblxc will also automatically dump the current
contents to disk.

As of this commit LXD will ignore lxc.console.logfile i.e. it cannot be
retrieved via the API. We still allow users to set this file via raw.lxc but
the API does not allow interaction with it. Users can either request the
in-memory ringbuffer contents or its on-disk representation so there' really no
point in having this exposed in the API.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>