### PR TITLE
storage: Use HostPath for dir/btrfs

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -108,7 +108,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 	s.pool.Config["volatile.initial_source"] = s.pool.Config["source"]
 
 	isBlockDev := false
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		source = filepath.Join(shared.VarPath("disks"), fmt.Sprintf("%s.img", s.pool.Name))
 		s.pool.Config["source"] = source
@@ -259,7 +259,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 func (s *storageBtrfs) StoragePoolDelete() error {
 	logger.Infof("Deleting BTRFS storage pool \"%s\".", s.pool.Name)
 
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		return fmt.Errorf("no \"source\" property found for the storage pool")
 	}
@@ -324,7 +324,7 @@ func (s *storageBtrfs) StoragePoolDelete() error {
 func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 	logger.Debugf("Mounting BTRFS storage pool \"%s\".", s.pool.Name)
 
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		return false, fmt.Errorf("no \"source\" property found for the storage pool")
 	}

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -56,7 +56,7 @@ func (s *storageDir) StoragePoolCreate() error {
 
 	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
 
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		source = filepath.Join(shared.VarPath("storage-pools"), s.pool.Name)
 		s.pool.Config["source"] = source
@@ -128,7 +128,7 @@ func (s *storageDir) StoragePoolCreate() error {
 func (s *storageDir) StoragePoolDelete() error {
 	logger.Infof("Deleting DIR storage pool \"%s\".", s.pool.Name)
 
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		return fmt.Errorf("no \"source\" property found for the storage pool")
 	}
@@ -163,7 +163,7 @@ func (s *storageDir) StoragePoolDelete() error {
 }
 
 func (s *storageDir) StoragePoolMount() (bool, error) {
-	source := s.pool.Config["source"]
+	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
 		return false, fmt.Errorf("no \"source\" property found for the storage pool")
 	}


### PR DESCRIPTION
dir and btrfs allow the bind-mounting of an existing fs path, as this
can be outside of the snap's mount namespace, we need to wrap those
paths using shared.HostPath.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>