### PR TITLE
lxd-benchmark: Change the default count of containers from 100 to 1

### DIFF
--- a/lxd-benchmark/main.go
+++ b/lxd-benchmark/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/lxc/lxd/shared/version"
 )
 
-var argCount = gnuflag.Int("count", 100, "Number of containers to create")
+var argCount = gnuflag.Int("count", 1, "Number of containers to create")
 var argParallel = gnuflag.Int("parallel", -1, "Number of threads to use")
 var argImage = gnuflag.String("image", "ubuntu:", "Image to use for the test")
 var argPrivileged = gnuflag.Bool("privileged", false, "Use privileged containers")


### PR DESCRIPTION
The default count for lxd-benchmark is 100 containers.
This can crash systems with less than 16GB of RAM.
The default should be 1, and then let the user select a bigger value.

Signed-off-by: Simos Xenitellis <simos@users.noreply.github.com>