### PR TITLE
Implements boot.stop.priority as described in #2082

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -72,7 +72,8 @@ _have lxc && {
       images.compression_algorithm images.remote_cache_expiry"
 
     container_keys="boot.autostart boot.autostart.delay \
-      boot.autostart.priority boot.host_shutdown_timeout environment. \
+      boot.autostart.priority boot.stop.priority \
+      boot.host_shutdown_timeout environment. \
       limits.cpu limits.cpu.allowance limits.cpu.priority \
       limits.disk.priority limits.memory limits.memory.enforce \
       limits.memory.swap limits.memory.swap.priority limits.network.priority \

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -22,6 +22,15 @@ to stop before killing it.
 
 Its value is only used on clean LXD daemon shutdown. It defaults to 30s.
 
+## container\_stop\_priority
+A `boot.stop.priority` container configuration key was introduced.
+
+It's an integer which indicates the priority of a container during shutdown.
+
+Containers will shutdown starting with the highest priority level.
+
+Containers with the same priority will shutdown in parallel.  It defaults to 0.
+
 ## container\_syscall\_filtering
 A number of new syscalls related container configuration keys were introduced.
 

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -28,6 +28,7 @@ boot.autostart                          | boolean   | -             | n/a       
 boot.autostart.delay                    | integer   | 0             | n/a           | -                                    | Number of seconds to wait after the container started before starting the next one
 boot.autostart.priority                 | integer   | 0             | n/a           | -                                    | What order to start the containers in (starting with highest)
 boot.host\_shutdown\_timeout            | integer   | 30            | yes           | container\_host\_shutdown\_timeout   | Seconds to wait for container to shutdown before it is force stopped
+boot.stop.priority                      | integer   | 0             | n/a           | container\_stop\_priority            | What order to shutdown the containers (starting with highest)
 environment.\*                          | string    | -             | yes (exec)    | -                                    | key/value environment variables to export to the container and set on exec
 limits.cpu                              | string    | - (all)       | yes           | -                                    | Number or range of CPUs to expose to the container
 limits.cpu.allowance                    | string    | 100%          | yes           | -                                    | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)

--- a/shared/container.go
+++ b/shared/container.go
@@ -94,6 +94,7 @@ var KnownContainerConfigKeys = map[string]func(value string) error{
 	"boot.autostart":             IsBool,
 	"boot.autostart.delay":       IsInt64,
 	"boot.autostart.priority":    IsInt64,
+	"boot.stop.priority":         IsInt64,
 	"boot.host_shutdown_timeout": IsInt64,
 
 	"limits.cpu": IsAny,

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -18,6 +18,7 @@ var APIVersion = "1.0"
 var APIExtensions = []string{
 	"storage_zfs_remove_snapshots",
 	"container_host_shutdown_timeout",
+	"container_stop_priority",
 	"container_syscall_filtering",
 	"auth_pki",
 	"container_last_used_at",


### PR DESCRIPTION
boot.stop.priority is now an attribute of a container and can be set similar to that of boot.autostart.priority.  Upon shutdown, containers will shutdown based on priority level with higher priority containers shutting down before those of lower priority containers.  If boot.stop.priority is never set on any container, the same performance and behavior of LXD prior to this change can be expected.

Signed-off-by: Kevin Pick  <cyberkpick@utexas.edu>