### PR TITLE
lxc/action: add `--all` flag

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -337,6 +337,10 @@ msgstr "automatisches Update: %s"
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
+#: lxc/action.go:133
+msgid "Both --all and container name given"
+msgstr ""
+
 #: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Bytes empfangen"
@@ -654,7 +658,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 #, fuzzy
 msgid "Force the container to shutdown"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -700,7 +704,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 #, fuzzy
 msgid "Ignore the container state (only for start)"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -844,7 +848,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 #, fuzzy
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -1131,6 +1135,10 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1222,7 +1230,7 @@ msgstr "Größe: %.2vMB\n"
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, fuzzy, c-format
 msgid "Some containers failed to %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1289,7 +1297,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Storage volume %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 #, fuzzy
 msgid "Store the container state (only for stop)"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1336,7 +1344,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1362,7 +1370,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 #, fuzzy
 msgid "Time to wait for the container before killing it"
 msgstr "Wartezeit bevor der Container gestoppt wird."
@@ -1402,7 +1410,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1441,10 +1449,10 @@ msgstr "Unbekannter Befehl %s für Abbild"
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, fuzzy, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2519,7 +2527,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, fuzzy, c-format
 msgid "error: %v"
 msgstr "Fehler: %v\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -229,6 +229,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -534,7 +538,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -578,7 +582,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -718,7 +722,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -993,6 +997,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1082,7 +1090,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1146,7 +1154,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1190,7 +1198,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1214,7 +1222,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1252,7 +1260,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1291,10 +1299,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2201,7 +2209,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-10-26 15:46+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -328,6 +328,10 @@ msgstr "Mise à jour auto. : %s"
 msgid "Bad property: %s"
 msgstr ""
 
+#: lxc/action.go:133
+msgid "Both --all and container name given"
+msgstr ""
+
 #: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Octets reçus"
@@ -638,7 +642,7 @@ msgstr "Empreinte : %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation de pseudo-terminal "
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr "Forcer le conteneur à s'arrêter"
 
@@ -687,7 +691,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr "Ignorer les alias pour déterminer la commande à exécuter"
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
@@ -831,7 +835,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
@@ -1111,6 +1115,10 @@ msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr "TAILLE"
@@ -1203,7 +1211,7 @@ msgstr "Taille : %.2f Mo"
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, fuzzy, c-format
 msgid "Some containers failed to %s"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1269,7 +1277,7 @@ msgstr "Profil %s créé"
 msgid "Storage volume %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
@@ -1318,7 +1326,7 @@ msgstr "Le périphérique n'existe pas"
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 #, fuzzy
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "Le pendant de `lxc pause` est `lxc start`."
@@ -1348,7 +1356,7 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr "Temps d'attente du conteneur avant de le tuer"
 
@@ -1387,7 +1395,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -1426,10 +1434,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, fuzzy, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2803,7 +2811,7 @@ msgstr "désactivé"
 msgid "enabled"
 msgstr "activé"
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr "erreur : %v"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -251,6 +251,10 @@ msgstr "Aggiornamento automatico: %s"
 #, c-format
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
+msgstr ""
 
 #: lxc/info.go:215
 msgid "Bytes received"
@@ -555,7 +559,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -599,7 +603,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -738,7 +742,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -1012,6 +1016,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1101,7 +1109,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1165,7 +1173,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1209,7 +1217,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1233,7 +1241,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1271,7 +1279,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1310,10 +1318,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2220,7 +2228,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -231,6 +231,10 @@ msgstr "自動更新: %s"
 #, c-format
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
+msgstr ""
 
 #: lxc/info.go:215
 msgid "Bytes received"
@@ -537,7 +541,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr "コンテナを強制シャットダウンします"
 
@@ -582,7 +586,7 @@ msgstr "初めて LXD を使う場合、lxd init と実行する必要があり�
 msgid "Ignore aliases when determining what command to run"
 msgstr "どのコマンドを実行するか決める際にエイリアスを無視します"
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr "コンテナの状態を無視します (startのみ)"
 
@@ -723,7 +727,7 @@ msgstr "コンテナを移動します (スナップショットは移動しま�
 msgid "Must run as root to import from directory"
 msgstr "ディレクトリからのインポートは root で実行する必要があります"
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
@@ -998,6 +1002,10 @@ msgstr "コンテナの状態を保存します (stopのみ)"
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1088,7 +1096,7 @@ msgstr "サイズ: %.2fMB"
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr "一部のコンテナで %s が失敗しました"
@@ -1152,7 +1160,7 @@ msgstr "ストレージボリューム %s を作成しました"
 msgid "Storage volume %s deleted"
 msgstr "ストレージボリューム %s を削除しました"
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr "コンテナの状態を保存します (stopのみ)"
 
@@ -1199,7 +1207,7 @@ msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:' を試してみてください。"
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr "\"lxc pause\" の反対のコマンドは \"lxc start\" です。"
 
@@ -1229,7 +1237,7 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr "コンテナを強制停止するまでの時間"
 
@@ -1271,7 +1279,7 @@ msgstr "コンテナを転送中: %s"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -1310,10 +1318,10 @@ msgstr "未知のファイルタイプ '%s'"
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/action.go:37
-#, c-format
+#: lxc/action.go:38
+#, fuzzy, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2920,7 +2928,7 @@ msgstr "無効"
 msgid "enabled"
 msgstr "有効"
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr "エラー: %v"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2017-11-30 21:51-0800\n"
+        "POT-Creation-Date: 2017-12-15 12:26+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -219,6 +219,10 @@ msgstr  ""
 #: lxc/image.go:706
 #, c-format
 msgid   "Bad property: %s"
+msgstr  ""
+
+#: lxc/action.go:133
+msgid   "Both --all and container name given"
 msgstr  ""
 
 #: lxc/info.go:215
@@ -520,7 +524,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid   "Force the container to shutdown"
 msgstr  ""
 
@@ -564,7 +568,7 @@ msgstr  ""
 msgid   "Ignore aliases when determining what command to run"
 msgstr  ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid   "Ignore the container state (only for start)"
 msgstr  ""
 
@@ -703,7 +707,7 @@ msgstr  ""
 msgid   "Must run as root to import from directory"
 msgstr  ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid   "Must supply container name for: "
 msgstr  ""
 
@@ -975,6 +979,10 @@ msgstr  ""
 msgid   "Retrieving image: %s"
 msgstr  ""
 
+#: lxc/action.go:52
+msgid   "Run command against all containers"
+msgstr  ""
+
 #: lxc/image.go:236
 msgid   "SIZE"
 msgstr  ""
@@ -1064,7 +1072,7 @@ msgstr  ""
 msgid   "Snapshots:"
 msgstr  ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid   "Some containers failed to %s"
 msgstr  ""
@@ -1128,7 +1136,7 @@ msgstr  ""
 msgid   "Storage volume %s deleted"
 msgstr  ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid   "Store the container state (only for stop)"
 msgstr  ""
 
@@ -1169,7 +1177,7 @@ msgstr  ""
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid   "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr  ""
 
@@ -1192,7 +1200,7 @@ msgid   "This is the LXD command line client.\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid   "Time to wait for the container before killing it"
 msgstr  ""
 
@@ -1230,7 +1238,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -1269,9 +1277,9 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
-msgid   "Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+msgid   "Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
         "\n"
         "%s%s"
 msgstr  ""
@@ -2087,7 +2095,7 @@ msgstr  ""
 msgid   "enabled"
 msgstr  ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid   "error: %v"
 msgstr  ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -314,6 +314,10 @@ msgstr "Авто-обновление: %s"
 msgid "Bad property: %s"
 msgstr ""
 
+#: lxc/action.go:133
+msgid "Both --all and container name given"
+msgstr ""
+
 #: lxc/info.go:215
 msgid "Bytes received"
 msgstr "Получено байтов"
@@ -618,7 +622,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -662,7 +666,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -802,7 +806,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -1077,6 +1081,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1166,7 +1174,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, fuzzy, c-format
 msgid "Some containers failed to %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1230,7 +1238,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1274,7 +1282,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1298,7 +1306,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1336,7 +1344,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1375,10 +1383,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, fuzzy, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2297,7 +2305,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2017-11-30 21:51-0800\n"
+"POT-Creation-Date: 2017-12-15 12:26+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -226,6 +226,10 @@ msgstr ""
 #: lxc/image.go:706
 #, c-format
 msgid "Bad property: %s"
+msgstr ""
+
+#: lxc/action.go:133
+msgid "Both --all and container name given"
 msgstr ""
 
 #: lxc/info.go:215
@@ -529,7 +533,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/action.go:46 lxc/action.go:47
+#: lxc/action.go:47 lxc/action.go:48
 msgid "Force the container to shutdown"
 msgstr ""
 
@@ -573,7 +577,7 @@ msgstr ""
 msgid "Ignore aliases when determining what command to run"
 msgstr ""
 
-#: lxc/action.go:50
+#: lxc/action.go:51
 msgid "Ignore the container state (only for start)"
 msgstr ""
 
@@ -712,7 +716,7 @@ msgstr ""
 msgid "Must run as root to import from directory"
 msgstr ""
 
-#: lxc/action.go:72
+#: lxc/action.go:74
 msgid "Must supply container name for: "
 msgstr ""
 
@@ -986,6 +990,10 @@ msgstr ""
 msgid "Retrieving image: %s"
 msgstr ""
 
+#: lxc/action.go:52
+msgid "Run command against all containers"
+msgstr ""
+
 #: lxc/image.go:236
 msgid "SIZE"
 msgstr ""
@@ -1075,7 +1083,7 @@ msgstr ""
 msgid "Snapshots:"
 msgstr ""
 
-#: lxc/action.go:142
+#: lxc/action.go:163
 #, c-format
 msgid "Some containers failed to %s"
 msgstr ""
@@ -1139,7 +1147,7 @@ msgstr ""
 msgid "Storage volume %s deleted"
 msgstr ""
 
-#: lxc/action.go:49
+#: lxc/action.go:50
 msgid "Store the container state (only for stop)"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
 
-#: lxc/action.go:34
+#: lxc/action.go:35
 msgid "The opposite of \"lxc pause\" is \"lxc start\"."
 msgstr ""
 
@@ -1207,7 +1215,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/action.go:45
+#: lxc/action.go:46
 msgid "Time to wait for the container before killing it"
 msgstr ""
 
@@ -1245,7 +1253,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:106 lxc/launch.go:77
+#: lxc/action.go:108 lxc/launch.go:77
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -1284,10 +1292,10 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/action.go:37
+#: lxc/action.go:38
 #, c-format
 msgid ""
-"Usage: lxc %s [<remote>:]<container> [[<remote>:]<container>...]\n"
+"Usage: lxc %s [--all] [<remote>:]<container> [[<remote>:]<container>...]\n"
 "\n"
 "%s%s"
 msgstr ""
@@ -2194,7 +2202,7 @@ msgstr ""
 msgid "enabled"
 msgstr ""
 
-#: lxc/action.go:134 lxc/main.go:33 lxc/main.go:191
+#: lxc/action.go:155 lxc/main.go:33 lxc/main.go:191
 #, c-format
 msgid "error: %v"
 msgstr ""

--- a/test/suites/basic.sh
+++ b/test/suites/basic.sh
@@ -436,6 +436,19 @@ test_basic_usage() {
   # Cleanup the containers
   lxc delete --force c1 c2 c3
 
+  # Test --all flag
+  lxc init testimage c1
+  lxc init testimage c2
+  lxc start --all
+  lxc list | grep c1 | grep RUNNING
+  lxc list | grep c2 | grep RUNNING
+  ! lxc stop --all c1 || false
+  lxc stop --all
+  lxc list | grep c1 | grep STOPPED
+  lxc list | grep c2 | grep STOPPED
+  # Cleanup the containers
+  lxc delete --force c1 c2
+
   # Ephemeral
   lxc launch testimage foo -e
 


### PR DESCRIPTION
Allow running actions (start, stop, ...) against all containers.

Signed-off-by: Michael Schubert <michael@kinvolk.io>