### PR TITLE
fix url pointing to contributing.md

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -95,7 +95,7 @@ Now that you have LXD running on your system you can read the [getting started g
 Bug reports can be filed at: <https://github.com/lxc/lxd/issues/new>
 
 ## Contributing
-Fixes and new features are greatly appreciated but please read our [contributing guidelines](contributing.md) first.
+Fixes and new features are greatly appreciated but please read our [contributing guidelines](doc/contributing.md) first.
 
 ## Support and discussions
 ### Forum


### PR DESCRIPTION
When one is browsing the repository through github and lands on a symlink it will display the symlink instead of following the symlink to the correct file.