### PR TITLE
mirgation: enable pre-dumping based on CRIU's feature check

### DIFF
--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -1102,7 +1102,6 @@ func (c *migrationSink) Do(migrateOp *operation) error {
 	if header.GetPredump() == true {
 		// If the other side wants pre-dump and if
 		// this side supports it, let's use it.
-		// TODO: check kernel+criu (and config?)
 		resp.Predump = proto.Bool(true)
 	} else {
 		resp.Predump = proto.Bool(false)

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -357,6 +357,51 @@ func snapshotToProtobuf(c container) *Snapshot {
 	}
 }
 
+// Check if CRIU supports pre-dumping and number of
+// pre-dump iterations
+func (s *migrationSourceWs) checkForPreDumpSupport() (bool, int) {
+	// TODO: ask CRIU if this system (kernel+criu) supports
+	// pre-copy (dirty memory tracking)
+	// The user should also be enable to influence it from the
+	// command-line.
+
+	// What does the configuration say about pre-copy
+	tmp := s.container.ExpandedConfig()["migration.incremental.memory"]
+
+	// default to false for pre-dumps as long as libxlc has no
+	// detection for the feature
+	use_pre_dumps := false
+
+	if tmp != "" {
+		use_pre_dumps = shared.IsTrue(tmp)
+	}
+	logger.Debugf("migration.incremental.memory %d", use_pre_dumps)
+
+
+	// migration.incremental.memory.iterations is the value after which the
+	// container will be definitely migrated, even if the remaining number
+	// of memory pages is below the defined threshold.
+	// TODO: implement threshold (needs reading of CRIU output files)
+	var max_iterations int
+	tmp = s.container.ExpandedConfig()["migration.incremental.memory.iterations"]
+	if tmp != "" {
+		max_iterations, _ = strconv.Atoi(tmp)
+	} else {
+		// default to 10
+		max_iterations = 10
+	}
+	if max_iterations > 999 {
+		// the pre-dump directory is hardcoded to a string
+		// with maximal 3 digits. 999 pre-dumps makes no
+		// sense at all, but let's make sure the number
+		// is not higher than this.
+		max_iterations = 999
+	}
+	logger.Debugf("using maximal %d iterations for pre-dumping", max_iterations)
+
+	return use_pre_dumps, max_iterations
+}
+
 // The function readCriuStatsDump() reads the CRIU 'stats-dump' file
 // in path and returns the pages_written, pages_skipped_parent, error.
 func readCriuStatsDump(path string) (uint64, uint64, error) {
@@ -552,43 +597,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 		}
 	}
 
-	// TODO: ask CRIU if this system (kernel+criu) supports
-	// pre-copy (dirty memory tracking)
-	// The user should also be enable to influence it from the
-	// command-line.
-
-	// What does the config say about pre-copy
-	tmp := s.container.ExpandedConfig()["migration.incremental.memory"]
-
-	// default to false for pre-dumps as long as libxlc has no
-	// detection for the feature
-	use_pre_dumps := false
-
-	if tmp != "" {
-		use_pre_dumps = shared.IsTrue(tmp)
-	}
-	logger.Debugf("migration.incremental.memory %d", use_pre_dumps)
-
-	// migration.incremental.memory.iterations is the value after which the
-	// container will be definitely migrated, even if the remaining number
-	// of memory pages is below the defined threshold.
-	// TODO: implement threshold (needs reading of CRIU output files)
-	var max_iterations int
-	tmp = s.container.ExpandedConfig()["migration.incremental.memory.iterations"]
-	if tmp != "" {
-		max_iterations, _ = strconv.Atoi(tmp)
-	} else {
-		// default to 10
-		max_iterations = 10
-	}
-	if max_iterations > 999 {
-		// the pre-dump directory is hardcoded to a string
-		// with maximal 3 digits. 999 pre-dumps makes no
-		// sense at all, but let's make sure the number
-		// is not higher than this.
-		max_iterations = 999
-	}
-	logger.Debugf("using maximal %d iterations for pre-dumping", max_iterations)
+	use_pre_dumps, max_iterations := s.checkForPreDumpSupport()
 
 	// The protocol says we have to send a header no matter what, so let's
 	// do that, but then immediately send an error.


### PR DESCRIPTION
With the previous commits pre-copy migration was opt-in as not all architecture/kernel/CRIU combinations support it. With the newly added CRIU feature checking support added to lxc and go-lxc the pre-copy migration is now switched from defaulting to off to default to what the platform actual supports.

If the architecture/kernel/CRIU combination supports pre-copy migration it is turned on. The user has still the chance to opt-out of pre-copy migration by setting 'migration.incremental.memory' to 'false'.