### PR TITLE
Improve storage cache, first-run flag and auto-start error handling

### DIFF
--- a/lxc/main.go
+++ b/lxc/main.go
@@ -155,7 +155,7 @@ func run() error {
 	// and this is the first time the client has been run by the user, then check to see
 	// if LXD has been properly configured.  Don't display the message if the var path
 	// does not exist (LXD not installed), as the user may be targeting a remote daemon.
-	if os.Args[0] != "help" && os.Args[0] != "version" && shared.PathExists(shared.VarPath("")) && !shared.PathExists(conf.ConfigDir) {
+	if os.Args[0] != "help" && os.Args[0] != "version" && shared.PathExists(shared.VarPath("")) && !shared.PathExists(configPath) {
 		// Create the config dir so that we don't get in here again for this user.
 		err = os.MkdirAll(conf.ConfigDir, 0750)
 		if err != nil {

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -123,13 +123,7 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		ServerVersion:          version.Version}
 
 	drivers := readStoragePoolDriversCache()
-	for _, driver := range drivers {
-		// Initialize a core storage interface for the given driver.
-		sCore, err := storageCoreInit(driver)
-		if err != nil {
-			continue
-		}
-
+	for driver, version := range drivers {
 		if env.Storage != "" {
 			env.Storage = env.Storage + " | " + driver
 		} else {
@@ -137,11 +131,10 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		}
 
 		// Get the version of the storage drivers in use.
-		sVersion := sCore.GetStorageTypeVersion()
 		if env.StorageVersion != "" {
-			env.StorageVersion = env.StorageVersion + " | " + sVersion
+			env.StorageVersion = env.StorageVersion + " | " + version
 		} else {
-			env.StorageVersion = sVersion
+			env.StorageVersion = version
 		}
 	}
 

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -137,7 +137,10 @@ func containersRestart(s *state.State) error {
 				continue
 			}
 
-			c.Start(false)
+			err = c.Start(false)
+			if err != nil {
+				logger.Errorf("Failed to start container '%s': %v", c.Name(), err)
+			}
 
 			autoStartDelayInt, err := strconv.Atoi(autoStartDelay)
 			if err == nil {


### PR DESCRIPTION
This moves all the data we need into the cache so that we don't cause
any filesystem related calls when we received "GET /1.0".

Closes #4025

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>