### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,9 @@
+<!--
 Github issues are used for bug reports. For support questions, please use [our forum](https://discuss.linuxcontainers.org).
 
 Please fill the template below as it will greatly help us track down your issue and reproduce it on our side.  
 Feel free to remove anything which doesn't apply to you and add more information where it makes sense.
+-->
 
 # Required information
 


### PR DESCRIPTION
Hide header when rendering by commenting it out so we don't
have to read it over and over again when looking at issues.