### PR TITLE
container_lxc: add unix device hotplug support

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -405,3 +405,6 @@ This makes it possible to retrieve symlinks using the file API.
 ## network\_leases
 Adds a new /1.0/networks/NAME/leases API endpoint to query the lease database on
 bridges which run a LXD-managed DHCP server.
+
+## unix\_device\_hotplug
+This adds support for the "required" property for unix devices.

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -360,6 +360,7 @@ minor       | int       | device on host    |                                   
 uid         | int       | 0                 |                                   | no        | UID of the device owner in the container
 gid         | int       | 0                 |                                   | no        | GID of the device owner in the container
 mode        | int       | 0660              |                                   | no        | Mode of the device in the container
+required    | boolean   | true              | unix\_device\_hotplug             | no        | Whether or not this device is required to start the container.
 
 ### Type: unix-block
 Unix block device entries simply make the requested block device
@@ -376,6 +377,7 @@ minor       | int       | device on host    |                                   
 uid         | int       | 0                 |                                   | no        | UID of the device owner in the container
 gid         | int       | 0                 |                                   | no        | GID of the device owner in the container
 mode        | int       | 0660              |                                   | no        | Mode of the device in the container
+required    | boolean   | true              | unix\_device\_hotplug             | no        | Whether or not this device is required to start the container.
 
 ### Type: usb
 USB device entries simply make the requested USB device appear in the

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -102,6 +102,8 @@ func containerValidDeviceConfigKey(t, k string) bool {
 			return true
 		case "path":
 			return true
+		case "required":
+			return true
 		case "uid":
 			return true
 		default:
@@ -397,7 +399,7 @@ func containerValidDevices(db *db.Node, devices types.Devices, profile bool, exp
 				return fmt.Errorf("Unix device entry is missing the required \"source\" or \"path\" property.")
 			}
 
-			if m["major"] == "" || m["minor"] == "" {
+			if (m["required"] == "" || shared.IsTrue(m["required"])) && (m["major"] == "" || m["minor"] == "") {
 				srcPath, exist := m["source"]
 				if !exist {
 					srcPath = m["path"]

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -412,6 +412,16 @@ func (d *Daemon) init() error {
 	if !d.os.MockMode {
 		/* Start the scheduler */
 		go deviceEventListener(d.State())
+
+		_, err := deviceInotifyInit(d.State())
+		if err != nil {
+			return err
+		}
+
+		deviceInotifyDirRescan(d.State())
+
+		go deviceInotifyHandler(d.State())
+
 		readSavedClientCAList(d)
 	}
 

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -16,11 +16,13 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	_ "github.com/mattn/go-sqlite3"
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/sys"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
@@ -1558,4 +1560,493 @@ func deviceLoadInfiniband() (map[string]IBF, error) {
 
 	// check whether the device is an infiniband device
 	return UseableDevices, nil
+}
+
+func deviceInotifyInit(s *state.State) (int, error) {
+	s.OS.InotifyWatch.Lock()
+	defer s.OS.InotifyWatch.Unlock()
+
+	if s.OS.InotifyWatch.Fd >= 0 {
+		return s.OS.InotifyWatch.Fd, nil
+	}
+
+	inFd, err := syscall.InotifyInit1(syscall.IN_CLOEXEC)
+	if err != nil {
+		logger.Errorf("Failed to initialize inotify")
+		return -1, err
+	}
+	logger.Debugf("Initialized inotify with file descriptor %d", inFd)
+
+	s.OS.InotifyWatch.Fd = inFd
+	return inFd, nil
+}
+
+func findClosestLivingAncestor(cleanPath string) (bool, string) {
+	if shared.PathExists(cleanPath) {
+		return true, cleanPath
+	}
+
+	s := cleanPath
+	for {
+		s = filepath.Dir(s)
+		if s == cleanPath {
+			return false, s
+		}
+		if shared.PathExists(s) {
+			return true, s
+		}
+	}
+}
+
+func deviceInotifyAddClosestLivingAncestor(s *state.State, path string) error {
+	cleanPath := filepath.Clean(path)
+	// Find first existing ancestor directory and add it to the target.
+	exists, watchDir := findClosestLivingAncestor(cleanPath)
+	if !exists {
+		return fmt.Errorf("No existing ancestor directory found for \"%s\"", path)
+	}
+
+	err := deviceInotifyAddTarget(s, watchDir)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func deviceInotifyAddTarget(s *state.State, path string) error {
+	s.OS.InotifyWatch.Lock()
+	defer s.OS.InotifyWatch.Unlock()
+
+	inFd := s.OS.InotifyWatch.Fd
+	if inFd < 0 {
+		return fmt.Errorf("Inotify instance not intialized")
+	}
+
+	// Do not add the same target twice.
+	_, ok := s.OS.InotifyWatch.Targets[path]
+	if ok {
+		logger.Debugf("Inotify is already watching \"%s\"", path)
+		return nil
+	}
+
+	mask := uint32(0)
+	mask |= syscall.IN_ONLYDIR
+	mask |= syscall.IN_CREATE
+	mask |= syscall.IN_DELETE
+	mask |= syscall.IN_DELETE_SELF
+	wd, err := syscall.InotifyAddWatch(inFd, path, mask)
+	if err != nil {
+		return err
+	}
+
+	s.OS.InotifyWatch.Targets[path] = &sys.InotifyTargetInfo{
+		Mask: mask,
+		Path: path,
+		Wd:   wd,
+	}
+
+	// Add a second key based on the watch file descriptor to the map that
+	// points to the same allocated memory. This is used to reverse engineer
+	// the absolute path when an event happens in the watched directory.
+	// We prefix the key with a \0 character as this is disallowed in
+	// directory and file names and thus guarantees uniqueness of the key.
+	wdString := fmt.Sprintf("\000:%d", wd)
+	s.OS.InotifyWatch.Targets[wdString] = s.OS.InotifyWatch.Targets[path]
+	return nil
+}
+
+func deviceInotifyDel(s *state.State) {
+	s.OS.InotifyWatch.Lock()
+	syscall.Close(s.OS.InotifyWatch.Fd)
+	s.OS.InotifyWatch.Fd = -1
+	s.OS.InotifyWatch.Unlock()
+}
+
+const LXD_BATCH_IN_EVENTS uint = 100
+const LXD_SINGLE_IN_EVENT_SIZE uint = (syscall.SizeofInotifyEvent + syscall.PathMax)
+const LXD_BATCH_IN_BUFSIZE uint = LXD_BATCH_IN_EVENTS * LXD_SINGLE_IN_EVENT_SIZE
+
+func deviceInotifyWatcher(s *state.State) (chan sys.InotifyTargetInfo, error) {
+	targetChan := make(chan sys.InotifyTargetInfo)
+	go func(target chan sys.InotifyTargetInfo) {
+		for {
+			buf := make([]byte, LXD_BATCH_IN_BUFSIZE)
+			n, errno := syscall.Read(s.OS.InotifyWatch.Fd, buf)
+			if errno != nil {
+				if errno == syscall.EINTR {
+					continue
+				}
+
+				deviceInotifyDel(s)
+				return
+			}
+
+			if n < syscall.SizeofInotifyEvent {
+				continue
+			}
+
+			var offset uint32
+			for offset <= uint32(n-syscall.SizeofInotifyEvent) {
+				name := ""
+				event := (*syscall.InotifyEvent)(unsafe.Pointer(&buf[offset]))
+
+				nameLen := uint32(event.Len)
+				if nameLen > 0 {
+					bytes := (*[syscall.PathMax]byte)(unsafe.Pointer(&buf[offset+syscall.SizeofInotifyEvent]))
+					name = strings.TrimRight(string(bytes[0:nameLen]), "\000")
+				}
+
+				target <- sys.InotifyTargetInfo{
+					Mask: uint32(event.Mask),
+					Path: name,
+					Wd:   int(event.Wd),
+				}
+
+				offset += (syscall.SizeofInotifyEvent + nameLen)
+			}
+		}
+	}(targetChan)
+
+	return targetChan, nil
+}
+
+func deviceInotifyDelWatcher(s *state.State, path string) error {
+	s.OS.InotifyWatch.Lock()
+	defer s.OS.InotifyWatch.Unlock()
+
+	if s.OS.InotifyWatch.Fd < 0 {
+		return nil
+	}
+
+	target, ok := s.OS.InotifyWatch.Targets[path]
+	if !ok {
+		logger.Debugf("Inotify target \"%s\" not present", path)
+		return nil
+	}
+
+	ret, err := syscall.InotifyRmWatch(s.OS.InotifyWatch.Fd, uint32(target.Wd))
+	if ret != 0 {
+		// When a file gets deleted the wd for that file will
+		// automatically be deleted from the inotify instance. So
+		// ignore errors here.
+		logger.Debugf("Inotify syscall returned %s for \"%s\"", err, path)
+	}
+	delete(s.OS.InotifyWatch.Targets, path)
+	wdString := fmt.Sprintf("\000:%d", target.Wd)
+	delete(s.OS.InotifyWatch.Targets, wdString)
+	return nil
+}
+
+func createAncestorPaths(cleanPath string) []string {
+	components := strings.Split(cleanPath, "/")
+	ancestors := []string{}
+	newPath := "/"
+	ancestors = append(ancestors, newPath)
+	for _, v := range components[1:] {
+		newPath = filepath.Join(newPath, v)
+		ancestors = append(ancestors, newPath)
+	}
+
+	return ancestors
+}
+
+func deviceInotifyEvent(s *state.State, target *sys.InotifyTargetInfo) {
+	if (target.Mask & syscall.IN_ISDIR) > 0 {
+		if (target.Mask & syscall.IN_CREATE) > 0 {
+			deviceInotifyDirCreateEvent(s, target)
+		} else if (target.Mask & syscall.IN_DELETE) > 0 {
+			deviceInotifyDirDeleteEvent(s, target)
+		}
+		deviceInotifyDirRescan(s)
+	} else if (target.Mask & syscall.IN_DELETE_SELF) > 0 {
+		deviceInotifyDirDeleteEvent(s, target)
+		deviceInotifyDirRescan(s)
+	} else {
+		deviceInotifyFileEvent(s, target)
+	}
+}
+
+func deviceInotifyDirDeleteEvent(s *state.State, target *sys.InotifyTargetInfo) {
+	parentKey := fmt.Sprintf("\000:%d", target.Wd)
+	s.OS.InotifyWatch.RLock()
+	parent, ok := s.OS.InotifyWatch.Targets[parentKey]
+	s.OS.InotifyWatch.RUnlock()
+	if !ok {
+		return
+	}
+
+	// The absolute path of the file for which we received an event?
+	targetName := filepath.Join(parent.Path, target.Path)
+	targetName = filepath.Clean(targetName)
+	err := deviceInotifyDelWatcher(s, targetName)
+	if err != nil {
+		logger.Errorf("Failed to remove \"%s\" from inotify targets: %s", targetName, err)
+	} else {
+		logger.Errorf("Removed \"%s\" from inotify targets", targetName)
+	}
+}
+
+func deviceInotifyDirRescan(s *state.State) {
+	containers, err := s.DB.ContainersList(db.CTypeRegular)
+	if err != nil {
+		logger.Errorf("Failed to load containers: %s", err)
+		return
+	}
+
+	for _, name := range containers {
+		containerIf, err := containerLoadByName(s, name)
+		if err != nil {
+			logger.Errorf("Failed to load container \"%s\": %s", name, err)
+			continue
+		}
+
+		c, ok := containerIf.(*containerLXC)
+		if !ok {
+			logger.Errorf("Received device event on non-LXC container")
+			return
+		}
+
+		if !c.IsRunning() {
+			continue
+		}
+
+		devices := c.ExpandedDevices()
+		for _, name := range devices.DeviceNames() {
+			m := devices[name]
+			if !shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
+				continue
+			}
+
+			if m["required"] == "" || shared.IsTrue(m["required"]) {
+				continue
+			}
+
+			cmp := m["source"]
+			if cmp == "" {
+				cmp = m["path"]
+			}
+			cleanDevPath := filepath.Clean(cmp)
+			if shared.PathExists(cleanDevPath) {
+				c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m)
+			} else {
+				c.removeUnixDevice(fmt.Sprintf("unix.%s", name), m, true)
+			}
+
+			// and add its nearest existing ancestor.
+			err = deviceInotifyAddClosestLivingAncestor(s, cleanDevPath)
+			if err != nil {
+				logger.Errorf("Failed to add \"%s\" to inotify targets: %s", cleanDevPath, err)
+			} else {
+				logger.Debugf("Added \"%s\" to inotify targets", cleanDevPath)
+			}
+		}
+	}
+}
+
+func deviceInotifyDirCreateEvent(s *state.State, target *sys.InotifyTargetInfo) {
+	parentKey := fmt.Sprintf("\000:%d", target.Wd)
+	s.OS.InotifyWatch.RLock()
+	parent, ok := s.OS.InotifyWatch.Targets[parentKey]
+	s.OS.InotifyWatch.RUnlock()
+	if !ok {
+		return
+	}
+
+	containers, err := s.DB.ContainersList(db.CTypeRegular)
+	if err != nil {
+		logger.Errorf("Failed to load containers: %s", err)
+		return
+	}
+
+	// The absolute path of the file for which we received an event?
+	targetName := filepath.Join(parent.Path, target.Path)
+	targetName = filepath.Clean(targetName)
+
+	// ancestors
+	del := createAncestorPaths(targetName)
+	keep := []string{}
+	for _, name := range containers {
+		containerIf, err := containerLoadByName(s, name)
+		if err != nil {
+			logger.Errorf("Failed to load container \"%s\": %s", name, err)
+			continue
+		}
+
+		c, ok := containerIf.(*containerLXC)
+		if !ok {
+			logger.Errorf("Received device event on non-LXC container")
+			return
+		}
+
+		if !c.IsRunning() {
+			continue
+		}
+
+		devices := c.ExpandedDevices()
+		for _, name := range devices.DeviceNames() {
+			m := devices[name]
+			if !shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
+				continue
+			}
+
+			if m["required"] == "" || shared.IsTrue(m["required"]) {
+				continue
+			}
+
+			cmp := m["source"]
+			if cmp == "" {
+				cmp = m["path"]
+			}
+			cleanDevPath := filepath.Clean(cmp)
+
+			for i := len(del) - 1; i >= 0; i-- {
+				// Only keep paths that can be deleted.
+				if strings.HasPrefix(cleanDevPath, del[i]) {
+					if shared.StringInSlice(del[i], keep) {
+						break
+					}
+
+					keep = append(keep, del[i])
+					break
+				}
+			}
+		}
+	}
+
+	for i, v := range del {
+		if shared.StringInSlice(v, keep) {
+			del[i] = ""
+		}
+	}
+
+	for _, v := range del {
+		if v == "" {
+			continue
+		}
+
+		err := deviceInotifyDelWatcher(s, v)
+		if err != nil {
+			logger.Errorf("Failed to remove \"%s\" from inotify targets: %s", v, err)
+		} else {
+			logger.Debugf("Removed \"%s\" from inotify targets", v)
+		}
+	}
+
+	for _, v := range keep {
+		if v == "" {
+			continue
+		}
+
+		err = deviceInotifyAddClosestLivingAncestor(s, v)
+		if err != nil {
+			logger.Errorf("Failed to add \"%s\" to inotify targets: %s", v, err)
+		} else {
+			logger.Debugf("Added \"%s\" to inotify targets", v)
+		}
+	}
+}
+
+func deviceInotifyFileEvent(s *state.State, target *sys.InotifyTargetInfo) {
+	parentKey := fmt.Sprintf("\000:%d", target.Wd)
+	s.OS.InotifyWatch.RLock()
+	parent, ok := s.OS.InotifyWatch.Targets[parentKey]
+	s.OS.InotifyWatch.RUnlock()
+	if !ok {
+		return
+	}
+
+	containers, err := s.DB.ContainersList(db.CTypeRegular)
+	if err != nil {
+		logger.Errorf("Failed to load containers: %s", err)
+		return
+	}
+
+	// Does the current file have watchers?
+	hasWatchers := false
+	// The absolute path of the file for which we received an event?
+	targetName := filepath.Join(parent.Path, target.Path)
+	for _, name := range containers {
+		containerIf, err := containerLoadByName(s, name)
+		if err != nil {
+			logger.Errorf("Failed to load container \"%s\": %s", name, err)
+			continue
+		}
+
+		c, ok := containerIf.(*containerLXC)
+		if !ok {
+			logger.Errorf("Received device event on non-LXC container")
+			return
+		}
+
+		if !c.IsRunning() {
+			continue
+		}
+
+		devices := c.ExpandedDevices()
+		for _, name := range devices.DeviceNames() {
+			m := devices[name]
+			if !shared.StringInSlice(m["type"], []string{"unix-char", "unix-block"}) {
+				continue
+			}
+
+			cmp := m["source"]
+			if cmp == "" {
+				cmp = m["path"]
+			}
+
+			if m["required"] == "" || shared.IsTrue(m["required"]) {
+				continue
+			}
+
+			cleanDevPath := filepath.Clean(cmp)
+			cleanInotPath := filepath.Clean(targetName)
+			if !hasWatchers && strings.HasPrefix(cleanDevPath, cleanInotPath) {
+				hasWatchers = true
+			}
+
+			if cleanDevPath != cleanInotPath {
+				continue
+			}
+
+			if (target.Mask & syscall.IN_CREATE) > 0 {
+				err := c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m)
+				if err != nil {
+					logger.Error("Failed to create unix device", log.Ctx{"err": err, "dev": m, "container": c.Name()})
+					continue
+				}
+			} else if (target.Mask & syscall.IN_DELETE) > 0 {
+				err := c.removeUnixDevice(fmt.Sprintf("unix.%s", name), m, true)
+				if err != nil {
+					logger.Error("Failed to remove unix device", log.Ctx{"err": err, "dev": m, "container": c.Name()})
+					continue
+				}
+			} else {
+				logger.Error("Uknown action for unix device", log.Ctx{"dev": m, "container": c.Name()})
+			}
+		}
+	}
+
+	if !hasWatchers {
+		err := deviceInotifyDelWatcher(s, targetName)
+		if err != nil {
+			logger.Errorf("Failed to remove \"%s\" from inotify targets: %s", targetName, err)
+		} else {
+			logger.Debugf("Removed \"%s\" from inotify targets", targetName)
+		}
+	}
+}
+
+func deviceInotifyHandler(s *state.State) {
+	watchChan, err := deviceInotifyWatcher(s)
+	if err != nil {
+		return
+	}
+
+	for {
+		select {
+		case v := <-watchChan:
+			deviceInotifyEvent(s, &v)
+		}
+	}
 }

--- a/shared/util.go
+++ b/shared/util.go
@@ -491,6 +491,20 @@ func IsTrue(value string) bool {
 	return false
 }
 
+func IsUnixDev(path string) bool {
+	stat, err := os.Stat(path)
+	if err != nil {
+		return false
+
+	}
+
+	if (stat.Mode() & os.ModeDevice) == 0 {
+		return false
+	}
+
+	return true
+}
+
 func IsBlockdev(fm os.FileMode) bool {
 	return ((fm&os.ModeDevice != 0) && (fm&os.ModeCharDevice == 0))
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -90,4 +90,5 @@ var APIExtensions = []string{
 	"network_dhcp_gateway",
 	"file_get_symlink",
 	"network_leases",
+	"unix_device_hotplug",
 }


### PR DESCRIPTION
This adds support to hotplug unix devices into the container by supporting the
"required" property.

Closes #3995.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>