### PR TITLE
Lxc list display number of processes inside of container

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -93,6 +93,8 @@ Pre-defined column shorthand chars:
 
 	n - Name
 
+	N - Number of Processes
+
 	p - PID of the container's init process
 
 	P - Profiles
@@ -463,6 +465,7 @@ func (c *listCmd) parseColumns() ([]column, error) {
 		'd': {i18n.G("DESCRIPTION"), c.descriptionColumnData, false, false},
 		'l': {i18n.G("LAST USED AT"), c.LastUsedColumnData, false, false},
 		'n': {i18n.G("NAME"), c.nameColumnData, false, false},
+		'N': {i18n.G("PROCESSES"), c.NumberOfProcessesColumnData, true, false},
 		'p': {i18n.G("PID"), c.PIDColumnData, true, false},
 		'P': {i18n.G("PROFILES"), c.ProfilesColumnData, false, false},
 		'S': {i18n.G("SNAPSHOTS"), c.numberSnapshotsColumnData, false, true},
@@ -674,4 +677,13 @@ func (c *listCmd) LastUsedColumnData(cInfo api.Container, cState *api.ContainerS
 	}
 
 	return ""
+}
+
+func (c *listCmd) NumberOfProcessesColumnData(cInfo api.Container, cState *api.ContainerState, cSnaps []api.ContainerSnapshot) string {
+	if cInfo.IsActive() && cState != nil {
+		return fmt.Sprintf("%d", cState.Processes)
+	}
+
+	return ""
+
 }

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,7 +52,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46abcdlnpPsSt"
+const shorthand = "46abcdlnNpPsSt"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -286,7 +286,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -366,7 +366,7 @@ msgstr " Prozessorauslastung:"
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -415,7 +415,7 @@ msgstr "Fingerabdruck des Zertifikats: % x\n"
 msgid "Client certificate stored at server: "
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -497,7 +497,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -542,7 +542,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -633,7 +633,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -666,7 +666,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -679,11 +679,11 @@ msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -777,7 +777,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -940,15 +940,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -1140,7 +1144,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1148,7 +1152,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1160,7 +1164,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1307,7 +1311,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1947,6 +1951,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -260,7 +260,7 @@ msgstr "  Χρήση CPU:"
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -384,7 +384,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -517,7 +517,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -546,7 +546,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -558,11 +558,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -654,7 +654,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -811,15 +811,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -1003,7 +1007,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1011,7 +1015,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1023,7 +1027,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1164,7 +1168,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1712,6 +1716,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-10-26 15:46+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -278,7 +278,7 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -357,7 +357,7 @@ msgstr "CPU utilisé :"
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -405,7 +405,7 @@ msgstr "Empreinte du certificat : %x"
 msgid "Client certificate stored at server: "
 msgstr "Certificat client enregistré sur le serveur : "
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -485,7 +485,7 @@ msgstr "Création de %s"
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -530,7 +530,7 @@ msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -620,7 +620,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -651,7 +651,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -664,11 +664,11 @@ msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 msgid "ID"
 msgstr "PID"
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -765,7 +765,7 @@ msgstr "IPs :"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
@@ -837,7 +837,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr "NOM"
@@ -925,15 +925,19 @@ msgstr "Options :"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr "PERSISTANT"
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -1121,7 +1125,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -1129,7 +1133,7 @@ msgstr "INSTANTANÉS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -1142,7 +1146,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -1287,7 +1291,7 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr "TYPE"
 
@@ -2069,6 +2073,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -203,7 +203,7 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -281,7 +281,7 @@ msgstr "Utilizzo CPU:"
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr "Certificato del client salvato dal server: "
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr "Colonne"
 
@@ -405,7 +405,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -449,7 +449,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -567,7 +567,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -579,11 +579,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -675,7 +675,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -744,7 +744,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -830,15 +830,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -1022,7 +1026,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1030,7 +1034,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1042,7 +1046,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1183,7 +1187,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1731,6 +1735,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-09-28 20:29+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -260,7 +260,7 @@ msgstr "CPU使用量:"
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -307,7 +307,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Client certificate stored at server: "
 msgstr "クライアント証明書がサーバに格納されました: "
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -386,7 +386,7 @@ msgstr "%s を作成中"
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -430,7 +430,7 @@ msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -518,7 +518,7 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
@@ -549,7 +549,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -562,11 +562,11 @@ msgstr "クライアント証明書を生成します。1分ぐらいかかり�
 msgid "ID"
 msgstr "PID"
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -659,7 +659,7 @@ msgstr "IPアドレス:"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -816,15 +816,19 @@ msgstr "オプション:"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -1009,7 +1013,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1017,7 +1021,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1029,7 +1033,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1171,7 +1175,7 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1966,6 +1970,7 @@ msgstr ""
 "    lxc launch ubuntu:16.04 u1"
 
 #: lxc/list.go:44
+#, fuzzy
 msgid ""
 "Usage: lxc list [<remote>:] [filters] [--format csv|json|table|yaml] [-c "
 "<columns>] [--fast]\n"
@@ -2022,6 +2027,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2018-01-04 11:36-0500\n"
+        "POT-Creation-Date: 2018-01-07 23:53-0500\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -172,7 +172,7 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -249,7 +249,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -294,7 +294,7 @@ msgstr  ""
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid   "Columns"
 msgstr  ""
 
@@ -372,7 +372,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525 lxc/storage.go:682 lxc/storage.go:793
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525 lxc/storage.go:682 lxc/storage.go:793
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -415,7 +415,7 @@ msgstr  ""
 msgid   "Disk usage:"
 msgstr  ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -503,7 +503,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -532,7 +532,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -544,11 +544,11 @@ msgstr  ""
 msgid   "ID"
 msgstr  ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid   "IPV6"
 msgstr  ""
 
@@ -638,7 +638,7 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid   "LAST USED AT"
 msgstr  ""
 
@@ -707,7 +707,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409 lxc/storage.go:681 lxc/storage.go:792
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409 lxc/storage.go:681 lxc/storage.go:792
 msgid   "NAME"
 msgstr  ""
 
@@ -792,15 +792,19 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid   "PERSISTENT"
 msgstr  ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid   "PROCESSES"
+msgstr  ""
+
+#: lxc/list.go:470
 msgid   "PROFILES"
 msgstr  ""
 
@@ -983,7 +987,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -991,7 +995,7 @@ msgstr  ""
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid   "STATE"
 msgstr  ""
 
@@ -1003,7 +1007,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -1144,7 +1148,7 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid   "TYPE"
 msgstr  ""
 
@@ -1641,6 +1645,8 @@ msgid   "Usage: lxc list [<remote>:] [filters] [--format csv|json|table|yaml] [-
         "	l - Last used date\n"
         "\n"
         "	n - Name\n"
+        "\n"
+        "	N - Number of Processes\n"
         "\n"
         "	p - PID of the container's init process\n"
         "\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -265,7 +265,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -344,7 +344,7 @@ msgstr " Использование ЦП:"
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -389,7 +389,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr "Сертификат клиента хранится на сервере: "
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -468,7 +468,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -601,7 +601,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -642,11 +642,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -738,7 +738,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -895,15 +895,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -1087,7 +1091,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1095,7 +1099,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1107,7 +1111,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1248,7 +1252,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1804,6 +1808,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-01-04 11:36-0500\n"
+"POT-Creation-Date: 2018-01-07 23:53-0500\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -256,7 +256,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "CREATED AT"
 msgstr ""
 
@@ -301,7 +301,7 @@ msgstr ""
 msgid "Client certificate stored at server: "
 msgstr ""
 
-#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:128 lxc/list.go:129
+#: lxc/image.go:174 lxc/image.go:175 lxc/list.go:130 lxc/list.go:131
 msgid "Columns"
 msgstr ""
 
@@ -380,7 +380,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:463 lxc/network.go:525
+#: lxc/image.go:234 lxc/image.go:1137 lxc/list.go:465 lxc/network.go:525
 #: lxc/storage.go:682 lxc/storage.go:793
 msgid "DESCRIPTION"
 msgstr ""
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
-#: lxc/list.go:619
+#: lxc/list.go:622
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:131
+#: lxc/list.go:133
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -541,7 +541,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:180 lxc/list.go:130
+#: lxc/image.go:180 lxc/list.go:132
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -553,11 +553,11 @@ msgstr ""
 msgid "ID"
 msgstr ""
 
-#: lxc/list.go:459
+#: lxc/list.go:461
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "IPV6"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:464
+#: lxc/list.go:466
 msgid "LAST USED AT"
 msgstr ""
 
@@ -718,7 +718,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
+#: lxc/list.go:467 lxc/network.go:522 lxc/profile.go:573 lxc/remote.go:409
 #: lxc/storage.go:681 lxc/storage.go:792
 msgid "NAME"
 msgstr ""
@@ -804,15 +804,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:621
+#: lxc/list.go:624
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:469
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:467
+#: lxc/list.go:468
+msgid "PROCESSES"
+msgstr ""
+
+#: lxc/list.go:470
 msgid "PROFILES"
 msgstr ""
 
@@ -996,7 +1000,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:468
+#: lxc/list.go:471
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/list.go:469
+#: lxc/list.go:472
 msgid "STATE"
 msgstr ""
 
@@ -1016,7 +1020,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:471
+#: lxc/list.go:474
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -1157,7 +1161,7 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
+#: lxc/list.go:473 lxc/network.go:523 lxc/operation.go:153 lxc/storage.go:791
 msgid "TYPE"
 msgstr ""
 
@@ -1705,6 +1709,8 @@ msgid ""
 "\tl - Last used date\n"
 "\n"
 "\tn - Name\n"
+"\n"
+"\tN - Number of Processes\n"
 "\n"
 "\tp - PID of the container's init process\n"
 "\n"


### PR DESCRIPTION
Title is self-explanatory :)

Reason to have this done is that I saw this post: https://discuss.linuxcontainers.org/t/lxc-list-column-for-process-number/1017/4 and seemed pretty easy to implement.
```
ubuntu@lxd-dev:~/go/bin$ ./lxc info c1 | grep Proc
  Processes: 26
ubuntu@lxd-dev:~/go/bin$ ./lxc list -c n,N
+------+-----------+
| NAME | PROCESSES |
+------+-----------+
| c1   | 26        |
+------+-----------+
ubuntu@lxd-dev:~/go/bin$ 
```
  