### PR TITLE
drop \n from IdmapSet's ToLxcString

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1135,7 +1135,7 @@ func (c *containerLXC) initLXC(config bool) error {
 	if idmapset != nil {
 		lines := idmapset.ToLxcString()
 		for _, line := range lines {
-			err := lxcSetConfigItem(cc, "lxc.idmap", strings.TrimSuffix(line, "\n"))
+			err := lxcSetConfigItem(cc, "lxc.idmap", line)
 			if err != nil {
 				return err
 			}

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -50,7 +50,7 @@ func GetIdmapSet() *idmap.IdmapSet {
 		if err == nil {
 			logger.Infof("Kernel uid/gid map:")
 			for _, lxcmap := range kernelIdmapSet.ToLxcString() {
-				logger.Infof(strings.TrimRight(" - "+lxcmap, "\n"))
+				logger.Infof(" - " + lxcmap)
 			}
 		}
 
@@ -68,7 +68,7 @@ func GetIdmapSet() *idmap.IdmapSet {
 				}
 
 				for _, lxcEntry := range lxcmap.ToLxcString() {
-					logger.Infof(" - %s%s", strings.TrimRight(lxcEntry, "\n"), suffix)
+					logger.Infof(" - %s%s", lxcEntry, suffix)
 				}
 			}
 

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -402,8 +402,8 @@ func (m IdmapSet) ToLxcString() []string {
 	var lines []string
 	for _, e := range m.Idmap {
 		for _, l := range e.ToLxcString() {
-			if !shared.StringInSlice(l+"\n", lines) {
-				lines = append(lines, l+"\n")
+			if !shared.StringInSlice(l, lines) {
+				lines = append(lines, l)
 			}
 		}
 	}


### PR DESCRIPTION
1. We just strip the newline everywhere we use this anyways, so we can drop
   the stripping code too.
2. liblxc itself doesn't even accept this string with a newline on the end,
   so it's not even an LxcString :)

Signed-off-by: Tycho Andersen <tycho@tycho.ws>