### PR TITLE
fix parsing for container name tab-completion

### DIFF
--- a/config/bash/lxd-client
+++ b/config/bash/lxd-client
@@ -6,11 +6,11 @@ _have lxc && {
       local state=$1
       local keys=$2
 
-      local cmd="lxc list --fast"
-      [ -n "$state" ] && cmd="$cmd | grep -E '$state'"
+      local cmd="lxc list --format=csv --columns=ns"
+      [ -n "$state" ] && cmd="$cmd | grep -E '$state$'"
 
       COMPREPLY=( $( compgen -W \
-        "$( eval $cmd | grep -Ev '(\+--|NAME)' | awk '{print $2}' ) $keys" "$cur" )
+        "$( eval $cmd | cut -d, -f1 ) $keys" "$cur" )
       )
     }
 


### PR DESCRIPTION
When containers have mulitple IP addresses, `lxc list` rows span over multiple lines, like:  

```
+------------------+---------+--------------------------------+-----------------------------------------------+------------+-----------+
| maas             | RUNNING | 192.168.200.1 (maas0)          | fd42:1fe6:bf48:a57d:216:3eff:fefd:a254 (eth0) | PERSISTENT | 0         |
|                  |         | 10.215.5.126 (eth0)            |                                               |            |           |
+------------------+---------+--------------------------------+-----------------------------------------------+------------+-----------+
```

This causes bash completion to include a `|` among container names.