### PR TITLE
shared/idmap:DefaultIdmapSet(): take a user argument

### DIFF
--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -45,7 +45,7 @@ func cmdActivateIfNeeded(args *Args) error {
 	}
 
 	// Load the idmap for unprivileged containers
-	d.os.IdmapSet, err = idmap.DefaultIdmapSet()
+	d.os.IdmapSet, err = idmap.DefaultIdmapSet("")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -827,7 +827,7 @@ func (cmd *CmdInit) askDefaultPrivileged() int {
 	// Detect lack of uid/gid
 	defaultPrivileged := -1
 	needPrivileged := false
-	idmapset, err := idmap.DefaultIdmapSet()
+	idmapset, err := idmap.DefaultIdmapSet("")
 	if err != nil || len(idmapset.Idmap) == 0 || idmapset.Usable() != nil {
 		needPrivileged = true
 	}

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -40,7 +40,7 @@ func GetArchitectures() ([]int, error) {
 
 // GetIdmapSet reads the uid/gid allocation.
 func GetIdmapSet() *idmap.IdmapSet {
-	idmapSet, err := idmap.DefaultIdmapSet()
+	idmapSet, err := idmap.DefaultIdmapSet("")
 	if err != nil {
 		logger.Warn("Error reading default uid/gid map", log.Ctx{"err": err.Error()})
 		logger.Warnf("Only privileged containers will be able to run")

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -661,20 +661,24 @@ func getFromProc(fname string) ([][]int64, error) {
 /*
  * Create a new default idmap
  */
-func DefaultIdmapSet() (*IdmapSet, error) {
+func DefaultIdmapSet(username string) (*IdmapSet, error) {
 	idmapset := new(IdmapSet)
 
-	// Check if shadow's uidmap tools are installed
-	newuidmap, _ := exec.LookPath("newuidmap")
-	newgidmap, _ := exec.LookPath("newgidmap")
-	if newuidmap != "" && newgidmap != "" && shared.PathExists("/etc/subuid") && shared.PathExists("/etc/subgid") {
+	if username == "" {
 		currentUser, err := user.Current()
 		if err != nil {
 			return nil, err
 		}
 
+		username = currentUser.Username
+	}
+
+	// Check if shadow's uidmap tools are installed
+	newuidmap, _ := exec.LookPath("newuidmap")
+	newgidmap, _ := exec.LookPath("newgidmap")
+	if newuidmap != "" && newgidmap != "" && shared.PathExists("/etc/subuid") && shared.PathExists("/etc/subgid") {
 		// Parse the shadow uidmap
-		entries, err := getFromShadow("/etc/subuid", currentUser.Username)
+		entries, err := getFromShadow("/etc/subuid", username)
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +697,7 @@ func DefaultIdmapSet() (*IdmapSet, error) {
 		}
 
 		// Parse the shadow gidmap
-		entries, err = getFromShadow("/etc/subgid", currentUser.Username)
+		entries, err = getFromShadow("/etc/subgid", username)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Make this more generally useful by accepting a username.  If that
is "", then use the current user.

Signed-off-by: Serge Hallyn <shallyn@cisco.com>