### PR TITLE
fix msgfmt error

### DIFF
--- a/po/ja.po
+++ b/po/ja.po
@@ -121,7 +121,7 @@ msgstr "自動更新: %s"
 #: lxc/image.go:519
 #, c-format
 msgid "Bad property: %s"
-msgstr "不正なプロパティ: %s\n"
+msgstr "不正なプロパティ: %s"
 
 #: lxc/info.go:186
 msgid "Bytes received"


### PR DESCRIPTION
po/ja.po:127: 'msgid' and 'msgstr' entries do not both end with '\n'
msgfmt: found 1 fatal error