### PR TITLE
shared/version: Include storage backends in agent

### DIFF
--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/lxd/shared/idmap"
 	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/version"
 )
 
 // lxdStorageLockMap is a hashmap that allows functions to check whether the
@@ -885,6 +886,14 @@ func storagePoolDriversCacheUpdate(dbNode *db.Node) {
 		// Grab the version
 		data[driver] = sCore.GetStorageTypeVersion()
 	}
+
+	backends := []string{}
+	for k, v := range data {
+		backends = append(backends, fmt.Sprintf("%s %s", k, v))
+	}
+
+	// Update the agent
+	version.UserAgentStorageBackends(backends)
 
 	storagePoolDriversCacheLock.Lock()
 	storagePoolDriversCacheVal.Store(data)

--- a/shared/version/useragent.go
+++ b/shared/version/useragent.go
@@ -9,19 +9,35 @@ import (
 )
 
 // UserAgent contains a string suitable as a user-agent
-var UserAgent = getUserAgent()
+var UserAgent = getUserAgent(nil)
 
-func getUserAgent() string {
+func getUserAgent(storageTokens []string) string {
 	archID, err := osarch.ArchitectureId(runtime.GOARCH)
 	if err != nil {
 		panic(err)
 	}
+
 	arch, err := osarch.ArchitectureName(archID)
 	if err != nil {
 		panic(err)
 	}
 
-	tokens := []string{strings.Title(runtime.GOOS), arch}
-	tokens = append(tokens, getPlatformVersionStrings()...)
-	return fmt.Sprintf("LXD %s (%s)", Version, strings.Join(tokens, "; "))
+	osTokens := []string{strings.Title(runtime.GOOS), arch}
+	osTokens = append(osTokens, getPlatformVersionStrings()...)
+
+	agent := fmt.Sprintf("LXD %s", Version)
+	if len(osTokens) > 0 {
+		agent = fmt.Sprintf("%s (%s)", agent, strings.Join(osTokens, "; "))
+	}
+
+	if len(storageTokens) > 0 {
+		agent = fmt.Sprintf("%s (%s)", agent, strings.Join(storageTokens, "; "))
+	}
+
+	return agent
+}
+
+// UserAgentStorageBackends updates the list of storage backends to include in the user-agent
+func UserAgentStorageBackends(backends []string) {
+	UserAgent = getUserAgent(backends)
 }


### PR DESCRIPTION
This can be used by some image server to return a different set of
images based on the storage backends in use and will also make it easier
for us to know what storage backends to focus efforts on.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>