### PR TITLE
scripts/bash: tweak complete line for snaps

### DIFF
--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -332,5 +332,5 @@ _have lxc && {
     return 0
   }
 
-  complete -o default -F _lxd_complete lxc
+  complete -o default -F _lxd_complete lxc lxd.lxc
 }


### PR DESCRIPTION
Inside snaps, bash completion snippets run for the _unaliased_ command. That means that the completion needs to be looking for `lxd.lxc`, not just `lxc`. Fortunately you can ask for both, so it's an easy tweak (and people are very unlikely to have an unrelated `lxd.lxc` command lying around with different completion).