### PR TITLE
container_lxc: keep full capability set

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -912,15 +912,17 @@ func (c *containerLXC) initLXC(config bool) error {
 		return nil
 	}
 
-	// Base config
-	toDrop := "sys_time sys_module sys_rawio"
-	if !c.state.OS.AppArmorStacking || c.state.OS.AppArmorStacked {
-		toDrop = toDrop + " mac_admin mac_override"
-	}
+	if c.IsPrivileged() {
+		// Base config
+		toDrop := "sys_time sys_module sys_rawio"
+		if !c.state.OS.AppArmorStacking || c.state.OS.AppArmorStacked {
+			toDrop = toDrop + " mac_admin mac_override"
+		}
 
-	err = lxcSetConfigItem(cc, "lxc.cap.drop", toDrop)
-	if err != nil {
-		return err
+		err = lxcSetConfigItem(cc, "lxc.cap.drop", toDrop)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Set an appropriate /proc, /sys/ and /sys/fs/cgroup


### PR DESCRIPTION
Unprivileged container don't need to drop any capabilities. The kernel will
enforce security for us.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>