### PR TITLE
Delete the namespaced veth before killing the process

### DIFF
--- a/test/includes/clustering.sh
+++ b/test/includes/clustering.sh
@@ -102,11 +102,11 @@ teardown_clustering_netns() {
   for ns in $(ls -1 "${TEST_DIR}/ns/"); do
       echo "==> Teardown clustering netns ${ns}"
 
-      pid="$(cat "${TEST_DIR}/ns/${ns}/PID")"
-      kill -9 "${pid}"
-
       veth1="v${ns}1"
       ip link del "${veth1}"
+
+      pid="$(cat "${TEST_DIR}/ns/${ns}/PID")"
+      kill -9 "${pid}"
 
       umount -l "${TEST_DIR}/ns/${ns}/net" >/dev/null 2>&1 || true
       rm -Rf "${TEST_DIR}/ns/${ns}"


### PR DESCRIPTION
It seems that on single-CPU machines the 'ip link del "${veth1}"' call
fails pretty much always. I assume because one side of the veth pair
is attached to the net namespace of the process being killed and the
kernel wipes it immediately, or something like that.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>