### PR TITLE
lxd/shutdown: Fix typo in error handling

### DIFF
--- a/lxd/main_shutdown.go
+++ b/lxd/main_shutdown.go
@@ -18,7 +18,7 @@ func cmdShutdown(args *Args) error {
 	}
 
 	_, _, err = c.RawQuery("PUT", "/internal/shutdown", nil, "")
-	if err != nil && strings.HasSuffix(err.Error(), ": EOF") {
+	if err != nil && !strings.HasSuffix(err.Error(), ": EOF") {
 		// NOTE: if we got an EOF error here it means that the daemon
 		// has shutdown so quickly that it already closed the unix
 		// socket. We consider the daemon dead in this case.


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>