### PR TITLE
idmap: get rid of new{u,g}idmap checks

### DIFF
--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"fmt"
 	"os"
-	"os/exec"
 	"os/user"
 	"path"
 	"path/filepath"
@@ -673,10 +672,7 @@ func DefaultIdmapSet(username string) (*IdmapSet, error) {
 		username = currentUser.Username
 	}
 
-	// Check if shadow's uidmap tools are installed
-	newuidmap, _ := exec.LookPath("newuidmap")
-	newgidmap, _ := exec.LookPath("newgidmap")
-	if newuidmap != "" && newgidmap != "" && shared.PathExists("/etc/subuid") && shared.PathExists("/etc/subgid") {
+	if shared.PathExists("/etc/subuid") && shared.PathExists("/etc/subgid") {
 		// Parse the shadow uidmap
 		entries, err := getFromShadow("/etc/subuid", username)
 		if err != nil {


### PR DESCRIPTION
I believe these checks are intended as a heuristic to indicate whether or
not the current userspace understands idmaps. However, it is perfectly
possible to have a userspace that knows about /etc/subuid, but doesn't have
newuidmap installed. In fact, on my recent upgrade to bionic, it helpfully
uninstalled newuidmap, which is how I noticed this in the first place.

Given that there are additional checks to see if /etc/uidmap actually
exists, we should just go with those and assume people know what they're
doing.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>