### PR TITLE
Clustering move ceph based containers

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -555,7 +555,12 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), container, "")
+	path := fmt.Sprintf("/containers/%s", url.QueryEscape(name))
+	if r.clusterTarget != "" {
+		path += fmt.Sprintf("?target=%s", r.clusterTarget)
+	}
+
+	op, _, err := r.queryOperation("POST", path, container, "")
 	if err != nil {
 		return nil, err
 	}

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/gnuflag"
 	"github.com/lxc/lxd/shared/i18n"
+	"github.com/pkg/errors"
 )
 
 type moveCmd struct {
@@ -46,7 +47,7 @@ func (c *moveCmd) flags() {
 }
 
 func (c *moveCmd) run(conf *config.Config, args []string) error {
-	if len(args) != 2 {
+	if len(args) != 2 && c.target == "" {
 		return errArgs
 	}
 
@@ -61,9 +62,14 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 		return err
 	}
 
-	destRemote, destName, err := conf.ParseRemote(args[1])
-	if err != nil {
-		return err
+	destRemote := sourceRemote
+	destName := ""
+	if len(args) == 2 {
+		var err error
+		destRemote, destName, err = conf.ParseRemote(args[1])
+		if err != nil {
+			return err
+		}
 	}
 
 	// Target node and destination remote can't be used together.
@@ -104,6 +110,26 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 		return op.Wait()
 	}
 
+	sourceResource := args[0]
+	destResource := sourceResource
+	if len(args) == 2 {
+		destResource = args[1]
+	}
+
+	// If the target option was specified, we're moving a container from a
+	// cluster node to another. In case the rootfs of the container is
+	// backed by ceph, we want to re-use the same ceph volume. This assumes
+	// that the container is not running.
+	if c.target != "" {
+		moved, err := maybeMoveCephContaner(conf, sourceResource, destResource, c.target)
+		if err != nil {
+			return err
+		}
+		if moved {
+			return nil
+		}
+	}
+
 	cpy := copyCmd{}
 	cpy.target = c.target
 
@@ -111,7 +137,7 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 
 	// A move is just a copy followed by a delete; however, we want to
 	// keep the volatile entries around since we are moving the container.
-	err = cpy.copyContainer(conf, args[0], args[1], true, -1, stateful, c.containerOnly, mode)
+	err = cpy.copyContainer(conf, sourceResource, destResource, true, -1, stateful, c.containerOnly, mode)
 	if err != nil {
 		return err
 	}
@@ -119,4 +145,96 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 	del := deleteCmd{}
 	del.force = true
 	return del.run(conf, args[:1])
+}
+
+// Helper to check if the container to be moved is backed by a ceph storage
+// pool, and use the special POST /containers/<name>?target=<node> API if so.
+//
+// It returns false if the container is not backed by ceph, true otherwise.
+func maybeMoveCephContaner(conf *config.Config, sourceResource, destResource, target string) (bool, error) {
+	// Parse the source.
+	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
+	if err != nil {
+		return false, err
+	}
+
+	// Parse the destination.
+	destRemote, destName, err := conf.ParseRemote(destResource)
+	if err != nil {
+		return false, err
+	}
+
+	if sourceRemote != destRemote {
+		return false, fmt.Errorf(
+			i18n.G("You must use the same source and destination remote when using --target"))
+	}
+
+	// Make sure we have a container or snapshot name.
+	if sourceName == "" {
+		return false, fmt.Errorf(i18n.G("You must specify a source container name"))
+	}
+
+	// The destination name is optional.
+	if destName == "" {
+		destName = sourceName
+	}
+
+	// Connect to the source host
+	source, err := conf.GetContainerServer(sourceRemote)
+	if err != nil {
+		return false, err
+	}
+
+	if shared.IsSnapshot(sourceName) {
+		// TODO: implement moving snapshots.
+		return false, fmt.Errorf("Moving ceph snapshots between cluster nodes is not yet implemented")
+	}
+
+	// Check if the container to be moved is backed by ceph.
+	container, _, err := source.GetContainer(sourceName)
+	if err != nil {
+		// If we are unable to connect, we assume that the source node
+		// is offline, and we'll try to perform the migration. If the
+		// container turns out to not be backed by ceph, the migrate
+		// API will still return an error.
+		if !strings.Contains(err.Error(), "Unable to connect") {
+			return false, errors.Wrapf(err, "Failed to get container %s", sourceName)
+		}
+	}
+	if container != nil {
+		devices := container.Devices
+		for key, value := range container.ExpandedDevices {
+			devices[key] = value
+		}
+		_, device, err := shared.GetRootDiskDevice(devices)
+		if err != nil {
+			return false, errors.Wrapf(err, "Failed parse root disk device")
+		}
+
+		poolName, ok := device["pool"]
+		if !ok {
+			return false, nil
+		}
+
+		pool, _, err := source.GetStoragePool(poolName)
+		if err != nil {
+			return false, errors.Wrapf(err, "Failed get root disk device pool %s", poolName)
+		}
+		if pool.Driver != "ceph" {
+			return false, nil
+		}
+	}
+
+	// The migrate API will do the right thing when passed a target.
+	source = source.UseTarget(target)
+	req := api.ContainerPost{Name: destName, Migration: true}
+	op, err := source.MigrateContainer(sourceName, req)
+	if err != nil {
+		return false, err
+	}
+	err = op.Wait()
+	if err != nil {
+		return false, err
+	}
+	return true, nil
 }

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -187,7 +187,7 @@ func maybeMoveCephContainer(conf *config.Config, sourceResource, destResource, t
 
 	if shared.IsSnapshot(sourceName) {
 		// TODO: implement moving snapshots.
-		return false, fmt.Errorf("Moving ceph snapshots between cluster nodes is not yet implemented")
+		return false, fmt.Errorf("Moving ceph snapshots is not supported")
 	}
 
 	// Check if the container to be moved is backed by ceph.

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -121,7 +121,7 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 	// backed by ceph, we want to re-use the same ceph volume. This assumes
 	// that the container is not running.
 	if c.target != "" {
-		moved, err := maybeMoveCephContaner(conf, sourceResource, destResource, c.target)
+		moved, err := maybeMoveCephContainer(conf, sourceResource, destResource, c.target)
 		if err != nil {
 			return err
 		}
@@ -151,7 +151,7 @@ func (c *moveCmd) run(conf *config.Config, args []string) error {
 // pool, and use the special POST /containers/<name>?target=<node> API if so.
 //
 // It returns false if the container is not backed by ceph, true otherwise.
-func maybeMoveCephContaner(conf *config.Config, sourceResource, destResource, target string) (bool, error) {
+func maybeMoveCephContainer(conf *config.Config, sourceResource, destResource, target string) (bool, error) {
 	// Parse the source.
 	sourceRemote, sourceName, err := conf.ParseRemote(sourceResource)
 	if err != nil {

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -30,6 +30,7 @@ var apiInternal = []Command{
 	internalContainersCmd,
 	internalSQLCmd,
 	internalClusterAcceptCmd,
+	internalClusterContainerMovedCmd,
 }
 
 func internalReady(d *Daemon, r *http.Request) Response {

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -281,36 +281,6 @@ func containerValidConfig(os *sys.OS, config map[string]string, profile bool, ex
 	return nil
 }
 
-func isRootDiskDevice(device types.Device) bool {
-	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" {
-		return true
-	}
-
-	return false
-}
-
-func containerGetRootDiskDevice(devices types.Devices) (string, types.Device, error) {
-	var devName string
-	var dev types.Device
-
-	for n, d := range devices {
-		if isRootDiskDevice(d) {
-			if devName != "" {
-				return "", types.Device{}, fmt.Errorf("More than one root device found.")
-			}
-
-			devName = n
-			dev = d
-		}
-	}
-
-	if devName != "" {
-		return devName, dev, nil
-	}
-
-	return "", types.Device{}, fmt.Errorf("No root device could be found.")
-}
-
 func containerValidDevices(db *db.Cluster, devices types.Devices, profile bool, expanded bool) error {
 	// Empty device list
 	if devices == nil {
@@ -447,7 +417,7 @@ func containerValidDevices(db *db.Cluster, devices types.Devices, profile bool, 
 
 	// Checks on the expanded config
 	if expanded {
-		_, _, err := containerGetRootDiskDevice(devices)
+		_, _, err := shared.GetRootDiskDevice(devices)
 		if err != nil {
 			return err
 		}
@@ -931,7 +901,7 @@ func containerCreateInternal(s *state.State, args db.ContainerArgs) (container, 
 
 func containerConfigureInternal(c container) error {
 	// Find the root device
-	_, rootDiskDevice, err := containerGetRootDiskDevice(c.ExpandedDevices())
+	_, rootDiskDevice, err := shared.GetRootDiskDevice(c.ExpandedDevices())
 	if err != nil {
 		return err
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -315,7 +315,7 @@ func containerLXCCreate(s *state.State, args db.ContainerArgs) (container, error
 	}
 
 	// Retrieve the container's storage pool
-	_, rootDiskDevice, err := containerGetRootDiskDevice(c.expandedDevices)
+	_, rootDiskDevice, err := shared.GetRootDiskDevice(c.expandedDevices)
 	if err != nil {
 		c.Delete()
 		return nil, err
@@ -1500,7 +1500,7 @@ func (c *containerLXC) initLXC(config bool) error {
 			// bump network index
 			networkidx++
 		} else if m["type"] == "disk" {
-			isRootfs := isRootDiskDevice(m)
+			isRootfs := shared.IsRootDiskDevice(m)
 
 			// source paths
 			srcPath := shared.HostPath(m["source"])
@@ -3719,19 +3719,19 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 	}
 
 	// Retrieve old root disk devices.
-	oldLocalRootDiskDeviceKey, oldLocalRootDiskDevice, _ := containerGetRootDiskDevice(oldLocalDevices)
+	oldLocalRootDiskDeviceKey, oldLocalRootDiskDevice, _ := shared.GetRootDiskDevice(oldLocalDevices)
 	var oldProfileRootDiskDevices []string
 	for k, v := range oldExpandedDevices {
-		if isRootDiskDevice(v) && k != oldLocalRootDiskDeviceKey && !shared.StringInSlice(k, oldProfileRootDiskDevices) {
+		if shared.IsRootDiskDevice(v) && k != oldLocalRootDiskDeviceKey && !shared.StringInSlice(k, oldProfileRootDiskDevices) {
 			oldProfileRootDiskDevices = append(oldProfileRootDiskDevices, k)
 		}
 	}
 
 	// Retrieve new root disk devices.
-	newLocalRootDiskDeviceKey, newLocalRootDiskDevice, _ := containerGetRootDiskDevice(c.localDevices)
+	newLocalRootDiskDeviceKey, newLocalRootDiskDevice, _ := shared.GetRootDiskDevice(c.localDevices)
 	var newProfileRootDiskDevices []string
 	for k, v := range c.expandedDevices {
-		if isRootDiskDevice(v) && k != newLocalRootDiskDeviceKey && !shared.StringInSlice(k, newProfileRootDiskDevices) {
+		if shared.IsRootDiskDevice(v) && k != newLocalRootDiskDeviceKey && !shared.StringInSlice(k, newProfileRootDiskDevices) {
 			newProfileRootDiskDevices = append(newProfileRootDiskDevices, k)
 		}
 	}

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -3,30 +3,103 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
 
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
 )
 
 func containerPost(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
+	targetNode := r.FormValue("target")
 
-	// Handle requests targeted to a container on a different node
-	response, err := ForwardedResponseIfContainerIsRemote(d, r, name)
-	if err != nil {
-		return SmartError(err)
-	}
-	if response != nil {
-		return response
+	sourceNodeOffline := false
+	targetNodeOffline := false
+
+	// A POST to /containers/<name>?target=<node> is meant to be
+	// used to move a container backed by a ceph storage pool.
+	if targetNode != "" {
+		// Determine if either the source node (the one currently
+		// running the container) or the target node are offline.
+		//
+		// If the target node is offline, we return an error.
+		//
+		// If the source node is offline, we'll assume that the
+		// container is not running and it's safe to move it.
+		//
+		// TODO: add some sort of "force" flag to the API, to signal
+		//       that the user really wants to move the container even
+		//       if we can't know for sure that it's indeed not
+		//       running?
+		err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
+			// Load cluster configuration.
+			config, err := cluster.ConfigLoad(tx)
+			if err != nil {
+				return errors.Wrap(err, "Failed to load LXD config")
+			}
+
+			// Load target node.
+			node, err := tx.NodeByName(targetNode)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get target node")
+			}
+			targetNodeOffline = node.IsOffline(config.OfflineThreshold())
+
+			// Load source node.
+			address, err := tx.ContainerNodeAddress(name)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get address of container's node")
+			}
+			if address == "" {
+				// Local node
+				sourceNodeOffline = false
+				return nil
+			}
+			node, err = tx.NodeByAddress(address)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to get source node for %s", address)
+			}
+			sourceNodeOffline = node.IsOffline(config.OfflineThreshold())
+
+			return nil
+		})
+		if err != nil {
+			return SmartError(err)
+		}
 	}
 
-	c, err := containerLoadByName(d.State(), name)
-	if err != nil {
-		return SmartError(err)
+	if targetNode != "" && targetNodeOffline {
+		return BadRequest(fmt.Errorf("Target node is offline"))
+	}
+
+	var c container
+
+	// For in-cluster migrations, only forward the request to the source
+	// node and load the container if the source node is online. We'll not
+	// check whether the container is running or try to unmap the RBD
+	// volume on it if the source node is offline.
+	if targetNode == "" || !sourceNodeOffline {
+		// Handle requests targeted to a container on a different node
+		response, err := ForwardedResponseIfContainerIsRemote(d, r, name)
+		if err != nil {
+			return SmartError(err)
+		}
+		if response != nil {
+			return response
+		}
+
+		c, err = containerLoadByName(d.State(), name)
+		if err != nil {
+			return SmartError(err)
+		}
 	}
 
 	body, err := ioutil.ReadAll(r.Body)
@@ -57,6 +130,21 @@ func containerPost(d *Daemon, r *http.Request) Response {
 	}
 
 	if req.Migration {
+		if targetNode != "" {
+			// Check if we are migrating a ceph-based container.
+			poolName, err := d.cluster.ContainerPool(name)
+			if err != nil {
+				return SmartError(err)
+			}
+			_, pool, err := d.cluster.StoragePoolGet(poolName)
+			if err != nil {
+				return SmartError(err)
+			}
+			if pool.Driver == "ceph" {
+				return containerPostClusteringMigrateWithCeph(d, c, name, req.Name, targetNode)
+			}
+		}
+
 		ws, err := NewMigrationSource(c, stateful, req.ContainerOnly)
 		if err != nil {
 			return InternalError(err)
@@ -108,4 +196,154 @@ func containerPost(d *Daemon, r *http.Request) Response {
 	}
 
 	return OperationResponse(op)
+}
+
+// Special case migrating a container backed by ceph across two cluster nodes.
+func containerPostClusteringMigrateWithCeph(d *Daemon, c container, oldName, newName, newNode string) Response {
+	if c != nil && c.IsRunning() {
+		return BadRequest(fmt.Errorf("Container is running"))
+	}
+
+	run := func(*operation) error {
+		// If source node is online (i.e. we're serving the request on
+		// it, and c != nil), let's unmap the RBD volume locally
+		if c != nil {
+			logger.Debugf(`Renaming RBD storage volume for source container "%s" from `+
+				`"%s" to "%s"`, c.Name(), c.Name(), newName)
+			poolName, err := c.StoragePool()
+			if err != nil {
+				return errors.Wrap(err, "Failed to get source container's storage pool name")
+			}
+			_, pool, err := d.cluster.StoragePoolGet(poolName)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get source container's storage pool")
+			}
+			if pool.Driver != "ceph" {
+				return fmt.Errorf("Source container's storage pool is not of type ceph")
+			}
+			si, err := storagePoolVolumeContainerLoadInit(d.State(), c.Name())
+			if err != nil {
+				return errors.Wrap(err, "Failed to initialize source container's storage pool")
+			}
+			s, ok := si.(*storageCeph)
+			if !ok {
+				return fmt.Errorf("Unexpected source container storage backend")
+			}
+			err = cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName, c.Name(),
+				storagePoolVolumeTypeNameContainer, s.UserName, true)
+			if err != nil {
+				return errors.Wrap(err, "Failed to unmap source container's RBD volume")
+			}
+
+		}
+
+		// Re-link the database entries against the new node name.
+		var poolName string
+		err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
+			err := tx.ContainerNodeMove(oldName, newName, newNode)
+			if err != nil {
+				return err
+			}
+			poolName, err = tx.ContainerPool(newName)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.Wrap(err, "Failed to relink container database data")
+		}
+
+		// Rename the RBD volume if necessary.
+		if newName != oldName {
+			s := storageCeph{}
+			_, s.pool, err = d.cluster.StoragePoolGet(poolName)
+			if err != nil {
+				return errors.Wrap(err, "Failed to get storage pool")
+			}
+			if err != nil {
+				return errors.Wrap(err, "Failed to get storage pool")
+			}
+			err = s.StoragePoolInit()
+			if err != nil {
+				return errors.Wrap(err, "Failed to initialize ceph storage pool")
+			}
+			err = cephRBDVolumeRename(s.ClusterName, s.OSDPoolName,
+				storagePoolVolumeTypeNameContainer, oldName, newName, s.UserName)
+			if err != nil {
+				return errors.Wrap(err, "Failed to rename ceph RBD volume")
+			}
+		}
+
+		// Create the container mount point on the target node
+		cert := d.endpoints.NetworkCert()
+		client, err := cluster.ConnectIfContainerIsRemote(d.cluster, newName, cert)
+		if err != nil {
+			return errors.Wrap(err, "Failed to connect to target node")
+		}
+		if client == nil {
+			err := containerPostCreateContainerMountPoint(d, newName)
+			if err != nil {
+				return errors.Wrap(err, "Failed to create mount point on target node")
+			}
+		} else {
+			path := fmt.Sprintf("/internal/cluster/container-moved/%s", newName)
+			resp, _, err := client.RawQuery("POST", path, nil, "")
+			if err != nil {
+				return errors.Wrap(err, "Failed to create mount point on target node")
+			}
+			if resp.StatusCode != 200 {
+				return fmt.Errorf("Failed to create mount point on target node: %s", resp.Error)
+			}
+		}
+
+		return nil
+	}
+
+	resources := map[string][]string{}
+	resources["containers"] = []string{oldName}
+	op, err := operationCreate(d.cluster, operationClassTask, "Moving container", resources, nil, run, nil, nil)
+	if err != nil {
+		return InternalError(err)
+	}
+
+	return OperationResponse(op)
+}
+
+var internalClusterContainerMovedCmd = Command{
+	name: "cluster/container-moved/{name}",
+	post: internalClusterContainerMovedPost,
+}
+
+// Notification that a container was moved.
+//
+// At the moment it's used for ceph-based containers, where the target node needs
+// to create the appropriate mount points.
+func internalClusterContainerMovedPost(d *Daemon, r *http.Request) Response {
+	containerName := mux.Vars(r)["name"]
+	err := containerPostCreateContainerMountPoint(d, containerName)
+	if err != nil {
+		return SmartError(err)
+	}
+	return EmptySyncResponse
+}
+
+// Used after to create the appropriate mount point after a container has been
+// moved.
+func containerPostCreateContainerMountPoint(d *Daemon, containerName string) error {
+	c, err := containerLoadByName(d.State(), containerName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to load moved container on target node")
+	}
+	poolName, err := c.StoragePool()
+	if err != nil {
+		return errors.Wrap(err, "Failed get pool name of moved container on target node")
+	}
+	// This is the target node itself.
+	containerMntPoint := getContainerMountPoint(poolName, containerName)
+	err = createContainerMountpoint(containerMntPoint, c.Path(), c.IsPrivileged())
+	if err != nil {
+		return errors.Wrap(err, "Failed to create container mount point on target node")
+	}
+	return nil
 }

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -200,7 +200,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 	storagePool := ""
 	storagePoolProfile := ""
 
-	localRootDiskDeviceKey, localRootDiskDevice, _ := containerGetRootDiskDevice(req.Devices)
+	localRootDiskDeviceKey, localRootDiskDevice, _ := shared.GetRootDiskDevice(req.Devices)
 	if localRootDiskDeviceKey != "" {
 		storagePool = localRootDiskDevice["pool"]
 	}
@@ -224,7 +224,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 				return SmartError(err)
 			}
 
-			k, v, _ := containerGetRootDiskDevice(p.Devices)
+			k, v, _ := shared.GetRootDiskDevice(p.Devices)
 			if k != "" && v["pool"] != "" {
 				// Keep going as we want the last one in the profile chain
 				storagePool = v["pool"]
@@ -306,7 +306,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 			return InternalError(err)
 		}
 
-		_, rootDiskDevice, err := containerGetRootDiskDevice(cM.ExpandedDevices())
+		_, rootDiskDevice, err := shared.GetRootDiskDevice(cM.ExpandedDevices())
 		if err != nil {
 			return InternalError(err)
 		}

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -140,13 +140,12 @@ INSERT INTO storage_volumes(name, storage_pool_id, node_id, type, description)
 		return errors.Wrap(err, "failed to create node ceph volumes")
 	}
 
+	// Create entries of all the ceph volumes configs for the new node.
 	stmt = `
 SELECT id FROM storage_volumes WHERE storage_pool_id=? AND node_id=?
   ORDER BY name, type
 `
-
-	// Create entries of all the ceph volumes configs for the new node.
-	volumeIDs, err := query.SelectIntegers(c.tx, stmt, poolID, otherNodeID)
+	volumeIDs, err := query.SelectIntegers(c.tx, stmt, poolID, nodeID)
 	if err != nil {
 		return errors.Wrap(err, "failed to get joining node's ceph volume IDs")
 	}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1725,7 +1725,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 			}
 
 			// Check for a root disk device entry
-			k, _, _ := containerGetRootDiskDevice(p.Devices)
+			k, _, _ := shared.GetRootDiskDevice(p.Devices)
 			if k != "" {
 				if p.Devices[k]["pool"] != "" {
 					continue
@@ -1820,14 +1820,14 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 		// Check if the container already has a valid root device entry (profile or previous upgrade)
 		expandedDevices := c.ExpandedDevices()
-		k, d, _ := containerGetRootDiskDevice(expandedDevices)
+		k, d, _ := shared.GetRootDiskDevice(expandedDevices)
 		if k != "" && d["pool"] != "" {
 			continue
 		}
 
 		// Look for a local root device entry
 		localDevices := c.LocalDevices()
-		k, _, _ = containerGetRootDiskDevice(localDevices)
+		k, _, _ = shared.GetRootDiskDevice(localDevices)
 		if k != "" {
 			localDevices[k]["pool"] = poolName
 		} else {

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 )
 
@@ -23,14 +24,14 @@ func doProfileUpdate(d *Daemon, name string, id int64, profile *api.Profile, req
 	containers := getContainersWithProfile(d.State(), name)
 
 	// Check if the root device is supposed to be changed or removed.
-	oldProfileRootDiskDeviceKey, oldProfileRootDiskDevice, _ := containerGetRootDiskDevice(profile.Devices)
-	_, newProfileRootDiskDevice, _ := containerGetRootDiskDevice(req.Devices)
+	oldProfileRootDiskDeviceKey, oldProfileRootDiskDevice, _ := shared.GetRootDiskDevice(profile.Devices)
+	_, newProfileRootDiskDevice, _ := shared.GetRootDiskDevice(req.Devices)
 	if len(containers) > 0 && oldProfileRootDiskDevice["pool"] != "" && newProfileRootDiskDevice["pool"] == "" || (oldProfileRootDiskDevice["pool"] != newProfileRootDiskDevice["pool"]) {
 		// Check for containers using the device
 		for _, container := range containers {
 			// Check if the device is locally overridden
 			localDevices := container.LocalDevices()
-			k, v, _ := containerGetRootDiskDevice(localDevices)
+			k, v, _ := shared.GetRootDiskDevice(localDevices)
 			if k != "" && v["pool"] != "" {
 				continue
 			}

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -2126,7 +2126,7 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 	// retrieve it from the expanded devices.
 	parentStoragePool := ""
 	parentExpandedDevices := container.ExpandedDevices()
-	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := containerGetRootDiskDevice(parentExpandedDevices)
+	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := shared.GetRootDiskDevice(parentExpandedDevices)
 	if parentLocalRootDiskDeviceKey != "" {
 		parentStoragePool = parentLocalRootDiskDevice["pool"]
 	}
@@ -2146,7 +2146,7 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 			// profile on the new instance as well we don't need to
 			// do anything.
 			if args.Devices != nil {
-				snapLocalRootDiskDeviceKey, _, _ := containerGetRootDiskDevice(args.Devices)
+				snapLocalRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(args.Devices)
 				if snapLocalRootDiskDeviceKey != "" {
 					args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 				}

--- a/lxd/storage_ceph_migration.go
+++ b/lxd/storage_ceph_migration.go
@@ -247,7 +247,7 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 	// set.
 	parentStoragePool := ""
 	parentExpandedDevices := c.ExpandedDevices()
-	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := containerGetRootDiskDevice(parentExpandedDevices)
+	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := shared.GetRootDiskDevice(parentExpandedDevices)
 	if parentLocalRootDiskDeviceKey != "" {
 		parentStoragePool = parentLocalRootDiskDevice["pool"]
 	}
@@ -313,7 +313,7 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 		// disk device for the snapshot comes from a profile on the new
 		// instance as well we don't need to do anything.
 		if args.Devices != nil {
-			snapLocalRootDiskDeviceKey, _, _ := containerGetRootDiskDevice(args.Devices)
+			snapLocalRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(args.Devices)
 			if snapLocalRootDiskDeviceKey != "" {
 				args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 			}

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -140,7 +140,7 @@ func rsyncMigrationSink(live bool, container container, snapshots []*migration.S
 	// disk device so we can simply retrieve it from the expanded devices.
 	parentStoragePool := ""
 	parentExpandedDevices := container.ExpandedDevices()
-	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := containerGetRootDiskDevice(parentExpandedDevices)
+	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := shared.GetRootDiskDevice(parentExpandedDevices)
 	if parentLocalRootDiskDeviceKey != "" {
 		parentStoragePool = parentLocalRootDiskDevice["pool"]
 	}
@@ -162,7 +162,7 @@ func rsyncMigrationSink(live bool, container container, snapshots []*migration.S
 				// profile on the new instance as well we don't need to
 				// do anything.
 				if args.Devices != nil {
-					snapLocalRootDiskDeviceKey, _, _ := containerGetRootDiskDevice(args.Devices)
+					snapLocalRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(args.Devices)
 					if snapLocalRootDiskDeviceKey != "" {
 						args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 					}
@@ -201,7 +201,7 @@ func rsyncMigrationSink(live bool, container container, snapshots []*migration.S
 				// profile on the new instance as well we don't need to
 				// do anything.
 				if args.Devices != nil {
-					snapLocalRootDiskDeviceKey, _, _ := containerGetRootDiskDevice(args.Devices)
+					snapLocalRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(args.Devices)
 					if snapLocalRootDiskDeviceKey != "" {
 						args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 					}

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -2295,7 +2295,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 	// retrieve it from the expanded devices.
 	parentStoragePool := ""
 	parentExpandedDevices := container.ExpandedDevices()
-	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := containerGetRootDiskDevice(parentExpandedDevices)
+	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := shared.GetRootDiskDevice(parentExpandedDevices)
 	if parentLocalRootDiskDeviceKey != "" {
 		parentStoragePool = parentLocalRootDiskDevice["pool"]
 	}
@@ -2314,7 +2314,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 		// profile on the new instance as well we don't need to
 		// do anything.
 		if args.Devices != nil {
-			snapLocalRootDiskDeviceKey, _, _ := containerGetRootDiskDevice(args.Devices)
+			snapLocalRootDiskDeviceKey, _, _ := shared.GetRootDiskDevice(args.Devices)
 			if snapLocalRootDiskDeviceKey != "" {
 				args.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 			}

--- a/shared/container.go
+++ b/shared/container.go
@@ -87,6 +87,40 @@ func IsAny(value string) error {
 	return nil
 }
 
+// IsRootDiskDevice returns true if the given device representation is
+// configured as root disk for a container. It typically get passed a specific
+// entry of api.Container.Devices.
+func IsRootDiskDevice(device map[string]string) bool {
+	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" {
+		return true
+	}
+
+	return false
+}
+
+// GetRootDiskDevice returns the container device that is configured as root disk
+func GetRootDiskDevice(devices map[string]map[string]string) (string, map[string]string, error) {
+	var devName string
+	var dev map[string]string
+
+	for n, d := range devices {
+		if IsRootDiskDevice(d) {
+			if devName != "" {
+				return "", nil, fmt.Errorf("More than one root device found.")
+			}
+
+			devName = n
+			dev = d
+		}
+	}
+
+	if devName != "" {
+		return devName, dev, nil
+	}
+
+	return "", nil, fmt.Errorf("No root device could be found.")
+}
+
 // KnownContainerConfigKeys maps all fully defined, well-known config keys
 // to an appropriate checker function, which validates whether or not a
 // given value is syntactically legal.


### PR DESCRIPTION
This implements moving ceph-based containers across cluster nodes.

It supports both moves with renames and without renames (the container keeps the same name), and moving a container also if the node currently hosting the container is offline.

As discussed, later down the road we'll want to extend this functionality to all kinds of containers, not only the ceph-based ones. At that point we might also rearrange the code to be more generic, if needed.

Closes #4306.