### PR TITLE
Always use transactions when querying the database

### DIFF
--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -326,7 +326,7 @@ func (c *Cluster) ContainerRemove(name string) error {
 		return err
 	}
 
-	_, err = exec(c.db, "DELETE FROM containers WHERE id=?", id)
+	err = exec(c.db, "DELETE FROM containers WHERE id=?", id)
 	if err != nil {
 		return err
 	}
@@ -539,7 +539,7 @@ func (c *Cluster) ContainerConfigGet(id int, key string) (string, error) {
 }
 
 func (c *Cluster) ContainerConfigRemove(id int, name string) error {
-	_, err := exec(c.db, "DELETE FROM containers_config WHERE key=? AND container_id=?", name, id)
+	err := exec(c.db, "DELETE FROM containers_config WHERE key=? AND container_id=?", name, id)
 	return err
 }
 
@@ -549,7 +549,7 @@ func (c *Cluster) ContainerSetStateful(id int, stateful bool) error {
 		statefulInt = 1
 	}
 
-	_, err := exec(c.db, "UPDATE containers SET stateful=? WHERE id=?", statefulInt, id)
+	err := exec(c.db, "UPDATE containers SET stateful=? WHERE id=?", statefulInt, id)
 	return err
 }
 
@@ -648,7 +648,7 @@ func (c *Cluster) ContainersList(cType ContainerType) ([]string, error) {
 
 func (c *Cluster) ContainersResetState() error {
 	// Reset all container states
-	_, err := exec(c.db, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
+	err := exec(c.db, "DELETE FROM containers_config WHERE key='volatile.last_state.power'")
 	return err
 }
 
@@ -739,7 +739,7 @@ func ContainerUpdate(tx *sql.Tx, id int, description string, architecture int, e
 
 func (c *Cluster) ContainerLastUsedUpdate(id int, date time.Time) error {
 	stmt := `UPDATE containers SET last_use_date=? WHERE id=?`
-	_, err := exec(c.db, stmt, date, id)
+	err := exec(c.db, stmt, date, id)
 	return err
 }
 

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -92,7 +92,7 @@ func (c *Cluster) ImageSourceInsert(imageId int, server string, protocol string,
 		return fmt.Errorf("Invalid protocol: %s", protocol)
 	}
 
-	_, err := exec(c.db, stmt, imageId, server, protocolInt, certificate, alias)
+	err := exec(c.db, stmt, imageId, server, protocolInt, certificate, alias)
 	return err
 }
 
@@ -375,7 +375,7 @@ func (c *Cluster) ImageAssociateNode(fingerprint string) error {
 }
 
 func (c *Cluster) ImageDelete(id int) error {
-	_, err := exec(c.db, "DELETE FROM images WHERE id=?", id)
+	err := exec(c.db, "DELETE FROM images WHERE id=?", id)
 	if err != nil {
 		return err
 	}
@@ -432,42 +432,42 @@ func (c *Cluster) ImageAliasGet(name string, isTrustedClient bool) (int, api.Ima
 }
 
 func (c *Cluster) ImageAliasRename(id int, name string) error {
-	_, err := exec(c.db, "UPDATE images_aliases SET name=? WHERE id=?", name, id)
+	err := exec(c.db, "UPDATE images_aliases SET name=? WHERE id=?", name, id)
 	return err
 }
 
 func (c *Cluster) ImageAliasDelete(name string) error {
-	_, err := exec(c.db, "DELETE FROM images_aliases WHERE name=?", name)
+	err := exec(c.db, "DELETE FROM images_aliases WHERE name=?", name)
 	return err
 }
 
 func (c *Cluster) ImageAliasesMove(source int, destination int) error {
-	_, err := exec(c.db, "UPDATE images_aliases SET image_id=? WHERE image_id=?", destination, source)
+	err := exec(c.db, "UPDATE images_aliases SET image_id=? WHERE image_id=?", destination, source)
 	return err
 }
 
 // Insert an alias ento the database.
 func (c *Cluster) ImageAliasAdd(name string, imageID int, desc string) error {
 	stmt := `INSERT INTO images_aliases (name, image_id, description) values (?, ?, ?)`
-	_, err := exec(c.db, stmt, name, imageID, desc)
+	err := exec(c.db, stmt, name, imageID, desc)
 	return err
 }
 
 func (c *Cluster) ImageAliasUpdate(id int, imageID int, desc string) error {
 	stmt := `UPDATE images_aliases SET image_id=?, description=? WHERE id=?`
-	_, err := exec(c.db, stmt, imageID, desc, id)
+	err := exec(c.db, stmt, imageID, desc, id)
 	return err
 }
 
 func (c *Cluster) ImageLastAccessUpdate(fingerprint string, date time.Time) error {
 	stmt := `UPDATE images SET last_use_date=? WHERE fingerprint=?`
-	_, err := exec(c.db, stmt, date, fingerprint)
+	err := exec(c.db, stmt, date, fingerprint)
 	return err
 }
 
 func (c *Cluster) ImageLastAccessInit(fingerprint string) error {
 	stmt := `UPDATE images SET cached=1, last_use_date=strftime("%s") WHERE fingerprint=?`
-	_, err := exec(c.db, stmt, fingerprint)
+	err := exec(c.db, stmt, fingerprint)
 	return err
 }
 
@@ -652,6 +652,6 @@ func (c *Cluster) ImageGetPoolNamesFromIDs(poolIDs []int64) ([]string, error) {
 
 // ImageUploadedAt updates the upload_date column and an image row.
 func (c *Cluster) ImageUploadedAt(id int, uploadedAt time.Time) error {
-	_, err := exec(c.db, "UPDATE images SET upload_date=? WHERE id=?", uploadedAt, id)
+	err := exec(c.db, "UPDATE images SET upload_date=? WHERE id=?", uploadedAt, id)
 	return err
 }

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -95,6 +95,7 @@ func (c *Cluster) ImportPreClusteringData(dump *Dump) error {
 	// gets created no matter what.
 	_, err = tx.Exec("DELETE FROM profiles WHERE id=1")
 	if err != nil {
+		tx.Rollback()
 		return errors.Wrap(err, "failed to delete default profile")
 	}
 
@@ -190,13 +191,16 @@ func (c *Cluster) ImportPreClusteringData(dump *Dump) error {
 			stmt += fmt.Sprintf(" VALUES %s", query.Params(len(columns)))
 			result, err := tx.Exec(stmt, row...)
 			if err != nil {
+				tx.Rollback()
 				return errors.Wrapf(err, "failed to insert row %d into %s", i, table)
 			}
 			n, err := result.RowsAffected()
 			if err != nil {
+				tx.Rollback()
 				return errors.Wrapf(err, "no result count for row %d of %s", i, table)
 			}
 			if n != 1 {
+				tx.Rollback()
 				return fmt.Errorf("could not insert %d int %s", i, table)
 			}
 

--- a/lxd/db/networks.go
+++ b/lxd/db/networks.go
@@ -556,7 +556,7 @@ func (c *Cluster) NetworkDelete(name string) error {
 		return err
 	}
 
-	_, err = exec(c.db, "DELETE FROM networks WHERE id=?", id)
+	err = exec(c.db, "DELETE FROM networks WHERE id=?", id)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -165,7 +165,7 @@ func (c *Cluster) ProfileDelete(name string) error {
 		return err
 	}
 
-	_, err = exec(c.db, "DELETE FROM profiles WHERE id=?", id)
+	err = exec(c.db, "DELETE FROM profiles WHERE id=?", id)
 	if err != nil {
 		return err
 	}
@@ -263,7 +263,7 @@ DELETE FROM profiles_config WHERE profile_id NOT IN (SELECT id FROM profiles);
 DELETE FROM profiles_devices WHERE profile_id NOT IN (SELECT id FROM profiles);
 DELETE FROM profiles_devices_config WHERE profile_device_id NOT IN (SELECT id FROM profiles_devices);
 `
-	_, err := c.db.Exec(stmt)
+	err := exec(c.db, stmt)
 	if err != nil {
 		return err
 	}

--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -19,7 +19,7 @@ func Retry(f func() error) error {
 	for i := 0; i < 20; i++ {
 		err = f()
 		if err != nil {
-			logger.Debugf("Database error %#v", err)
+			logger.Debugf("Database error: %#v", err)
 
 			if IsRetriableError(err) {
 				logger.Debugf("Retry failed db interaction (%v)", err)

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -659,7 +659,7 @@ func (c *Cluster) StoragePoolDelete(poolName string) (*api.StoragePool, error) {
 		return nil, err
 	}
 
-	_, err = exec(c.db, "DELETE FROM storage_pools WHERE id=?", poolID)
+	err = exec(c.db, "DELETE FROM storage_pools WHERE id=?", poolID)
 	if err != nil {
 		return nil, err
 	}
@@ -842,6 +842,7 @@ func (c *Cluster) StoragePoolVolumeUpdate(volumeName string, volumeType int, poo
 		return StorageVolumeDescriptionUpdate(tx, volumeID, volumeDescription)
 	})
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 
@@ -1051,6 +1052,6 @@ func StoragePoolVolumeTypeToName(volumeType int) (string, error) {
 }
 
 func (c *Cluster) StoragePoolInsertZfsDriver() error {
-	_, err := exec(c.db, "UPDATE storage_pools SET driver='zfs', description='' WHERE driver=''")
+	err := exec(c.db, "UPDATE storage_pools SET driver='zfs', description='' WHERE driver=''")
 	return err
 }

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -178,17 +178,17 @@ func (c *Cluster) StorageVolumeCleanupImages(fingerprints []string) error {
 	for _, fingerprint := range fingerprints {
 		args = append(args, fingerprint)
 	}
-	_, err := exec(c.db, stmt, args...)
+	err := exec(c.db, stmt, args...)
 	return err
 }
 
 func (c *Cluster) StorageVolumeMoveToLVMThinPoolNameKey() error {
-	_, err := exec(c.db, "UPDATE storage_pools_config SET key='lvm.thinpool_name' WHERE key='volume.lvm.thinpool_name';")
+	err := exec(c.db, "UPDATE storage_pools_config SET key='lvm.thinpool_name' WHERE key='volume.lvm.thinpool_name';")
 	if err != nil {
 		return err
 	}
 
-	_, err = exec(c.db, "DELETE FROM storage_volumes_config WHERE key='lvm.thinpool_name';")
+	err = exec(c.db, "DELETE FROM storage_volumes_config WHERE key='lvm.thinpool_name';")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Make all our DB APIs use transactions.

This change is in preparation of a new dqlite release that properly supports distributed checkpoints (iow, compacting the write-head log file content atomically across all nodes). In order to safely do that, dqlite needs to know about ongoing transactions, so now LXD explicitly goes through the BEGIN,COMMIT/ROLLBACK dance in every database API.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>