### PR TITLE
Adapt to new dqlite api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ POTFILE=po/$(DOMAIN).pot
 # TODO: use git describe for versioning
 VERSION=$(shell grep "var Version" shared/version/flex.go | cut -d'"' -f2)
 ARCHIVE=lxd-$(VERSION).tar
-TAGS=$(shell printf "\#include <sqlite3.h>\nvoid main(){int n = SQLITE_REPLICATION;}" | $(CC) -o /dev/null -xc - >/dev/null 2>&1 && echo "-tags libsqlite3")
+TAGS=$(shell printf "\#include <sqlite3.h>\nvoid main(){int n = SQLITE_CONFIG_REPLICATION;}" | $(CC) -o /dev/null -xc - >/dev/null 2>&1 && echo "-tags libsqlite3")
 
 .PHONY: default
 default:

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -405,14 +405,7 @@ func (g *Gateway) init() error {
 	// exposed it over gRPC.
 	if raft != nil {
 		config := dqlite.DriverConfig{}
-		if raft.HandlerFunc() == nil {
-			// FIXME enable auto-checkpoint to avoid WAL growing
-			// indefinitely. This should be disabled when proper
-			// checkpoint support is added for multi-node
-			// deployments.
-			config.AutoCheckpoint = 1000
-		}
-		driver, err := dqlite.NewDriver(raft.FSM(), raft.Raft(), config)
+		driver, err := dqlite.NewDriver(raft.Registry(), raft.Raft(), config)
 		if err != nil {
 			return errors.Wrap(err, "failed to create dqlite driver")
 		}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -193,6 +193,7 @@ func OpenCluster(name string, dialer grpcsql.Dialer, address string) (*Cluster, 
 		db: db,
 	}
 	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(1)
 
 	// Figure out the ID of this node.
 	err = cluster.Transaction(func(tx *ClusterTx) error {

--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -50,7 +50,9 @@ func IsRetriableError(err error) bool {
 	if strings.Contains(err.Error(), "bad connection") {
 		return true
 	}
-	if strings.Contains(err.Error(), "leadership lost") {
+
+	// Despite the description this is usually a lost leadership error.
+	if strings.Contains(err.Error(), "disk I/O error") {
 		return true
 	}
 


### PR DESCRIPTION
This adapts the LXD code to the new dqlite API which supports proper checkpointing.

Note that the forked sqlite source code now needs to be built with "--enable-replication", otherwise the replication API won't be available. This was done to hopefully facilitate merging the replication patch upstream (all experimental or less used SQLite APIs generally require to pass a non-default ./configure flag)

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>