### PR TITLE
lxc/image: Fix crash due to bad arg parsing

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -642,7 +642,6 @@ func (c *cmdImageImport) Run(cmd *cobra.Command, args []string) error {
 
 	if imageFile == "" {
 		imageFile = args[0]
-		properties = properties[1:]
 	}
 
 	if shared.PathExists(shared.HostPath(filepath.Clean(imageFile))) {


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>