### PR TITLE
lxd: add missing limits.h include

### DIFF
--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -17,6 +17,7 @@ import (
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <limits.h>
 
 extern char* advance_arg(bool required);
 extern void error(char *msg);


### PR DESCRIPTION
On systems without glibc, as Alpine, you might lack definition of PATH_MAX.
This patch adds the limits.h header to solve this issue.

Signed-off-by: Roberto Oliveira <robertoguimaraes8@gmail.com>