### PR TITLE
lxd/init: Don't setup a remote storage pool by default

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -375,7 +375,7 @@ func (c *cmdInit) askStorage(config *initData, d lxd.ContainerServer) error {
 			}
 		}
 
-		if cli.AskBool("Do you want to configure a new remote storage pool (yes/no) [default=yes]? ", "yes") {
+		if cli.AskBool("Do you want to configure a new remote storage pool (yes/no) [default=no]? ", "no") {
 			err := c.askStoragePool(config, d, "remote")
 			if err != nil {
 				return err


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>