### PR TITLE
lxc/config: Fix adding trust cert on snap

### DIFF
--- a/lxc/config_trust.go
+++ b/lxc/config_trust.go
@@ -86,7 +86,7 @@ func (c *cmdConfigTrustAdd) Run(cmd *cobra.Command, args []string) error {
 
 	// Add trust relationship
 	fname := args[len(args)-1]
-	x509Cert, err := shared.ReadCert(fname)
+	x509Cert, err := shared.ReadCert(shared.HostPath(fname))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes #4418

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>