### PR TITLE
devices: fail if Nvidia device minor is missing

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -211,6 +211,9 @@ func deviceLoadGpu() ([]gpuDevice, []nvidiaGpuDevices, error) {
 				}
 				strBuf := strings.TrimSpace(string(buf))
 				idx := strings.Index(strBuf, "Device Minor:")
+				if idx == -1 {
+					return nil, nil, fmt.Errorf("No device minor index detected")
+				}
 				idx += len("Device Minor:")
 				strBuf = strBuf[idx:]
 				strBuf = strings.TrimSpace(strBuf)


### PR DESCRIPTION
Closes #4441.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>