### PR TITLE
Pass a logger to raft-http

### DIFF
--- a/lxd/cluster/raft.go
+++ b/lxd/cluster/raft.go
@@ -308,7 +308,7 @@ func raftNetworkTransport(
 	logger *log.Logger,
 	timeout time.Duration,
 	dial rafthttp.Dial) (raft.Transport, *rafthttp.Handler, *rafthttp.Layer, error) {
-	handler := rafthttp.NewHandler()
+	handler := rafthttp.NewHandlerWithLogger(logger)
 	addr, err := net.ResolveTCPAddr("tcp", address)
 	if err != nil {
 		return nil, nil, nil, errors.Wrap(err, "invalid node address")


### PR DESCRIPTION
This will use the raftLogger wrapper that we already have, and forward to our
logger. The output will be just a few INFO messages when connecting between
nodes, joining and leaving, so pretty low noise. It helps in case of errors at that
layer because error messages will be logged.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>