### PR TITLE
Log the error that made Daemon.Init() fail

### DIFF
--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -81,6 +81,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 	err = d.Init()
 	if err != nil {
+		logger.Errorf("Daemon failed to start: %v", err)
 		return err
 	}
 


### PR DESCRIPTION
Should make debugging startup failures a bit easier.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>