### PR TITLE
Rename database files

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -296,7 +296,7 @@ func (g *Gateway) Reset(cert *shared.CertInfo) error {
 	if err != nil {
 		return err
 	}
-	err = os.RemoveAll(filepath.Join(g.db.Dir(), "raft"))
+	err = os.RemoveAll(filepath.Join(g.db.Dir(), "global"))
 	if err != nil {
 		return err
 	}

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -146,7 +146,7 @@ func TestGateway_RaftNodesNotLeader(t *testing.T) {
 // happens.
 func newGateway(t *testing.T, db *db.Node, certInfo *shared.CertInfo) *cluster.Gateway {
 	logging.Testing(t)
-	require.NoError(t, os.Mkdir(filepath.Join(db.Dir(), "raft"), 0755))
+	require.NoError(t, os.Mkdir(filepath.Join(db.Dir(), "global"), 0755))
 	gateway, err := cluster.NewGateway(
 		db, certInfo, cluster.Latency(0.2), cluster.LogLevel("TRACE"))
 	require.NoError(t, err)

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -286,7 +286,7 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 	if err != nil {
 		return errors.Wrap(err, "failed to shutdown gRPC SQL gateway")
 	}
-	err = os.RemoveAll(filepath.Join(state.OS.VarDir, "raft"))
+	err = os.RemoveAll(state.OS.GlobalDatabaseDir())
 	if err != nil {
 		return errors.Wrap(err, "failed to remove existing raft data")
 	}
@@ -582,7 +582,7 @@ func Promote(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	// Wipe all existing raft data, for good measure (perhaps they were
 	// somehow leftover).
-	err = os.RemoveAll(filepath.Join(state.OS.VarDir, "raft"))
+	err = os.RemoveAll(state.OS.GlobalDatabaseDir())
 	if err != nil {
 		return errors.Wrap(err, "failed to remove existing raft data")
 	}

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -237,8 +237,8 @@ func importNodeAssociation(entity string, columns []string, row []interface{}, t
 	return nil
 }
 
-// Dump is a dump of all the user data in lxd.db prior the migration to the
-// cluster db.
+// Dump is a dump of all the user data in the local db prior the migration to
+// the cluster db.
 type Dump struct {
 	// Map table names to the names or their columns.
 	Schema map[string][]string

--- a/lxd/db/node/open.go
+++ b/lxd/db/node/open.go
@@ -12,7 +12,7 @@ import (
 
 // Open the node-local database object.
 func Open(dir string) (*sql.DB, error) {
-	path := filepath.Join(dir, "lxd.db")
+	path := filepath.Join(dir, "local.db")
 	db, err := sqliteOpen(path)
 	if err != nil {
 		return nil, fmt.Errorf("cannot open node database: %v", err)
@@ -32,8 +32,8 @@ func EnsureSchema(db *sql.DB, dir string, hook schema.Hook) (int, error) {
 	schema := Schema()
 	schema.Hook(func(version int, tx *sql.Tx) error {
 		if !backupDone {
-			logger.Infof("Updating the LXD database schema. Backup made as \"lxd.db.bak\"")
-			path := filepath.Join(dir, "lxd.db")
+			logger.Infof("Updating the LXD database schema. Backup made as \"local.db.bak\"")
+			path := filepath.Join(dir, "local.db")
 			err := shared.FileCopy(path, path+".bak")
 			if err != nil {
 				return err

--- a/lxd/sys/fs.go
+++ b/lxd/sys/fs.go
@@ -3,7 +3,35 @@ package sys
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
 )
+
+// LocalDatabasePath returns the path of the local database file.
+func (s *OS) LocalDatabasePath() string {
+	return filepath.Join(s.VarDir, "database", "local.db")
+}
+
+// LegacyLocalDatabasePath returns the path of legacy local database file.
+func (s *OS) LegacyLocalDatabasePath() string {
+	return filepath.Join(s.VarDir, "lxd.db")
+}
+
+// GlobalDatabaseDir returns the path of the global database directory.
+func (s *OS) GlobalDatabaseDir() string {
+	return filepath.Join(s.VarDir, "database", "global")
+}
+
+// GlobalDatabasePath returns the path of the global database SQLite file
+// managed by dqlite.
+func (s *OS) GlobalDatabasePath() string {
+	return filepath.Join(s.GlobalDatabaseDir(), "db.bin")
+}
+
+// LegacyGlobalDatabasePath returns the path of legacy global database file.
+func (s *OS) LegacyGlobalDatabasePath() string {
+	return filepath.Join(s.VarDir, "raft", "db.bin")
+}
 
 // Make sure all our directories are available.
 func (s *OS) initDirs() error {
@@ -13,7 +41,7 @@ func (s *OS) initDirs() error {
 	}{
 		{s.VarDir, 0711},
 		{s.CacheDir, 0700},
-		{filepath.Join(s.VarDir, "raft"), 0700},
+		{filepath.Join(s.VarDir, "database"), 0700},
 		{filepath.Join(s.VarDir, "containers"), 0711},
 		{filepath.Join(s.VarDir, "devices"), 0711},
 		{filepath.Join(s.VarDir, "devlxd"), 0755},
@@ -30,7 +58,7 @@ func (s *OS) initDirs() error {
 	for _, dir := range dirs {
 		err := os.Mkdir(dir.path, dir.mode)
 		if err != nil && !os.IsExist(err) {
-			return err
+			return errors.Wrapf(err, "failed to init dir %s", dir.path)
 		}
 	}
 

--- a/test/includes/lxd.sh
+++ b/test/includes/lxd.sh
@@ -164,8 +164,8 @@ kill_lxd() {
         done
 
         echo "==> Checking for locked DB tables"
-        for table in $(echo .tables | sqlite3 "${daemon_dir}/lxd.db"); do
-            echo "SELECT * FROM ${table};" | sqlite3 "${daemon_dir}/lxd.db" >/dev/null
+        for table in $(echo .tables | sqlite3 "${daemon_dir}/local.db"); do
+            echo "SELECT * FROM ${table};" | sqlite3 "${daemon_dir}/local.db" >/dev/null
         done
 
         # Kill the daemon
@@ -203,27 +203,27 @@ kill_lxd() {
         echo "==> Checking for leftover cluster DB entries"
         # FIXME: we should not use the command line sqlite client, since it's
         #        not compatible with dqlite
-        check_empty_table "${daemon_dir}/raft/db.bin" "containers"
-        check_empty_table "${daemon_dir}/raft/db.bin" "containers_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "containers_devices"
-        check_empty_table "${daemon_dir}/raft/db.bin" "containers_devices_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "containers_profiles"
-        check_empty_table "${daemon_dir}/raft/db.bin" "images"
-        check_empty_table "${daemon_dir}/raft/db.bin" "images_aliases"
-        check_empty_table "${daemon_dir}/raft/db.bin" "images_properties"
-        check_empty_table "${daemon_dir}/raft/db.bin" "images_source"
-        check_empty_table "${daemon_dir}/raft/db.bin" "images_nodes"
-        check_empty_table "${daemon_dir}/raft/db.bin" "networks"
-        check_empty_table "${daemon_dir}/raft/db.bin" "networks_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "profiles"
-        check_empty_table "${daemon_dir}/raft/db.bin" "profiles_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "profiles_devices"
-        check_empty_table "${daemon_dir}/raft/db.bin" "profiles_devices_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "storage_pools"
-        check_empty_table "${daemon_dir}/raft/db.bin" "storage_pools_nodes"
-        check_empty_table "${daemon_dir}/raft/db.bin" "storage_pools_config"
-        check_empty_table "${daemon_dir}/raft/db.bin" "storage_volumes"
-        check_empty_table "${daemon_dir}/raft/db.bin" "storage_volumes_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "containers"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "containers_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "containers_devices"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "containers_devices_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "containers_profiles"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "images"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "images_aliases"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "images_properties"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "images_source"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "images_nodes"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "networks"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "networks_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "profiles"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "profiles_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "profiles_devices"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "profiles_devices_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "storage_pools"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "storage_pools_nodes"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "storage_pools_config"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "storage_volumes"
+        check_empty_table "${daemon_dir}/database/global/db.bin" "storage_volumes_config"
     fi
 
     # teardown storage

--- a/test/suites/database_update.sh
+++ b/test/suites/database_update.sh
@@ -1,6 +1,7 @@
 test_database_update(){
   LXD_MIGRATE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
-  MIGRATE_DB=${LXD_MIGRATE_DIR}/lxd.db
+  mkdir -p "${LXD_MIGRATE_DIR}/database"
+  MIGRATE_DB=${LXD_MIGRATE_DIR}/database/local.db
 
   # Create the version 1 schema as the database
   sqlite3 "${MIGRATE_DB}" > /dev/null < deps/schema1.sql


### PR DESCRIPTION
As per #4390, this renames $LXD_DIR/lxd.db to $LXD_DIR/database/local.db and $LXD_DIR/raft to $LXD_DIR/database/global.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>