### PR TITLE
Allow configuration of mount-propagation

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -454,3 +454,7 @@ This adds the ability to copy and move custom storage volumes between remote.
 Adds a `nvidia_runtime` config option for containers, setting this to
 true will have the NVIDIA runtime and CUDA libraries passed to the
 container.
+
+## container\_mount\_propagation
+This adds a new "propagation" option to the disk device type, allowing
+the configuration of kernel mount propagation.

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -343,6 +343,7 @@ readonly        | boolean   | false             | no        | Controls whether t
 size            | string    | -                 | no        | Disk size in bytes (supports kB, MB, GB, TB, PB and EB suffixes). This is only supported for the rootfs (/).
 recursive       | boolean   | false             | no        | Whether or not to recursively mount the source path
 pool            | string    | -                 | no        | The storage pool the disk device belongs to. This is only applicable for storage volumes managed by LXD.
+propagation     | string    | -                 | no        | Controls how a bind-mount is shared between the container and the host. (Can be one of `private`, the default, or `shared`, `slave`, `unbindable`,  `rshared`, `rslave`, `runbindable`,  `rprivate`. Please see the Linux Kernel [shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) documentation for a full explanation)
 
 If multiple disks, backed by the same block device, have I/O limits set,
 the average of the limits will be used.

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1626,6 +1626,10 @@ func (c *containerLXC) initLXC(config bool) error {
 					rbind = "r"
 				}
 
+				if m["propagation"] != "" {
+					options = append(options, m["propagation"])
+				}
+
 				if isFile {
 					options = append(options, "create=file")
 				} else {
@@ -6246,7 +6250,7 @@ func (c *containerLXC) createUnixDevice(prefix string, m types.Device) ([]string
 		}
 		f.Close()
 
-		err = deviceMountDisk(srcPath, devPath, false, false)
+		err = deviceMountDisk(srcPath, devPath, false, false, "")
 		if err != nil {
 			return nil, err
 		}
@@ -7497,7 +7501,7 @@ func (c *containerLXC) createDiskDevice(name string, m types.Device) (string, er
 	}
 
 	// Mount the fs
-	err := deviceMountDisk(srcPath, devPath, isReadOnly, isRecursive)
+	err := deviceMountDisk(srcPath, devPath, isReadOnly, isRecursive, m["propagation"])
 	if err != nil {
 		return "", err
 	}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -964,7 +964,7 @@ func deviceRemoveInterface(nic string) error {
 	return err
 }
 
-func deviceMountDisk(srcPath string, dstPath string, readonly bool, recursive bool) error {
+func deviceMountDisk(srcPath string, dstPath string, readonly bool, recursive bool, propagation string) error {
 	var err error
 
 	// Prepare the mount flags
@@ -982,6 +982,29 @@ func deviceMountDisk(srcPath string, dstPath string, readonly bool, recursive bo
 		}
 	} else {
 		flags |= syscall.MS_BIND
+		if propagation != "" {
+			switch propagation {
+			case "private":
+				flags |= syscall.MS_PRIVATE
+			case "shared":
+				flags |= syscall.MS_SHARED
+			case "slave":
+				flags |= syscall.MS_SLAVE
+			case "unbindable":
+				flags |= syscall.MS_UNBINDABLE
+			case "rprivate":
+				flags |= syscall.MS_PRIVATE | syscall.MS_REC
+			case "rshared":
+				flags |= syscall.MS_SHARED | syscall.MS_REC
+			case "rslave":
+				flags |= syscall.MS_SLAVE | syscall.MS_REC
+			case "runbindable":
+				flags |= syscall.MS_UNBINDABLE | syscall.MS_REC
+			default:
+				return fmt.Errorf("Invalid propagation mode '%s'", propagation)
+			}
+		}
+
 		if recursive {
 			flags |= syscall.MS_REC
 		}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -102,6 +102,7 @@ var APIExtensions = []string{
 	"event_lifecycle",
 	"storage_api_remote_volume_handling",
 	"nvidia_runtime",
+	"container_mount_propagation",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
we add a new option `propagation`, which allows to specify exactly how
bind-mounts will be shared between the host and a container.

Signed-off-by: Igor Galić <igor.galic@automatic-server.com>