### PR TITLE
lxd init: fix maas.api.url check when setting up existing bridge

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -306,7 +306,7 @@ func (c *cmdInit) askNetworking(config *initData, d lxd.ContainerServer) error {
 					config.Profiles[0].Devices["eth0"]["nictype"] = "bridged"
 				}
 
-				if config.Config["maas.api.url"] != "" && cli.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes") {
+				if config.Config["maas.api.url"] != nil && cli.AskBool("Is this interface connected to your MAAS server? (yes/no) [default=yes]: ", "yes") {
 					maasSubnetV4 := cli.AskString("MAAS IPv4 subnet name for this interface (empty for no subnet): ", "",
 						func(input string) error { return nil })
 


### PR DESCRIPTION
When one selects the `no` option when setting up MAAS and then selects the option to set up a custom bridge, the prompt still appears to ask if the interface is connected to MAAS. This is due to the value `config.Config["maas.api.url"]` is set to nil and not to `""`.