### PR TITLE
add --format option to lxc remote list

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -405,8 +405,9 @@ func (c *cmdRemoteGetDefault) Run(cmd *cobra.Command, args []string) error {
 
 // List
 type cmdRemoteList struct {
-	global     *cmdGlobal
-	remote     *cmdRemote
+	global *cmdGlobal
+	remote *cmdRemote
+
 	flagFormat string
 }
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -290,11 +290,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
@@ -311,7 +311,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -324,7 +324,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -390,7 +390,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -502,12 +502,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 
@@ -630,7 +630,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
@@ -799,8 +799,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1068,7 +1068,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1076,7 +1076,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
@@ -1189,7 +1189,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
@@ -1240,7 +1240,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1581,7 +1581,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1722,11 +1722,11 @@ msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1799,7 +1799,7 @@ msgstr "kein Wert in %q gefunden\n"
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1948,7 +1948,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1985,27 +1985,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
@@ -2043,7 +2043,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove profiles from containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -2074,7 +2074,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -2166,21 +2166,21 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2312,7 +2312,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show the container's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2696,7 +2696,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2961,7 +2961,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3264,7 +3264,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 #, fuzzy
 msgid "ok (y/n)?"
 msgstr "OK (y/n)? "
@@ -3334,7 +3334,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3366,7 +3366,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3435,11 +3435,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2017-02-14 17:11+0000\n"
 "Last-Translator: Tim Rose <tim@netlope.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -290,7 +290,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -477,7 +477,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -799,8 +799,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1068,7 +1068,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1209,7 +1209,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1722,11 +1722,11 @@ msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1836,11 +1836,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1985,12 +1985,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -2000,7 +2000,7 @@ msgstr "entfernte Instanz %s existiert nicht"
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -2043,7 +2043,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Remove profiles from containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -2074,7 +2074,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -2150,7 +2150,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2216,11 +2216,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Set storage volume configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2573,7 +2573,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2653,7 +2653,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2781,7 +2781,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2999,7 +2999,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3366,7 +3366,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3435,11 +3435,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -186,11 +186,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -206,7 +206,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -218,7 +218,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -282,7 +282,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -389,12 +389,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -671,8 +671,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -937,7 +937,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1048,7 +1048,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1097,7 +1097,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1408,7 +1408,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1540,11 +1540,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1615,7 +1615,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1761,7 +1761,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1795,27 +1795,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1878,7 +1878,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1950,7 +1950,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1966,19 +1966,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2011,11 +2011,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2103,7 +2103,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2468,7 +2468,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2719,7 +2719,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3013,7 +3013,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3063,7 +3063,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3095,7 +3095,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3155,11 +3155,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -671,8 +671,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -929,7 +929,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1067,7 +1067,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1288,7 +1288,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1540,11 +1540,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1652,11 +1652,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1795,12 +1795,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1810,7 +1810,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1849,7 +1849,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1878,7 +1878,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1950,7 +1950,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2011,11 +2011,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2428,7 +2428,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2552,7 +2552,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2757,7 +2757,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3071,7 +3071,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3095,7 +3095,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3155,11 +3155,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2018-02-10 11:39+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -243,7 +243,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -421,7 +421,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %s"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -729,8 +729,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1346,7 +1346,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1599,11 +1599,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1710,11 +1710,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1853,12 +1853,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1868,7 +1868,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2069,11 +2069,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3214,11 +3214,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2018-02-10 11:39+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -243,11 +243,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
@@ -264,7 +264,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -276,7 +276,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -340,7 +340,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -421,7 +421,7 @@ msgstr "No se puede jalar un directorio sin - recursivo"
 msgid "Can't read from stdin: %s"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -446,12 +446,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "Certificado del cliente almacenado en el servidor:"
 
@@ -570,7 +570,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -729,8 +729,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -986,7 +986,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -994,7 +994,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1105,7 +1105,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1124,7 +1124,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1346,7 +1346,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1466,7 +1466,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1599,11 +1599,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1673,7 +1673,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1710,11 +1710,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1819,7 +1819,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1853,27 +1853,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1907,7 +1907,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1936,7 +1936,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -2008,7 +2008,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -2024,19 +2024,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2069,11 +2069,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2161,7 +2161,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2486,7 +2486,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2526,7 +2526,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2778,7 +2778,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2816,7 +2816,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3072,7 +3072,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3122,7 +3122,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3130,7 +3130,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3154,7 +3154,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3214,11 +3214,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2018-03-06 13:50+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -283,12 +283,12 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
@@ -305,7 +305,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -318,7 +318,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -383,7 +383,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -466,7 +466,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -494,12 +494,12 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "Certificat client enregistré sur le serveur : "
 
@@ -626,7 +626,7 @@ msgstr "Copie de l'image : %s"
 msgid "Copying the storage volume: %s"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
@@ -811,8 +811,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1085,7 +1085,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
@@ -1216,7 +1216,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
@@ -1235,7 +1235,7 @@ msgstr "Clé de configuration invalide"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
@@ -1266,7 +1266,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1649,7 +1649,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1792,11 +1792,11 @@ msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr "NON"
 
@@ -1870,7 +1870,7 @@ msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -1907,11 +1907,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -2017,7 +2017,7 @@ msgstr "Profils : %s"
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -2056,27 +2056,27 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
@@ -2114,7 +2114,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove profiles from containers"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -2221,7 +2221,7 @@ msgstr "SOURCE"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -2238,21 +2238,21 @@ msgstr "ENSEMBLE DE STOCKAGE"
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -2291,11 +2291,11 @@ msgstr "Clé de configuration invalide"
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 #, fuzzy
 msgid "Set the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -2394,7 +2394,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show the container's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -2655,7 +2655,7 @@ msgstr "Type : persistant"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr "URL"
 
@@ -2741,7 +2741,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr "OUI"
 
@@ -2784,7 +2784,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr "par défaut"
 
@@ -3052,7 +3052,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 #, fuzzy
 msgid "get-default"
 msgstr "par défaut"
@@ -3091,7 +3091,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3378,7 +3378,7 @@ msgstr "Nom du réseau"
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr "ok (y/n) ?"
 
@@ -3455,7 +3455,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 #, fuzzy
 msgid "remote"
 msgstr "Serveur distant : %s"
@@ -3464,7 +3464,7 @@ msgstr "Serveur distant : %s"
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3560,12 +3560,12 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 #, fuzzy
 msgid "set-default <remote>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2018-03-06 13:50+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -283,7 +283,7 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
@@ -466,7 +466,7 @@ msgstr "impossible de récupérer un répertoire sans --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -811,8 +811,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1085,7 +1085,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1235,7 +1235,7 @@ msgstr "Clé de configuration invalide"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
@@ -1522,7 +1522,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1792,11 +1792,11 @@ msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr "NON"
 
@@ -1907,11 +1907,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -2056,12 +2056,12 @@ msgstr "Récupération de l'image : %s"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
@@ -2071,7 +2071,7 @@ msgstr "le serveur distant %s n'existe pas"
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
@@ -2114,7 +2114,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Remove profiles from containers"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -2144,7 +2144,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -2221,7 +2221,7 @@ msgstr "SOURCE"
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr "STATIQUE"
 
@@ -2291,11 +2291,11 @@ msgstr "Clé de configuration invalide"
 msgid "Set storage volume configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 #, fuzzy
 msgid "Set the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -2655,7 +2655,7 @@ msgstr "Type : persistant"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr "URL"
 
@@ -2741,7 +2741,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr "OUI"
 
@@ -2869,7 +2869,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr "par défaut"
 
@@ -3091,7 +3091,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3464,7 +3464,7 @@ msgstr "Serveur distant : %s"
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3488,7 +3488,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3560,12 +3560,12 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 #, fuzzy
 msgid "set-default <remote>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -208,11 +208,11 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
@@ -229,7 +229,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Alias:"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -241,7 +241,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Password amministratore per %s: "
@@ -305,7 +305,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -387,7 +387,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -412,12 +412,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "Certificato del client salvato dal server: "
 
@@ -536,7 +536,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -696,8 +696,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -962,7 +962,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
@@ -1124,7 +1124,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1439,7 +1439,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1571,11 +1571,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1645,7 +1645,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1682,11 +1682,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1792,7 +1792,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1826,27 +1826,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1998,19 +1998,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2043,11 +2043,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2135,7 +2135,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2504,7 +2504,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2756,7 +2756,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3050,7 +3050,7 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
@@ -3100,7 +3100,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3108,7 +3108,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3132,7 +3132,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3192,11 +3192,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -208,7 +208,7 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -696,8 +696,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -954,7 +954,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
@@ -1317,7 +1317,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1571,11 +1571,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1682,11 +1682,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1826,12 +1826,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
@@ -1841,7 +1841,7 @@ msgstr "il remote %s non esiste"
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
@@ -1880,7 +1880,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1909,7 +1909,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1982,7 +1982,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2043,11 +2043,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2386,7 +2386,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2794,7 +2794,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3108,7 +3108,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3132,7 +3132,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3192,11 +3192,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2018-04-16 01:37+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -187,11 +187,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
@@ -207,7 +207,7 @@ msgstr "コンテナもしくはプロファイルにデバイスを追加しま
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
@@ -219,7 +219,7 @@ msgstr "新たに信頼済みのクライアントを追加します"
 msgid "Add profiles to containers"
 msgstr "コンテナにプロファイルを追加します"
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "%s の管理者パスワード: "
@@ -287,7 +287,7 @@ msgstr ""
 "このコマンドはコンテナのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -369,7 +369,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
@@ -396,12 +396,12 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "クライアント証明書がサーバに格納されました: "
 
@@ -529,7 +529,7 @@ msgstr "イメージのコピー中: %s"
 msgid "Copying the storage volume: %s"
 msgstr "ストレージボリュームのコピー中: %s"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
@@ -691,8 +691,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -963,7 +963,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -971,7 +971,7 @@ msgstr "フォーマット (csv|json|table|yaml)"
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
@@ -1086,7 +1086,7 @@ msgstr "入力するデータ"
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
@@ -1106,7 +1106,7 @@ msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %q"
@@ -1139,7 +1139,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -1409,7 +1409,7 @@ msgstr "プロファイルを一覧表示します"
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -1546,7 +1546,7 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
@@ -1682,11 +1682,11 @@ msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1756,7 +1756,7 @@ msgstr "%q に設定する値が指定されていません"
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチできます。"
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -1793,11 +1793,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1902,7 +1902,7 @@ msgstr "プロファイル: %s"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -1936,27 +1936,27 @@ msgstr "イメージを更新します"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
@@ -1990,7 +1990,7 @@ msgstr "コンテナのデバイスを削除します"
 msgid "Remove profiles from containers"
 msgstr "コンテナからプロファイルを削除します"
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -2019,7 +2019,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -2113,19 +2113,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr "サーバの認証タイプ (tls もしくは macaroons)"
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -2158,11 +2158,11 @@ msgstr "ストレージプールの設定項目を設定します"
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr "デフォルトのリモートを設定します"
 
@@ -2250,7 +2250,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show the container's last 100 log lines?"
 msgstr "コンテナログの最後の 100 行を表示しますか?"
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -2509,7 +2509,7 @@ msgstr "タイプ: persistent"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2631,7 +2631,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2887,7 +2887,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3278,7 +3278,7 @@ msgstr "network"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
@@ -3334,7 +3334,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr "remote"
 
@@ -3342,7 +3342,7 @@ msgstr "remote"
 msgid "remove <alias>"
 msgstr "remove <alias>"
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3366,7 +3366,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3426,11 +3426,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr "set-default <remote>"
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2018-04-16 01:37+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -369,7 +369,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
@@ -691,8 +691,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -963,7 +963,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -1106,7 +1106,7 @@ msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %q"
@@ -1409,7 +1409,7 @@ msgstr "プロファイルを一覧表示します"
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
@@ -1682,11 +1682,11 @@ msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1793,11 +1793,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1936,12 +1936,12 @@ msgstr "イメージを更新します"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
@@ -1951,7 +1951,7 @@ msgstr "リモート %s は存在しません"
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
@@ -1990,7 +1990,7 @@ msgstr "コンテナのデバイスを削除します"
 msgid "Remove profiles from containers"
 msgstr "コンテナからプロファイルを削除します"
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
@@ -2019,7 +2019,7 @@ msgstr "ネットワーク名を変更します"
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -2097,7 +2097,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2158,11 +2158,11 @@ msgstr "ストレージプールの設定項目を設定します"
 msgid "Set storage volume configuration keys"
 msgstr "ストレージボリュームの設定項目を設定します"
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr "デフォルトのリモートを設定します"
 
@@ -2509,7 +2509,7 @@ msgstr "タイプ: persistent"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2589,7 +2589,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2715,7 +2715,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2925,7 +2925,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3342,7 +3342,7 @@ msgstr "remote"
 msgid "remove <alias>"
 msgstr "remove <alias>"
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3366,7 +3366,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3426,11 +3426,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr "set-default <remote>"
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2018-05-03 21:05+0200\n"
+        "POT-Creation-Date: 2018-05-03 22:00+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -176,7 +176,7 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid   "AUTH TYPE"
 msgstr  ""
 
@@ -350,7 +350,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -613,7 +613,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:243 lxc/cluster.go:290 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:179 lxc/config_device.go:252 lxc/config_device.go:318 lxc/config_device.go:405 lxc/config_device.go:493 lxc/config_device.go:582 lxc/config_device.go:650 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:35 lxc/delete.go:30 lxc/exec.go:39 lxc/file.go:40 lxc/file.go:73 lxc/file.go:122 lxc/file.go:185 lxc/file.go:352 lxc/image.go:42 lxc/image.go:131 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:571 lxc/image.go:775 lxc/image.go:889 lxc/image.go:1211 lxc/image.go:1284 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:46 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:31 lxc/network.go:32 lxc/network.go:104 lxc/network.go:177 lxc/network.go:250 lxc/network.go:320 lxc/network.go:367 lxc/network.go:452 lxc/network.go:537 lxc/network.go:660 lxc/network.go:719 lxc/network.go:808 lxc/network.go:873 lxc/network.go:920 lxc/network.go:989 lxc/network.go:1051 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:98 lxc/operation.go:174 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:163 lxc/profile.go:241 lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520 lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753 lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418 lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328 lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645 lxc/storage.go:729 lxc/storage_volume.go:34 lxc/storage_volume.go:122 lxc/storage_volume.go:201 lxc/storage_volume.go:283 lxc/storage_volume.go:412 lxc/storage_volume.go:487 lxc/storage_volume.go:547 lxc/storage_volume.go:629 lxc/storage_volume.go:710 lxc/storage_volume.go:839 lxc/storage_volume.go:904 lxc/storage_volume.go:980 lxc/storage_volume.go:1011 lxc/storage_volume.go:1075 lxc/storage_volume.go:1152 lxc/storage_volume.go:1227 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:243 lxc/cluster.go:290 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:179 lxc/config_device.go:252 lxc/config_device.go:318 lxc/config_device.go:405 lxc/config_device.go:493 lxc/config_device.go:582 lxc/config_device.go:650 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:35 lxc/delete.go:30 lxc/exec.go:39 lxc/file.go:40 lxc/file.go:73 lxc/file.go:122 lxc/file.go:185 lxc/file.go:352 lxc/image.go:42 lxc/image.go:131 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:571 lxc/image.go:775 lxc/image.go:889 lxc/image.go:1211 lxc/image.go:1284 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:46 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:31 lxc/network.go:32 lxc/network.go:104 lxc/network.go:177 lxc/network.go:250 lxc/network.go:320 lxc/network.go:367 lxc/network.go:452 lxc/network.go:537 lxc/network.go:660 lxc/network.go:719 lxc/network.go:808 lxc/network.go:873 lxc/network.go:920 lxc/network.go:989 lxc/network.go:1051 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:98 lxc/operation.go:174 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:163 lxc/profile.go:241 lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520 lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753 lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419 lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328 lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645 lxc/storage.go:729 lxc/storage_volume.go:34 lxc/storage_volume.go:122 lxc/storage_volume.go:201 lxc/storage_volume.go:283 lxc/storage_volume.go:412 lxc/storage_volume.go:487 lxc/storage_volume.go:547 lxc/storage_volume.go:629 lxc/storage_volume.go:710 lxc/storage_volume.go:839 lxc/storage_volume.go:904 lxc/storage_volume.go:980 lxc/storage_volume.go:1011 lxc/storage_volume.go:1075 lxc/storage_volume.go:1152 lxc/storage_volume.go:1227 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -851,7 +851,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -986,7 +986,7 @@ msgstr  ""
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
@@ -1200,7 +1200,7 @@ msgstr  ""
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -1430,11 +1430,11 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613 lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613 lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid   "NO"
 msgstr  ""
 
@@ -1541,11 +1541,11 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -1682,12 +1682,12 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
@@ -1697,7 +1697,7 @@ msgstr  ""
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
@@ -1736,7 +1736,7 @@ msgstr  ""
 msgid   "Remove profiles from containers"
 msgstr  ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -1764,7 +1764,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -1834,7 +1834,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid   "STATIC"
 msgstr  ""
 
@@ -1895,11 +1895,11 @@ msgstr  ""
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid   "Set the default remote"
 msgstr  ""
 
@@ -2230,7 +2230,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid   "URL"
 msgstr  ""
 
@@ -2302,7 +2302,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid   "YES"
 msgstr  ""
 
@@ -2422,7 +2422,7 @@ msgstr  ""
 msgid   "create [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid   "default"
 msgstr  ""
 
@@ -2623,7 +2623,7 @@ msgstr  ""
 msgid   "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid   "list"
 msgstr  ""
 
@@ -2897,7 +2897,7 @@ msgstr  ""
 msgid   "remove <alias>"
 msgstr  ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid   "remove <remote>"
 msgstr  ""
 
@@ -2921,7 +2921,7 @@ msgstr  ""
 msgid   "rename <old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid   "rename <remote> <new-name>"
 msgstr  ""
 
@@ -2981,11 +2981,11 @@ msgstr  ""
 msgid   "set [<remote>:][<container>] <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid   "set-default <remote>"
 msgstr  ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid   "set-url <remote> <URL>"
 msgstr  ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2018-05-02 15:53+0000\n"
+        "POT-Creation-Date: 2018-05-03 21:05+0200\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -176,11 +176,11 @@ msgstr  ""
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid   "Accept certificate"
 msgstr  ""
 
@@ -196,7 +196,7 @@ msgstr  ""
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid   "Add new remote servers"
 msgstr  ""
 
@@ -208,7 +208,7 @@ msgstr  ""
 msgid   "Add profiles to containers"
 msgstr  ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid   "Admin password for %s: "
 msgstr  ""
@@ -271,7 +271,7 @@ msgid   "Attach to container consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -350,7 +350,7 @@ msgstr  ""
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid   "Can't remove the default remote"
 msgstr  ""
 
@@ -375,12 +375,12 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid   "Client certificate stored at server: "
 msgstr  ""
 
@@ -488,7 +488,7 @@ msgstr  ""
 msgid   "Copying the storage volume: %s"
 msgstr  ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid   "Could not create server cert dir"
 msgstr  ""
 
@@ -613,7 +613,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:243 lxc/cluster.go:290 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:179 lxc/config_device.go:252 lxc/config_device.go:318 lxc/config_device.go:405 lxc/config_device.go:493 lxc/config_device.go:582 lxc/config_device.go:650 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:35 lxc/delete.go:30 lxc/exec.go:39 lxc/file.go:40 lxc/file.go:73 lxc/file.go:122 lxc/file.go:185 lxc/file.go:352 lxc/image.go:42 lxc/image.go:131 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:571 lxc/image.go:775 lxc/image.go:889 lxc/image.go:1211 lxc/image.go:1284 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:46 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:31 lxc/network.go:32 lxc/network.go:104 lxc/network.go:177 lxc/network.go:250 lxc/network.go:320 lxc/network.go:367 lxc/network.go:452 lxc/network.go:537 lxc/network.go:660 lxc/network.go:719 lxc/network.go:808 lxc/network.go:873 lxc/network.go:920 lxc/network.go:989 lxc/network.go:1051 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:98 lxc/operation.go:174 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:163 lxc/profile.go:241 lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520 lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753 lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414 lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328 lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645 lxc/storage.go:729 lxc/storage_volume.go:34 lxc/storage_volume.go:122 lxc/storage_volume.go:201 lxc/storage_volume.go:283 lxc/storage_volume.go:412 lxc/storage_volume.go:487 lxc/storage_volume.go:547 lxc/storage_volume.go:629 lxc/storage_volume.go:710 lxc/storage_volume.go:839 lxc/storage_volume.go:904 lxc/storage_volume.go:980 lxc/storage_volume.go:1011 lxc/storage_volume.go:1075 lxc/storage_volume.go:1152 lxc/storage_volume.go:1227 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:243 lxc/cluster.go:290 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:179 lxc/config_device.go:252 lxc/config_device.go:318 lxc/config_device.go:405 lxc/config_device.go:493 lxc/config_device.go:582 lxc/config_device.go:650 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:35 lxc/delete.go:30 lxc/exec.go:39 lxc/file.go:40 lxc/file.go:73 lxc/file.go:122 lxc/file.go:185 lxc/file.go:352 lxc/image.go:42 lxc/image.go:131 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:571 lxc/image.go:775 lxc/image.go:889 lxc/image.go:1211 lxc/image.go:1284 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:46 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:31 lxc/network.go:32 lxc/network.go:104 lxc/network.go:177 lxc/network.go:250 lxc/network.go:320 lxc/network.go:367 lxc/network.go:452 lxc/network.go:537 lxc/network.go:660 lxc/network.go:719 lxc/network.go:808 lxc/network.go:873 lxc/network.go:920 lxc/network.go:989 lxc/network.go:1051 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:98 lxc/operation.go:174 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:163 lxc/profile.go:241 lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520 lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753 lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418 lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328 lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645 lxc/storage.go:729 lxc/storage_volume.go:34 lxc/storage_volume.go:122 lxc/storage_volume.go:201 lxc/storage_volume.go:283 lxc/storage_volume.go:412 lxc/storage_volume.go:487 lxc/storage_volume.go:547 lxc/storage_volume.go:629 lxc/storage_volume.go:710 lxc/storage_volume.go:839 lxc/storage_volume.go:904 lxc/storage_volume.go:980 lxc/storage_volume.go:1011 lxc/storage_volume.go:1075 lxc/storage_volume.go:1152 lxc/storage_volume.go:1227 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -851,7 +851,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -859,7 +859,7 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
@@ -967,7 +967,7 @@ msgstr  ""
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
@@ -986,7 +986,7 @@ msgstr  ""
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
@@ -1015,7 +1015,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -1200,7 +1200,7 @@ msgstr  ""
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid   "List the available remotes"
 msgstr  ""
 
@@ -1317,7 +1317,7 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
@@ -1430,11 +1430,11 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613 lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613 lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid   "NO"
 msgstr  ""
 
@@ -1504,7 +1504,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be attached to containers."
 msgstr  ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -1541,11 +1541,11 @@ msgstr  ""
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -1648,7 +1648,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid   "Public image server"
 msgstr  ""
 
@@ -1682,27 +1682,27 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid   "Remote admin password"
 msgstr  ""
 
@@ -1736,7 +1736,7 @@ msgstr  ""
 msgid   "Remove profiles from containers"
 msgstr  ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid   "Remove remotes"
 msgstr  ""
 
@@ -1764,7 +1764,7 @@ msgstr  ""
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -1834,7 +1834,7 @@ msgstr  ""
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid   "STATIC"
 msgstr  ""
 
@@ -1850,19 +1850,19 @@ msgstr  ""
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid   "Server authentication type (tls or macaroons)"
 msgstr  ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -1895,11 +1895,11 @@ msgstr  ""
 msgid   "Set storage volume configuration keys"
 msgstr  ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid   "Set the default remote"
 msgstr  ""
 
@@ -1987,7 +1987,7 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -2230,7 +2230,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid   "URL"
 msgstr  ""
 
@@ -2302,7 +2302,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid   "YES"
 msgstr  ""
 
@@ -2342,7 +2342,7 @@ msgstr  ""
 msgid   "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid   "add [<remote>] <IP|FQDN|URL>"
 msgstr  ""
 
@@ -2422,7 +2422,7 @@ msgstr  ""
 msgid   "create [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid   "default"
 msgstr  ""
 
@@ -2587,7 +2587,7 @@ msgstr  ""
 msgid   "get [<remote>:][<container>] <key>"
 msgstr  ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid   "get-default"
 msgstr  ""
 
@@ -2623,7 +2623,7 @@ msgstr  ""
 msgid   "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid   "list"
 msgstr  ""
 
@@ -2845,7 +2845,7 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid   "ok (y/n)?"
 msgstr  ""
 
@@ -2889,7 +2889,7 @@ msgstr  ""
 msgid   "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid   "remote"
 msgstr  ""
 
@@ -2897,7 +2897,7 @@ msgstr  ""
 msgid   "remove <alias>"
 msgstr  ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid   "remove <remote>"
 msgstr  ""
 
@@ -2921,7 +2921,7 @@ msgstr  ""
 msgid   "rename <old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid   "rename <remote> <new-name>"
 msgstr  ""
 
@@ -2981,11 +2981,11 @@ msgstr  ""
 msgid   "set [<remote>:][<container>] <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid   "set-default <remote>"
 msgstr  ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid   "set-url <remote> <URL>"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2018-03-08 09:21+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -200,11 +200,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -220,7 +220,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -232,7 +232,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -296,7 +296,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -377,7 +377,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -402,12 +402,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -526,7 +526,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -684,8 +684,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -941,7 +941,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1060,7 +1060,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1109,7 +1109,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1420,7 +1420,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1551,11 +1551,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1625,7 +1625,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1662,11 +1662,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1771,7 +1771,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1805,27 +1805,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1859,7 +1859,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1976,19 +1976,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2021,11 +2021,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2113,7 +2113,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2361,7 +2361,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2438,7 +2438,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2478,7 +2478,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2729,7 +2729,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3023,7 +3023,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3073,7 +3073,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3081,7 +3081,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3105,7 +3105,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3165,11 +3165,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2018-03-08 09:21+0000\n"
 "Last-Translator: Paulo Coghi <paulo@coghi.com.br>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -200,7 +200,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -377,7 +377,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -684,8 +684,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -941,7 +941,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1079,7 +1079,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1300,7 +1300,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1551,11 +1551,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1662,11 +1662,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1805,12 +1805,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1820,7 +1820,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1859,7 +1859,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1888,7 +1888,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1960,7 +1960,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2021,11 +2021,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2361,7 +2361,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2438,7 +2438,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2562,7 +2562,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2767,7 +2767,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3081,7 +3081,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3105,7 +3105,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3165,11 +3165,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -270,11 +270,11 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
@@ -291,7 +291,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -303,7 +303,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -367,7 +367,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -475,12 +475,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr "Сертификат клиента хранится на сервере: "
 
@@ -600,7 +600,7 @@ msgstr "Копирование образа: %s"
 msgid "Copying the storage volume: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
@@ -766,8 +766,8 @@ msgstr "Копирование образа: %s"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1034,7 +1034,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1196,7 +1196,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1513,7 +1513,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1648,11 +1648,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1723,7 +1723,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1760,11 +1760,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1904,27 +1904,27 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1959,7 +1959,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -2078,19 +2078,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2123,11 +2123,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2217,7 +2217,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2584,7 +2584,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2669,7 +2669,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2848,7 +2848,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3146,7 +3146,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3212,7 +3212,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3220,7 +3220,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3244,7 +3244,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3312,11 +3312,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: 2017-09-05 16:48+0000\n"
 "Last-Translator: Ilya Yakimavets <ilya.yakimavets@backend.expert>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -270,7 +270,7 @@ msgstr "ARCH"
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -450,7 +450,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -766,8 +766,8 @@ msgstr "Копирование образа: %s"
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1166,7 +1166,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1390,7 +1390,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1648,11 +1648,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1760,11 +1760,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1904,12 +1904,12 @@ msgstr "Копирование образа: %s"
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1959,7 +1959,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1989,7 +1989,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2123,11 +2123,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2467,7 +2467,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2544,7 +2544,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2669,7 +2669,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3220,7 +3220,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3244,7 +3244,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3312,11 +3312,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-02 15:53+0000\n"
+"POT-Creation-Date: 2018-05-03 21:05+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,11 +183,11 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:88
+#: lxc/remote.go:91
 msgid "Accept certificate"
 msgstr ""
 
@@ -203,7 +203,7 @@ msgstr ""
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83 lxc/remote.go:84
+#: lxc/remote.go:86 lxc/remote.go:87
 msgid "Add new remote servers"
 msgstr ""
 
@@ -215,7 +215,7 @@ msgstr ""
 msgid "Add profiles to containers"
 msgstr ""
 
-#: lxc/remote.go:325
+#: lxc/remote.go:328
 #, c-format
 msgid "Admin password for %s: "
 msgstr ""
@@ -279,7 +279,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:308
+#: lxc/remote.go:311
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:577
+#: lxc/remote.go:613
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -385,12 +385,12 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:252
+#: lxc/remote.go:255
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:364
+#: lxc/remote.go:367
 msgid "Client certificate stored at server: "
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Copying the storage volume: %s"
 msgstr ""
 
-#: lxc/remote.go:267
+#: lxc/remote.go:270
 msgid "Could not create server cert dir"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:34 lxc/remote.go:84 lxc/remote.go:380 lxc/remote.go:414
-#: lxc/remote.go:487 lxc/remote.go:549 lxc/remote.go:598 lxc/remote.go:636
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
+#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -932,7 +932,7 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:211
+#: lxc/remote.go:214
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
@@ -1043,7 +1043,7 @@ msgstr ""
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:163
+#: lxc/remote.go:166
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1092,7 +1092,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:152
+#: lxc/remote.go:155
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:413 lxc/remote.go:414
+#: lxc/remote.go:417 lxc/remote.go:418
 msgid "List the available remotes"
 msgstr ""
 
@@ -1403,7 +1403,7 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:33 lxc/remote.go:34
+#: lxc/remote.go:36 lxc/remote.go:37
 msgid "Manage the list of remote servers"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:463 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:434 lxc/remote.go:439
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
 msgid "NO"
 msgstr ""
 
@@ -1608,7 +1608,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be attached to containers."
 msgstr ""
 
-#: lxc/remote.go:146
+#: lxc/remote.go:149
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:465
+#: lxc/remote.go:466
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:467
+#: lxc/image.go:923 lxc/remote.go:468
 msgid "PUBLIC"
 msgstr ""
 
@@ -1754,7 +1754,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:92
+#: lxc/remote.go:95
 msgid "Public image server"
 msgstr ""
 
@@ -1788,27 +1788,27 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:551
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:507 lxc/remote.go:569 lxc/remote.go:618 lxc/remote.go:656
+#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:116
+#: lxc/remote.go:119
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:511 lxc/remote.go:573 lxc/remote.go:660
+#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:89
+#: lxc/remote.go:92
 msgid "Remote admin password"
 msgstr ""
 
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:548 lxc/remote.go:549
+#: lxc/remote.go:584 lxc/remote.go:585
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:486 lxc/remote.go:487
+#: lxc/remote.go:522 lxc/remote.go:523
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:468
+#: lxc/remote.go:469
 msgid "STATIC"
 msgstr ""
 
@@ -1959,19 +1959,19 @@ msgstr ""
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:91
+#: lxc/remote.go:94
 msgid "Server authentication type (tls or macaroons)"
 msgstr ""
 
-#: lxc/remote.go:260
+#: lxc/remote.go:263
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:360
+#: lxc/remote.go:363
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:90
+#: lxc/remote.go:93
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:635 lxc/remote.go:636
+#: lxc/remote.go:671 lxc/remote.go:672
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:597 lxc/remote.go:598
+#: lxc/remote.go:633 lxc/remote.go:634
 msgid "Set the default remote"
 msgstr ""
 
@@ -2096,7 +2096,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:379 lxc/remote.go:380
+#: lxc/remote.go:382 lxc/remote.go:383
 msgid "Show the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:464
+#: lxc/cluster.go:125 lxc/remote.go:465
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:436 lxc/remote.go:441
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
 msgid "YES"
 msgstr ""
 
@@ -2461,7 +2461,7 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:85
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:453
+#: lxc/remote.go:458
 msgid "default"
 msgstr ""
 
@@ -2712,7 +2712,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:378
+#: lxc/remote.go:381
 msgid "get-default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:411
+#: lxc/alias.go:96 lxc/remote.go:415
 msgid "list"
 msgstr ""
 
@@ -3006,7 +3006,7 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:253
+#: lxc/remote.go:256
 msgid "ok (y/n)?"
 msgstr ""
 
@@ -3056,7 +3056,7 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:32
+#: lxc/remote.go:35
 msgid "remote"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:546
+#: lxc/remote.go:582
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:484
+#: lxc/remote.go:520
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:596
+#: lxc/remote.go:632
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:634
+#: lxc/remote.go:670
 msgid "set-url <remote> <URL>"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-05-03 21:05+0200\n"
+"POT-Creation-Date: 2018-05-03 22:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:467
+#: lxc/remote.go:468
 msgid "AUTH TYPE"
 msgstr ""
 
@@ -360,7 +360,7 @@ msgstr ""
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:613
+#: lxc/remote.go:614
 msgid "Can't remove the default remote"
 msgstr ""
 
@@ -667,8 +667,8 @@ msgstr ""
 #: lxc/profile.go:297 lxc/profile.go:348 lxc/profile.go:396 lxc/profile.go:520
 #: lxc/profile.go:568 lxc/profile.go:632 lxc/profile.go:705 lxc/profile.go:753
 #: lxc/profile.go:812 lxc/profile.go:866 lxc/publish.go:34 lxc/query.go:30
-#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:418
-#: lxc/remote.go:523 lxc/remote.go:585 lxc/remote.go:634 lxc/remote.go:672
+#: lxc/remote.go:37 lxc/remote.go:87 lxc/remote.go:383 lxc/remote.go:419
+#: lxc/remote.go:524 lxc/remote.go:586 lxc/remote.go:635 lxc/remote.go:673
 #: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33
 #: lxc/storage.go:89 lxc/storage.go:161 lxc/storage.go:208 lxc/storage.go:328
 #: lxc/storage.go:383 lxc/storage.go:491 lxc/storage.go:573 lxc/storage.go:645
@@ -924,7 +924,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:422
+#: lxc/image.go:912 lxc/list.go:113 lxc/remote.go:423
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1062,7 +1062,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:506
+#: lxc/image.go:1195 lxc/list.go:365 lxc/remote.go:507
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1283,7 +1283,7 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "List the available remotes"
 msgstr ""
 
@@ -1534,11 +1534,11 @@ msgid "Must supply container name for: "
 msgstr ""
 
 #: lxc/cluster.go:124 lxc/list.go:453 lxc/network.go:781 lxc/profile.go:613
-#: lxc/remote.go:464 lxc/storage.go:544 lxc/storage_volume.go:952
+#: lxc/remote.go:465 lxc/storage.go:544 lxc/storage_volume.go:952
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:439 lxc/remote.go:444
+#: lxc/network.go:763 lxc/operation.go:138 lxc/remote.go:440 lxc/remote.go:445
 msgid "NO"
 msgstr ""
 
@@ -1645,11 +1645,11 @@ msgstr ""
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:466
+#: lxc/remote.go:467
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:923 lxc/remote.go:468
+#: lxc/image.go:923 lxc/remote.go:469
 msgid "PUBLIC"
 msgstr ""
 
@@ -1788,12 +1788,12 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:551
+#: lxc/remote.go:552
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/remote.go:543 lxc/remote.go:605 lxc/remote.go:654 lxc/remote.go:692
+#: lxc/remote.go:544 lxc/remote.go:606 lxc/remote.go:655 lxc/remote.go:693
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
@@ -1803,7 +1803,7 @@ msgstr ""
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:547 lxc/remote.go:609 lxc/remote.go:696
+#: lxc/remote.go:548 lxc/remote.go:610 lxc/remote.go:697
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
@@ -1842,7 +1842,7 @@ msgstr ""
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:584 lxc/remote.go:585
+#: lxc/remote.go:585 lxc/remote.go:586
 msgid "Remove remotes"
 msgstr ""
 
@@ -1871,7 +1871,7 @@ msgstr ""
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/remote.go:522 lxc/remote.go:523
+#: lxc/remote.go:523 lxc/remote.go:524
 msgid "Rename remotes"
 msgstr ""
 
@@ -1943,7 +1943,7 @@ msgstr ""
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:469
+#: lxc/remote.go:470
 msgid "STATIC"
 msgstr ""
 
@@ -2004,11 +2004,11 @@ msgstr ""
 msgid "Set storage volume configuration keys"
 msgstr ""
 
-#: lxc/remote.go:671 lxc/remote.go:672
+#: lxc/remote.go:672 lxc/remote.go:673
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/remote.go:633 lxc/remote.go:634
+#: lxc/remote.go:634 lxc/remote.go:635
 msgid "Set the default remote"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:465
+#: lxc/cluster.go:125 lxc/remote.go:466
 msgid "URL"
 msgstr ""
 
@@ -2421,7 +2421,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:441 lxc/remote.go:446
+#: lxc/network.go:765 lxc/operation.go:140 lxc/remote.go:442 lxc/remote.go:447
 msgid "YES"
 msgstr ""
 
@@ -2545,7 +2545,7 @@ msgstr ""
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/remote.go:458
+#: lxc/remote.go:459
 msgid "default"
 msgstr ""
 
@@ -2750,7 +2750,7 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:415
+#: lxc/alias.go:96 lxc/remote.go:416
 msgid "list"
 msgstr ""
 
@@ -3064,7 +3064,7 @@ msgstr ""
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:582
+#: lxc/remote.go:583
 msgid "remove <remote>"
 msgstr ""
 
@@ -3088,7 +3088,7 @@ msgstr ""
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:520
+#: lxc/remote.go:521
 msgid "rename <remote> <new-name>"
 msgstr ""
 
@@ -3148,11 +3148,11 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:632
+#: lxc/remote.go:633
 msgid "set-default <remote>"
 msgstr ""
 
-#: lxc/remote.go:670
+#: lxc/remote.go:671
 msgid "set-url <remote> <URL>"
 msgstr ""
 


### PR DESCRIPTION
This adds the --format option to lxc remote list
closes #4500 