### PR TITLE
devices: clone mode of device

### DIFF
--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -798,7 +798,7 @@ func deviceUSBEvent(s *state.State, usb usbDevice) {
 			}
 
 			if usb.action == "add" {
-				err := c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", name), m, usb.major, usb.minor, usb.path)
+				err := c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", name), m, usb.major, usb.minor, usb.path, false)
 				if err != nil {
 					logger.Error("failed to create usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
@@ -1829,7 +1829,7 @@ func deviceInotifyDirRescan(s *state.State) {
 			}
 			cleanDevPath := filepath.Clean(cmp)
 			if shared.PathExists(cleanDevPath) {
-				c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m)
+				c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m, false)
 			} else {
 				c.removeUnixDevice(fmt.Sprintf("unix.%s", name), m, true)
 			}
@@ -2011,7 +2011,7 @@ func deviceInotifyFileEvent(s *state.State, target *sys.InotifyTargetInfo) {
 			}
 
 			if (target.Mask & syscall.IN_CREATE) > 0 {
-				err := c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m)
+				err := c.insertUnixDevice(fmt.Sprintf("unix.%s", name), m, false)
 				if err != nil {
 					logger.Error("Failed to create unix device", log.Ctx{"err": err, "dev": m, "container": c.Name()})
 					continue

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -335,6 +335,23 @@ func GetFileStat(p string) (uid int, gid int, major int, minor int,
 	return
 }
 
+// FileCopy copies a file, overwriting the target if it exists.
+func GetPathMode(path string) (os.FileMode, error) {
+	s, err := os.Open(path)
+	if err != nil {
+		return os.FileMode(0000), err
+	}
+	defer s.Close()
+
+	fi, err := s.Stat()
+	if err != nil {
+		return os.FileMode(0000), err
+	}
+
+	mode, _, _ := GetOwnerMode(fi)
+	return mode, nil
+}
+
 func parseMountinfo(name string) int {
 	// In case someone uses symlinks we need to look for the actual
 	// mountpoint.


### PR DESCRIPTION
Copy the mode of a devices for:
- Implicitly Added Devices:
  Some device types (e.g. infiniband or (Nvidia) gpu) implicitly add devices to
  guarantee correct functionality.
- Nvidia GPUs:
  In order for Nvidia tools to correctly function we need to copy the mode of
  the devices. We should do this for GPUs in general.
- Hotplugged Devices:
  We can retrieve the mode of devices that are supposed to be hotplugged.

Closes #4534.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>