### PR TITLE
container_lxc: fix optional property for disk devs

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7527,6 +7527,10 @@ func (c *containerLXC) insertDiskDevice(name string, m types.Device) error {
 		return fmt.Errorf("Failed to setup device: %s", err)
 	}
 
+	if devPath == "" && shared.IsTrue(m["optional"]) {
+		return nil
+	}
+
 	flags := syscall.MS_BIND
 	if isRecursive {
 		flags |= syscall.MS_REC


### PR DESCRIPTION
Closes #4538.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>