### PR TITLE
lxd/callhook: Respect LXD_SOCKET environment variable

### DIFF
--- a/lxd/main_callhook.go
+++ b/lxd/main_callhook.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -54,7 +55,11 @@ func (c *cmdCallhook) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Connect to LXD
-	d, err := lxd.ConnectLXDUnix(fmt.Sprintf("%s/unix.socket", path), nil)
+	socket := os.Getenv("LXD_SOCKET")
+	if socket == "" {
+		socket = filepath.Join(path, "unix.socket")
+	}
+	d, err := lxd.ConnectLXDUnix(socket, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It seems that I didn't properly check the `LXD_SOCKET` implementation in #4426 . Because in the meantime I found a missing piece: `lxd callhook` also needs to support the environmental variable (see ganto/copr-lxc3#4).

> First check the LXD_SOCKET environment variable which might
> contain a user provided Unix socket before trying to connect
> to default LXD socket.