### PR TITLE
Serialize reads to the cluster database

### DIFF
--- a/lxd/containers_get.go
+++ b/lxd/containers_get.go
@@ -80,7 +80,6 @@ func doContainersGet(d *Daemon, r *http.Request) (interface{}, error) {
 		resultMu.Unlock()
 	}
 
-	wg := sync.WaitGroup{}
 	for address, containers := range result {
 		// If this is an internal request from another cluster node,
 		// ignore containers from other nodes, and return only the ones
@@ -101,9 +100,7 @@ func doContainersGet(d *Daemon, r *http.Request) (interface{}, error) {
 		// For recursion requests we need to fetch the state of remote
 		// containers from their respective nodes.
 		if recursion && address != "" && !isClusterNotification(r) {
-			wg.Add(1)
-			go func(address string, containers []string) {
-				defer wg.Done()
+			func(address string, containers []string) {
 				cert := d.endpoints.NetworkCert()
 
 				cs, err := doContainersGetFromNode(address, cert)
@@ -138,7 +135,6 @@ func doContainersGet(d *Daemon, r *http.Request) (interface{}, error) {
 			}
 		}
 	}
-	wg.Wait()
 
 	if !recursion {
 		return resultString, nil

--- a/lxd/profiles_test.go
+++ b/lxd/profiles_test.go
@@ -9,7 +9,10 @@ import (
 func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
-	db := cluster.DB()
+	tx, err := cluster.DB().Begin()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Insert a container and a related profile. Dont't forget that the profile
 	// we insert is profile ID 2 (there is a default profile already).
@@ -21,7 +24,11 @@ func Test_removing_a_profile_deletes_associated_configuration_entries(t *testing
     INSERT INTO profiles_config (key, value, profile_id) VALUES ('thekey', 'thevalue', 2);
     INSERT INTO profiles_devices_config (profile_device_id, key, value) VALUES (1, 'something', 'boring');`
 
-	_, err := db.Exec(statements)
+	_, err = tx.Exec(statements)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tx.Commit()
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This change makes us use transactions also in test code, and the /internal/sql
API endpoint which was not doing that before.

It also drops concurrent calls in the GET /containers and cluster heartbeat
code, since at the moment they are hardly going to take advantage of
concurrency, as the nodes are going to serialize db reads anyways (and db reads
atm are a substantial part of the total time spent in handling an API request).

The lower-level change to actually serialize reads was committed partly in
go-grpc-sql and partly in dqlite.

This should mitigate #4548 for now. Listing containers will still be relatively slow, but the timing is going to be predictable and consistent.

Moving forward we should start optimizing dqlite to be faster (I believe there
are substantial gains to be made there) , and perhaps also change the LXD code
that interacts with the database to be more efficient (e.g. caching prepared
statements, not entering/exiting a transaction for every query, etc).

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>