### PR TITLE
Redirect container/snapshost publish API requests to the relevant node

### DIFF
--- a/test/main.sh
+++ b/test/main.sh
@@ -208,6 +208,7 @@ run_test test_clustering_membership "clustering membership"
 run_test test_clustering_containers "clustering containers"
 run_test test_clustering_storage "clustering storage"
 run_test test_clustering_network "clustering network"
+run_test test_clustering_publish "clustering publish"
 #run_test test_clustering_upgrade "clustering upgrade"
 
 # shellcheck disable=SC2034

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -750,3 +750,50 @@ test_clustering_upgrade() {
   kill_lxd "${LXD_TWO_DIR}"
   kill_lxd "${LXD_THREE_DIR}"
 }
+
+test_clustering_publish() {
+  setup_clustering_bridge
+  prefix="lxd$$"
+  bridge="${prefix}"
+
+  setup_clustering_netns 1
+  LXD_ONE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_ONE_DIR}"
+  ns1="${prefix}1"
+  spawn_lxd_and_bootstrap_cluster "${ns1}" "${bridge}" "${LXD_ONE_DIR}"
+
+  # Add a newline at the end of each line. YAML as weird rules..
+  cert=$(sed ':a;N;$!ba;s/\n/\n\n/g' "${LXD_ONE_DIR}/server.crt")
+
+  # Spawn a second node
+  setup_clustering_netns 2
+  LXD_TWO_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
+  chmod +x "${LXD_TWO_DIR}"
+  ns2="${prefix}2"
+  spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
+
+  # Init a container on node2, using a client connected to node1
+  LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage
+  LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage foo
+
+  LXD_DIR="${LXD_ONE_DIR}" lxc publish foo --alias=foo-image
+  LXD_DIR="${LXD_ONE_DIR}" lxc image show foo-image | grep -q "public: false"
+  LXD_DIR="${LXD_TWO_DIR}" lxc image delete foo-image
+
+  LXD_DIR="${LXD_TWO_DIR}" lxc snapshot foo backup
+  LXD_DIR="${LXD_ONE_DIR}" lxc publish foo/backup --alias=foo-backup-image
+  LXD_DIR="${LXD_ONE_DIR}" lxc image show foo-backup-image | grep -q "public: false"
+
+  LXD_DIR="${LXD_TWO_DIR}" lxd shutdown
+  LXD_DIR="${LXD_ONE_DIR}" lxd shutdown
+  sleep 2
+  rm -f "${LXD_TWO_DIR}/unix.socket"
+  rm -f "${LXD_ONE_DIR}/unix.socket"
+
+  teardown_clustering_netns
+  teardown_clustering_bridge
+
+  kill_lxd "${LXD_ONE_DIR}"
+  kill_lxd "${LXD_TWO_DIR}"
+}
+


### PR DESCRIPTION
This fixes #4569.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>