### PR TITLE
gpu: fallback to default device mode

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -6204,7 +6204,11 @@ func (c *containerLXC) createUnixDevice(prefix string, m types.Device, defaultMo
 	} else if !defaultMode {
 		mode, err = shared.GetPathMode(srcPath)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to retrieve mode of device %s: %s", m["path"], err)
+			errno, isErrno := shared.GetErrno(err)
+			if !isErrno || errno != syscall.ENOENT {
+				return nil, fmt.Errorf("Failed to retrieve mode of device %s: %s", m["path"], err)
+			}
+			mode = os.FileMode(0660)
 		}
 	}
 


### PR DESCRIPTION
When the device in question does not exist we should fallback to the default
device mode.

Closes #4591.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>