### PR TITLE
Drop manual GC calls

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -11,7 +11,6 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -318,18 +317,6 @@ func (d *Daemon) createCmd(restAPI *mux.Router, version string, c Command) {
 				logger.Errorf("Failed writing error for error, giving up")
 			}
 		}
-
-		/*
-		 * When we create a new lxc.Container, it adds a finalizer (via
-		 * SetFinalizer) that frees the struct. However, it sometimes
-		 * takes the go GC a while to actually free the struct,
-		 * presumably since it is a small amount of memory.
-		 * Unfortunately, the struct also keeps the log fd open, so if
-		 * we leave too many of these around, we end up running out of
-		 * fds. So, let's explicitly do a GC to collect these at the
-		 * end of each request.
-		 */
-		runtime.GC()
 	})
 }
 

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"net/http"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -100,18 +99,6 @@ func (op *operation) done() {
 		if err != nil {
 			logger.Warnf("Failed to delete operation %s: %s", op.id, err)
 		}
-
-		/*
-		 * When we create a new lxc.Container, it adds a finalizer (via
-		 * SetFinalizer) that frees the struct. However, it sometimes
-		 * takes the go GC a while to actually free the struct,
-		 * presumably since it is a small amount of memory.
-		 * Unfortunately, the struct also keeps the log fd open, so if
-		 * we leave too many of these around, we end up running out of
-		 * fds. So, let's explicitly do a GC to collect these at the
-		 * end of each request.
-		 */
-		runtime.GC()
 	})
 }
 


### PR DESCRIPTION
The GC has come a long way since we had to add those calls to avoid fd
leaks when getting rid of references to the lxc struct.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>