### PR TITLE
Fix the storage_pool_id filter from the WHERE clause of StoragePoolsConfig

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -254,11 +254,11 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 	var networks map[string]map[string]string
 	var operations []string
 	err = state.Cluster.Transaction(func(tx *db.ClusterTx) error {
-		pools, err = tx.StoragePoolConfigs()
+		pools, err = tx.StoragePoolsNodeConfig()
 		if err != nil {
 			return err
 		}
-		networks, err = tx.NetworkConfigs()
+		networks, err = tx.NetworksNodeConfig()
 		if err != nil {
 			return err
 		}
@@ -367,13 +367,6 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 				if !ok {
 					return fmt.Errorf("joining node has no config for pool %s", name)
 				}
-				// We only need to add the node-specific keys, since
-				// the other keys are global and are already there.
-				for key := range config {
-					if !shared.StringInSlice(key, db.StoragePoolNodeConfigKeys) {
-						delete(config, key)
-					}
-				}
 				err = tx.StoragePoolConfigAdd(id, node.ID, config)
 				if err != nil {
 					return errors.Wrap(err, "failed to add joining node's pool config")
@@ -394,13 +387,6 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 			err := tx.NetworkNodeJoin(id, node.ID)
 			if err != nil {
 				return errors.Wrap(err, "failed to add joining node's to the network")
-			}
-			// We only need to add the node-specific keys, since
-			// the other keys are global and are already there.
-			for key := range config {
-				if !shared.StringInSlice(key, db.NetworkNodeConfigKeys) {
-					delete(config, key)
-				}
 			}
 			err = tx.NetworkConfigAdd(id, node.ID, config)
 			if err != nil {

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -29,7 +29,7 @@ func TestNetworksNodeConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, config, map[string]map[string]string{
-		"lxdbr0": map[string]string{"bridge.external_interfaces": "vlan0"},
+		"lxdbr0": {"bridge.external_interfaces": "vlan0"},
 	})
 }
 

--- a/lxd/db/networks_test.go
+++ b/lxd/db/networks_test.go
@@ -8,6 +8,31 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The NetworksNodeConfigs method returns only node-specific config values.
+func TestNetworksNodeConfigs(t *testing.T) {
+	cluster, cleanup := db.NewTestCluster(t)
+	defer cleanup()
+
+	_, err := cluster.NetworkCreate("lxdbr0", "", map[string]string{
+		"dns.mode":                   "none",
+		"bridge.external_interfaces": "vlan0",
+	})
+	require.NoError(t, err)
+
+	var config map[string]map[string]string
+
+	err = cluster.Transaction(func(tx *db.ClusterTx) error {
+		var err error
+		config, err = tx.NetworksNodeConfig()
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config, map[string]map[string]string{
+		"lxdbr0": map[string]string{"bridge.external_interfaces": "vlan0"},
+	})
+}
+
 func TestNetworkCreatePending(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()

--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -12,13 +12,9 @@ import (
 	"github.com/lxc/lxd/shared/api"
 )
 
-// StoragePoolConfigs returns a map associating each storage pool name to its
-// config values.
-//
-// The config values are the ones defined for the node this function is run
-// on. They are used by cluster.Join when a new node joins the cluster and its
-// configuration needs to be migrated to the cluster database.
-func (c *ClusterTx) StoragePoolConfigs() (map[string]map[string]string, error) {
+// StoragePoolsNodeConfig returns a map associating each storage pool name to
+// its node-specific config values (i.e. the ones where node_id is not NULL).
+func (c *ClusterTx) StoragePoolsNodeConfig() (map[string]map[string]string, error) {
 	names, err := query.SelectStrings(c.tx, "SELECT name FROM storage_pools")
 	if err != nil {
 		return nil, err
@@ -29,7 +25,7 @@ func (c *ClusterTx) StoragePoolConfigs() (map[string]map[string]string, error) {
 storage_pools_config JOIN storage_pools ON storage_pools.id=storage_pools_config.storage_pool_id
 `
 		config, err := query.SelectConfig(
-			c.tx, table, "storage_pools.name=? AND storage_pools_config.storage_pool_id=?",
+			c.tx, table, "storage_pools.name=? AND storage_pools_config.node_id=?",
 			name, c.nodeID)
 		if err != nil {
 			return nil, err

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -42,7 +42,7 @@ func TestStoragePoolsNodeConfigs(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, config, map[string]map[string]string{
-		"BTRFS": map[string]string{"source": "/egg/baz"},
+		"BTRFS": {"source": "/egg/baz"},
 	})
 }
 

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -8,6 +8,44 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// The StoragePoolsNodeConfigs method returns only node-specific config values.
+func TestStoragePoolsNodeConfigs(t *testing.T) {
+	cluster, cleanup := db.NewTestCluster(t)
+	defer cleanup()
+
+	// Create a storage pool named "local" (like the default LXD clustering
+	// one), then delete it and create another one.
+	_, err := cluster.StoragePoolCreate("local", "", "dir", map[string]string{
+		"rsync.bwlimit": "1",
+		"source":        "/foo/bar",
+	})
+	require.NoError(t, err)
+
+	_, err = cluster.StoragePoolDelete("local")
+	require.NoError(t, err)
+
+	_, err = cluster.StoragePoolCreate("BTRFS", "", "dir", map[string]string{
+		"rsync.bwlimit": "1",
+		"source":        "/egg/baz",
+	})
+	require.NoError(t, err)
+
+	// Check that the config map returned by StoragePoolsConfigs actually
+	// contains the value of the "BTRFS" storage pool.
+	var config map[string]map[string]string
+
+	err = cluster.Transaction(func(tx *db.ClusterTx) error {
+		var err error
+		config, err = tx.StoragePoolsNodeConfig()
+		return err
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, config, map[string]map[string]string{
+		"BTRFS": map[string]string{"source": "/egg/baz"},
+	})
+}
+
 func TestStoragePoolsCreatePending(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
@@ -116,7 +154,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 	cluster, cleanup := db.NewTestCluster(t)
 	defer cleanup()
 
-	// Create a second no (beyond the default one).
+	// Create a second node (beyond the default one).
 	err := cluster.Transaction(func(tx *db.ClusterTx) error {
 		_, err := tx.NodeAdd("n1", "1.2.3.4:666")
 		return err


### PR DESCRIPTION
The filter was broken since it should have been "storage_pools_config.node_id=?"
instead.

The method has been renamed to StoragePoolsNodeConfig for extra clarity.

I changed the logic of NetworksConfig to perform node filtering as well (and
renamed it to NetworksNodeConfig), and dropped Go-land manual filtering in the
call sites.

This fixes #4629.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>