### PR TITLE
Enable tcp KeepAlive

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -31,6 +31,10 @@ func RFC3493Dialer(network, address string) (net.Conn, error) {
 		if err != nil {
 			continue
 		}
+		if tc, ok := c.(*net.TCPConn); ok {
+			tc.SetKeepAlive(true)
+			tc.SetKeepAlivePeriod(3 * time.Second)
+		}
 		return c, err
 	}
 	return nil, fmt.Errorf("Unable to connect to: " + address)


### PR DESCRIPTION
With out keep alive, lxc will block indefinitely when there is network change.