### PR TITLE
lxd: Cleanup logging

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -68,7 +68,7 @@ func internalContainerOnStart(d *Daemon, r *http.Request) Response {
 
 	err = c.OnStart()
 	if err != nil {
-		logger.Error("start hook failed", log.Ctx{"container": c.Name(), "err": err})
+		logger.Error("The start hook failed", log.Ctx{"container": c.Name(), "err": err})
 		return SmartError(err)
 	}
 
@@ -93,7 +93,7 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 
 	err = c.OnStop(target)
 	if err != nil {
-		logger.Error("stop hook failed", log.Ctx{"container": c.Name(), "err": err})
+		logger.Error("The stop hook failed", log.Ctx{"container": c.Name(), "err": err})
 		return SmartError(err)
 	}
 

--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -477,7 +477,7 @@ func AADestroy(c container) error {
 	if state.OS.AppArmorStacking && !state.OS.AppArmorStacked {
 		p := path.Join("/sys/kernel/security/apparmor/policy/namespaces", AANamespace(c))
 		if err := os.Remove(p); err != nil {
-			logger.Error("error removing apparmor namespace", log.Ctx{"err": err, "ns": p})
+			logger.Error("Error removing apparmor namespace", log.Ctx{"err": err, "ns": p})
 		}
 	}
 

--- a/lxd/container_console.go
+++ b/lxd/container_console.go
@@ -44,7 +44,7 @@ type consoleWs struct {
 	// channel to wait until the control socket is connected
 	controlConnected chan bool
 
-	// map file descriptors -> secret
+	// map file descriptors to secret
 	fds map[int]string
 
 	// terminal width

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -178,9 +178,9 @@ func (s *execWs) Do(op *operation) error {
 					// If an abnormal closure occurred, kill the attached process.
 					err := syscall.Kill(attachedChildPid, syscall.SIGKILL)
 					if err != nil {
-						logger.Debugf("Failed to send SIGKILL to pid %d.", attachedChildPid)
+						logger.Debugf("Failed to send SIGKILL to pid %d", attachedChildPid)
 					} else {
-						logger.Debugf("Sent SIGKILL to pid %d.", attachedChildPid)
+						logger.Debugf("Sent SIGKILL to pid %d", attachedChildPid)
 					}
 					return
 				}
@@ -498,7 +498,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 
 		err = op.UpdateMetadata(metadata)
 		if err != nil {
-			logger.Error("error updating metadata for cmd", log.Ctx{"err": err, "cmd": post.Command})
+			logger.Error("Error updating metadata for cmd", log.Ctx{"err": err, "cmd": post.Command})
 		}
 
 		return cmdErr

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3578,7 +3578,7 @@ func writeBackupFile(c container) error {
 
 	/* deal with the container occasionally not being monuted */
 	if !shared.PathExists(c.RootfsPath()) {
-		logger.Warn("Unable to update backup.yaml at this time.", log.Ctx{"name": c.Name()})
+		logger.Warn("Unable to update backup.yaml at this time", log.Ctx{"name": c.Name()})
 		return nil
 	}
 
@@ -4341,7 +4341,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 
 					err := c.removeUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.major, gpu.minor, gpu.path)
 					if err != nil {
-						logger.Error("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						logger.Error("Failed to remove GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -4351,7 +4351,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 
 					err = c.removeUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.nvidia.major, gpu.nvidia.minor, gpu.nvidia.path)
 					if err != nil {
-						logger.Error("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						logger.Error("Failed to remove GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 				}
@@ -4373,7 +4373,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						}
 						err = c.removeUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.major, gpu.minor, gpu.path)
 						if err != nil {
-							logger.Error("Failed to remove GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							logger.Error("Failed to remove GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 							return err
 						}
 					}
@@ -4444,7 +4444,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 
 					err = c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, usb.major, usb.minor, usb.path, false)
 					if err != nil {
-						logger.Error("failed to insert usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
+						logger.Error("Failed to insert usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					}
 				}
 			} else if m["type"] == "gpu" {
@@ -4469,7 +4469,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 
 					err = c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.major, gpu.minor, gpu.path, false)
 					if err != nil {
-						logger.Error("Failed to insert GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						logger.Error("Failed to insert GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -4479,7 +4479,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 
 					err = c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.nvidia.major, gpu.nvidia.minor, gpu.nvidia.path, false)
 					if err != nil {
-						logger.Error("Failed to insert GPU device.", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+						logger.Error("Failed to insert GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 						return err
 					}
 
@@ -4493,7 +4493,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						}
 						err = c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", k), m, gpu.major, gpu.minor, gpu.path, false)
 						if err != nil {
-							logger.Error("failed to insert GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
+							logger.Error("Failed to insert GPU device", log.Ctx{"err": err, "gpu": gpu, "container": c.Name()})
 							return err
 						}
 					}
@@ -5057,7 +5057,7 @@ func (c *containerLXC) Migrate(args *CriuMigrationArgs) error {
 		prettyCmd = "feature-check"
 	default:
 		prettyCmd = "unknown"
-		logger.Warn("unknown migrate call", log.Ctx{"cmd": args.cmd})
+		logger.Warn("Unknown migrate call", log.Ctx{"cmd": args.cmd})
 	}
 
 	preservesInodes := c.storage.PreservesInodes()
@@ -5742,7 +5742,6 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 	r, w, err := shared.Pipe()
 	defer r.Close()
 	if err != nil {
-		logger.Errorf("%s", err)
 		return nil, -1, -1, err
 	}
 
@@ -6522,7 +6521,7 @@ func (c *containerLXC) removeUnixDeviceNum(prefix string, m types.Device, major 
 
 	err := c.removeUnixDevice(prefix, temp, true)
 	if err != nil {
-		logger.Error("failed to remove device", log.Ctx{"err": err, m["type"]: path, "container": c.Name()})
+		logger.Error("Failed to remove device", log.Ctx{"err": err, m["type"]: path, "container": c.Name()})
 		return err
 	}
 
@@ -6780,7 +6779,7 @@ func (c *containerLXC) removeUnixDevices() error {
 		devicePath := filepath.Join(c.DevicesPath(), f.Name())
 		err := os.Remove(devicePath)
 		if err != nil {
-			logger.Error("failed removing unix device", log.Ctx{"err": err, "path": devicePath})
+			logger.Error("Failed removing unix device", log.Ctx{"err": err, "path": devicePath})
 		}
 	}
 

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -208,8 +208,7 @@ func containerPostClusteringMigrateWithCeph(d *Daemon, c container, oldName, new
 		// If source node is online (i.e. we're serving the request on
 		// it, and c != nil), let's unmap the RBD volume locally
 		if c != nil {
-			logger.Debugf(`Renaming RBD storage volume for source container "%s" from `+
-				`"%s" to "%s"`, c.Name(), c.Name(), newName)
+			logger.Debugf(`Renaming RBD storage volume for source container "%s" from "%s" to "%s"`, c.Name(), c.Name(), newName)
 			poolName, err := c.StoragePool()
 			if err != nil {
 				return errors.Wrap(err, "Failed to get source container's storage pool name")

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -271,9 +271,6 @@ func containersShutdown(s *state.State) error {
 }
 
 func containerDeleteSnapshots(s *state.State, cname string) error {
-	logger.Debug("containerDeleteSnapshots",
-		log.Ctx{"container": cname})
-
 	results, err := s.Cluster.ContainerGetSnapshots(cname)
 	if err != nil {
 		return err

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -250,7 +250,7 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 		}
 	}
 
-	logger.Debugf("No valid storage pool in the container's local root disk device and profiles found.")
+	logger.Debugf("No valid storage pool in the container's local root disk device and profiles found")
 	// If there is just a single pool in the database, use that
 	if storagePool == "" {
 		pools, err := d.cluster.StoragePools()

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -267,20 +267,20 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		}
 
 		if shared.Int64InSlice(poolID, poolIDs) {
-			logger.Debugf("Image already exists on storage pool \"%s\".", storagePool)
+			logger.Debugf("Image already exists on storage pool \"%s\"", storagePool)
 			return info, nil
 		}
 
 		// Import the image in the pool
-		logger.Debugf("Image does not exist on storage pool \"%s\".", storagePool)
+		logger.Debugf("Image does not exist on storage pool \"%s\"", storagePool)
 
 		err = imageCreateInPool(d, info, storagePool)
 		if err != nil {
-			logger.Debugf("Failed to create image on storage pool \"%s\": %s.", storagePool, err)
+			logger.Debugf("Failed to create image on storage pool \"%s\": %s", storagePool, err)
 			return nil, err
 		}
 
-		logger.Debugf("Created image on storage pool \"%s\".", storagePool)
+		logger.Debugf("Created image on storage pool \"%s\"", storagePool)
 		return info, nil
 	}
 

--- a/lxd/db/migration.go
+++ b/lxd/db/migration.go
@@ -204,7 +204,7 @@ func (c *Cluster) ImportPreClusteringData(dump *Dump) error {
 				return fmt.Errorf("could not insert %d int %s", i, table)
 			}
 
-			// Also insert the image ID -> node ID association.
+			// Also insert the image ID to node ID association.
 			if shared.StringInSlice(table, []string{"images", "networks", "storage_pools"}) {
 				entity := table[:len(table)-1]
 				importNodeAssociation(entity, columns, row, tx)

--- a/lxd/db/node/update.go
+++ b/lxd/db/node/update.go
@@ -382,7 +382,7 @@ func updateFromV18(tx *sql.Tx) error {
 		// Deal with completely broken values
 		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
-			logger.Debugf("Invalid container memory limit, id=%d value=%s, removing.", id, value)
+			logger.Debugf("Invalid container memory limit, id=%d value=%s, removing", id, value)
 			_, err = tx.Exec("DELETE FROM containers_config WHERE id=?;", id)
 			if err != nil {
 				return err
@@ -427,7 +427,7 @@ func updateFromV18(tx *sql.Tx) error {
 		// Deal with completely broken values
 		_, err = shared.ParseByteSizeString(value)
 		if err != nil {
-			logger.Debugf("Invalid profile memory limit, id=%d value=%s, removing.", id, value)
+			logger.Debugf("Invalid profile memory limit, id=%d value=%s, removing", id, value)
 			_, err = tx.Exec("DELETE FROM profiles_config WHERE id=?;", id)
 			if err != nil {
 				return err

--- a/lxd/db/query/transaction.go
+++ b/lxd/db/query/transaction.go
@@ -32,7 +32,7 @@ func Transaction(db *sql.DB, f func(*sql.Tx) error) error {
 func rollback(tx *sql.Tx, reason error) error {
 	err := tx.Rollback()
 	if err != nil {
-		logger.Warnf("failed to rollback transaction after error (%v): %v", reason, err)
+		logger.Warnf("Failed to rollback transaction after error (%v): %v", reason, err)
 	}
 
 	return reason

--- a/lxd/db/schema/schema.go
+++ b/lxd/db/schema/schema.go
@@ -362,8 +362,7 @@ func checkSchemaVersionsHaveNoHoles(versions []int) error {
 	// versions.
 	for i := range versions[:len(versions)-1] {
 		if versions[i+1] != versions[i]+1 {
-			return fmt.Errorf(
-				"missing updates: %d -> %d", versions[i], versions[i+1])
+			return fmt.Errorf("Missing updates: %d to %d", versions[i], versions[i+1])
 		}
 	}
 	return nil

--- a/lxd/db/schema/schema_test.go
+++ b/lxd/db/schema/schema_test.go
@@ -79,7 +79,7 @@ func TestSchemaEnsure_MissingVersion(t *testing.T) {
 
 	_, err = schema.Ensure(db)
 	assert.NotNil(t, err)
-	assert.EqualError(t, err, "missing updates: 1 -> 3")
+	assert.EqualError(t, err, "Missing updates: 1 to 3")
 }
 
 // If the schema has no update, the schema table gets created and has no version.

--- a/lxd/debug/memory.go
+++ b/lxd/debug/memory.go
@@ -37,10 +37,10 @@ func memoryWatcher(ctx context.Context, signals <-chan os.Signal, filename strin
 	for {
 		select {
 		case sig := <-signals:
-			logger.Debugf("Received '%s signal', dumping memory.", sig)
+			logger.Debugf("Received '%s signal', dumping memory", sig)
 			memoryDump(filename)
 		case <-ctx.Done():
-			logger.Debugf("Shutdown memory profiler.")
+			logger.Debugf("Shutdown memory profiler")
 			return
 		}
 	}

--- a/lxd/debug/memory_test.go
+++ b/lxd/debug/memory_test.go
@@ -35,12 +35,12 @@ func TestMemory(t *testing.T) {
 	syscall.Kill(os.Getpid(), syscall.SIGUSR1)
 	record := logging.WaitRecord(records, time.Second)
 	require.NotNil(t, record)
-	assert.Equal(t, "Received 'user defined signal 1 signal', dumping memory.", record.Msg)
+	assert.Equal(t, "Received 'user defined signal 1 signal', dumping memory", record.Msg)
 
 	go stop()
 	record = logging.WaitRecord(records, time.Second)
 	require.NotNil(t, record)
-	assert.Equal(t, "Shutdown memory profiler.", record.Msg)
+	assert.Equal(t, "Shutdown memory profiler", record.Msg)
 
 	// The memory dump actually exists on disk.
 	_, err = os.Stat(file.Name())

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -75,7 +75,7 @@ type nvidiaGpuDevices struct {
 }
 
 // /dev/dri/card0. If we detect that vendor == nvidia, then nvidia will contain
-// the corresponding nvidia car, e.g. {/dev/dri/card1 --> /dev/nvidia1}.
+// the corresponding nvidia car, e.g. {/dev/dri/card1 to /dev/nvidia1}.
 type gpuDevice struct {
 	vendorid  string
 	productid string
@@ -529,7 +529,7 @@ func deviceNetlinkListener() (chan []string, chan []string, chan usbDevice, erro
 					devname,
 				)
 				if err != nil {
-					logger.Error("error reading usb device", log.Ctx{"err": err, "path": props["PHYSDEVPATH"]})
+					logger.Error("Error reading usb device", log.Ctx{"err": err, "path": props["PHYSDEVPATH"]})
 					continue
 				}
 
@@ -651,7 +651,7 @@ func deviceTaskBalance(s *state.State) {
 	// Iterate through the containers
 	containers, err := s.Cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
-		logger.Error("problem loading containers list", log.Ctx{"err": err})
+		logger.Error("Problem loading containers list", log.Ctx{"err": err})
 		return
 	}
 	fixedContainers := map[int][]container{}
@@ -808,7 +808,7 @@ func deviceNetworkPriority(s *state.State, netif string) {
 func deviceUSBEvent(s *state.State, usb usbDevice) {
 	containers, err := s.Cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
-		logger.Error("problem loading containers list", log.Ctx{"err": err})
+		logger.Error("Problem loading containers list", log.Ctx{"err": err})
 		return
 	}
 
@@ -820,7 +820,7 @@ func deviceUSBEvent(s *state.State, usb usbDevice) {
 
 		c, ok := containerIf.(*containerLXC)
 		if !ok {
-			logger.Errorf("got device event on non-LXC container?")
+			logger.Errorf("Got device event on non-LXC container?")
 			return
 		}
 
@@ -842,17 +842,17 @@ func deviceUSBEvent(s *state.State, usb usbDevice) {
 			if usb.action == "add" {
 				err := c.insertUnixDeviceNum(fmt.Sprintf("unix.%s", name), m, usb.major, usb.minor, usb.path, false)
 				if err != nil {
-					logger.Error("failed to create usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
+					logger.Error("Failed to create usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
 				}
 			} else if usb.action == "remove" {
 				err := c.removeUnixDeviceNum(fmt.Sprintf("unix.%s", name), m, usb.major, usb.minor, usb.path)
 				if err != nil {
-					logger.Error("failed to remove usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
+					logger.Error("Failed to remove usb device", log.Ctx{"err": err, "usb": usb, "container": c.Name()})
 					return
 				}
 			} else {
-				logger.Error("unknown action for usb device", log.Ctx{"usb": usb})
+				logger.Error("Unknown action for usb device", log.Ctx{"usb": usb})
 				continue
 			}
 		}
@@ -862,7 +862,7 @@ func deviceUSBEvent(s *state.State, usb usbDevice) {
 func deviceEventListener(s *state.State) {
 	chNetlinkCPU, chNetlinkNetwork, chUSB, err := deviceNetlinkListener()
 	if err != nil {
-		logger.Errorf("scheduler: couldn't setup netlink listener: %v", err)
+		logger.Errorf("scheduler: Couldn't setup netlink listener: %v", err)
 		return
 	}
 

--- a/lxd/endpoints/network.go
+++ b/lxd/endpoints/network.go
@@ -139,7 +139,7 @@ func (e *Endpoints) NetworkUpdateCert(cert *shared.CertInfo) {
 func networkCreateListener(address string, cert *shared.CertInfo) net.Listener {
 	listener, err := net.Listen("tcp", util.CanonicalNetworkAddress(address))
 	if err != nil {
-		logger.Error("cannot listen on https socket, skipping...", log.Ctx{"err": err})
+		logger.Error("Cannot listen on https socket, skipping...", log.Ctx{"err": err})
 		return nil
 	}
 	return networkTLSListener(listener, cert)

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -58,7 +58,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	if !shared.PathExists(d.os.LocalDatabasePath()) {
 		path = d.os.LegacyLocalDatabasePath()
 		if !shared.PathExists(path) {
-			logger.Debugf("No DB, so no need to start the daemon now.")
+			logger.Debugf("No DB, so no need to start the daemon now")
 			return nil
 		}
 	}
@@ -95,7 +95,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	if !shared.PathExists(path) {
 		path = d.os.LegacyGlobalDatabasePath()
 		if !shared.PathExists(path) {
-			logger.Debugf("No DB, so no need to start the daemon now.")
+			logger.Debugf("No DB, so no need to start the daemon now")
 			return nil
 		}
 	}
@@ -137,7 +137,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	sqldb.Close()
-	logger.Debugf("No need to start the daemon now.")
+	logger.Debugf("No need to start the daemon now")
 	return nil
 }
 

--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -94,15 +94,15 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	select {
 	case sig := <-ch:
 		if sig == syscall.SIGPWR {
-			logger.Infof("Received '%s signal', shutting down containers.", sig)
+			logger.Infof("Received '%s signal', shutting down containers", sig)
 			containersShutdown(s)
 			networkShutdown(s)
 		} else {
-			logger.Infof("Received '%s signal', exiting.", sig)
+			logger.Infof("Received '%s signal', exiting", sig)
 		}
 
 	case <-d.shutdownChan:
-		logger.Infof("Asked to shutdown by API, shutting down containers.")
+		logger.Infof("Asked to shutdown by API, shutting down containers")
 		d.Kill()
 		containersShutdown(s)
 		networkShutdown(s)

--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -387,7 +387,7 @@ func (c *cmdForkproxy) Run(cmd *cobra.Command, args []string) error {
 		defer os.Remove(lAddr.addr)
 	}
 
-	fmt.Printf("Starting %s <-> %s proxy\n", lAddr.connType, cAddr.connType)
+	fmt.Printf("Starting %s to %s proxy\n", lAddr.connType, cAddr.connType)
 	if lAddr.connType == "udp" {
 		for {
 			ret, revents, err := shared.GetPollRevents(udpFD, -1, (shared.POLLIN | shared.POLLPRI | shared.POLLERR | shared.POLLHUP | shared.POLLRDHUP | shared.POLLNVAL))

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -170,7 +170,7 @@ func (s *migrationSourceWs) checkForPreDumpSupport() (bool, int) {
 		// is not higher than this.
 		max_iterations = 999
 	}
-	logger.Debugf("using maximal %d iterations for pre-dumping", max_iterations)
+	logger.Debugf("Using maximal %d iterations for pre-dumping", max_iterations)
 
 	return use_pre_dumps, max_iterations
 }
@@ -201,7 +201,6 @@ func readCriuStatsDump(path string) (uint64, uint64, error) {
 
 	// Next, read the size of the image payload
 	size := binary.LittleEndian.Uint32(in[8:12])
-	logger.Debugf("stats-dump payload size %d", size)
 
 	statsEntry := &migration.StatsEntry{}
 	if err = proto.Unmarshal(in[12:12+size], statsEntry); err != nil {
@@ -593,7 +592,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 				logger.Debugf("Dump finished, continuing with restore...")
 			}
 		} else {
-			logger.Debugf("liblxc version is older than 2.0.4 and the live migration will probably fail")
+			logger.Debugf("The version of liblxc is older than 2.0.4 and the live migration will probably fail")
 			defer os.RemoveAll(checkpointDir)
 			criuMigrationArgs := CriuMigrationArgs{
 				cmd:          lxc.MIGRATE_DUMP,
@@ -646,7 +645,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 		restoreSuccess <- *msg.Success
 		err := <-dumpSuccess
 		if err != nil {
-			logger.Errorf("dump failed after successful restore?: %q", err)
+			logger.Errorf("Dump failed after successful restore?: %q", err)
 		}
 	}
 
@@ -917,14 +916,13 @@ func (c *migrationSink) Do(migrateOp *operation) error {
 						restore <- err
 						return
 					}
-					logger.Debugf("rsync receive done")
+					logger.Debugf("Done receiving from rsync")
 
 					logger.Debugf("About to receive header")
 					// Check if this was the last pre-dump
 					// Only the FinalPreDump element if of interest
 					mtype, data, err := criuConn.ReadMessage()
 					if err != nil {
-						logger.Debugf("err %s", err)
 						restore <- err
 						return
 					}
@@ -934,7 +932,6 @@ func (c *migrationSink) Do(migrateOp *operation) error {
 					}
 					err = proto.Unmarshal(data, sync)
 					if err != nil {
-						logger.Debugf("err %s", err)
 						restore <- err
 						return
 					}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -324,14 +324,14 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
-			logger.Warnf("Database already contains a valid entry for the storage pool: %s.", defaultPoolName)
+			logger.Warnf("Database already contains a valid entry for the storage pool: %s", defaultPoolName)
 		}
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
 		tmp, pool, err := d.cluster.StoragePoolGet(defaultPoolName)
 		if err != nil {
-			logger.Errorf("Failed to query database: %s.", err)
+			logger.Errorf("Failed to query database: %s", err)
 			return err
 		}
 		poolID = tmp
@@ -363,7 +363,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			return err
 		}
 	} else { // Shouldn't happen.
-		logger.Errorf("Failed to query database: %s.", err)
+		logger.Errorf("Failed to query database: %s", err)
 		return err
 	}
 
@@ -395,7 +395,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the container.")
+			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
@@ -404,7 +404,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
+				logger.Errorf("Could not insert a storage volume for container \"%s\"", ct)
 				return err
 			}
 		} else {
@@ -427,7 +427,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 				output, err := rsyncLocalCopy(oldContainerMntPoint, newContainerMntPoint, "")
 				if err != nil {
-					logger.Errorf("Failed to rsync: %s: %s.", output, err)
+					logger.Errorf("Failed to rsync: %s: %s", output, err)
 					return err
 				}
 
@@ -442,7 +442,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		}
 
 		// Create a symlink to the mountpoint of the container:
-		// ${LXD_DIR}/containers/<container_name> ->
+		// ${LXD_DIR}/containers/<container_name> to
 		// ${LXD_DIR}/storage-pools/<pool>/containers/<container_name>
 		doesntMatter := false
 		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
@@ -483,7 +483,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
-				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
+				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
@@ -492,7 +492,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.StoragePoolVolumeCreate(cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
-					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
+					logger.Errorf("Could not insert a storage volume for snapshot \"%s\"", cs)
 					return err
 				}
 			} else {
@@ -514,7 +514,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 					output, err := rsyncLocalCopy(oldSnapshotMntPoint, newSnapshotMntPoint, "")
 					if err != nil {
-						logger.Errorf("Failed to rsync: %s: %s.", output, err)
+						logger.Errorf("Failed to rsync: %s: %s", output, err)
 						return err
 					}
 
@@ -539,7 +539,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			// Create a new symlink from the snapshots directory of
 			// the container to the snapshots directory on the
 			// storage pool:
-			// ${LXD_DIR}/snapshots/<container_name> -> ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
+			// ${LXD_DIR}/snapshots/<container_name> to ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
 			snapshotsPath := shared.VarPath("snapshots", ct)
 			newSnapshotMntPoint := getSnapshotMountPoint(defaultPoolName, ct)
 			os.Remove(snapshotsPath)
@@ -564,7 +564,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the image.")
+			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
@@ -573,7 +573,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
+				logger.Errorf("Could not insert a storage volume for image \"%s\"", img)
 				return err
 			}
 		} else {
@@ -621,14 +621,14 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
-			logger.Warnf("Database already contains a valid entry for the storage pool: %s.", defaultPoolName)
+			logger.Warnf("Database already contains a valid entry for the storage pool: %s", defaultPoolName)
 		}
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
 		tmp, pool, err := d.cluster.StoragePoolGet(defaultPoolName)
 		if err != nil {
-			logger.Errorf("Failed to query database: %s.", err)
+			logger.Errorf("Failed to query database: %s", err)
 			return err
 		}
 		poolID = tmp
@@ -660,7 +660,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			return err
 		}
 	} else { // Shouldn't happen.
-		logger.Errorf("Failed to query database: %s.", err)
+		logger.Errorf("Failed to query database: %s", err)
 		return err
 	}
 
@@ -682,7 +682,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the container.")
+			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
@@ -691,7 +691,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
+				logger.Errorf("Could not insert a storage volume for container \"%s\"", ct)
 				return err
 			}
 		} else {
@@ -718,7 +718,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				output, err := rsyncLocalCopy(oldContainerMntPoint, newContainerMntPoint, "")
 				if err != nil {
-					logger.Errorf("Failed to rsync: %s: %s.", output, err)
+					logger.Errorf("Failed to rsync: %s: %s", output, err)
 					return err
 				}
 				err = os.RemoveAll(oldContainerMntPoint)
@@ -765,7 +765,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			if err != nil {
 				output, err := rsyncLocalCopy(oldSnapshotMntPoint, newSnapshotMntPoint, "")
 				if err != nil {
-					logger.Errorf("Failed to rsync: %s: %s.", output, err)
+					logger.Errorf("Failed to rsync: %s: %s", output, err)
 					return err
 				}
 				err = os.RemoveAll(oldSnapshotMntPoint)
@@ -799,7 +799,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
+			logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 			err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 			if err != nil {
 				return err
@@ -808,7 +808,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
+				logger.Errorf("Could not insert a storage volume for snapshot \"%s\"", cs)
 				return err
 			}
 		} else {
@@ -829,7 +829,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the image.")
+			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
@@ -838,7 +838,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
+				logger.Errorf("Could not insert a storage volume for image \"%s\"", img)
 				return err
 			}
 		} else {
@@ -908,7 +908,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	// Activate volume group
 	err = storageVGActivate(defaultPoolName)
 	if err != nil {
-		logger.Errorf("Could not activate volume group \"%s\". Manual intervention needed.", defaultPoolName)
+		logger.Errorf("Could not activate volume group \"%s\". Manual intervention needed", defaultPoolName)
 		return err
 	}
 
@@ -920,14 +920,14 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(defaultPoolName, pools) {
-			logger.Warnf("Database already contains a valid entry for the storage pool: %s.", defaultPoolName)
+			logger.Warnf("Database already contains a valid entry for the storage pool: %s", defaultPoolName)
 		}
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
 		tmp, pool, err := d.cluster.StoragePoolGet(defaultPoolName)
 		if err != nil {
-			logger.Errorf("Failed to query database: %s.", err)
+			logger.Errorf("Failed to query database: %s", err)
 			return err
 		}
 		poolID = tmp
@@ -949,7 +949,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		}
 		poolID = tmp
 	} else { // Shouldn't happen.
-		logger.Errorf("Failed to query database: %s.", err)
+		logger.Errorf("Failed to query database: %s", err)
 		return err
 	}
 
@@ -991,7 +991,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the container.")
+			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
@@ -1000,7 +1000,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
+				logger.Errorf("Could not insert a storage volume for container \"%s\"", ct)
 				return err
 			}
 		} else {
@@ -1013,7 +1013,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		if shared.IsMountPoint(oldContainerMntPoint) {
 			err := tryUnmount(oldContainerMntPoint, syscall.MNT_DETACH)
 			if err != nil {
-				logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s.", oldContainerMntPoint, err)
+				logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s", oldContainerMntPoint, err)
 				return err
 			}
 		}
@@ -1036,7 +1036,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				if shared.PathExists(oldContainerMntPoint) && !shared.PathExists(newContainerMntPoint) {
 					err = os.Rename(oldContainerMntPoint, newContainerMntPoint)
 					if err != nil {
-						logger.Errorf("Failed to rename LVM container mountpoint from %s to %s: %s.", oldContainerMntPoint, newContainerMntPoint, err)
+						logger.Errorf("Failed to rename LVM container mountpoint from %s to %s: %s", oldContainerMntPoint, newContainerMntPoint, err)
 						return err
 					}
 				}
@@ -1045,7 +1045,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				if shared.PathExists(oldContainerMntPoint + ".lv") {
 					err := os.Remove(oldContainerMntPoint + ".lv")
 					if err != nil {
-						logger.Errorf("Failed to remove old LVM container mountpoint %s: %s.", oldContainerMntPoint+".lv", err)
+						logger.Errorf("Failed to remove old LVM container mountpoint %s.lv: %s", oldContainerMntPoint, err)
 						return err
 					}
 				}
@@ -1053,7 +1053,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// Rename the logical volume.
 				msg, err := shared.TryRunCommand("lvrename", defaultPoolName, ctLvName, newContainerLvName)
 				if err != nil {
-					logger.Errorf("Failed to rename LVM logical volume from %s to %s: %s.", ctLvName, newContainerLvName, msg)
+					logger.Errorf("Failed to rename LVM logical volume from %s to %s: %s", ctLvName, newContainerLvName, msg)
 					return err
 				}
 			} else if shared.PathExists(oldContainerMntPoint) && shared.IsDir(oldContainerMntPoint) {
@@ -1065,14 +1065,14 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// container.
 				ctStorage, err := storagePoolVolumeContainerLoadInit(d.State(), ct)
 				if err != nil {
-					logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s.", ct, err)
+					logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s", ct, err)
 					return err
 				}
 
 				// Load the container from the database.
 				ctStruct, err := containerLoadByName(d.State(), ct)
 				if err != nil {
-					logger.Errorf("Failed to load LVM container %s: %s.", ct, err)
+					logger.Errorf("Failed to load LVM container %s: %s", ct, err)
 					return err
 				}
 
@@ -1080,7 +1080,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// container.
 				err = ctStorage.ContainerCreate(ctStruct)
 				if err != nil {
-					logger.Errorf("Failed to create empty LVM logical volume for container %s: %s.", ct, err)
+					logger.Errorf("Failed to create empty LVM logical volume for container %s: %s", ct, err)
 					return err
 				}
 
@@ -1089,7 +1089,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				if !shared.IsMountPoint(newContainerMntPoint) {
 					_, err = ctStorage.ContainerMount(ctStruct)
 					if err != nil {
-						logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s.", ct, err)
+						logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", ct, err)
 						return err
 					}
 				}
@@ -1104,7 +1104,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// Remove the old container.
 				err = os.RemoveAll(oldContainerMntPoint)
 				if err != nil {
-					logger.Errorf("Failed to remove old container %s: %s.", oldContainerMntPoint, err)
+					logger.Errorf("Failed to remove old container %s: %s", oldContainerMntPoint, err)
 					return err
 				}
 			}
@@ -1114,7 +1114,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		doesntMatter := false
 		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
 		if err != nil {
-			logger.Errorf("Failed to create container mountpoint \"%s\" for LVM logical volume: %s.", newContainerMntPoint, err)
+			logger.Errorf("Failed to create container mountpoint \"%s\" for LVM logical volume: %s", newContainerMntPoint, err)
 			return err
 		}
 
@@ -1146,7 +1146,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
-				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
+				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
@@ -1155,7 +1155,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.StoragePoolVolumeCreate(cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
-					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
+					logger.Errorf("Could not insert a storage volume for snapshot \"%s\"", cs)
 					return err
 				}
 			} else {
@@ -1188,7 +1188,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					if shared.IsMountPoint(oldSnapshotMntPoint) {
 						err := tryUnmount(oldSnapshotMntPoint, syscall.MNT_DETACH)
 						if err != nil {
-							logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s.", oldSnapshotMntPoint, err)
+							logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s", oldSnapshotMntPoint, err)
 							return err
 						}
 					}
@@ -1198,7 +1198,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					if shared.PathExists(oldSnapshotMntPoint) && !shared.PathExists(newSnapshotMntPoint) {
 						err := os.Rename(oldSnapshotMntPoint, newSnapshotMntPoint)
 						if err != nil {
-							logger.Errorf("Failed to rename LVM container mountpoint from %s to %s: %s.", oldSnapshotMntPoint, newSnapshotMntPoint, err)
+							logger.Errorf("Failed to rename LVM container mountpoint from %s to %s: %s", oldSnapshotMntPoint, newSnapshotMntPoint, err)
 							return err
 						}
 					}
@@ -1206,7 +1206,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					// Rename the logical volume.
 					msg, err := shared.TryRunCommand("lvrename", defaultPoolName, csLvName, newSnapshotLvName)
 					if err != nil {
-						logger.Errorf("Failed to rename LVM logical volume from %s to %s: %s.", csLvName, newSnapshotLvName, msg)
+						logger.Errorf("Failed to rename LVM logical volume from %s to %s: %s", csLvName, newSnapshotLvName, msg)
 						return err
 					}
 				} else if shared.PathExists(oldSnapshotMntPoint) && shared.IsDir(oldSnapshotMntPoint) {
@@ -1218,14 +1218,14 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					// snapshot.
 					csStorage, err := storagePoolVolumeContainerLoadInit(d.State(), cs)
 					if err != nil {
-						logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s.", cs, err)
+						logger.Errorf("Failed to initialize new storage interface for LVM container %s: %s", cs, err)
 						return err
 					}
 
 					// Load the snapshot from the database.
 					csStruct, err := containerLoadByName(d.State(), cs)
 					if err != nil {
-						logger.Errorf("Failed to load LVM container %s: %s.", cs, err)
+						logger.Errorf("Failed to load LVM container %s: %s", cs, err)
 						return err
 					}
 
@@ -1233,7 +1233,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					// for the snapshot.
 					err = csStorage.ContainerSnapshotCreateEmpty(csStruct)
 					if err != nil {
-						logger.Errorf("Failed to create empty LVM logical volume for container %s: %s.", cs, err)
+						logger.Errorf("Failed to create empty LVM logical volume for container %s: %s", cs, err)
 						return err
 					}
 
@@ -1243,7 +1243,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					if !shared.IsMountPoint(newSnapshotMntPoint) {
 						_, err = csStorage.ContainerMount(csStruct)
 						if err != nil {
-							logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s.", cs, err)
+							logger.Errorf("Failed to mount new empty LVM logical volume for container %s: %s", cs, err)
 							return err
 						}
 					}
@@ -1258,7 +1258,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					// Remove the old snapshot.
 					err = os.RemoveAll(oldSnapshotMntPoint)
 					if err != nil {
-						logger.Errorf("Failed to remove old container %s: %s.", oldSnapshotMntPoint, err)
+						logger.Errorf("Failed to remove old container %s: %s", oldSnapshotMntPoint, err)
 						return err
 					}
 				}
@@ -1269,7 +1269,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			// Create a new symlink from the snapshots directory of
 			// the container to the snapshots directory on the
 			// storage pool:
-			// ${LXD_DIR}/snapshots/<container_name> -> ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
+			// ${LXD_DIR}/snapshots/<container_name> to ${LXD_DIR}/storage-pools/<pool>/snapshots/<container_name>
 			snapshotsPath := shared.VarPath("snapshots", ct)
 			newSnapshotsPath := getSnapshotMountPoint(defaultPoolName, ct)
 			if shared.PathExists(snapshotsPath) {
@@ -1291,7 +1291,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		if !shared.IsMountPoint(newContainerMntPoint) {
 			err := tryMount(containerLvDevPath, newContainerMntPoint, lvFsType, 0, mountOptions)
 			if err != nil {
-				logger.Errorf("Failed to mount LVM logical \"%s\" onto \"%s\" : %s.", containerLvDevPath, newContainerMntPoint, err)
+				logger.Errorf("Failed to mount LVM logical \"%s\" onto \"%s\" : %s", containerLvDevPath, newContainerMntPoint, err)
 				return err
 			}
 		}
@@ -1317,7 +1317,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the image.")
+			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
@@ -1326,7 +1326,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
+				logger.Errorf("Could not insert a storage volume for image \"%s\"", img)
 				return err
 			}
 		} else {
@@ -1420,14 +1420,14 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 	if err == nil { // Already exist valid storage pools.
 		// Check if the storage pool already has a db entry.
 		if shared.StringInSlice(poolName, pools) {
-			logger.Warnf("Database already contains a valid entry for the storage pool: %s.", poolName)
+			logger.Warnf("Database already contains a valid entry for the storage pool: %s", poolName)
 		}
 
 		// Get the pool ID as we need it for storage volume creation.
 		// (Use a tmp variable as Go's scoping is freaking me out.)
 		tmp, pool, err := d.cluster.StoragePoolGet(poolName)
 		if err != nil {
-			logger.Errorf("Failed to query database: %s.", err)
+			logger.Errorf("Failed to query database: %s", err)
 			return err
 		}
 		poolID = tmp
@@ -1473,11 +1473,11 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		// (Use a tmp variable as Go's scoping is freaking me out.)
 		tmp, err := dbStoragePoolCreateAndUpdateCache(d.cluster, poolName, "", defaultStorageTypeName, poolConfig)
 		if err != nil {
-			logger.Warnf("Storage pool already exists in the database. Proceeding...")
+			logger.Warnf("Storage pool already exists in the database, proceeding...")
 		}
 		poolID = tmp
 	} else { // Shouldn't happen.
-		logger.Errorf("Failed to query database: %s.", err)
+		logger.Errorf("Failed to query database: %s", err)
 		return err
 	}
 
@@ -1492,7 +1492,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if !shared.PathExists(containersSubvolumePath) {
 			err := os.MkdirAll(containersSubvolumePath, 0711)
 			if err != nil {
-				logger.Warnf("Failed to create path: %s.", containersSubvolumePath)
+				logger.Warnf("Failed to create path: %s", containersSubvolumePath)
 			}
 		}
 	}
@@ -1509,7 +1509,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the container.")
+			logger.Warnf("Storage volumes database already contains an entry for the container")
 			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
@@ -1518,7 +1518,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(ct, "", storagePoolVolumeTypeContainer, poolID, containerPoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for container \"%s\".", ct)
+				logger.Errorf("Could not insert a storage volume for container \"%s\"", ct)
 				return err
 			}
 		} else {
@@ -1536,7 +1536,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if shared.IsMountPoint(oldContainerMntPoint) {
 			_, err := shared.TryRunCommand("zfs", "unmount", "-f", ctDataset)
 			if err != nil {
-				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount. Trying lazy umount (MNT_DETACH)...")
+				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount, trying lazy umount (MNT_DETACH)...")
 				err := tryUnmount(oldContainerMntPoint, syscall.MNT_DETACH)
 				if err != nil {
 					failedUpgradeEntities = append(failedUpgradeEntities, fmt.Sprintf("containers/%s: Failed to umount zfs filesystem.", ct))
@@ -1555,7 +1555,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		newContainerMntPoint := getContainerMountPoint(poolName, ct)
 		err = createContainerMountpoint(newContainerMntPoint, oldContainerMntPoint, doesntMatter)
 		if err != nil {
-			logger.Warnf("Failed to create mountpoint for the container: %s.", newContainerMntPoint)
+			logger.Warnf("Failed to create mountpoint for the container: %s", newContainerMntPoint)
 			failedUpgradeEntities = append(failedUpgradeEntities, fmt.Sprintf("containers/%s: Failed to create container mountpoint: %s", ct, err))
 			continue
 		}
@@ -1568,7 +1568,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			fmt.Sprintf("mountpoint=%s", newContainerMntPoint),
 			ctDataset)
 		if err != nil {
-			logger.Warnf("Failed to set new ZFS mountpoint: %s.", output)
+			logger.Warnf("Failed to set new ZFS mountpoint: %s", output)
 			failedUpgradeEntities = append(failedUpgradeEntities, fmt.Sprintf("containers/%s: Failed to set new zfs mountpoint: %s", ct, err))
 			continue
 		}
@@ -1595,7 +1595,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
-				logger.Warnf("Storage volumes database already contains an entry for the snapshot.")
+				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
 				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
@@ -1604,7 +1604,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 				// Insert storage volumes for containers into the database.
 				_, err := d.cluster.StoragePoolVolumeCreate(cs, "", storagePoolVolumeTypeContainer, poolID, snapshotPoolVolumeConfig)
 				if err != nil {
-					logger.Errorf("Could not insert a storage volume for snapshot \"%s\".", cs)
+					logger.Errorf("Could not insert a storage volume for snapshot \"%s\"", cs)
 					return err
 				}
 			} else {
@@ -1618,7 +1618,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			if !shared.PathExists(newSnapshotMntPoint) {
 				err = os.MkdirAll(newSnapshotMntPoint, 0711)
 				if err != nil {
-					logger.Warnf("Failed to create mountpoint for snapshot: %s.", newSnapshotMntPoint)
+					logger.Warnf("Failed to create mountpoint for snapshot: %s", newSnapshotMntPoint)
 					failedUpgradeEntities = append(failedUpgradeEntities, fmt.Sprintf("snapshots/%s: Failed to create mountpoint for snapshot.", cs))
 					continue
 				}
@@ -1633,7 +1633,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			if !shared.PathExists(newSnapshotsMntPoint) {
 				err := os.Symlink(newSnapshotsMntPoint, snapshotsPath)
 				if err != nil {
-					logger.Warnf("Failed to create symlink for snapshots: %s -> %s.", snapshotsPath, newSnapshotsMntPoint)
+					logger.Warnf("Failed to create symlink for snapshots: %s to %s", snapshotsPath, newSnapshotsMntPoint)
 				}
 			}
 		}
@@ -1651,7 +1651,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
-			logger.Warnf("Storage volumes database already contains an entry for the image.")
+			logger.Warnf("Storage volumes database already contains an entry for the image")
 			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
@@ -1660,7 +1660,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			// Insert storage volumes for containers into the database.
 			_, err := d.cluster.StoragePoolVolumeCreate(img, "", storagePoolVolumeTypeImage, poolID, imagePoolVolumeConfig)
 			if err != nil {
-				logger.Errorf("Could not insert a storage volume for image \"%s\".", img)
+				logger.Errorf("Could not insert a storage volume for image \"%s\"", img)
 				return err
 			}
 		} else {
@@ -1672,7 +1672,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if !shared.PathExists(imageMntPoint) {
 			err := os.MkdirAll(imageMntPoint, 0700)
 			if err != nil {
-				logger.Warnf("Failed to create image mountpoint. Proceeding...")
+				logger.Warnf("Failed to create image mountpoint, proceeding...")
 			}
 		}
 
@@ -1684,7 +1684,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		if shared.PathExists(oldImageMntPoint) && shared.IsMountPoint(oldImageMntPoint) {
 			_, err := shared.TryRunCommand("zfs", "unmount", "-f", imageDataset)
 			if err != nil {
-				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount. Trying lazy umount (MNT_DETACH)...")
+				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount, trying lazy umount (MNT_DETACH)...")
 				err := tryUnmount(oldImageMntPoint, syscall.MNT_DETACH)
 				if err != nil {
 					logger.Warnf("Failed to unmount ZFS filesystem: %s", err)
@@ -1698,7 +1698,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		// automatically mounted.
 		output, err := shared.RunCommand("zfs", "set", "mountpoint=none", imageDataset)
 		if err != nil {
-			logger.Warnf("Failed to set new ZFS mountpoint: %s.", output)
+			logger.Warnf("Failed to set new ZFS mountpoint: %s", output)
 		}
 	}
 
@@ -1722,7 +1722,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 		for _, pName := range profiles {
 			pID, p, err := d.cluster.ProfileGet(pName)
 			if err != nil {
-				logger.Errorf("Could not query database: %s.", err)
+				logger.Errorf("Could not query database: %s", err)
 				return err
 			}
 
@@ -1768,28 +1768,28 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 			err = db.ProfileConfigClear(tx, pID)
 			if err != nil {
-				logger.Errorf("Failed to clear old profile configuration for profile %s: %s.", pName, err)
+				logger.Errorf("Failed to clear old profile configuration for profile %s: %s", pName, err)
 				tx.Rollback()
 				continue
 			}
 
 			err = db.ProfileConfigAdd(tx, pID, p.Config)
 			if err != nil {
-				logger.Errorf("Failed to add new profile configuration: %s: %s.", pName, err)
+				logger.Errorf("Failed to add new profile configuration: %s: %s", pName, err)
 				tx.Rollback()
 				continue
 			}
 
 			err = db.DevicesAdd(tx, "profile", pID, p.Devices)
 			if err != nil {
-				logger.Errorf("Failed to add new profile profile root disk device: %s: %s.", pName, err)
+				logger.Errorf("Failed to add new profile profile root disk device: %s: %s", pName, err)
 				tx.Rollback()
 				continue
 			}
 
 			err = tx.Commit()
 			if err != nil {
-				logger.Errorf("Failed to commit database transaction: %s: %s.", pName, err)
+				logger.Errorf("Failed to commit database transaction: %s: %s", pName, err)
 				tx.Rollback()
 				continue
 			}
@@ -1876,7 +1876,7 @@ func patchStorageApiV1(name string, d *Daemon) error {
 	}
 
 	if len(pools) != 1 {
-		logger.Warnf("More than one storage pool found. Not rerunning upgrade.")
+		logger.Warnf("More than one storage pool found. Not rerunning upgrade")
 		return nil
 	}
 
@@ -2218,7 +2218,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 
 		poolName := pool.Config["lvm.vg_name"]
 		if poolName == "" {
-			logger.Errorf("The \"lvm.vg_name\" key should not be empty.")
+			logger.Errorf("The \"lvm.vg_name\" key should not be empty")
 			return fmt.Errorf("The \"lvm.vg_name\" key should not be empty.")
 		}
 
@@ -2241,7 +2241,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 			lvmLvDevPath := getLvmDevPath(poolName, volumeTypeApiEndpoint, lvmName)
 			size, err := lvmGetLVSize(lvmLvDevPath)
 			if err != nil {
-				logger.Errorf("Failed to detect size of logical volume: %s.", err)
+				logger.Errorf("Failed to detect size of logical volume: %s", err)
 				return err
 			}
 
@@ -2473,8 +2473,7 @@ func patchStorageApiDirBindMount(name string, d *Daemon) error {
 
 		err = syscall.Mount(mountSource, poolMntPoint, "", uintptr(mountFlags), "")
 		if err != nil {
-			logger.Errorf(`Failed to mount DIR storage pool "%s" onto `+
-				`"%s": %s`, mountSource, poolMntPoint, err)
+			logger.Errorf(`Failed to mount DIR storage pool "%s" onto "%s": %s`, mountSource, poolMntPoint, err)
 			return err
 		}
 
@@ -2993,7 +2992,7 @@ func patchUpdateFromV15(d *Daemon) error {
 		}
 		newLinkDest := fmt.Sprintf("/dev/%s/%s", vgName, newLVName)
 		if err := os.Symlink(newLinkDest, lvLinkPath); err != nil {
-			return fmt.Errorf("Couldn't recreate symlink '%s'->'%s'", lvLinkPath, newLinkDest)
+			return fmt.Errorf("Couldn't recreate symlink '%s' to '%s'", lvLinkPath, newLinkDest)
 		}
 	}
 

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -413,7 +413,7 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 	if poolVolumePut.Config["volatile.idmap.last"] != "" {
 		lastIdmap, err = idmapsetFromString(poolVolumePut.Config["volatile.idmap.last"])
 		if err != nil {
-			logger.Errorf("failed to unmarshal last idmapping: %s", poolVolumePut.Config["volatile.idmap.last"])
+			logger.Errorf("Failed to unmarshal last idmapping: %s", poolVolumePut.Config["volatile.idmap.last"])
 			return nil, err
 		}
 	}
@@ -484,7 +484,7 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 			defer func() {
 				_, err := st.StoragePoolVolumeUmount()
 				if err != nil {
-					logger.Warnf("failed to unmount storage volume")
+					logger.Warnf("Failed to unmount storage volume")
 				}
 			}()
 		}
@@ -827,10 +827,10 @@ func SetupStorageDriver(s *state.State, forceCheck bool) error {
 	pools, err := s.Cluster.StoragePoolsNotPending()
 	if err != nil {
 		if err == db.ErrNoSuchObject {
-			logger.Debugf("No existing storage pools detected.")
+			logger.Debugf("No existing storage pools detected")
 			return nil
 		}
-		logger.Debugf("Failed to retrieve existing storage pools.")
+		logger.Debugf("Failed to retrieve existing storage pools")
 		return err
 	}
 
@@ -847,17 +847,17 @@ func SetupStorageDriver(s *state.State, forceCheck bool) error {
 		}
 
 		if !shared.StringInSlice("storage_api", appliedPatches) {
-			logger.Warnf("Incorrectly applied \"storage_api\" patch. Skipping storage pool initialization as it might be corrupt.")
+			logger.Warnf("Incorrectly applied \"storage_api\" patch, skipping storage pool initialization as it might be corrupt")
 			return nil
 		}
 
 	}
 
 	for _, pool := range pools {
-		logger.Debugf("Initializing and checking storage pool \"%s\".", pool)
+		logger.Debugf("Initializing and checking storage pool \"%s\"", pool)
 		s, err := storagePoolInit(s, pool)
 		if err != nil {
-			logger.Errorf("Error initializing storage pool \"%s\": %s. Correct functionality of the storage pool cannot be guaranteed.", pool, err)
+			logger.Errorf("Error initializing storage pool \"%s\": %s, correct functionality of the storage pool cannot be guaranteed", pool, err)
 			continue
 		}
 

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -86,7 +86,7 @@ func (s *storageBtrfs) StorageCoreInit() error {
 		return fmt.Errorf("The 'btrfs' tool isn't working properly")
 	}
 
-	logger.Debugf("Initializing a BTRFS driver.")
+	logger.Debugf("Initializing a BTRFS driver")
 	return nil
 }
 
@@ -102,12 +102,12 @@ func (s *storageBtrfs) StoragePoolInit() error {
 func (s *storageBtrfs) StoragePoolCheck() error {
 	// FIXEM(brauner): Think of something smart or useful (And then think
 	// again if it is worth implementing it. :)).
-	logger.Debugf("Checking BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checking BTRFS storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolCreate() error {
-	logger.Infof("Creating BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Creating BTRFS storage pool \"%s\"", s.pool.Name)
 	s.pool.Config["volatile.initial_source"] = s.pool.Config["source"]
 
 	isBlockDev := false
@@ -208,10 +208,10 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 		// we granted it above. So try to call btrfs filesystem show and
 		// parse it out. (I __hate__ this!)
 		if devUUID == "" {
-			logger.Warnf("Failed to detect UUID by looking at /dev/disk/by-uuid.")
+			logger.Warnf("Failed to detect UUID by looking at /dev/disk/by-uuid")
 			devUUID, err1 = s.btrfsLookupFsUUID(source)
 			if err1 != nil {
-				logger.Errorf("Failed to detect UUID by parsing filesystem info.")
+				logger.Errorf("Failed to detect UUID by parsing filesystem info")
 				return err1
 			}
 		}
@@ -260,12 +260,12 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 		return err
 	}
 
-	logger.Infof("Created BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Created BTRFS storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolDelete() error {
-	logger.Infof("Deleting BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleting BTRFS storage pool \"%s\"", s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if strings.HasPrefix(source, "/") {
@@ -314,7 +314,7 @@ func (s *storageBtrfs) StoragePoolDelete() error {
 		sourcePath := shared.VarPath("disks", s.pool.Name)
 		loopFilePath := sourcePath + ".img"
 		if cleanSource == loopFilePath {
-			// This is a loop file --> simply remove it.
+			// This is a loop file so simply remove it.
 			err = os.Remove(source)
 		} else {
 			if !isBtrfsFilesystem(source) && isBtrfsSubVolume(source) {
@@ -329,12 +329,12 @@ func (s *storageBtrfs) StoragePoolDelete() error {
 	// Remove the mountpoint for the storage pool.
 	os.RemoveAll(getStoragePoolMountPoint(s.pool.Name))
 
-	logger.Infof("Deleted BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleted BTRFS storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolMount() (bool, error) {
-	logger.Debugf("Mounting BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Mounting BTRFS storage pool \"%s\"", s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if strings.HasPrefix(source, "/") {
@@ -352,7 +352,7 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[poolMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage pool.
@@ -436,12 +436,12 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Mounted BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Mounted BTRFS storage pool \"%s\"", s.pool.Name)
 	return true, nil
 }
 
 func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
-	logger.Debugf("Unmounting BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Unmounting BTRFS storage pool \"%s\"", s.pool.Name)
 
 	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
 
@@ -450,7 +450,7 @@ func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[poolUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage pool.
@@ -478,7 +478,7 @@ func (s *storageBtrfs) StoragePoolUmount() (bool, error) {
 		}
 	}
 
-	logger.Debugf("Unmounted BTRFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Unmounted BTRFS storage pool \"%s\"", s.pool.Name)
 	return true, nil
 }
 
@@ -527,7 +527,7 @@ func (s *storageBtrfs) GetContainerPoolInfo() (int64, string, string) {
 
 // Functions dealing with storage volumes.
 func (s *storageBtrfs) StoragePoolVolumeCreate() error {
-	logger.Infof("Creating BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Creating BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -563,12 +563,12 @@ func (s *storageBtrfs) StoragePoolVolumeCreate() error {
 		}
 	}
 
-	logger.Infof("Created BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Created BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolVolumeDelete() error {
-	logger.Infof("Deleting BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleting BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -597,17 +597,15 @@ func (s *storageBtrfs) StoragePoolVolumeDelete() error {
 		storagePoolVolumeTypeCustom,
 		s.poolID)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for BTRFS `+
-			`storage volume "%s" on storage pool "%s"`,
-			s.volume.Name, s.pool.Name)
+		logger.Errorf(`Failed to delete database entry for BTRFS storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	}
 
-	logger.Infof("Deleted BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleted BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) StoragePoolVolumeMount() (bool, error) {
-	logger.Debugf("Mounting BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -615,7 +613,7 @@ func (s *storageBtrfs) StoragePoolVolumeMount() (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Mounted BTRFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted BTRFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
@@ -707,7 +705,7 @@ func (s *storageBtrfs) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageBtrfs) doContainerCreate(name string, privileged bool) error {
-	logger.Debugf("Creating empty BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -742,7 +740,7 @@ func (s *storageBtrfs) doContainerCreate(name string, privileged bool) error {
 		return err
 	}
 
-	logger.Debugf("Created empty BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -757,7 +755,7 @@ func (s *storageBtrfs) ContainerCreate(container container) error {
 
 // And this function is why I started hating on btrfs...
 func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint string) error {
-	logger.Debugf("Creating BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -791,7 +789,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint
 	if waitChannel, ok := lxdStorageOngoingOperationMap[imageStoragePoolLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 	} else {
 		lxdStorageOngoingOperationMap[imageStoragePoolLockID] = make(chan bool)
@@ -838,7 +836,7 @@ func (s *storageBtrfs) ContainerCreateFromImage(container container, fingerprint
 		}
 	}
 
-	logger.Debugf("Created BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return container.TemplateApply("create")
 }
 
@@ -847,7 +845,7 @@ func (s *storageBtrfs) ContainerCanRestore(container container, sourceContainer 
 }
 
 func (s *storageBtrfs) ContainerDelete(container container) error {
-	logger.Debugf("Deleting BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	// The storage pool needs to be mounted.
 	_, err := s.StoragePoolMount()
@@ -880,7 +878,7 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 	}
 
 	// Delete potential symlink
-	// ${LXD_DIR}/snapshots/<container_name> -> ${POOL}/snapshots/<container_name>
+	// ${LXD_DIR}/snapshots/<container_name> to ${POOL}/snapshots/<container_name>
 	snapshotSymlink := shared.VarPath("snapshots", container.Name())
 	if shared.PathExists(snapshotSymlink) {
 		err := os.Remove(snapshotSymlink)
@@ -899,7 +897,7 @@ func (s *storageBtrfs) ContainerDelete(container container) error {
 		s.ContainerBackupDelete(backupName)
 	}
 
-	logger.Debugf("Deleted BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -1041,7 +1039,7 @@ func (s *storageBtrfs) doCrossPoolContainerCopy(target container, source contain
 }
 
 func (s *storageBtrfs) ContainerCopy(target container, source container, containerOnly bool) error {
-	logger.Debugf("Copying BTRFS container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copying BTRFS container storage %s to %s", source.Name(), target.Name())
 
 	// The storage pool needs to be mounted.
 	_, err := s.StoragePoolMount()
@@ -1069,7 +1067,7 @@ func (s *storageBtrfs) ContainerCopy(target container, source container, contain
 	}
 
 	if containerOnly {
-		logger.Debugf("Copied BTRFS container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied BTRFS container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -1079,7 +1077,7 @@ func (s *storageBtrfs) ContainerCopy(target container, source container, contain
 	}
 
 	if len(snapshots) == 0 {
-		logger.Debugf("Copied BTRFS container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied BTRFS container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -1102,12 +1100,12 @@ func (s *storageBtrfs) ContainerCopy(target container, source container, contain
 		}
 	}
 
-	logger.Debugf("Copied BTRFS container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copied BTRFS container storage %s to %s", source.Name(), target.Name())
 	return nil
 }
 
 func (s *storageBtrfs) ContainerMount(c container) (bool, error) {
-	logger.Debugf("Mounting BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -1115,7 +1113,7 @@ func (s *storageBtrfs) ContainerMount(c container) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Mounted BTRFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted BTRFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
@@ -1124,7 +1122,7 @@ func (s *storageBtrfs) ContainerUmount(name string, path string) (bool, error) {
 }
 
 func (s *storageBtrfs) ContainerRename(container container, newName string) error {
-	logger.Debugf("Renaming BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming BTRFS storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -1179,12 +1177,12 @@ func (s *storageBtrfs) ContainerRename(container container, newName string) erro
 		s.ContainerBackupRename(backup, newName)
 	}
 
-	logger.Debugf("Renamed BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed BTRFS storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerRestore(container container, sourceContainer container) error {
-	logger.Debugf("Restoring BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+	logger.Debugf("Restoring BTRFS storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceContainer.Name(), container.Name())
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -1241,7 +1239,7 @@ func (s *storageBtrfs) ContainerRestore(container container, sourceContainer con
 			output, err := rsyncLocalCopy(sourceContainerSubvolumeName, targetContainerSubvolumeName, bwlimit)
 			if err != nil {
 				s.ContainerDelete(container)
-				logger.Errorf("ContainerRestore: rsync failed: %s.", string(output))
+				logger.Errorf("ContainerRestore: rsync failed: %s", string(output))
 				failure = err
 			}
 		} else {
@@ -1266,7 +1264,7 @@ func (s *storageBtrfs) ContainerRestore(container container, sourceContainer con
 		os.RemoveAll(backupTargetContainerSubvolumeName)
 	}
 
-	logger.Debugf("Restored BTRFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+	logger.Debugf("Restored BTRFS storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceContainer.Name(), container.Name())
 	return failure
 }
 
@@ -1275,7 +1273,7 @@ func (s *storageBtrfs) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageBtrfs) doContainerSnapshotCreate(targetName string, sourceName string) error {
-	logger.Debugf("Creating BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1319,7 +1317,7 @@ func (s *storageBtrfs) doContainerSnapshotCreate(targetName string, sourceName s
 		return err
 	}
 
-	logger.Debugf("Created BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -1358,7 +1356,7 @@ func btrfsSnapshotDeleteInternal(poolName string, snapshotName string) error {
 }
 
 func (s *storageBtrfs) ContainerSnapshotDelete(snapshotContainer container) error {
-	logger.Debugf("Deleting BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1370,12 +1368,12 @@ func (s *storageBtrfs) ContainerSnapshotDelete(snapshotContainer container) erro
 		return err
 	}
 
-	logger.Debugf("Deleted BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerSnapshotStart(container container) (bool, error) {
-	logger.Debugf("Initializing BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Initializing BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1385,7 +1383,7 @@ func (s *storageBtrfs) ContainerSnapshotStart(container container) (bool, error)
 	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, container.Name())
 	roSnapshotSubvolumeName := fmt.Sprintf("%s.ro", snapshotSubvolumeName)
 	if shared.PathExists(roSnapshotSubvolumeName) {
-		logger.Debugf("The BTRFS snapshot is already mounted read-write.")
+		logger.Debugf("The BTRFS snapshot is already mounted read-write")
 		return false, nil
 	}
 
@@ -1399,12 +1397,12 @@ func (s *storageBtrfs) ContainerSnapshotStart(container container) (bool, error)
 		return false, err
 	}
 
-	logger.Debugf("Initialized BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Initialized BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageBtrfs) ContainerSnapshotStop(container container) (bool, error) {
-	logger.Debugf("Stopping BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopping BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1414,7 +1412,7 @@ func (s *storageBtrfs) ContainerSnapshotStop(container container) (bool, error) 
 	snapshotSubvolumeName := getSnapshotMountPoint(s.pool.Name, container.Name())
 	roSnapshotSubvolumeName := fmt.Sprintf("%s.ro", snapshotSubvolumeName)
 	if !shared.PathExists(roSnapshotSubvolumeName) {
-		logger.Debugf("The BTRFS snapshot is currently not mounted read-write.")
+		logger.Debugf("The BTRFS snapshot is currently not mounted read-write")
 		return false, nil
 	}
 
@@ -1430,13 +1428,13 @@ func (s *storageBtrfs) ContainerSnapshotStop(container container) (bool, error) 
 		return false, err
 	}
 
-	logger.Debugf("Stopped BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopped BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
 // ContainerSnapshotRename renames a snapshot of a container.
 func (s *storageBtrfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
-	logger.Debugf("Renaming BTRFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming BTRFS storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -1453,14 +1451,14 @@ func (s *storageBtrfs) ContainerSnapshotRename(snapshotContainer container, newN
 		return err
 	}
 
-	logger.Debugf("Renamed BTRFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed BTRFS storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 // Needed for live migration where an empty snapshot needs to be created before
 // rsyncing into it.
 func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	logger.Debugf("Creating empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	// Mount the storage pool.
 	_, err := s.StoragePoolMount()
@@ -1493,7 +1491,7 @@ func (s *storageBtrfs) ContainerSnapshotCreateEmpty(snapshotContainer container)
 		}
 	}
 
-	logger.Debugf("Created empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty BTRFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -1694,7 +1692,7 @@ func (s *storageBtrfs) doContainerBackupCreateVanilla(backup backup, source cont
 }
 
 func (s *storageBtrfs) ContainerBackupCreate(backup backup, source container) error {
-	logger.Debugf("Creating BTRFS storage volume for backup \"%s\" on storage pool \"%s\".", backup.Name(), s.pool.Name)
+	logger.Debugf("Creating BTRFS storage volume for backup \"%s\" on storage pool \"%s\"", backup.Name(), s.pool.Name)
 
 	// start storage
 	ourStart, err := source.StorageStart()
@@ -1706,7 +1704,7 @@ func (s *storageBtrfs) ContainerBackupCreate(backup backup, source container) er
 	}
 
 	if backup.optimizedStorage {
-		logger.Debugf("Created BTRFS storage volume for backup \"%s\" on storage pool \"%s\".", backup.Name(), s.pool.Name)
+		logger.Debugf("Created BTRFS storage volume for backup \"%s\" on storage pool \"%s\"", backup.Name(), s.pool.Name)
 		return s.doContainerBackupCreateOptimized(backup, source)
 	}
 
@@ -1714,7 +1712,7 @@ func (s *storageBtrfs) ContainerBackupCreate(backup backup, source container) er
 }
 
 func (s *storageBtrfs) ContainerBackupDelete(name string) error {
-	logger.Debugf("Deleting BTRFS storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleting BTRFS storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	backupContainerMntPoint := getBackupMountPoint(s.pool.Name, name)
 	if shared.PathExists(backupContainerMntPoint) {
 		err := os.RemoveAll(backupContainerMntPoint)
@@ -1733,12 +1731,12 @@ func (s *storageBtrfs) ContainerBackupDelete(name string) error {
 		}
 	}
 
-	logger.Debugf("Deleted BTRFS storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleted BTRFS storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ContainerBackupRename(backup backup, newName string) error {
-	logger.Debugf("Renaming BTRFS storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renaming BTRFS storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	oldBackupMntPoint := getBackupMountPoint(s.pool.Name, backup.Name())
 	newBackupMntPoint := getBackupMountPoint(s.pool.Name, newName)
 
@@ -1750,7 +1748,7 @@ func (s *storageBtrfs) ContainerBackupRename(backup backup, newName string) erro
 		}
 	}
 
-	logger.Debugf("Renamed BTRFS storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renamed BTRFS storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	return nil
 }
 
@@ -1907,7 +1905,7 @@ func (s *storageBtrfs) doContainerBackupLoadVanilla(info backupInfo, data io.Rea
 }
 
 func (s *storageBtrfs) ContainerBackupLoad(info backupInfo, data io.ReadSeeker) error {
-	logger.Debugf("Loading BTRFS storage volume for backup \"%s\" on storage pool \"%s\".", info.Name, s.pool.Name)
+	logger.Debugf("Loading BTRFS storage volume for backup \"%s\" on storage pool \"%s\"", info.Name, s.pool.Name)
 
 	if info.HasBinaryFormat {
 		return s.doContainerBackupLoadOptimized(info, data)
@@ -1917,7 +1915,7 @@ func (s *storageBtrfs) ContainerBackupLoad(info backupInfo, data io.ReadSeeker) 
 }
 
 func (s *storageBtrfs) ImageCreate(fingerprint string) error {
-	logger.Debugf("Creating BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Creating BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	// Create the subvolume.
 	source := s.pool.Config["source"]
@@ -1994,12 +1992,12 @@ func (s *storageBtrfs) ImageCreate(fingerprint string) error {
 
 	undo = false
 
-	logger.Debugf("Created BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Created BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ImageDelete(fingerprint string) error {
-	logger.Debugf("Deleting BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleting BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -2030,12 +2028,12 @@ func (s *storageBtrfs) ImageDelete(fingerprint string) error {
 		}
 	}
 
-	logger.Debugf("Deleted BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleted BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageBtrfs) ImageMount(fingerprint string) (bool, error) {
-	logger.Debugf("Mounting BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounting BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	// The storage pool must be mounted.
 	_, err := s.StoragePoolMount()
@@ -2043,7 +2041,7 @@ func (s *storageBtrfs) ImageMount(fingerprint string) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Mounted BTRFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounted BTRFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return true, nil
 }
 
@@ -2066,7 +2064,7 @@ func btrfsSubVolumeCreate(subvol string) error {
 		"create",
 		subvol)
 	if err != nil {
-		logger.Errorf("Failed to create BTRFS subvolume \"%s\": %s.", subvol, output)
+		logger.Errorf("Failed to create BTRFS subvolume \"%s\": %s", subvol, output)
 		return err
 	}
 
@@ -2253,7 +2251,7 @@ func (s *storageBtrfs) btrfsPoolVolumesSnapshot(source string, dest string, read
 			// also don't make subvolumes readonly.
 			readonly = false
 
-			logger.Warnf("Subvolumes detected, ignoring ro flag.")
+			logger.Warnf("Subvolumes detected, ignoring ro flag")
 		}
 
 		for _, subsubvol := range subsubvols {
@@ -2392,12 +2390,12 @@ func (s *btrfsMigrationSourceDriver) send(conn *websocket.Conn, btrfsPath string
 
 	output, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		logger.Errorf("Problem reading btrfs send stderr: %s.", err)
+		logger.Errorf("Problem reading btrfs send stderr: %s", err)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		logger.Errorf("Problem with btrfs send: %s.", string(output))
+		logger.Errorf("Problem with btrfs send: %s", string(output))
 	}
 
 	return err
@@ -2577,7 +2575,7 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 		// Remove the existing pre-created subvolume
 		err := btrfsSubVolumesDelete(targetPath)
 		if err != nil {
-			logger.Errorf("Failed to delete pre-created BTRFS subvolume: %s.", btrfsPath)
+			logger.Errorf("Failed to delete pre-created BTRFS subvolume: %s", btrfsPath)
 			return err
 		}
 
@@ -2605,12 +2603,12 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 
 		output, err := ioutil.ReadAll(stderr)
 		if err != nil {
-			logger.Debugf("Problem reading btrfs receive stderr %s.", err)
+			logger.Debugf("Problem reading btrfs receive stderr %s", err)
 		}
 
 		err = cmd.Wait()
 		if err != nil {
-			logger.Errorf("Problem with btrfs receive: %s.", string(output))
+			logger.Errorf("Problem with btrfs receive: %s", string(output))
 			return err
 		}
 
@@ -2626,13 +2624,13 @@ func (s *storageBtrfs) MigrationSink(live bool, container container, snapshots [
 			err = s.btrfsPoolVolumesSnapshot(receivedSnapshot, targetPath, false, true)
 		}
 		if err != nil {
-			logger.Errorf("Problem with btrfs snapshot: %s.", err)
+			logger.Errorf("Problem with btrfs snapshot: %s", err)
 			return err
 		}
 
 		err = btrfsSubVolumesDelete(receivedSnapshot)
 		if err != nil {
-			logger.Errorf("Failed to delete BTRFS subvolume \"%s\": %s.", btrfsPath, err)
+			logger.Errorf("Failed to delete BTRFS subvolume \"%s\": %s", btrfsPath, err)
 			return err
 		}
 

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -131,13 +131,10 @@ func (s *storageCeph) StoragePoolCreate() error {
 			s.ClusterName, "osd", "pool", "create", s.OSDPoolName,
 			s.PGNum)
 		if err != nil {
-			logger.Errorf(`Failed to create CEPH osd storage pool `+
-				`"%s" in cluster "%s": %s`, s.OSDPoolName,
-				s.ClusterName, msg)
+			logger.Errorf(`Failed to create CEPH osd storage pool "%s" in cluster "%s": %s`, s.OSDPoolName, s.ClusterName, msg)
 			return err
 		}
-		logger.Debugf(`Created CEPH osd storage pool "%s" in cluster `+
-			`"%s"`, s.OSDPoolName, s.ClusterName)
+		logger.Debugf(`Created CEPH osd storage pool "%s" in cluster "%s"`, s.OSDPoolName, s.ClusterName)
 
 		defer func() {
 			if !revert {
@@ -147,9 +144,7 @@ func (s *storageCeph) StoragePoolCreate() error {
 			err := cephOSDPoolDestroy(s.ClusterName, s.OSDPoolName,
 				s.UserName)
 			if err != nil {
-				logger.Warnf(`Failed to delete ceph storage `+
-					`pool "%s" in cluster "%s": %s`,
-					s.OSDPoolName, s.ClusterName, err)
+				logger.Warnf(`Failed to delete ceph storage pool "%s" in cluster "%s": %s`, s.OSDPoolName, s.ClusterName, err)
 			}
 		}()
 
@@ -162,22 +157,14 @@ func (s *storageCeph) StoragePoolCreate() error {
 			"--cluster", s.ClusterName, "osd", "pool", "get",
 			s.OSDPoolName, "pg_num")
 		if err != nil {
-			logger.Errorf(`Failed to retrieve number of placement `+
-				`groups for CEPH osd storage pool "%s" in `+
-				`cluster "%s": %s`, s.OSDPoolName,
-				s.ClusterName, msg)
+			logger.Errorf(`Failed to retrieve number of placement groups for CEPH osd storage pool "%s" in cluster "%s": %s`, s.OSDPoolName, s.ClusterName, msg)
 			return err
 		}
-		logger.Debugf(`Retrieved number of placement groups or CEPH `+
-			`osd storage pool "%s" in cluster "%s"`, s.OSDPoolName,
-			s.ClusterName)
+		logger.Debugf(`Retrieved number of placement groups or CEPH osd storage pool "%s" in cluster "%s"`, s.OSDPoolName, s.ClusterName)
 
 		idx := strings.Index(msg, "pg_num:")
 		if idx == -1 {
-			logger.Errorf(`Failed to parse number of placement `+
-				`groups for CEPH osd storage pool "%s" in `+
-				`cluster "%s": %s`, s.OSDPoolName,
-				s.ClusterName, msg)
+			logger.Errorf(`Failed to parse number of placement groups for CEPH osd storage pool "%s" in cluster "%s": %s`, s.OSDPoolName, s.ClusterName, msg)
 		}
 
 		msg = msg[(idx + len("pg_num:")):]
@@ -211,13 +198,10 @@ func (s *storageCeph) StoragePoolCreate() error {
 	poolMntPoint := getStoragePoolMountPoint(s.pool.Name)
 	err := os.MkdirAll(poolMntPoint, 0711)
 	if err != nil {
-		logger.Errorf(`Failed to create mountpoint "%s" for ceph `+
-			`storage pool "%s" in cluster "%s": %s`, poolMntPoint,
-			s.OSDPoolName, s.ClusterName, err)
+		logger.Errorf(`Failed to create mountpoint "%s" for ceph storage pool "%s" in cluster "%s": %s`, poolMntPoint, s.OSDPoolName, s.ClusterName, err)
 		return err
 	}
-	logger.Debugf(`Created mountpoint "%s" for ceph storage pool "%s" in `+
-		`cluster "%s"`, poolMntPoint, s.OSDPoolName, s.ClusterName)
+	logger.Debugf(`Created mountpoint "%s" for ceph storage pool "%s" in cluster "%s"`, poolMntPoint, s.OSDPoolName, s.ClusterName)
 
 	defer func() {
 		if !revert {
@@ -226,9 +210,7 @@ func (s *storageCeph) StoragePoolCreate() error {
 
 		err := os.Remove(poolMntPoint)
 		if err != nil {
-			logger.Errorf(`Failed to delete mountpoint "%s" for `+
-				`ceph storage pool "%s" in cluster "%s": %s`,
-				poolMntPoint, s.OSDPoolName, s.ClusterName, err)
+			logger.Errorf(`Failed to delete mountpoint "%s" for ceph storage pool "%s" in cluster "%s": %s`, poolMntPoint, s.OSDPoolName, s.ClusterName, err)
 		}
 	}()
 
@@ -243,13 +225,10 @@ func (s *storageCeph) StoragePoolCreate() error {
 		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName,
 			s.OSDPoolName, "lxd", "0", s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to create RBD storage volume `+
-				`"%s" on storage pool "%s": %s`, s.pool.Name,
-				s.pool.Name, err)
+			logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, s.pool.Name, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Created RBD storage volume "%s" on storage `+
-			`pool "%s"`, s.pool.Name, s.pool.Name)
+		logger.Debugf(`Created RBD storage volume "%s" on storage pool "%s"`, s.pool.Name, s.pool.Name)
 	} else {
 		msg := fmt.Sprintf(`CEPH OSD storage pool "%s" in cluster `+
 			`"%s" seems to be in use by another LXD instace`,
@@ -279,25 +258,20 @@ func (s *storageCeph) StoragePoolDelete() error {
 	// test if pool exists
 	poolExists := cephOSDPoolExists(s.ClusterName, s.OSDPoolName, s.UserName)
 	if !poolExists {
-		logger.Warnf(`CEPH osd storage pool "%s" does not exist `+
-			`in cluster "%s"`, s.OSDPoolName, s.ClusterName)
+		logger.Warnf(`CEPH osd storage pool "%s" does not exist in cluster "%s"`, s.OSDPoolName, s.ClusterName)
 	}
 
 	// Check whether we own the pool and only remove in this case.
 	if s.pool.Config["volatile.pool.pristine"] != "" &&
 		shared.IsTrue(s.pool.Config["volatile.pool.pristine"]) {
-		logger.Debugf(`Detected that this LXD instance is the owner `+
-			`of the CEPH osd storage pool "%s" in cluster "%s"`,
-			s.OSDPoolName, s.ClusterName)
+		logger.Debugf(`Detected that this LXD instance is the owner of the CEPH osd storage pool "%s" in cluster "%s"`, s.OSDPoolName, s.ClusterName)
 
 		// Delete the osd pool.
 		if poolExists {
 			err := cephOSDPoolDestroy(s.ClusterName, s.OSDPoolName,
 				s.UserName)
 			if err != nil {
-				logger.Errorf(`Failed to delete CEPH OSD storage pool `+
-					`"%s" in cluster "%s": %s`, s.pool.Name,
-					s.ClusterName, err)
+				logger.Errorf(`Failed to delete CEPH OSD storage pool "%s" in cluster "%s": %s`, s.pool.Name, s.ClusterName, err)
 				return err
 			}
 		}
@@ -310,13 +284,10 @@ func (s *storageCeph) StoragePoolDelete() error {
 	if shared.PathExists(poolMntPoint) {
 		err := os.RemoveAll(poolMntPoint)
 		if err != nil {
-			logger.Errorf(`Failed to delete mountpoint "%s" for CEPH osd `+
-				`storage pool "%s" in cluster "%s": %s`, poolMntPoint,
-				s.OSDPoolName, s.ClusterName, err)
+			logger.Errorf(`Failed to delete mountpoint "%s" for CEPH osd storage pool "%s" in cluster "%s": %s`, poolMntPoint, s.OSDPoolName, s.ClusterName, err)
 			return err
 		}
-		logger.Debugf(`Deleted mountpoint "%s" for CEPH osd storage pool "%s" `+
-			`in cluster "%s"`, poolMntPoint, s.OSDPoolName, s.ClusterName)
+		logger.Debugf(`Deleted mountpoint "%s" for CEPH osd storage pool "%s" in cluster "%s"`, poolMntPoint, s.OSDPoolName, s.ClusterName)
 	}
 
 	logger.Infof(`Deleted CEPH OSD storage pool "%s" in cluster "%s"`,
@@ -363,20 +334,16 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 	// get size
 	RBDSize, err := s.getRBDSize()
 	if err != nil {
-		logger.Errorf(`Failed to retrieve size of RBD storage volume `+
-			`"%s" on storage pool "%s": %s`, s.volume.Name,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to retrieve size of RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Retrieved size "%s" of RBD storage volume "%s" on `+
-		`storage pool "%s"`, RBDSize, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Retrieved size "%s" of RBD storage volume "%s" on storage pool "%s"`, RBDSize, s.volume.Name, s.pool.Name)
 
 	// create volume
 	err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, s.volume.Name,
 		storagePoolVolumeTypeNameCustom, RBDSize, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to create RBD storage volume "%s" on `+
-			`storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
+		logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		return err
 	}
 	logger.Debugf(`Created RBD storage volume "%s" on storage pool "%s"`,
@@ -390,17 +357,14 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 		err := cephRBDVolumeDelete(s.ClusterName, s.OSDPoolName,
 			s.volume.Name, storagePoolVolumeTypeNameCustom, s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to delete RBD storage volume `+
-				`"%s" on storage pool "%s": %s`, s.volume.Name,
-				s.pool.Name, err)
+			logger.Warnf(`Failed to delete RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		}
 	}()
 
 	RBDDevPath, err := cephRBDVolumeMap(s.ClusterName, s.OSDPoolName,
 		s.volume.Name, storagePoolVolumeTypeNameCustom, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for "%s" on `+
-			`storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
+		logger.Errorf(`Failed to map RBD storage volume for "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		return err
 	}
 	logger.Debugf(`Mapped RBD storage volume for "%s" on storage pool "%s"`,
@@ -415,41 +379,28 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 			s.volume.Name, storagePoolVolumeTypeNameCustom,
 			s.UserName, true)
 		if err != nil {
-			logger.Warnf(`Failed to unmap RBD storage volume `+
-				`"%s" on storage pool "%s": %s`, s.volume.Name,
-				s.pool.Name, err)
+			logger.Warnf(`Failed to unmap RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		}
 	}()
 
 	// get filesystem
 	RBDFilesystem := s.getRBDFilesystem()
-	logger.Debugf(`Retrieved filesystem type "%s" of RBD storage volume `+
-		`"%s" on storage pool "%s"`, RBDFilesystem, s.volume.Name,
-		s.pool.Name)
+	logger.Debugf(`Retrieved filesystem type "%s" of RBD storage volume "%s" on storage pool "%s"`, RBDFilesystem, s.volume.Name, s.pool.Name)
 
 	msg, err := makeFSType(RBDDevPath, RBDFilesystem, nil)
 	if err != nil {
-		logger.Errorf(`Failed to create filesystem type "%s" on `+
-			`device path "%s" for RBD storage volume "%s" on `+
-			`storage pool "%s": %s`, RBDFilesystem, RBDDevPath,
-			s.volume.Name, s.pool.Name, msg)
+		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume "%s" on storage pool "%s": %s`, RBDFilesystem, RBDDevPath, s.volume.Name, s.pool.Name, msg)
 		return err
 	}
-	logger.Debugf(`Created filesystem type "%s" on device path "%s" for `+
-		`RBD storage volume "%s" on storage pool "%s"`, RBDFilesystem,
-		RBDDevPath, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Created filesystem type "%s" on device path "%s" for RBD storage volume "%s" on storage pool "%s"`, RBDFilesystem, RBDDevPath, s.volume.Name, s.pool.Name)
 
 	volumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 	err = os.MkdirAll(volumeMntPoint, 0711)
 	if err != nil {
-		logger.Errorf(`Failed to create mountpoint "%s" for RBD `+
-			`storage volume "%s" on storage pool "%s": %s"`,
-			volumeMntPoint, s.volume.Name, s.pool.Name, err)
+		logger.Errorf(`Failed to create mountpoint "%s" for RBD storage volume "%s" on storage pool "%s": %s"`, volumeMntPoint, s.volume.Name, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created mountpoint "%s" for RBD storage volume "%s" `+
-		`on storage pool "%s"`, volumeMntPoint, s.volume.Name,
-		s.pool.Name)
+	logger.Debugf(`Created mountpoint "%s" for RBD storage volume "%s" on storage pool "%s"`, volumeMntPoint, s.volume.Name, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -458,9 +409,7 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 
 		err := os.Remove(volumeMntPoint)
 		if err != nil {
-			logger.Warnf(`Failed to delete mountpoint "%s" for RBD `+
-				`storage volume "%s" on storage pool "%s": %s"`,
-				volumeMntPoint, s.volume.Name, s.pool.Name, err)
+			logger.Warnf(`Failed to delete mountpoint "%s" for RBD storage volume "%s" on storage pool "%s": %s"`, volumeMntPoint, s.volume.Name, s.pool.Name, err)
 		}
 	}()
 
@@ -493,12 +442,9 @@ func (s *storageCeph) StoragePoolVolumeDelete() error {
 	if shared.IsMountPoint(volumeMntPoint) {
 		err := tryUnmount(volumeMntPoint, syscall.MNT_DETACH)
 		if err != nil {
-			logger.Errorf(`Failed to unmount RBD storage volume `+
-				`"%s" on storage pool "%s": %s`, s.volume.Name,
-				s.pool.Name, err)
+			logger.Errorf(`Failed to unmount RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		}
-		logger.Debugf(`Unmounted RBD storage volume "%s" on storage `+
-			`pool "%s"`, s.volume.Name, s.pool.Name)
+		logger.Debugf(`Unmounted RBD storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	}
 
 	rbdVolumeExists := cephRBDVolumeExists(s.ClusterName, s.OSDPoolName,
@@ -521,24 +467,17 @@ func (s *storageCeph) StoragePoolVolumeDelete() error {
 		storagePoolVolumeTypeCustom,
 		s.poolID)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for RBD `+
-			`storage volume "%s" on storage pool "%s"`,
-			s.volume.Name, s.pool.Name)
+		logger.Errorf(`Failed to delete database entry for RBD storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	}
-	logger.Debugf(`Deleted database entry for RBD storage volume "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Deleted database entry for RBD storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	if shared.PathExists(volumeMntPoint) {
 		err = os.Remove(volumeMntPoint)
 		if err != nil {
-			logger.Errorf(`Failed to delete mountpoint "%s" for RBD `+
-				`storage volume "%s" on storage pool "%s": %s"`,
-				volumeMntPoint, s.volume.Name, s.pool.Name, err)
+			logger.Errorf(`Failed to delete mountpoint "%s" for RBD storage volume "%s" on storage pool "%s": %s"`, volumeMntPoint, s.volume.Name, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Deleted mountpoint "%s" for RBD storage volume "%s" `+
-			`on storage pool "%s"`, volumeMntPoint, s.volume.Name,
-			s.pool.Name)
+		logger.Debugf(`Deleted mountpoint "%s" for RBD storage volume "%s" on storage pool "%s"`, volumeMntPoint, s.volume.Name, s.pool.Name)
 	}
 
 	logger.Debugf(`Deleted RBD storage volume "%s" on storage pool "%s"`,
@@ -558,14 +497,11 @@ func (s *storageCeph) StoragePoolVolumeMount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf(`Received value over semaphore. This ` +
-				`should not have happened`)
+			logger.Warnf(`Received value over semaphore. This should not have happened`)
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
-		logger.Debugf(`RBD storage volume "%s" on storage pool "%s" `+
-			`appears to be already mounted`, s.volume.Name,
-			s.pool.Name)
+		logger.Debugf(`RBD storage volume "%s" on storage pool "%s" appears to be already mounted`, s.volume.Name, s.pool.Name)
 		return false, nil
 	}
 
@@ -598,9 +534,7 @@ func (s *storageCeph) StoragePoolVolumeMount() (bool, error) {
 	lxdStorageMapLock.Unlock()
 
 	if customerr != nil || ret < 0 {
-		logger.Errorf(`Failed to mount RBD storage volume "%s" on `+
-			`storage pool "%s": %s`, s.volume.Name, s.pool.Name,
-			customerr)
+		logger.Errorf(`Failed to mount RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, customerr)
 		return false, customerr
 	}
 
@@ -620,14 +554,11 @@ func (s *storageCeph) StoragePoolVolumeUmount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf(`Received value over semaphore. This ` +
-				`should not have happened`)
+			logger.Warnf(`Received value over semaphore. This should not have happened`)
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
-		logger.Debugf(`RBD storage volume "%s" on storage pool "%s" `+
-			`appears to be already unmounted`, s.volume.Name,
-			s.pool.Name)
+		logger.Debugf(`RBD storage volume "%s" on storage pool "%s" appears to be already unmounted`, s.volume.Name, s.pool.Name)
 		return false, nil
 	}
 
@@ -639,9 +570,7 @@ func (s *storageCeph) StoragePoolVolumeUmount() (bool, error) {
 	if shared.IsMountPoint(volumeMntPoint) {
 		customerr = tryUnmount(volumeMntPoint, syscall.MNT_DETACH)
 		ourUmount = true
-		logger.Debugf(`Path "%s" is a mountpoint for RBD storage `+
-			`volume "%s" on storage pool "%s"`, volumeMntPoint,
-			s.volume.Name, s.pool.Name)
+		logger.Debugf(`Path "%s" is a mountpoint for RBD storage volume "%s" on storage pool "%s"`, volumeMntPoint, s.volume.Name, s.pool.Name)
 	}
 
 	lxdStorageMapLock.Lock()
@@ -652,9 +581,7 @@ func (s *storageCeph) StoragePoolVolumeUmount() (bool, error) {
 	lxdStorageMapLock.Unlock()
 
 	if customerr != nil {
-		logger.Errorf(`Failed to unmount RBD storage volume "%s" on `+
-			`storage pool "%s": %s`, s.volume.Name, s.pool.Name,
-			customerr)
+		logger.Errorf(`Failed to unmount RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, customerr)
 		return false, customerr
 	}
 
@@ -723,8 +650,7 @@ func (s *storageCeph) StoragePoolVolumeRename(newName string) error {
 		s.volume.Name, storagePoolVolumeTypeNameCustom,
 		s.UserName, true)
 	if err != nil {
-		logger.Errorf(`Failed to unmap RBD storage volume for `+`container "%s" on storage pool "%s": %s`,
-			s.volume.Name, s.pool.Name, err)
+		logger.Errorf(`Failed to unmap RBD storage volume for container "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		return err
 	}
 	logger.Debugf(`Unmapped RBD storage volume for container "%s" on storage pool "%s"`,
@@ -785,19 +711,16 @@ func (s *storageCeph) StoragePoolUpdate(writable *api.StoragePoolPut, changedCon
 }
 
 func (s *storageCeph) ContainerStorageReady(name string) bool {
-	logger.Debugf(`Checking if RBD storage volume for container "%s" `+
-		`on storage pool "%s" is ready`, name, s.pool.Name)
+	logger.Debugf(`Checking if RBD storage volume for container "%s" on storage pool "%s" is ready`, name, s.pool.Name)
 
 	ok := cephRBDVolumeExists(s.ClusterName, s.OSDPoolName, name,
 		storagePoolVolumeTypeNameContainer, s.UserName)
 	if !ok {
-		logger.Debugf(`RBD storage volume for container "%s" `+
-			`on storage pool "%s" does not exist`, name, s.pool.Name)
+		logger.Debugf(`RBD storage volume for container "%s" on storage pool "%s" does not exist`, name, s.pool.Name)
 		return false
 	}
 
-	logger.Debugf(`RBD storage volume for container "%s" `+
-		`on storage pool "%s" is ready`, name, s.pool.Name)
+	logger.Debugf(`RBD storage volume for container "%s" on storage pool "%s" is ready`, name, s.pool.Name)
 	return true
 }
 
@@ -810,21 +733,18 @@ func (s *storageCeph) ContainerCreate(container container) error {
 
 	err = container.TemplateApply("create")
 	if err != nil {
-		logger.Errorf(`Failed to apply create template for container `+
-			`"%s": %s`, containerName, err)
+		logger.Errorf(`Failed to apply create template for container "%s": %s`, containerName, err)
 		return err
 	}
 	logger.Debugf(`Applied create template for container "%s"`,
 		containerName)
 
-	logger.Debugf(`Created RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Created RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	return nil
 }
 
 func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint string) error {
-	logger.Debugf(`Creating RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Creating RBD storage volume for container "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	revert := true
 
@@ -838,8 +758,7 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 	if waitChannel, ok := lxdStorageOngoingOperationMap[imageStoragePoolLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf(`Received value over semaphore. This ` +
-				`should not have happened`)
+			logger.Warnf(`Received value over semaphore. This should not have happened`)
 		}
 	} else {
 		lxdStorageOngoingOperationMap[imageStoragePoolLockID] = make(chan bool)
@@ -884,8 +803,7 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 		storagePoolVolumeTypeNameImage, "readonly", s.OSDPoolName,
 		containerName, storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to clone new RBD storage volume for `+
-			`container "%s": %s`, containerName, err)
+		logger.Errorf(`Failed to clone new RBD storage volume for container "%s": %s`, containerName, err)
 		return err
 	}
 	logger.Debugf(`Cloned new RBD storage volume for container "%s"`,
@@ -900,16 +818,14 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 			containerName, storagePoolVolumeTypeNameContainer,
 			s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to delete RBD storage volume `+
-				`for container "%s": %s`, containerName, err)
+			logger.Warnf(`Failed to delete RBD storage volume for container "%s": %s`, containerName, err)
 		}
 	}()
 
 	RBDDevPath, err := cephRBDVolumeMap(s.ClusterName, s.OSDPoolName,
 		containerName, storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for container `+
-			`"%s"`, containerName)
+		logger.Errorf(`Failed to map RBD storage volume for container "%s"`, containerName)
 		return err
 	}
 	logger.Debugf(`Mapped RBD storage volume for container "%s"`,
@@ -924,8 +840,7 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 			containerName, storagePoolVolumeTypeNameContainer,
 			s.UserName, true)
 		if err != nil {
-			logger.Warnf(`Failed to unmap RBD storage volume `+
-				`for container "%s": %s`, containerName, err)
+			logger.Warnf(`Failed to unmap RBD storage volume for container "%s": %s`, containerName, err)
 		}
 	}()
 
@@ -942,13 +857,10 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 	err = createContainerMountpoint(containerPoolVolumeMntPoint,
 		containerPath, privileged)
 	if err != nil {
-		logger.Errorf(`Failed to create mountpoint "%s" for container `+
-			`"%s" for RBD storage volume: %s`,
-			containerPoolVolumeMntPoint, containerName, err)
+		logger.Errorf(`Failed to create mountpoint "%s" for container "%s" for RBD storage volume: %s`, containerPoolVolumeMntPoint, containerName, err)
 		return err
 	}
-	logger.Debugf(`Created mountpoint "%s" for container "%s" for RBD `+
-		`storage volume`, containerPoolVolumeMntPoint, containerName)
+	logger.Debugf(`Created mountpoint "%s" for container "%s" for RBD storage volume`, containerPoolVolumeMntPoint, containerName)
 
 	defer func() {
 		if !revert {
@@ -957,9 +869,7 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 
 		err := os.Remove(containerPoolVolumeMntPoint)
 		if err != nil {
-			logger.Warnf(`Failed to delete mountpoint "%s" for `+
-				`container "%s" for RBD storage volume: %s`,
-				containerPoolVolumeMntPoint, containerName, err)
+			logger.Warnf(`Failed to delete mountpoint "%s" for container "%s" for RBD storage volume: %s`, containerPoolVolumeMntPoint, containerName, err)
 		}
 	}()
 
@@ -974,48 +884,35 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 	if !privileged {
 		err := s.shiftRootfs(container)
 		if err != nil {
-			logger.Errorf(`Failed to shift rootfs for container `+
-				`"%s": %s`, containerName, err)
+			logger.Errorf(`Failed to shift rootfs for container "%s": %s`, containerName, err)
 			return err
 		}
 		logger.Debugf(`Shifted rootfs for container "%s"`, containerName)
 
 		err = os.Chmod(containerPoolVolumeMntPoint, 0711)
 		if err != nil {
-			logger.Errorf(`Failed change mountpoint "%s" `+
-				`permissions to 0711 for container "%s" for `+
-				`RBD storage volume: %s`,
-				containerPoolVolumeMntPoint, containerName, err)
+			logger.Errorf(`Failed change mountpoint "%s" permissions to 0711 for container "%s" for RBD storage volume: %s`, containerPoolVolumeMntPoint, containerName, err)
 			return err
 		}
-		logger.Debugf(`Changed mountpoint "%s" permissions to 0711 for `+
-			`container "%s" for RBD storage volume`,
-			containerPoolVolumeMntPoint, containerName)
+		logger.Debugf(`Changed mountpoint "%s" permissions to 0711 for container "%s" for RBD storage volume`, containerPoolVolumeMntPoint, containerName)
 	} else {
 		err := os.Chmod(containerPoolVolumeMntPoint, 0700)
 		if err != nil {
-			logger.Errorf(`Failed change mountpoint "%s" `+
-				`permissions to 0700 for container "%s" for `+
-				`RBD storage volume: %s`,
-				containerPoolVolumeMntPoint, containerName, err)
+			logger.Errorf(`Failed change mountpoint "%s" permissions to 0700 for container "%s" for RBD storage volume: %s`, containerPoolVolumeMntPoint, containerName, err)
 			return err
 		}
-		logger.Debugf(`Changed mountpoint "%s" permissions to 0700 `+
-			`for container "%s" for RBD storage volume`,
-			containerPoolVolumeMntPoint, containerName)
+		logger.Debugf(`Changed mountpoint "%s" permissions to 0700 for container "%s" for RBD storage volume`, containerPoolVolumeMntPoint, containerName)
 	}
 
 	err = container.TemplateApply("create")
 	if err != nil {
-		logger.Errorf(`Failed to apply create template for container `+
-			`"%s": %s`, containerName, err)
+		logger.Errorf(`Failed to apply create template for container "%s": %s`, containerName, err)
 		return err
 	}
 	logger.Debugf(`Applied create template for container "%s"`,
 		containerName)
 
-	logger.Debugf(`Created RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Created RBD storage volume for container "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	revert = false
 
@@ -1028,8 +925,7 @@ func (s *storageCeph) ContainerCanRestore(container container, sourceContainer c
 
 func (s *storageCeph) ContainerDelete(container container) error {
 	containerName := container.Name()
-	logger.Debugf(`Deleting RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Deleting RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	// umount
 	containerPath := container.Path()
@@ -1059,15 +955,11 @@ func (s *storageCeph) ContainerDelete(container container) error {
 	err := deleteContainerMountpoint(containerMntPoint, containerPath,
 		s.GetStorageTypeName())
 	if err != nil {
-		logger.Errorf(`Failed to delete mountpoint %s for RBD storage `+
-			`volume of container "%s" for RBD storage volume on `+
-			`storage pool "%s": %s`, containerMntPoint,
+		logger.Errorf(`Failed to delete mountpoint %s for RBD storage volume of container "%s" for RBD storage volume on storage pool "%s": %s`, containerMntPoint,
 			containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Deleted mountpoint %s for RBD storage volume of `+
-		`container "%s" for RBD storage volume on storage pool "%s"`,
-		containerMntPoint, containerName, s.pool.Name)
+	logger.Debugf(`Deleted mountpoint %s for RBD storage volume of container "%s" for RBD storage volume on storage pool "%s"`, containerMntPoint, containerName, s.pool.Name)
 
 	backups, err := container.Backups()
 	if err != nil {
@@ -1079,8 +971,7 @@ func (s *storageCeph) ContainerDelete(container container) error {
 		s.ContainerBackupDelete(backupName)
 	}
 
-	logger.Debugf(`Deleted RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Deleted RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	return nil
 }
 
@@ -1179,15 +1070,14 @@ func (s *storageCeph) doCrossPoolContainerCopy(target container, source containe
 func (s *storageCeph) ContainerCopy(target container, source container,
 	containerOnly bool) error {
 	sourceContainerName := source.Name()
-	logger.Debugf(`Copying RBD container storage %s -> %s`,
+	logger.Debugf(`Copying RBD container storage %s to %s`,
 		sourceContainerName, target.Name())
 
 	revert := true
 
 	ourStart, err := source.StorageStart()
 	if err != nil {
-		logger.Errorf(`Failed to initialize storage for container `+
-			`"%s": %s`, sourceContainerName, err)
+		logger.Errorf(`Failed to initialize storage for container "%s": %s`, sourceContainerName, err)
 		return err
 	}
 	logger.Debugf(`Initialized storage for container "%s"`,
@@ -1204,8 +1094,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 
 	snapshots, err := source.Snapshots()
 	if err != nil {
-		logger.Errorf(`Failed to retrieve snapshots of container `+
-			`"%s": %s`, sourceContainerName, err)
+		logger.Errorf(`Failed to retrieve snapshots of container "%s": %s`, sourceContainerName, err)
 		return err
 	}
 	logger.Debugf(`Retrieved snapshots of container "%s"`,
@@ -1222,17 +1111,15 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 			err = s.copyWithoutSnapshotsSparse(target, source)
 		}
 		if err != nil {
-			logger.Errorf(`Failed to copy RBD container storage `+
-				`%s -> %s`, sourceContainerName, target.Name())
+			logger.Errorf(`Failed to copy RBD container storage %s to %s`, sourceContainerName, target.Name())
 			return err
 		}
 
-		logger.Debugf(`Copied RBD container storage %s -> %s`,
+		logger.Debugf(`Copied RBD container storage %s to %s`,
 			sourceContainerName, target.Name())
 		return nil
 	} else {
-		logger.Debugf(`Creating non-sparse copy of RBD storage volume `+
-			`for container "%s" -> "%s" including snapshots`,
+		logger.Debugf(`Creating non-sparse copy of RBD storage volume for container "%s" to "%s" including snapshots`,
 			sourceContainerName, targetContainerName)
 
 		// create mountpoint for container
@@ -1245,15 +1132,10 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 			targetContainerPath,
 			target.IsPrivileged())
 		if err != nil {
-			logger.Errorf(`Failed to create mountpoint "%s" for `+
-				`RBD storage volume "%s" on storage pool `+
-				`"%s": %s"`, targetContainerMountPoint,
-				s.volume.Name, s.pool.Name, err)
+			logger.Errorf(`Failed to create mountpoint "%s" for RBD storage volume "%s" on storage pool "%s": %s"`, targetContainerMountPoint, s.volume.Name, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Created mountpoint "%s" for RBD storage `+
-			`volume "%s" on storage pool "%s"`,
-			targetContainerMountPoint, s.volume.Name, s.pool.Name)
+		logger.Debugf(`Created mountpoint "%s" for RBD storage volume "%s" on storage pool "%s"`, targetContainerMountPoint, s.volume.Name, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -1265,11 +1147,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 				targetContainerPath,
 				"")
 			if err != nil {
-				logger.Warnf(`Failed to delete mountpoint `+
-					`"%s" for RBD storage volume "%s" on `+
-					`storage pool "%s": %s"`,
-					targetContainerMountPoint,
-					s.volume.Name, s.pool.Name, err)
+				logger.Warnf(`Failed to delete mountpoint "%s" for RBD storage volume "%s" on storage pool "%s": %s"`, targetContainerMountPoint, s.volume.Name, s.pool.Name, err)
 			}
 		}()
 
@@ -1278,9 +1156,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 			targetContainerName, storagePoolVolumeTypeNameContainer,
 			"0", s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to create RBD storage volume "%s" on `+
-				`storage pool "%s": %s`, targetContainerName,
-				s.pool.Name, err)
+			logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 			return err
 		}
 		logger.Debugf(`Created RBD storage volume "%s" on storage pool "%s"`,
@@ -1295,9 +1171,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 				targetContainerName,
 				storagePoolVolumeTypeNameContainer, s.UserName)
 			if err != nil {
-				logger.Warnf(`Failed to delete RBD storage `+
-					`volume "%s" on storage pool "%s": %s`,
-					targetContainerName, s.pool.Name, err)
+				logger.Warnf(`Failed to delete RBD storage volume "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 			}
 		}()
 
@@ -1328,12 +1202,11 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 				targetVolumeName,
 				prev)
 			if err != nil {
-				logger.Errorf(`Failed to copy RBD container `+
-					`storage %s -> %s`, sourceVolumeName,
+				logger.Errorf(`Failed to copy RBD container storage %s to %s`, sourceVolumeName,
 					targetVolumeName)
 				return err
 			}
-			logger.Debugf(`Copied RBD container storage %s -> %s`,
+			logger.Debugf(`Copied RBD container storage %s to %s`,
 				sourceVolumeName, targetVolumeName)
 
 			defer func() {
@@ -1346,10 +1219,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 					storagePoolVolumeTypeNameContainer,
 					snapOnlyName, s.UserName)
 				if err != nil {
-					logger.Warnf(`Failed to delete RBD `+
-						`container storage for `+
-						`snapshot "%s" of container "%s"`,
-						snapOnlyName, targetContainerName)
+					logger.Warnf(`Failed to delete RBD container storage for snapshot "%s" of container "%s"`, snapOnlyName, targetContainerName)
 				}
 			}()
 
@@ -1376,23 +1246,10 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 				snapshotMntPointSymlinkTarget,
 				snapshotMntPointSymlink)
 			if err != nil {
-				logger.Errorf(`Failed to create mountpoint `+
-					`"%s", snapshot symlink target "%s", `+
-					`snapshot mountpoint symlink"%s" for `+
-					`RBD storage volume "%s" on storage `+
-					`pool "%s": %s`, containersPath,
-					snapshotMntPointSymlinkTarget,
-					snapshotMntPointSymlink, s.volume.Name,
-					s.pool.Name, err)
+				logger.Errorf(`Failed to create mountpoint "%s", snapshot symlink target "%s", snapshot mountpoint symlink"%s" for RBD storage volume "%s" on storage pool "%s": %s`, containersPath, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, s.volume.Name, s.pool.Name, err)
 				return err
 			}
-			logger.Debugf(`Created mountpoint "%s", snapshot `+
-				`symlink target "%s", snapshot mountpoint `+
-				`symlink"%s" for RBD storage volume "%s" on `+
-				`storage pool "%s"`, containersPath,
-				snapshotMntPointSymlinkTarget,
-				snapshotMntPointSymlink, s.volume.Name,
-				s.pool.Name)
+			logger.Debugf(`Created mountpoint "%s", snapshot symlink target "%s", snapshot mountpoint symlink"%s" for RBD storage volume "%s" on storage pool "%s"`, containersPath, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, s.volume.Name, s.pool.Name)
 
 			defer func() {
 				if !revert {
@@ -1404,16 +1261,7 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 					snapshotMntPointSymlinkTarget,
 					snapshotMntPointSymlink)
 				if err != nil {
-					logger.Warnf(`Failed to delete `+
-						`mountpoint "%s", snapshot `+
-						`symlink target "%s", `+
-						`snapshot mountpoint `+
-						`symlink "%s" for RBD storage `+
-						`volume "%s" on storage pool `+
-						`"%s": %s`, containersPath,
-						snapshotMntPointSymlinkTarget,
-						snapshotMntPointSymlink,
-						s.volume.Name, s.pool.Name, err)
+					logger.Warnf(`Failed to delete mountpoint "%s", snapshot symlink target "%s", snapshot mountpoint symlink "%s" for RBD storage volume "%s" on storage pool "%s": %s`, containersPath, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, s.volume.Name, s.pool.Name, err)
 				}
 			}()
 		}
@@ -1428,12 +1276,10 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 			targetVolumeName,
 			lastSnap)
 		if err != nil {
-			logger.Errorf(`Failed to copy RBD container storage `+
-				`%s -> %s`, sourceVolumeName, targetVolumeName)
+			logger.Errorf(`Failed to copy RBD container storage %s to %s`, sourceVolumeName, targetVolumeName)
 			return err
 		}
-		logger.Debugf(`Copied RBD container storage %s -> %s`,
-			sourceVolumeName, targetVolumeName)
+		logger.Debugf(`Copied RBD container storage %s to %s`, sourceVolumeName, targetVolumeName)
 
 		// Note, we don't need to register another cleanup function for
 		// the actual container's storage volume since we already
@@ -1444,16 +1290,12 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 			targetContainerName, storagePoolVolumeTypeNameContainer,
 			s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to map RBD storage volume for `+
-				`container "%s" on storage pool "%s": %s`,
-				targetContainerName, s.pool.Name, err)
+			logger.Errorf(`Failed to map RBD storage volume for container "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Mapped RBD storage volume for container "%s" `+
-			`on storage pool "%s"`, targetContainerName, s.pool.Name)
+		logger.Debugf(`Mapped RBD storage volume for container "%s" on storage pool "%s"`, targetContainerName, s.pool.Name)
 
-		logger.Debugf(`Created non-sparse copy of RBD storage volume `+
-			`for container "%s" -> "%s" including snapshots`,
+		logger.Debugf(`Created non-sparse copy of RBD storage volume for container "%s" to "%s" including snapshots`,
 			sourceContainerName, targetContainerName)
 	}
 
@@ -1472,14 +1314,12 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 
 	err = target.TemplateApply("copy")
 	if err != nil {
-		logger.Errorf(`Failed to apply copy template for container `+
-			`"%s": %s`, target.Name(), err)
+		logger.Errorf(`Failed to apply copy template for container "%s": %s`, target.Name(), err)
 		return err
 	}
 	logger.Debugf(`Applied copy template for container "%s"`, target.Name())
 
-	logger.Debugf(`Copied RBD container storage %s -> %s`,
-		sourceContainerName, target.Name())
+	logger.Debugf(`Copied RBD container storage %s to %s`, sourceContainerName, target.Name())
 
 	revert = false
 
@@ -1487,19 +1327,19 @@ func (s *storageCeph) ContainerCopy(target container, source container,
 }
 
 func (s *storageCeph) ContainerMount(c container) (bool, error) {
-	logger.Debugf("Mounting RBD storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting RBD storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	ourMount, err := s.doContainerMount(c.Name())
 	if err != nil {
 		return false, err
 	}
 
-	logger.Debugf("Mounted RBD storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted RBD storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageCeph) ContainerUmount(name string, path string) (bool, error) {
-	logger.Debugf("Unmounting RBD storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounting RBD storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerMntPoint := getContainerMountPoint(s.pool.Name, name)
 	if shared.IsSnapshot(name) {
@@ -1511,7 +1351,7 @@ func (s *storageCeph) ContainerUmount(name string, path string) (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
@@ -1541,7 +1381,7 @@ func (s *storageCeph) ContainerUmount(name string, path string) (bool, error) {
 		return false, mounterr
 	}
 
-	logger.Debugf("Unmounted RBD storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounted RBD storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -1551,8 +1391,7 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 
 	revert := true
 
-	logger.Debugf(`Renaming RBD storage volume for container "%s" from `+
-		`"%s" to "%s"`, oldName, oldName, newName)
+	logger.Debugf(`Renaming RBD storage volume for container "%s" from "%s" to "%s"`, oldName, oldName, newName)
 
 	// unmount
 	_, err := s.ContainerUmount(oldName, containerPath)
@@ -1564,13 +1403,10 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 	err = cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName, oldName,
 		storagePoolVolumeTypeNameContainer, s.UserName, true)
 	if err != nil {
-		logger.Errorf(`Failed to unmap RBD storage volume for `+
-			`container "%s" on storage pool "%s": %s`, oldName,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to unmap RBD storage volume for container "%s" on storage pool "%s": %s`, oldName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Unmapped RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, oldName, s.pool.Name)
+	logger.Debugf(`Unmapped RBD storage volume for container "%s" on storage pool "%s"`, oldName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1580,21 +1416,17 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 		_, err := cephRBDVolumeMap(s.ClusterName, s.OSDPoolName,
 			oldName, storagePoolVolumeTypeNameContainer, s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to Map RBD storage volume `+
-				`for container "%s": %s`, oldName, err)
+			logger.Warnf(`Failed to Map RBD storage volume for container "%s": %s`, oldName, err)
 		}
 	}()
 
 	err = cephRBDVolumeRename(s.ClusterName, s.OSDPoolName,
 		storagePoolVolumeTypeNameContainer, oldName, newName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to rename RBD storage volume for `+
-			`container "%s" on storage pool "%s": %s`,
-			oldName, s.pool.Name, err)
+		logger.Errorf(`Failed to rename RBD storage volume for container "%s" on storage pool "%s": %s`, oldName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Renamed RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, oldName, s.pool.Name)
+	logger.Debugf(`Renamed RBD storage volume for container "%s" on storage pool "%s"`, oldName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1605,9 +1437,7 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 			storagePoolVolumeTypeNameContainer, newName, oldName,
 			s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to rename RBD storage volume for `+
-				`container "%s" on storage pool "%s": %s`,
-				newName, s.pool.Name, err)
+			logger.Warnf(`Failed to rename RBD storage volume for container "%s" on storage pool "%s": %s`, newName, s.pool.Name, err)
 		}
 	}()
 
@@ -1615,13 +1445,10 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 	_, err = cephRBDVolumeMap(s.ClusterName, s.OSDPoolName, newName,
 		storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for `+
-			`container "%s" on storage pool "%s": %s`, newName,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to map RBD storage volume for container "%s" on storage pool "%s": %s`, newName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Mapped RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, newName, s.pool.Name)
+	logger.Debugf(`Mapped RBD storage volume for container "%s" on storage pool "%s"`, newName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1631,8 +1458,7 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 		err := cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName, newName,
 			storagePoolVolumeTypeNameContainer, s.UserName, true)
 		if err != nil {
-			logger.Warnf(`Failed to unmap RBD storage volume `+
-				`for container "%s": %s`, newName, err)
+			logger.Warnf(`Failed to unmap RBD storage volume for container "%s": %s`, newName, err)
 		}
 	}()
 
@@ -1715,8 +1541,7 @@ func (s *storageCeph) ContainerRename(c container, newName string) error {
 		s.ContainerBackupRename(backup, newName)
 	}
 
-	logger.Debugf(`Renamed RBD storage volume for container "%s" from `+
-		`"%s" to "%s"`, oldName, oldName, newName)
+	logger.Debugf(`Renamed RBD storage volume for container "%s" from "%s" to "%s"`, oldName, oldName, newName)
 
 	revert = false
 
@@ -1727,8 +1552,7 @@ func (s *storageCeph) ContainerRestore(target container, source container) error
 	sourceName := source.Name()
 	targetName := target.Name()
 
-	logger.Debugf(`Restoring RBD storage volume for container "%s" from `+
-		`%s to %s`, targetName, sourceName, targetName)
+	logger.Debugf(`Restoring RBD storage volume for container "%s" from %s to %s`, targetName, sourceName, targetName)
 
 	ourStorageStop, err := source.StorageStop()
 	if err != nil {
@@ -1752,14 +1576,11 @@ func (s *storageCeph) ContainerRestore(target container, source container) error
 		sourceContainerOnlyName, storagePoolVolumeTypeNameContainer,
 		prefixedSourceSnapOnlyName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to restore RBD storage volume for `+
-			`container "%s" from "%s": %s`,
-			targetName, sourceName, err)
+		logger.Errorf(`Failed to restore RBD storage volume for container "%s" from "%s": %s`, targetName, sourceName, err)
 		return err
 	}
 
-	logger.Debugf(`Restored RBD storage volume for container "%s" from `+
-		`%s to %s`, targetName, sourceName, targetName)
+	logger.Debugf(`Restored RBD storage volume for container "%s" from %s to %s`, targetName, sourceName, targetName)
 	return nil
 }
 
@@ -1784,8 +1605,7 @@ func (s *storageCeph) ContainerSnapshotCreate(snapshotContainer container, sourc
 }
 
 func (s *storageCeph) ContainerSnapshotDelete(snapshotContainer container) error {
-	logger.Debugf(`Deleting RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Deleting RBD storage volume for snapshot "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	snapshotContainerName := snapshotContainer.Name()
 	sourceContainerName, sourceContainerSnapOnlyName, _ :=
@@ -1814,18 +1634,10 @@ func (s *storageCeph) ContainerSnapshotDelete(snapshotContainer container) error
 	if shared.PathExists(snapshotContainerMntPoint) {
 		err := os.RemoveAll(snapshotContainerMntPoint)
 		if err != nil {
-			logger.Errorf(`Failed to delete mountpoint "%s" of `+
-				`RBD snapshot "%s" of container "%s" on `+
-				`storage pool "%s": %s`,
-				snapshotContainerMntPoint,
-				sourceContainerSnapOnlyName,
-				sourceContainerName, s.OSDPoolName, err)
+			logger.Errorf(`Failed to delete mountpoint "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s": %s`, snapshotContainerMntPoint, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName, err)
 			return err
 		}
-		logger.Debugf(`Deleted mountpoint "%s" of RBD snapshot "%s" `+
-			`of container "%s" on storage pool "%s"`,
-			snapshotContainerMntPoint, sourceContainerSnapOnlyName,
-			sourceContainerName, s.OSDPoolName)
+		logger.Debugf(`Deleted mountpoint "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s"`, snapshotContainerMntPoint, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName)
 	}
 
 	// check if snapshot directory is empty
@@ -1836,18 +1648,10 @@ func (s *storageCeph) ContainerSnapshotDelete(snapshotContainer container) error
 		// remove snapshot directory for container
 		err := os.Remove(snapshotContainerPath)
 		if err != nil {
-			logger.Errorf(`Failed to delete snapshot directory  `+
-				`"%s" of RBD snapshot "%s" of container "%s" `+
-				`on storage pool "%s": %s`,
-				snapshotContainerPath,
-				sourceContainerSnapOnlyName,
-				sourceContainerName, s.OSDPoolName, err)
+			logger.Errorf(`Failed to delete snapshot directory "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s": %s`, snapshotContainerPath, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName, err)
 			return err
 		}
-		logger.Debugf(`Deleted snapshot directory  "%s" of RBD `+
-			`snapshot "%s" of container "%s" on storage pool "%s"`,
-			snapshotContainerPath, sourceContainerSnapOnlyName,
-			sourceContainerName, s.OSDPoolName)
+		logger.Debugf(`Deleted snapshot directory  "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s"`, snapshotContainerPath, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName)
 
 		// remove the snapshot symlink if possible
 		snapshotSymlink := shared.VarPath("snapshots",
@@ -1855,31 +1659,20 @@ func (s *storageCeph) ContainerSnapshotDelete(snapshotContainer container) error
 		if shared.PathExists(snapshotSymlink) {
 			err := os.Remove(snapshotSymlink)
 			if err != nil {
-				logger.Errorf(`Failed to delete snapshot `+
-					`symlink "%s" of RBD snapshot "%s" of `+
-					`container "%s" on storage pool "%s": %s`,
-					snapshotSymlink,
-					sourceContainerSnapOnlyName,
-					sourceContainerName, s.OSDPoolName, err)
+				logger.Errorf(`Failed to delete snapshot symlink "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s": %s`, snapshotSymlink, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName, err)
 				return err
 			}
-			logger.Debugf(`Deleted snapshot symlink "%s" of RBD `+
-				`snapshot "%s" of container "%s" on storage `+
-				`pool "%s"`, snapshotSymlink,
-				sourceContainerSnapOnlyName,
-				sourceContainerName, s.OSDPoolName)
+			logger.Debugf(`Deleted snapshot symlink "%s" of RBD snapshot "%s" of container "%s" on storage pool "%s"`, snapshotSymlink, sourceContainerSnapOnlyName, sourceContainerName, s.OSDPoolName)
 		}
 	}
 
-	logger.Debugf(`Deleted RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Deleted RBD storage volume for snapshot "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageCeph) ContainerSnapshotRename(c container, newName string) error {
 	oldName := c.Name()
-	logger.Debugf(`Renaming RBD storage volume for snapshot "%s" from `+
-		`"%s" to "%s"`, oldName, oldName, newName)
+	logger.Debugf(`Renaming RBD storage volume for snapshot "%s" from "%s" to "%s"`, oldName, oldName, newName)
 
 	revert := true
 
@@ -1891,9 +1684,7 @@ func (s *storageCeph) ContainerSnapshotRename(c container, newName string) error
 		containerOnlyName, storagePoolVolumeTypeNameContainer, oldSnapOnlyName,
 		newSnapOnlyName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to rename RBD storage volume for `+
-			`snapshot "%s" from "%s" to "%s": %s`, oldName, oldName,
-			newName, err)
+		logger.Errorf(`Failed to rename RBD storage volume for snapshot "%s" from "%s" to "%s": %s`, oldName, oldName, newName, err)
 		return err
 	}
 
@@ -1906,10 +1697,7 @@ func (s *storageCeph) ContainerSnapshotRename(c container, newName string) error
 			containerOnlyName, storagePoolVolumeTypeNameContainer,
 			newSnapOnlyName, oldSnapOnlyName, s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to rename RBD storage `+
-				`volume for container "%s" on storage `+
-				`pool "%s": %s`, oldName, s.pool.Name,
-				err)
+			logger.Warnf(`Failed to rename RBD storage volume for container "%s" on storage pool "%s": %s`, oldName, s.pool.Name, err)
 		}
 	}()
 
@@ -1917,17 +1705,12 @@ func (s *storageCeph) ContainerSnapshotRename(c container, newName string) error
 	newSnapshotMntPoint := getSnapshotMountPoint(s.pool.Name, newName)
 	err = os.Rename(oldSnapshotMntPoint, newSnapshotMntPoint)
 	if err != nil {
-		logger.Errorf(`Failed to rename mountpoint for RBD storage `+
-			`volume for snapshot "%s" from "%s" to "%s": %s`,
-			oldName, oldSnapshotMntPoint, newSnapshotMntPoint, err)
+		logger.Errorf(`Failed to rename mountpoint for RBD storage volume for snapshot "%s" from "%s" to "%s": %s`, oldName, oldSnapshotMntPoint, newSnapshotMntPoint, err)
 		return err
 	}
-	logger.Debugf(`Renamed mountpoint for RBD storage volume for `+
-		`snapshot "%s" from "%s" to "%s"`, oldName, oldSnapshotMntPoint,
-		newSnapshotMntPoint)
+	logger.Debugf(`Renamed mountpoint for RBD storage volume for snapshot "%s" from "%s" to "%s"`, oldName, oldSnapshotMntPoint, newSnapshotMntPoint)
 
-	logger.Debugf(`Renamed RBD storage volume for snapshot "%s" from `+
-		`"%s" to "%s"`, oldName, oldName, newName)
+	logger.Debugf(`Renamed RBD storage volume for snapshot "%s" from "%s" to "%s"`, oldName, oldName, newName)
 
 	revert = false
 
@@ -1936,8 +1719,7 @@ func (s *storageCeph) ContainerSnapshotRename(c container, newName string) error
 
 func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 	containerName := c.Name()
-	logger.Debugf(`Initializing RBD storage volume for snapshot "%s" `+
-		`on storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Initializing RBD storage volume for snapshot "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	revert := true
 
@@ -1949,13 +1731,10 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 		containerOnlyName, storagePoolVolumeTypeNameContainer,
 		prefixedSnapOnlyName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to protect snapshot of RBD storage `+
-			`volume for container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to protect snapshot of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return false, err
 	}
-	logger.Debugf(`Protected snapshot of RBD storage volume for container `+
-		`"%s" on storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Protected snapshot of RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1966,9 +1745,7 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 			containerOnlyName, storagePoolVolumeTypeNameContainer,
 			prefixedSnapOnlyName, s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to unprotect snapshot of RBD `+
-				`storage volume for container "%s" on storage `+
-				`pool "%s": %s`, containerName, s.pool.Name, err)
+			logger.Warnf(`Failed to unprotect snapshot of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		}
 	}()
 
@@ -1979,13 +1756,10 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 		prefixedSnapOnlyName, s.OSDPoolName, cloneName, "snapshots",
 		s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to create clone of RBD storage volume `+
-			`for container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to create clone of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return false, err
 	}
-	logger.Debugf(`Created clone of RBD storage volume for container "%s" `+
-		`on storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Created clone of RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1996,9 +1770,7 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 		err = cephRBDVolumeDelete(s.ClusterName, s.OSDPoolName,
 			cloneName, "snapshots", s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to delete clone of RBD storage `+
-				`volume for container "%s" on storage pool `+
-				`"%s": %s`, containerName, s.pool.Name, err)
+			logger.Errorf(`Failed to delete clone of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		}
 	}()
 
@@ -2006,13 +1778,10 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 	RBDDevPath, err := cephRBDVolumeMap(s.ClusterName, s.OSDPoolName,
 		cloneName, "snapshots", s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for `+
-			`container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to map RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return false, err
 	}
-	logger.Debugf(`Mapped RBD storage volume for container "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Mapped RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -2022,9 +1791,7 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 		err := cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName,
 			cloneName, "snapshots", s.UserName, true)
 		if err != nil {
-			logger.Warnf(`Failed to unmap RBD storage volume for `+
-				`container "%s" on storage pool "%s": %s`,
-				containerName, s.pool.Name, err)
+			logger.Warnf(`Failed to unmap RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		}
 	}()
 
@@ -2045,8 +1812,7 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 	logger.Debugf("Mounted RBD device %s onto %s", RBDDevPath,
 		containerMntPoint)
 
-	logger.Debugf(`Initialized RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Initialized RBD storage volume for snapshot "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	revert = false
 
@@ -2055,8 +1821,7 @@ func (s *storageCeph) ContainerSnapshotStart(c container) (bool, error) {
 
 func (s *storageCeph) ContainerSnapshotStop(c container) (bool, error) {
 	containerName := c.Name()
-	logger.Debugf(`Stopping RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Stopping RBD storage volume for snapshot "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	containerMntPoint := getSnapshotMountPoint(s.pool.Name, containerName)
 	if shared.IsMountPoint(containerMntPoint) {
@@ -2075,12 +1840,9 @@ func (s *storageCeph) ContainerSnapshotStop(c container) (bool, error) {
 	err := cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName, cloneName,
 		"snapshots", s.UserName, true)
 	if err != nil {
-		logger.Warnf(`Failed to unmap RBD storage volume for `+
-			`container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Warnf(`Failed to unmap RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 	} else {
-		logger.Debugf(`Unmapped RBD storage volume for container "%s" `+
-			`on storage pool "%s"`, containerName, s.pool.Name)
+		logger.Debugf(`Unmapped RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	}
 
 	rbdVolumeExists := cephRBDVolumeExists(s.ClusterName, s.OSDPoolName,
@@ -2091,26 +1853,20 @@ func (s *storageCeph) ContainerSnapshotStop(c container) (bool, error) {
 		err = cephRBDVolumeDelete(s.ClusterName, s.OSDPoolName, cloneName,
 			"snapshots", s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to delete clone of RBD storage volume `+
-				`for container "%s" on storage pool "%s": %s`,
-				containerName, s.pool.Name, err)
+			logger.Errorf(`Failed to delete clone of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 			return false, err
 		}
-		logger.Debugf(`Deleted clone of RBD storage volume for container "%s" `+
-			`on storage pool "%s"`, containerName, s.pool.Name)
+		logger.Debugf(`Deleted clone of RBD storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	}
 
-	logger.Debugf(`Stopped RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Stopped RBD storage volume for snapshot "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageCeph) ContainerSnapshotCreateEmpty(c container) error {
-	logger.Debugf(`Creating empty RBD storage volume for snapshot "%s" `+
-		`on storage pool "%s" (noop)`, c.Name(), s.pool.Name)
+	logger.Debugf(`Creating empty RBD storage volume for snapshot "%s" on storage pool "%s" (noop)`, c.Name(), s.pool.Name)
 
-	logger.Debugf(`Created empty RBD storage volume for snapshot "%s" `+
-		`on storage pool "%s" (noop)`, c.Name(), s.pool.Name)
+	logger.Debugf(`Created empty RBD storage volume for snapshot "%s" on storage pool "%s" (noop)`, c.Name(), s.pool.Name)
 	return nil
 }
 
@@ -2157,7 +1913,7 @@ func (s *storageCeph) ContainerBackupCreate(backup backup, source container) err
 }
 
 func (s *storageCeph) ContainerBackupDelete(name string) error {
-	logger.Debugf("Deleting RBD storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleting RBD storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	backupContainerMntPoint := getBackupMountPoint(s.pool.Name, name)
 	if shared.PathExists(backupContainerMntPoint) {
 		err := os.RemoveAll(backupContainerMntPoint)
@@ -2176,12 +1932,12 @@ func (s *storageCeph) ContainerBackupDelete(name string) error {
 		}
 	}
 
-	logger.Debugf("Deleted RBD storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleted RBD storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	return nil
 }
 
 func (s *storageCeph) ContainerBackupRename(backup backup, newName string) error {
-	logger.Debugf("Renaming RBD storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renaming RBD storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	oldBackupMntPoint := getBackupMountPoint(s.pool.Name, backup.Name())
 	newBackupMntPoint := getBackupMountPoint(s.pool.Name, newName)
 
@@ -2193,7 +1949,7 @@ func (s *storageCeph) ContainerBackupRename(backup backup, newName string) error
 		}
 	}
 
-	logger.Debugf("Renamed RBD storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renamed RBD storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	return nil
 }
 
@@ -2284,8 +2040,7 @@ func (s *storageCeph) ContainerBackupLoad(info backupInfo, data io.ReadSeeker) e
 }
 
 func (s *storageCeph) ImageCreate(fingerprint string) error {
-	logger.Debugf(`Creating RBD storage volume for image "%s" on storage `+
-		`pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Creating RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 	revert := true
 
@@ -2294,15 +2049,10 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 	if !shared.PathExists(imageMntPoint) {
 		err := os.MkdirAll(imageMntPoint, 0700)
 		if err != nil {
-			logger.Errorf(`Failed to create mountpoint "%s" for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, imageMntPoint, fingerprint,
-				s.pool.Name, err)
+			logger.Errorf(`Failed to create mountpoint "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, imageMntPoint, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Created mountpoint "%s" for RBD storage volume `+
-			`for image "%s" on storage pool "%s"`, imageMntPoint,
-			fingerprint, s.pool.Name)
+		logger.Debugf(`Created mountpoint "%s" for RBD storage volume for image "%s" on storage pool "%s"`, imageMntPoint, fingerprint, s.pool.Name)
 	}
 
 	defer func() {
@@ -2312,10 +2062,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 
 		err := os.Remove(imageMntPoint)
 		if err != nil {
-			logger.Warnf(`Failed to delete mountpoint "%s" for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, imageMntPoint, fingerprint,
-				s.pool.Name, err)
+			logger.Warnf(`Failed to delete mountpoint "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, imageMntPoint, fingerprint, s.pool.Name, err)
 		}
 	}()
 
@@ -2325,33 +2072,25 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 	ok := cephRBDVolumeExists(s.ClusterName, s.OSDPoolName, fingerprint,
 		prefixedType, s.UserName)
 	if !ok {
-		logger.Debugf(`RBD storage volume for image "%s" on storage `+
-			`pool "%s" does not exist`, fingerprint, s.pool.Name)
+		logger.Debugf(`RBD storage volume for image "%s" on storage pool "%s" does not exist`, fingerprint, s.pool.Name)
 
 		// get size
 		RBDSize, err := s.getRBDSize()
 		if err != nil {
-			logger.Errorf(`Failed to retrieve size of RBD storage `+
-				`volume for image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to retrieve size of RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Retrieve size "%s" of RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, RBDSize, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Retrieve size "%s" of RBD storage volume for image "%s" on storage pool "%s"`, RBDSize, fingerprint, s.pool.Name)
 
 		// create volume
 		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, RBDSize,
 			s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to create RBD storage volume `+
-				`for image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to create RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Created RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Created RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -2362,10 +2101,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 				fingerprint, storagePoolVolumeTypeNameImage,
 				s.UserName)
 			if err != nil {
-				logger.Warnf(`Failed to delete RBD storage `+
-					`volume for image "%s" on storage `+
-					`pool "%s": %s`, fingerprint,
-					s.pool.Name, err)
+				logger.Warnf(`Failed to delete RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			}
 		}()
 
@@ -2373,13 +2109,10 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 			s.OSDPoolName, fingerprint,
 			storagePoolVolumeTypeNameImage, s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to map RBD storage volume for `+
-				`image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to map RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Mapped RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Mapped RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -2390,10 +2123,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 				fingerprint, storagePoolVolumeTypeNameImage,
 				s.UserName, true)
 			if err != nil {
-				logger.Warnf(`Failed to unmap RBD storage `+
-					`volume for image "%s" on storage `+
-					`pool "%s": %s`, fingerprint,
-					s.pool.Name, err)
+				logger.Warnf(`Failed to unmap RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			}
 		}()
 
@@ -2401,15 +2131,11 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 		RBDFilesystem := s.getRBDFilesystem()
 		msg, err := makeFSType(RBDDevPath, RBDFilesystem, nil)
 		if err != nil {
-			logger.Errorf(`Failed to create filesystem "%s" for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, RBDFilesystem, fingerprint,
+			logger.Errorf(`Failed to create filesystem "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, RBDFilesystem, fingerprint,
 				s.pool.Name, msg)
 			return err
 		}
-		logger.Debugf(`Created filesystem "%s" for RBD storage volume `+
-			`for image "%s" on storage pool "%s"`, RBDFilesystem,
-			fingerprint, s.pool.Name)
+		logger.Debugf(`Created filesystem "%s" for RBD storage volume for image "%s" on storage pool "%s"`, RBDFilesystem, fingerprint, s.pool.Name)
 
 		// mount image
 		_, err = s.ImageMount(fingerprint)
@@ -2421,17 +2147,13 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 		imagePath := shared.VarPath("images", fingerprint)
 		err = unpackImage(imagePath, imageMntPoint, storageTypeCeph, s.s.OS.RunningInUserNS)
 		if err != nil {
-			logger.Errorf(`Failed to unpack image for RBD storage `+
-				`volume for image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unpack image for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 
 			// umount image
 			s.ImageUmount(fingerprint)
 			return err
 		}
-		logger.Debugf(`Unpacked image for RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Unpacked image for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// umount image
 		s.ImageUmount(fingerprint)
@@ -2441,27 +2163,20 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName,
 			true)
 		if err != nil {
-			logger.Errorf(`Failed to unmap RBD storage volume for `+
-				`image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unmap RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Unmapped RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Unmapped RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// make snapshot of volume
 		err = cephRBDSnapshotCreate(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, "readonly",
 			s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to create snapshot for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to create snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Created snapshot for RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Created snapshot for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -2473,10 +2188,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 				storagePoolVolumeTypeNameImage, "readonly",
 				s.UserName)
 			if err != nil {
-				logger.Warnf(`Failed to delete snapshot for `+
-					`RBD storage volume for image "%s" on `+
-					`storage pool "%s": %s`, fingerprint,
-					s.pool.Name, err)
+				logger.Warnf(`Failed to delete snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			}
 		}()
 
@@ -2485,15 +2197,10 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 			fingerprint, storagePoolVolumeTypeNameImage, "readonly",
 			s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to protect snapshot for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, fingerprint, s.pool.Name,
-				err)
+			logger.Errorf(`Failed to protect snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Protected snapshot for RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Protected snapshot for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -2505,28 +2212,21 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 				storagePoolVolumeTypeNameImage, "readonly",
 				s.UserName)
 			if err != nil {
-				logger.Warnf(`Failed to unprotect snapshot for `+
-					`RBD storage volume for image "%s" on `+
-					`storage pool "%s": %s`, fingerprint,
-					s.pool.Name, err)
+				logger.Warnf(`Failed to unprotect snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			}
 		}()
 	} else {
-		logger.Debugf(`RBD storage volume for image "%s" on storage `+
-			`pool "%s" does exist`, fingerprint, s.pool.Name)
+		logger.Debugf(`RBD storage volume for image "%s" on storage pool "%s" does exist`, fingerprint, s.pool.Name)
 
 		// unmark deleted
 		err := cephRBDVolumeUnmarkDeleted(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName,
 			s.volume.Config["block.filesystem"], "")
 		if err != nil {
-			logger.Errorf(`Failed to unmark RBD storage volume `+
-				`for image "%s" on storage pool "%s" as
-				zombie: %s`, fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unmark RBD storage volume for image "%s" on storage pool "%s" as zombie: %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Unmarked RBD storage volume for image "%s" on `+
-			`storage pool "%s" as zombie`, fingerprint, s.pool.Name)
+		logger.Debugf(`Unmarked RBD storage volume for image "%s" on storage pool "%s" as zombie`, fingerprint, s.pool.Name)
 
 		defer func() {
 			if !revert {
@@ -2538,26 +2238,19 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 				fingerprint, fingerprint, s.UserName,
 				s.volume.Config["block.filesystem"])
 			if err != nil {
-				logger.Warnf(`Failed to mark RBD storage `+
-					`volume for image "%s" on storage `+
-					`pool "%s" as zombie: %s`, fingerprint,
-					s.pool.Name, err)
+				logger.Warnf(`Failed to mark RBD storage volume for image "%s" on storage pool "%s" as zombie: %s`, fingerprint, s.pool.Name, err)
 			}
 		}()
 	}
 
 	err := s.createImageDbPoolVolume(fingerprint)
 	if err != nil {
-		logger.Errorf(`Failed to create database entry for RBD storage `+
-			`volume for image "%s" on storage pool "%s": %s`,
-			fingerprint, s.pool.Name, err)
+		logger.Errorf(`Failed to create database entry for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Createdd database entry for RBD storage volume for `+
-		`image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Createdd database entry for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
-	logger.Debugf(`Created RBD storage volume for image "%s" on storage `+
-		`pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Created RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 	revert = false
 
@@ -2565,8 +2258,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 }
 
 func (s *storageCeph) ImageDelete(fingerprint string) error {
-	logger.Debugf(`Deleting RBD storage volume for image "%s" on storage `+
-		`pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Deleting RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 	// try to umount but don't fail
 	s.ImageUmount(fingerprint)
@@ -2577,79 +2269,58 @@ func (s *storageCeph) ImageDelete(fingerprint string) error {
 		s.UserName)
 	if err != nil {
 		if err != db.ErrNoSuchObject {
-			logger.Errorf(`Failed to list clones of RBD storage `+
-				`volume for image "%s" on storage pool "%s":
-				%s`, fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to list clones of RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Retrieved no clones of RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Retrieved no clones of RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// unprotect snapshot
 		err = cephRBDSnapshotUnprotect(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, "readonly",
 			s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to unprotect snapshot for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unprotect snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Unprotected snapshot for RBD storage volume `+
-			`for image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Unprotected snapshot for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// delete snapshots
 		err = cephRBDSnapshotsPurge(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to delete snapshot for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to delete snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Deleted snapshot for RBD storage volume for `+
-			`image "%s" on storage pool "%s"`, fingerprint,
-			s.pool.Name)
+		logger.Debugf(`Deleted snapshot for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// unmap
 		err = cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName,
 			true)
 		if err != nil {
-			logger.Errorf(`Failed to unmap RBD storage volume for `+
-				`image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unmap RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Unmapped RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Unmapped RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// delete volume
 		err = cephRBDVolumeDelete(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to delete RBD storage volume `+
-				`for image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to delete RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Deleted RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Deleted RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 	} else {
 		// unmap
 		err = cephRBDVolumeUnmap(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, s.UserName,
 			true)
 		if err != nil {
-			logger.Errorf(`Failed to unmap RBD storage volume for `+
-				`image "%s" on storage pool "%s": %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to unmap RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Unmapped RBD storage volume for image "%s" on `+
-			`storage pool "%s"`, fingerprint, s.pool.Name)
+		logger.Debugf(`Unmapped RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 		// mark deleted
 		err := cephRBDVolumeMarkDeleted(s.ClusterName, s.OSDPoolName,
@@ -2657,47 +2328,35 @@ func (s *storageCeph) ImageDelete(fingerprint string) error {
 			fingerprint, s.UserName,
 			s.volume.Config["block.filesystem"])
 		if err != nil {
-			logger.Errorf(`Failed to mark RBD storage volume for `+
-				`image "%s" on storage pool "%s" as zombie: %s`,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to mark RBD storage volume for image "%s" on storage pool "%s" as zombie: %s`, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Marked RBD storage volume for image "%s" on `+
-			`storage pool "%s" as zombie`, fingerprint, s.pool.Name)
+		logger.Debugf(`Marked RBD storage volume for image "%s" on storage pool "%s" as zombie`, fingerprint, s.pool.Name)
 	}
 
 	err = s.deleteImageDbPoolVolume(fingerprint)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for RBD `+
-			`storage volume for image "%s" on storage pool "%s":
-			%s`, fingerprint, s.pool.Name, err)
+		logger.Errorf(`Failed to delete database entry for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Deleted database entry for RBD storage volume for `+
-		`image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Deleted database entry for RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if shared.PathExists(imageMntPoint) {
 		err := os.Remove(imageMntPoint)
 		if err != nil {
-			logger.Errorf(`Failed to delete image mountpoint "%s" `+
-				`for RBD storage volume for image "%s" on `+
-				`storage pool "%s": %s`, imageMntPoint,
-				fingerprint, s.pool.Name, err)
+			logger.Errorf(`Failed to delete image mountpoint "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, imageMntPoint, fingerprint, s.pool.Name, err)
 			return err
 		}
-		logger.Debugf(`Deleted image mountpoint "%s" for RBD storage `+
-			`volume for image "%s" on storage pool "%s"`,
-			imageMntPoint, fingerprint, s.pool.Name)
+		logger.Debugf(`Deleted image mountpoint "%s" for RBD storage volume for image "%s" on storage pool "%s"`, imageMntPoint, fingerprint, s.pool.Name)
 	}
 
-	logger.Debugf(`Deleted RBD storage volume for image "%s" on storage `+
-		`pool "%s"`, fingerprint, s.pool.Name)
+	logger.Debugf(`Deleted RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageCeph) ImageMount(fingerprint string) (bool, error) {
-	logger.Debugf("Mounting RBD storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounting RBD storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if shared.IsMountPoint(imageMntPoint) {
@@ -2718,16 +2377,15 @@ func (s *storageCeph) ImageMount(fingerprint string) (bool, error) {
 
 	err := tryMount(RBDDevPath, imageMntPoint, RBDFilesystem, mountFlags, mountOptions)
 	if err != nil || ret < 0 {
-		logger.Errorf("%s: %s", errMsg, err)
 		return false, err
 	}
 
-	logger.Debugf("Mounted RBD storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounted RBD storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageCeph) ImageUmount(fingerprint string) (bool, error) {
-	logger.Debugf("Unmounting RBD storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Unmounting RBD storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if !shared.IsMountPoint(imageMntPoint) {
@@ -2739,7 +2397,7 @@ func (s *storageCeph) ImageUmount(fingerprint string) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Unmounted RBD storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Unmounted RBD storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return true, nil
 }
 

--- a/lxd/storage_ceph_migration.go
+++ b/lxd/storage_ceph_migration.go
@@ -37,9 +37,7 @@ func (s *rbdMigrationSourceDriver) Cleanup() {
 			containerName, storagePoolVolumeTypeNameContainer,
 			s.stoppedSnapName, s.ceph.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to delete RBD snapshot "%s" of `+
-				`container "%s"`, s.stoppedSnapName,
-				containerName)
+			logger.Warnf(`Failed to delete RBD snapshot "%s" of container "%s"`, s.stoppedSnapName, containerName)
 		}
 	}
 
@@ -48,9 +46,7 @@ func (s *rbdMigrationSourceDriver) Cleanup() {
 			containerName, storagePoolVolumeTypeNameContainer,
 			s.runningSnapName, s.ceph.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to delete RBD snapshot "%s" of `+
-				`container "%s"`, s.runningSnapName,
-				containerName)
+			logger.Warnf(`Failed to delete RBD snapshot "%s" of container "%s"`, s.runningSnapName, containerName)
 		}
 	}
 }
@@ -62,9 +58,7 @@ func (s *rbdMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn, bwl
 		containerName, storagePoolVolumeTypeNameContainer,
 		s.stoppedSnapName, s.ceph.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to create snapshot "%s" for RBD storage `+
-			`volume for image "%s" on storage pool "%s": %s`,
-			s.stoppedSnapName, containerName, s.ceph.pool.Name, err)
+		logger.Errorf(`Failed to create snapshot "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, s.stoppedSnapName, containerName, s.ceph.pool.Name, err)
 		return err
 	}
 
@@ -72,13 +66,10 @@ func (s *rbdMigrationSourceDriver) SendAfterCheckpoint(conn *websocket.Conn, bwl
 		containerName, s.stoppedSnapName)
 	err = s.rbdSend(conn, cur, s.runningSnapName, nil)
 	if err != nil {
-		logger.Errorf(`Failed to send exported diff of RBD storage `+
-			`volume "%s" from snapshot "%s": %s`, cur,
-			s.runningSnapName, err)
+		logger.Errorf(`Failed to send exported diff of RBD storage volume "%s" from snapshot "%s": %s`, cur, s.runningSnapName, err)
 		return err
 	}
-	logger.Debugf(`Sent exported diff of RBD storage volume "%s" from `+
-		`snapshot "%s"`, cur, s.stoppedSnapName)
+	logger.Debugf(`Sent exported diff of RBD storage volume "%s" from snapshot "%s"`, cur, s.stoppedSnapName)
 
 	return nil
 }
@@ -131,15 +122,10 @@ func (s *rbdMigrationSourceDriver) SendWhileRunning(conn *websocket.Conn,
 				prev,
 				wrapper)
 			if err != nil {
-				logger.Errorf(`Failed to send exported diff `+
-					`of RBD storage volume "%s" from `+
-					`snapshot "%s": %s`, sendSnapName,
-					prev, err)
+				logger.Errorf(`Failed to send exported diff of RBD storage volume "%s" from snapshot "%s": %s`, sendSnapName, prev, err)
 				return err
 			}
-			logger.Debugf(`Sent exported diff of RBD storage `+
-				`volume "%s" from snapshot "%s"`, sendSnapName,
-				prev)
+			logger.Debugf(`Sent exported diff of RBD storage volume "%s" from snapshot "%s"`, sendSnapName, prev)
 		}
 	}
 
@@ -148,9 +134,7 @@ func (s *rbdMigrationSourceDriver) SendWhileRunning(conn *websocket.Conn,
 		containerName, storagePoolVolumeTypeNameContainer,
 		s.runningSnapName, s.ceph.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to create snapshot "%s" for RBD storage `+
-			`volume for image "%s" on storage pool "%s": %s`,
-			s.runningSnapName, containerName, s.ceph.pool.Name, err)
+		logger.Errorf(`Failed to create snapshot "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, s.runningSnapName, containerName, s.ceph.pool.Name, err)
 		return err
 	}
 
@@ -159,13 +143,10 @@ func (s *rbdMigrationSourceDriver) SendWhileRunning(conn *websocket.Conn,
 	wrapper := StorageProgressReader(op, "fs_progress", containerName)
 	err = s.rbdSend(conn, cur, lastSnap, wrapper)
 	if err != nil {
-		logger.Errorf(`Failed to send exported diff of RBD storage `+
-			`volume "%s" from snapshot "%s": %s`, s.runningSnapName,
-			lastSnap, err)
+		logger.Errorf(`Failed to send exported diff of RBD storage volume "%s" from snapshot "%s": %s`, s.runningSnapName, lastSnap, err)
 		return err
 	}
-	logger.Debugf(`Sent exported diff of RBD storage volume "%s" from `+
-		`snapshot "%s"`, s.runningSnapName, lastSnap)
+	logger.Debugf(`Sent exported diff of RBD storage volume "%s" from snapshot "%s"`, s.runningSnapName, lastSnap)
 
 	return nil
 }
@@ -197,9 +178,7 @@ func (s *storageCeph) MigrationSource(c container, containerOnly bool) (Migratio
 
 	containerName := c.Name()
 	if containerOnly {
-		logger.Debugf(`Only migrating the RBD storage volume for `+
-			`container "%s" on storage pool "%s`, containerName,
-			s.pool.Name)
+		logger.Debugf(`Only migrating the RBD storage volume for container "%s" on storage pool "%s`, containerName, s.pool.Name)
 		return &driver, nil
 	}
 
@@ -257,8 +236,7 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 		return fmt.Errorf(`Detected that the container's root device ` +
 			`is missing the pool property during RBD migration`)
 	}
-	logger.Debugf(`Detected root disk device with pool property set to `+
-		`"%s" during RBD migration`, parentStoragePool)
+	logger.Debugf(`Detected root disk device with pool property set to "%s" during RBD migration`, parentStoragePool)
 
 	// create empty volume for container
 	// TODO: The cluster name can be different between LXD instances. Find
@@ -320,14 +298,10 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 		}
 		_, err := containerCreateEmptySnapshot(c.DaemonState(), args)
 		if err != nil {
-			logger.Errorf(`Failed to create empty RBD storage `+
-				`volume for container "%s" on storage pool "%s: %s`,
-				containerName, s.OSDPoolName, err)
+			logger.Errorf(`Failed to create empty RBD storage volume for container "%s" on storage pool "%s: %s`, containerName, s.OSDPoolName, err)
 			return err
 		}
-		logger.Debugf(`Created empty RBD storage volume for `+
-			`container "%s" on storage pool "%s`, containerName,
-			s.OSDPoolName)
+		logger.Debugf(`Created empty RBD storage volume for container "%s" on storage pool "%s`, containerName, s.OSDPoolName)
 
 		wrapper := StorageProgressWriter(op, "fs_progress", curSnapName)
 		err = s.rbdRecv(conn, recvName, wrapper)
@@ -362,10 +336,7 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 					storagePoolVolumeTypeNameContainer,
 					snapOnlyName, s.UserName)
 				if err != nil {
-					logger.Warnf(`Failed to delete RBD container `+
-						`storage for snapshot "%s" of `+
-						`container "%s"`, snapOnlyName,
-						containerName)
+					logger.Warnf(`Failed to delete RBD container storage for snapshot "%s" of container "%s"`, snapOnlyName, containerName)
 				}
 			}
 		}
@@ -383,8 +354,7 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 	if live {
 		err := s.rbdRecv(conn, recvName, wrapper)
 		if err != nil {
-			logger.Errorf(`Failed to receive RBD storage volume `+
-				`"%s": %s`, recvName, err)
+			logger.Errorf(`Failed to receive RBD storage volume "%s": %s`, recvName, err)
 			return err
 		}
 		logger.Debugf(`Received RBD storage volume "%s"`, recvName)
@@ -396,15 +366,10 @@ func (s *storageCeph) MigrationSink(live bool, c container,
 		c.Path(),
 		c.IsPrivileged())
 	if err != nil {
-		logger.Errorf(`Failed to create mountpoint "%s" for RBD `+
-			`storage volume for container "%s" on storage pool `+
-			`"%s": %s"`, containerMntPoint, containerName,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to create mountpoint "%s" for RBD storage volume for container "%s" on storage pool "%s": %s"`, containerMntPoint, containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created mountpoint "%s" for RBD storage volume for `+
-		`container "%s" on storage pool "%s""`, containerMntPoint,
-		containerName, s.pool.Name)
+	logger.Debugf(`Created mountpoint "%s" for RBD storage volume for container "%s" on storage pool "%s""`, containerMntPoint, containerName, s.pool.Name)
 
 	return nil
 }

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -704,9 +704,7 @@ func (s *storageCeph) getRBDMountOptions() string {
 // volume and the target RBD storage volume.
 func (s *storageCeph) copyWithoutSnapshotsFull(target container,
 	source container) error {
-	logger.Debugf(`Creating non-sparse copy of RBD storage volume for `+
-		`container "%s" -> "%s" without snapshots`, source.Name(),
-		target.Name())
+	logger.Debugf(`Creating non-sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(), target.Name())
 
 	sourceIsSnapshot := source.IsSnapshot()
 	sourceContainerName := source.Name()
@@ -726,17 +724,14 @@ func (s *storageCeph) copyWithoutSnapshotsFull(target container,
 	err := cephRBDVolumeCopy(s.ClusterName, oldVolumeName, newVolumeName,
 		s.UserName)
 	if err != nil {
-		logger.Debugf(`Failed to create full RBD copy "%s" -> `+
-			`"%s": %s`, source.Name(), target.Name(), err)
+		logger.Debugf(`Failed to create full RBD copy "%s" to "%s": %s`, source.Name(), target.Name(), err)
 		return err
 	}
 
 	_, err = cephRBDVolumeMap(s.ClusterName, s.OSDPoolName, targetContainerName,
 		storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for image `+
-			`"%s" on storage pool "%s": %s`, targetContainerName,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to map RBD storage volume for image "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 		return err
 	}
 
@@ -758,14 +753,12 @@ func (s *storageCeph) copyWithoutSnapshotsFull(target container,
 
 	err = target.TemplateApply("copy")
 	if err != nil {
-		logger.Errorf(`Failed to apply copy template for container `+
-			`"%s": %s`, target.Name(), err)
+		logger.Errorf(`Failed to apply copy template for container "%s": %s`, target.Name(), err)
 		return err
 	}
 	logger.Debugf(`Applied copy template for container "%s"`, target.Name())
 
-	logger.Debugf(`Created non-sparse copy of RBD storage volume for `+
-		`container "%s" -> "%s" without snapshots`, source.Name(),
+	logger.Debugf(`Created non-sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(),
 		target.Name())
 	return nil
 }
@@ -775,8 +768,7 @@ func (s *storageCeph) copyWithoutSnapshotsFull(target container,
 // and the target RBD storage volume.
 func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 	source container) error {
-	logger.Debugf(`Creating sparse copy of RBD storage volume for `+
-		`container "%s" -> "%s" without snapshots`, source.Name(),
+	logger.Debugf(`Creating sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(),
 		target.Name())
 
 	sourceIsSnapshot := source.IsSnapshot()
@@ -796,10 +788,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 			sourceContainerName, storagePoolVolumeTypeNameContainer,
 			snapshotName, s.UserName)
 		if err != nil {
-			logger.Errorf(`Failed to create snapshot for RBD `+
-				`storage volume for image "%s" on storage `+
-				`pool "%s": %s`, targetContainerName,
-				s.pool.Name, err)
+			logger.Errorf(`Failed to create snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 			return err
 		}
 	}
@@ -809,9 +798,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 		sourceContainerOnlyName, storagePoolVolumeTypeNameContainer,
 		snapshotName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to protect snapshot for RBD storage `+
-			`volume for image "%s" on storage pool "%s": %s`,
-			snapshotName, s.pool.Name, err)
+		logger.Errorf(`Failed to protect snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, snapshotName, s.pool.Name, err)
 		return err
 	}
 
@@ -820,8 +807,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 		snapshotName, s.OSDPoolName, targetContainerName,
 		storagePoolVolumeTypeNameContainer, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to clone new RBD storage volume for `+
-			`container "%s": %s`, targetContainerName, err)
+		logger.Errorf(`Failed to clone new RBD storage volume for container "%s": %s`, targetContainerName, err)
 		return err
 	}
 
@@ -829,8 +815,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 		targetContainerName, storagePoolVolumeTypeNameContainer,
 		s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to map RBD storage volume for image `+
-			`"%s" on storage pool "%s": %s`, targetContainerName,
+		logger.Errorf(`Failed to map RBD storage volume for image "%s" on storage pool "%s": %s`, targetContainerName,
 			s.pool.Name, err)
 		return err
 	}
@@ -861,14 +846,12 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 
 	err = target.TemplateApply("copy")
 	if err != nil {
-		logger.Errorf(`Failed to apply copy template for container `+
-			`"%s": %s`, target.Name(), err)
+		logger.Errorf(`Failed to apply copy template for container "%s": %s`, target.Name(), err)
 		return err
 	}
 	logger.Debugf(`Applied copy template for container "%s"`, target.Name())
 
-	logger.Debugf(`Created sparse copy of RBD storage volume for `+
-		`container "%s" -> "%s" without snapshots`, source.Name(),
+	logger.Debugf(`Created sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(),
 		target.Name())
 	return nil
 }
@@ -879,8 +862,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
 // volume and the target RBD storage volume.
 func (s *storageCeph) copyWithSnapshots(sourceVolumeName string,
 	targetVolumeName string, sourceParentSnapshot string) error {
-	logger.Debugf(`Creating non-sparse copy of RBD storage volume `+
-		`"%s -> "%s"`, sourceVolumeName, targetVolumeName)
+	logger.Debugf(`Creating non-sparse copy of RBD storage volume "%s to "%s"`, sourceVolumeName, targetVolumeName)
 
 	args := []string{
 		"export-diff",
@@ -924,8 +906,7 @@ func (s *storageCeph) copyWithSnapshots(sourceVolumeName string,
 		return err
 	}
 
-	logger.Debugf(`Created non-sparse copy of RBD storage volume `+
-		`"%s -> "%s"`, sourceVolumeName, targetVolumeName)
+	logger.Debugf(`Created non-sparse copy of RBD storage volume "%s" to "%s"`, sourceVolumeName, targetVolumeName)
 	return nil
 }
 
@@ -962,16 +943,13 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 			ret := cephContainerSnapshotDelete(clusterName,
 				poolName, volumeName, volumeType, snap, userName)
 			if ret < 0 {
-				logger.Errorf(`Failed to delete RBD storage `+
-					`volume "%s"`, logEntry)
+				logger.Errorf(`Failed to delete RBD storage volume "%s"`, logEntry)
 				return -1
 			} else if ret == 1 {
-				logger.Debugf(`Marked RBD storage volume "%s" `+
-					`as zombie`, logEntry)
+				logger.Debugf(`Marked RBD storage volume "%s" as zombie`, logEntry)
 				zombies++
 			} else {
-				logger.Debugf(`Deleted RBD storage volume "%s"`,
-					logEntry)
+				logger.Debugf(`Deleted RBD storage volume "%s"`, logEntry)
 			}
 		}
 
@@ -980,16 +958,13 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 			err = cephRBDVolumeUnmap(clusterName, poolName,
 				volumeName, volumeType, userName, true)
 			if err != nil {
-				logger.Errorf(`Failed to unmap RBD storage `+
-					`volume "%s": %s`, logEntry, err)
+				logger.Errorf(`Failed to unmap RBD storage volume "%s": %s`, logEntry, err)
 				return -1
 			}
-			logger.Debugf(`Unmapped RBD storage volume "%s"`,
-				logEntry)
+			logger.Debugf(`Unmapped RBD storage volume "%s"`, logEntry)
 
 			if strings.HasPrefix(volumeType, "zombie_") {
-				logger.Debugf(`RBD storage volume "%s" `+
-					`already marked as zombie`, logEntry)
+				logger.Debugf(`RBD storage volume "%s" already marked as zombie`, logEntry)
 				return 1
 			}
 
@@ -999,48 +974,37 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 				volumeType, volumeName, newVolumeName, userName,
 				"")
 			if err != nil {
-				logger.Errorf(`Failed to mark RBD storage `+
-					`volume "%s" as zombie: %s`, logEntry,
-					err)
+				logger.Errorf(`Failed to mark RBD storage volume "%s" as zombie: %s`, logEntry, err)
 				return -1
 			}
-			logger.Debugf(`Marked RBD storage volume "%s" as `+
-				`zombie`, logEntry)
+			logger.Debugf(`Marked RBD storage volume "%s" as zombie`, logEntry)
 
 			return 1
 		}
 	} else {
 		if err != db.ErrNoSuchObject {
-			logger.Errorf(`Failed to retrieve snapshots of RBD `+
-				`storage volume: %s`, err)
+			logger.Errorf(`Failed to retrieve snapshots of RBD storage volume: %s`, err)
 			return -1
 		}
 
 		parent, err := cephRBDVolumeGetParent(clusterName, poolName,
 			volumeName, volumeType, userName)
 		if err == nil {
-			logger.Debugf(`Detected "%s" as parent of RBD storage `+
-				`volume "%s"`, parent, logEntry)
+			logger.Debugf(`Detected "%s" as parent of RBD storage volume "%s"`, parent, logEntry)
 			_, parentVolumeType, parentVolumeName,
 				parentSnapshotName, err := parseParent(parent)
 			if err != nil {
-				logger.Errorf(`Failed to parse parent "%s" of `+
-					`RBD storage volume "%s"`, parent,
-					logEntry)
+				logger.Errorf(`Failed to parse parent "%s" of RBD storage volume "%s"`, parent, logEntry)
 				return -1
 			}
-			logger.Debugf(`Split parent "%s" of RBD storage `+
-				`volume "%s" into volume type "%s", volume`+
-				`name "%s", and snapshot name "%s"`,
-				parent, logEntry, parentVolumeType,
+			logger.Debugf(`Split parent "%s" of RBD storage volume "%s" into volume type "%s", volume name "%s", and snapshot name "%s"`, parent, logEntry, parentVolumeType,
 				parentVolumeName, parentSnapshotName)
 
 			// unmap
 			err = cephRBDVolumeUnmap(clusterName, poolName,
 				volumeName, volumeType, userName, true)
 			if err != nil {
-				logger.Errorf(`Failed to unmap RBD storage `+
-					`volume "%s": %s`, logEntry, err)
+				logger.Errorf(`Failed to unmap RBD storage volume "%s": %s`, logEntry, err)
 				return -1
 			}
 			logger.Debugf(`Unmapped RBD storage volume "%s"`, logEntry)
@@ -1049,8 +1013,7 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 			err = cephRBDVolumeDelete(clusterName, poolName,
 				volumeName, volumeType, userName)
 			if err != nil {
-				logger.Errorf(`Failed to delete RBD storage `+
-					`volume "%s": %s`, logEntry, err)
+				logger.Errorf(`Failed to delete RBD storage volume "%s": %s`, logEntry, err)
 				return -1
 			}
 			logger.Debugf(`Deleted RBD storage volume "%s"`, logEntry)
@@ -1065,33 +1028,25 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 					parentVolumeType, parentSnapshotName,
 					userName)
 				if ret < 0 {
-					logger.Errorf(`Failed to delete `+
-						`snapshot "%s" of RBD storage `+
-						`volume "%s"`,
-						parentSnapshotName, logEntry)
+					logger.Errorf(`Failed to delete snapshot "%s" of RBD storage volume "%s"`, parentSnapshotName, logEntry)
 					return -1
 				}
-				logger.Debugf(`Deleteed snapshot "%s" of RBD `+
-					`storage volume "%s"`,
-					parentSnapshotName, logEntry)
+				logger.Debugf(`Deleteed snapshot "%s" of RBD storage volume "%s"`, parentSnapshotName, logEntry)
 			}
 
 			return 0
 		} else {
 			if err != db.ErrNoSuchObject {
-				logger.Errorf(`Failed to retrieve parent of `+
-					`RBD storage volume "%s"`, logEntry)
+				logger.Errorf(`Failed to retrieve parent of RBD storage volume "%s"`, logEntry)
 				return -1
 			}
-			logger.Debugf(`RBD storage volume "%s" does not have `+
-				`parent`, logEntry)
+			logger.Debugf(`RBD storage volume "%s" does not have parent`, logEntry)
 
 			// unmap
 			err = cephRBDVolumeUnmap(clusterName, poolName,
 				volumeName, volumeType, userName, true)
 			if err != nil {
-				logger.Errorf(`Failed to unmap RBD storage `+
-					`volume "%s": %s`, logEntry, err)
+				logger.Errorf(`Failed to unmap RBD storage volume "%s": %s`, logEntry, err)
 				return -1
 			}
 			logger.Debugf(`Unmapped RBD storage volume "%s"`, logEntry)
@@ -1100,8 +1055,7 @@ func cephContainerDelete(clusterName string, poolName string, volumeName string,
 			err = cephRBDVolumeDelete(clusterName, poolName,
 				volumeName, volumeType, userName)
 			if err != nil {
-				logger.Errorf(`Failed to delete RBD storage `+
-					`volume "%s": %s`, logEntry, err)
+				logger.Errorf(`Failed to delete RBD storage volume "%s": %s`, logEntry, err)
 				return -1
 			}
 			logger.Debugf(`Deleted RBD storage volume "%s"`, logEntry)
@@ -1141,50 +1095,37 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 		volumeName, volumeType, snapshotName, userName)
 	if err != nil {
 		if err != db.ErrNoSuchObject {
-			logger.Errorf(`Failed to list clones of RBD `+
-				`snapshot "%s" of RBD storage volume "%s": %s`,
-				logSnapshotEntry, logImageEntry, err)
+			logger.Errorf(`Failed to list clones of RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 			return -1
 		}
-		logger.Debugf(`RBD snapshot "%s" of RBD storage volume "%s" `+
-			`does not have any clones`, logSnapshotEntry,
-			logImageEntry)
+		logger.Debugf(`RBD snapshot "%s" of RBD storage volume "%s" does not have any clones`, logSnapshotEntry, logImageEntry)
 
 		// unprotect
 		err = cephRBDSnapshotUnprotect(clusterName, poolName, volumeName,
 			volumeType, snapshotName, userName)
 		if err != nil {
-			logger.Errorf(`Failed to unprotect RBD snapshot "%s" `+
-				`of RBD storage volume "%s": %s`,
-				logSnapshotEntry, logImageEntry, err)
+			logger.Errorf(`Failed to unprotect RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 			return -1
 		}
-		logger.Debugf(`Unprotected RBD snapshot "%s" of RBD storage volume "%s"`,
-			logSnapshotEntry, logImageEntry)
+		logger.Debugf(`Unprotected RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 		// unmap
 		err = cephRBDVolumeSnapshotUnmap(clusterName, poolName,
 			volumeName, volumeType, snapshotName, userName, true)
 		if err != nil {
-			logger.Errorf(`Failed to unmap RBD snapshot "%s" of `+
-				`RBD storage volume "%s": %s`, logSnapshotEntry,
-				logImageEntry, err)
+			logger.Errorf(`Failed to unmap RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 			return -1
 		}
-		logger.Debugf(`Unmapped RBD snapshot "%s" of RBD storage volume "%s"`,
-			logSnapshotEntry, logImageEntry)
+		logger.Debugf(`Unmapped RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 		// delete
 		err = cephRBDSnapshotDelete(clusterName, poolName, volumeName,
 			volumeType, snapshotName, userName)
 		if err != nil {
-			logger.Errorf(`Failed to delete RBD snapshot "%s" of `+
-				`RBD storage volume "%s": %s`, logSnapshotEntry,
-				logImageEntry, err)
+			logger.Errorf(`Failed to delete RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 			return -1
 		}
-		logger.Debugf(`Deleted RBD snapshot "%s" of RBD storage volume "%s"`,
-			logSnapshotEntry, logImageEntry)
+		logger.Debugf(`Deleted RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 		// Only delete the parent image if it is a zombie. If it is not
 		// we know that LXD is still using it.
@@ -1201,25 +1142,16 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 
 		return 0
 	} else {
-		logger.Debugf(`Detected "%v" as clones of RBD snapshot "%s" `+
-			`of RBD storage volume "%s"`,
-			clones, logSnapshotEntry, logImageEntry)
+		logger.Debugf(`Detected "%v" as clones of RBD snapshot "%s" of RBD storage volume "%s"`, clones, logSnapshotEntry, logImageEntry)
 
 		canDelete := true
 		for _, clone := range clones {
 			clonePool, cloneType, cloneName, err := parseClone(clone)
 			if err != nil {
-				logger.Errorf(`Failed to parse clone "%s" `+
-					`of RBD snapshot "%s" of RBD `+
-					`storage volume "%s"`,
-					clone, logSnapshotEntry, logImageEntry)
+				logger.Errorf(`Failed to parse clone "%s" of RBD snapshot "%s" of RBD storage volume "%s"`, clone, logSnapshotEntry, logImageEntry)
 				return -1
 			}
-			logger.Debugf(`Split clone "%s" of RBD snapshot `+
-				`"%s" of RBD storage volume "%s" into `+
-				`pool name "%s", volume type "%s", and `+
-				`volume name "%s"`, clone, logSnapshotEntry,
-				logImageEntry, clonePool, cloneType, cloneName)
+			logger.Debugf(`Split clone "%s" of RBD snapshot "%s" of RBD storage volume "%s" into pool name "%s", volume type "%s", and volume name "%s"`, clone, logSnapshotEntry, logImageEntry, clonePool, cloneType, cloneName)
 
 			if !strings.HasPrefix(cloneType, "zombie_") {
 				canDelete = false
@@ -1229,10 +1161,7 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 			ret := cephContainerDelete(clusterName, clonePool,
 				cloneName, cloneType, userName)
 			if ret < 0 {
-				logger.Errorf(`Failed to delete clone "%s" `+
-					`of RBD snapshot "%s" of RBD `+
-					`storage volume "%s"`,
-					clone, logSnapshotEntry, logImageEntry)
+				logger.Errorf(`Failed to delete clone "%s" of RBD snapshot "%s" of RBD storage volume "%s"`, clone, logSnapshotEntry, logImageEntry)
 				return -1
 			} else if ret == 1 {
 				// Only marked as zombie
@@ -1241,50 +1170,35 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 		}
 
 		if canDelete {
-			logger.Debugf(`Deleted all clones of RBD snapshot `+
-				`"%s" of RBD storage volume "%s"`,
-				logSnapshotEntry, logImageEntry)
+			logger.Debugf(`Deleted all clones of RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			// unprotect
 			err = cephRBDSnapshotUnprotect(clusterName, poolName,
 				volumeName, volumeType, snapshotName, userName)
 			if err != nil {
-				logger.Errorf(`Failed to unprotect RBD `+
-					`snapshot "%s" of RBD storage volume `+
-					`"%s": %s`, logSnapshotEntry,
-					logImageEntry, err)
+				logger.Errorf(`Failed to unprotect RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 				return -1
 			}
-			logger.Debugf(`Unprotected RBD snapshot "%s" of RBD `+
-				`storage volume "%s"`, logSnapshotEntry,
-				logImageEntry)
+			logger.Debugf(`Unprotected RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			// unmap
 			err = cephRBDVolumeSnapshotUnmap(clusterName, poolName,
 				volumeName, volumeType, snapshotName, userName,
 				true)
 			if err != nil {
-				logger.Errorf(`Failed to unmap RBD snapshot `+
-					`"%s" of RBD storage volume "%s": %s`,
-					logSnapshotEntry, logImageEntry, err)
+				logger.Errorf(`Failed to unmap RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 				return -1
 			}
-			logger.Debugf(`Unmapped RBD snapshot "%s" of RBD `+
-				`storage volume "%s"`, logSnapshotEntry,
-				logImageEntry)
+			logger.Debugf(`Unmapped RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			// delete
 			err = cephRBDSnapshotDelete(clusterName, poolName,
 				volumeName, volumeType, snapshotName, userName)
 			if err != nil {
-				logger.Errorf(`Failed to delete RBD snapshot `+
-					`"%s" of RBD storage volume "%s": %s`,
-					logSnapshotEntry, logImageEntry, err)
+				logger.Errorf(`Failed to delete RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 				return -1
 			}
-			logger.Debugf(`Deleted RBD snapshot "%s" of RBD `+
-				`storage volume "%s"`, logSnapshotEntry,
-				logImageEntry)
+			logger.Debugf(`Deleted RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			// Only delete the parent image if it is a zombie. If it
 			// is not we know that LXD is still using it.
@@ -1293,18 +1207,14 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 					poolName, volumeName, volumeType,
 					userName)
 				if ret < 0 {
-					logger.Errorf(`Failed to delete RBD `+
-						`storage volume "%s"`,
-						logImageEntry)
+					logger.Errorf(`Failed to delete RBD storage volume "%s"`, logImageEntry)
 					return -1
 				}
 				logger.Debugf(`Deleted RBD storage volume "%s"`,
 					logImageEntry)
 			}
 		} else {
-			logger.Debugf(`Could not delete all clones of RBD `+
-				`snapshot "%s" of RBD storage volume "%s"`,
-				logSnapshotEntry, logImageEntry)
+			logger.Debugf(`Could not delete all clones of RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			if strings.HasPrefix(snapshotName, "zombie_") {
 				return 1
@@ -1314,14 +1224,10 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 				volumeName, volumeType, snapshotName, userName,
 				true)
 			if err != nil {
-				logger.Errorf(`Failed to unmap RBD `+
-					`snapshot "%s" of RBD storage volume "%s": %s`,
-					logSnapshotEntry, logImageEntry, err)
+				logger.Errorf(`Failed to unmap RBD snapshot "%s" of RBD storage volume "%s": %s`, logSnapshotEntry, logImageEntry, err)
 				return -1
 			}
-			logger.Debug(`Unmapped RBD `+
-				`snapshot "%s" of RBD storage volume "%s"`,
-				logSnapshotEntry, logImageEntry)
+			logger.Debug(`Unmapped RBD snapshot "%s" of RBD storage volume "%s"`, logSnapshotEntry, logImageEntry)
 
 			newSnapshotName := fmt.Sprintf("zombie_%s", snapshotName)
 			logSnapshotNewEntry := fmt.Sprintf("%s/%s_%s@%s",
@@ -1330,15 +1236,10 @@ func cephContainerSnapshotDelete(clusterName string, poolName string,
 				volumeName, volumeType, snapshotName,
 				newSnapshotName, userName)
 			if err != nil {
-				logger.Errorf(`Failed to rename RBD `+
-					`snapshot "%s" of RBD storage volume "%s" `+
-					`to %s`, logSnapshotEntry, logImageEntry,
-					logSnapshotNewEntry)
+				logger.Errorf(`Failed to rename RBD snapshot "%s" of RBD storage volume "%s" to %s`, logSnapshotEntry, logImageEntry, logSnapshotNewEntry)
 				return -1
 			}
-			logger.Debugf(`Renamed RBD snapshot "%s" of RBD `+
-				`storage volume "%s" to %s`, logSnapshotEntry,
-				logImageEntry, logSnapshotNewEntry)
+			logger.Debugf(`Renamed RBD snapshot "%s" of RBD storage volume "%s" to %s`, logSnapshotEntry, logImageEntry, logSnapshotNewEntry)
 		}
 
 	}
@@ -1585,7 +1486,7 @@ func (s *storageCeph) rbdShrink(path string, size int64, fsType string,
 			%s`, path, msg)
 	}
 
-	logger.Debugf("reduce underlying %s filesystem for LV \"%s\"", fsType, path)
+	logger.Debugf("Reduce underlying %s filesystem for LV \"%s\"", fsType, path)
 	return nil
 }
 
@@ -1677,7 +1578,7 @@ func parseCephSize(numStr string) (uint64, error) {
 // This does not introduce a dependency relation between the source RBD storage
 // volume and the target RBD storage volume.
 func (s *storageCeph) cephRBDVolumeDumpToFile(sourceVolumeName string, file string) error {
-	logger.Debugf(`Dumping RBD storage volume "%s -> "%s"`, sourceVolumeName, file)
+	logger.Debugf(`Dumping RBD storage volume "%s" to "%s"`, sourceVolumeName, file)
 
 	args := []string{
 		"export",
@@ -1693,7 +1594,7 @@ func (s *storageCeph) cephRBDVolumeDumpToFile(sourceVolumeName string, file stri
 		return err
 	}
 
-	logger.Debugf(`Dumped RBD storage volume "%s -> "%s"`, sourceVolumeName, file)
+	logger.Debugf(`Dumped RBD storage volume "%s" to "%s"`, sourceVolumeName, file)
 	return nil
 }
 
@@ -1904,7 +1805,7 @@ func (s *storageCeph) doContainerMount(name string) (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
@@ -1947,8 +1848,7 @@ func (s *storageCeph) doContainerMount(name string) (bool, error) {
 }
 
 func (s *storageCeph) doContainerSnapshotCreate(targetName string, sourceName string) error {
-	logger.Debugf(`Creating RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, targetName, s.pool.Name)
+	logger.Debugf(`Creating RBD storage volume for snapshot "%s" on storage pool "%s"`, targetName, s.pool.Name)
 
 	revert := true
 
@@ -1958,13 +1858,10 @@ func (s *storageCeph) doContainerSnapshotCreate(targetName string, sourceName st
 		sourceName, storagePoolVolumeTypeNameContainer,
 		targetSnapshotName, s.UserName)
 	if err != nil {
-		logger.Errorf(`Failed to create snapshot for RBD storage `+
-			`volume for image "%s" on storage pool "%s": %s`,
-			targetName, s.pool.Name, err)
+		logger.Errorf(`Failed to create snapshot for RBD storage volume for image "%s" on storage pool "%s": %s`, targetName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created snapshot for RBD storage volume for image `+
-		`"%s" on storage pool "%s"`, targetName, s.pool.Name)
+	logger.Debugf(`Created snapshot for RBD storage volume for image "%s" on storage pool "%s"`, targetName, s.pool.Name)
 
 	defer func() {
 		if !revert {
@@ -1975,10 +1872,7 @@ func (s *storageCeph) doContainerSnapshotCreate(targetName string, sourceName st
 			sourceName, storagePoolVolumeTypeNameContainer,
 			targetSnapshotName, s.UserName)
 		if err != nil {
-			logger.Warnf(`Failed to delete RBD `+
-				`container storage for `+
-				`snapshot "%s" of container "%s"`,
-				targetSnapshotOnlyName, sourceName)
+			logger.Warnf(`Failed to delete RBD container storage for snapshot "%s" of container "%s"`, targetSnapshotOnlyName, sourceName)
 		}
 	}()
 
@@ -1988,21 +1882,13 @@ func (s *storageCeph) doContainerSnapshotCreate(targetName string, sourceName st
 	snapshotMntPointSymlink := shared.VarPath("snapshots", sourceOnlyName)
 	err = createSnapshotMountpoint(targetContainerMntPoint, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
 	if err != nil {
-		logger.Errorf(`Failed to create mountpoint "%s", snapshot `+
-			`symlink target "%s", snapshot mountpoint symlink"%s" `+
-			`for RBD storage volume "%s" on storage pool "%s": %s`,
-			targetContainerMntPoint, snapshotMntPointSymlinkTarget,
+		logger.Errorf(`Failed to create mountpoint "%s", snapshot symlink target "%s", snapshot mountpoint symlink"%s" for RBD storage volume "%s" on storage pool "%s": %s`, targetContainerMntPoint, snapshotMntPointSymlinkTarget,
 			snapshotMntPointSymlink, s.volume.Name, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created mountpoint "%s", snapshot symlink target `+
-		`"%s", snapshot mountpoint symlink"%s" for RBD storage `+
-		`volume "%s" on storage pool "%s"`, targetContainerMntPoint,
-		snapshotMntPointSymlinkTarget, snapshotMntPointSymlink,
-		s.volume.Name, s.pool.Name)
+	logger.Debugf(`Created mountpoint "%s", snapshot symlink target "%s", snapshot mountpoint symlink"%s" for RBD storage volume "%s" on storage pool "%s"`, targetContainerMntPoint, snapshotMntPointSymlinkTarget, snapshotMntPointSymlink, s.volume.Name, s.pool.Name)
 
-	logger.Debugf(`Created RBD storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, targetName, s.pool.Name)
+	logger.Debugf(`Created RBD storage volume for snapshot "%s" on storage pool "%s"`, targetName, s.pool.Name)
 
 	revert = false
 

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -33,7 +33,7 @@ func (s *storageDir) StorageCoreInit() error {
 	s.sTypeName = typeName
 	s.sTypeVersion = "1"
 
-	logger.Debugf("Initializing a DIR driver.")
+	logger.Debugf("Initializing a DIR driver")
 	return nil
 }
 
@@ -49,12 +49,12 @@ func (s *storageDir) StoragePoolInit() error {
 
 // Initialize a full storage interface.
 func (s *storageDir) StoragePoolCheck() error {
-	logger.Debugf("Checking DIR storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checking DIR storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolCreate() error {
-	logger.Infof("Creating DIR storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Creating DIR storage pool \"%s\"", s.pool.Name)
 
 	s.pool.Config["volatile.initial_source"] = s.pool.Config["source"]
 
@@ -125,12 +125,12 @@ func (s *storageDir) StoragePoolCreate() error {
 
 	revert = false
 
-	logger.Infof("Created DIR storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Created DIR storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolDelete() error {
-	logger.Infof("Deleting DIR storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleting DIR storage pool \"%s\"", s.pool.Name)
 
 	source := shared.HostPath(s.pool.Config["source"])
 	if source == "" {
@@ -162,7 +162,7 @@ func (s *storageDir) StoragePoolDelete() error {
 		}
 	}
 
-	logger.Infof("Deleted DIR storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleted DIR storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
@@ -177,14 +177,14 @@ func (s *storageDir) StoragePoolMount() (bool, error) {
 		return true, nil
 	}
 
-	logger.Debugf("Mounting DIR storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Mounting DIR storage pool \"%s\"", s.pool.Name)
 
 	poolMountLockID := getPoolMountLockID(s.pool.Name)
 	lxdStorageMapLock.Lock()
 	if waitChannel, ok := lxdStorageOngoingOperationMap[poolMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage pool.
@@ -213,12 +213,11 @@ func (s *storageDir) StoragePoolMount() (bool, error) {
 
 	err := syscall.Mount(mountSource, poolMntPoint, "", uintptr(mountFlags), "")
 	if err != nil {
-		logger.Errorf(`Failed to mount DIR storage pool "%s" onto `+
-			`"%s": %s`, mountSource, poolMntPoint, err)
+		logger.Errorf(`Failed to mount DIR storage pool "%s" onto "%s": %s`, mountSource, poolMntPoint, err)
 		return false, err
 	}
 
-	logger.Debugf("Mounted DIR storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Mounted DIR storage pool \"%s\"", s.pool.Name)
 
 	return true, nil
 }
@@ -234,14 +233,14 @@ func (s *storageDir) StoragePoolUmount() (bool, error) {
 		return true, nil
 	}
 
-	logger.Debugf("Unmounting DIR storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Unmounting DIR storage pool \"%s\"", s.pool.Name)
 
 	poolUmountLockID := getPoolUmountLockID(s.pool.Name)
 	lxdStorageMapLock.Lock()
 	if waitChannel, ok := lxdStorageOngoingOperationMap[poolUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage pool.
@@ -271,7 +270,7 @@ func (s *storageDir) StoragePoolUmount() (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Unmounted DIR pool \"%s\".", s.pool.Name)
+	logger.Debugf("Unmounted DIR pool \"%s\"", s.pool.Name)
 	return true, nil
 }
 
@@ -323,7 +322,7 @@ func (s *storageDir) StoragePoolUpdate(writable *api.StoragePoolPut, changedConf
 
 // Functions dealing with storage pools.
 func (s *storageDir) StoragePoolVolumeCreate() error {
-	logger.Infof("Creating DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Creating DIR storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -341,12 +340,12 @@ func (s *storageDir) StoragePoolVolumeCreate() error {
 		return err
 	}
 
-	logger.Infof("Created DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Created DIR storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) StoragePoolVolumeDelete() error {
-	logger.Infof("Deleting DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleting DIR storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -368,12 +367,11 @@ func (s *storageDir) StoragePoolVolumeDelete() error {
 		storagePoolVolumeTypeCustom,
 		s.poolID)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for DIR `+
-			`storage volume "%s" on storage pool "%s"`,
+		logger.Errorf(`Failed to delete database entry for DIR storage volume "%s" on storage pool "%s"`,
 			s.volume.Name, s.pool.Name)
 	}
 
-	logger.Infof("Deleted DIR storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleted DIR storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -448,7 +446,7 @@ func (s *storageDir) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageDir) ContainerCreate(container container) error {
-	logger.Debugf("Creating empty DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -480,12 +478,12 @@ func (s *storageDir) ContainerCreate(container container) error {
 
 	revert = false
 
-	logger.Debugf("Created empty DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerCreateFromImage(container container, imageFingerprint string) error {
-	logger.Debugf("Creating DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -532,7 +530,7 @@ func (s *storageDir) ContainerCreateFromImage(container container, imageFingerpr
 
 	revert = false
 
-	logger.Debugf("Created DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -541,7 +539,7 @@ func (s *storageDir) ContainerCanRestore(container container, sourceContainer co
 }
 
 func (s *storageDir) ContainerDelete(container container) error {
-	logger.Debugf("Deleting DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -583,7 +581,7 @@ func (s *storageDir) ContainerDelete(container container) error {
 	}
 
 	// Delete potential leftover snapshot symlinks:
-	// ${LXD_DIR}/snapshots/<container_name> -> ${POOL}/snapshots/<container_name>
+	// ${LXD_DIR}/snapshots/<container_name> to ${POOL}/snapshots/<container_name>
 	snapshotSymlink := shared.VarPath("snapshots", container.Name())
 	if shared.PathExists(snapshotSymlink) {
 		err := os.Remove(snapshotSymlink)
@@ -602,7 +600,7 @@ func (s *storageDir) ContainerDelete(container container) error {
 		s.ContainerBackupDelete(backupName)
 	}
 
-	logger.Debugf("Deleted DIR storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -664,7 +662,7 @@ func (s *storageDir) copySnapshot(target container, targetPool string, source co
 }
 
 func (s *storageDir) ContainerCopy(target container, source container, containerOnly bool) error {
-	logger.Debugf("Copying DIR container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copying DIR container storage %s to %s", source.Name(), target.Name())
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -712,7 +710,7 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 	}
 
 	if containerOnly {
-		logger.Debugf("Copied DIR container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied DIR container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -722,7 +720,7 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 	}
 
 	if len(snapshots) == 0 {
-		logger.Debugf("Copied DIR container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied DIR container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -745,7 +743,7 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 		}
 	}
 
-	logger.Debugf("Copied DIR container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copied DIR container storage %s to %s", source.Name(), target.Name())
 	return nil
 }
 
@@ -758,7 +756,7 @@ func (s *storageDir) ContainerUmount(name string, path string) (bool, error) {
 }
 
 func (s *storageDir) ContainerRename(container container, newName string) error {
-	logger.Debugf("Renaming DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -801,7 +799,7 @@ func (s *storageDir) ContainerRename(container container, newName string) error 
 		}
 
 		// Create the new snapshot symlink:
-		// ${LXD_DIR}/snapshots/<new_container_name> -> ${POOL}/snapshots/<new_container_name>
+		// ${LXD_DIR}/snapshots/<new_container_name> to ${POOL}/snapshots/<new_container_name>
 		err = os.Symlink(newSnapshotsMntPoint, newSnapshotSymlink)
 		if err != nil {
 			return err
@@ -819,12 +817,12 @@ func (s *storageDir) ContainerRename(container container, newName string) error 
 		s.ContainerBackupRename(backup, newName)
 	}
 
-	logger.Debugf("Renamed DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageDir) ContainerRestore(container container, sourceContainer container) error {
-	logger.Debugf("Restoring DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+	logger.Debugf("Restoring DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceContainer.Name(), container.Name())
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -846,7 +844,7 @@ func (s *storageDir) ContainerRestore(container container, sourceContainer conta
 		return err
 	}
 
-	logger.Debugf("Restored DIR storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceContainer.Name(), container.Name())
+	logger.Debugf("Restored DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceContainer.Name(), container.Name())
 	return nil
 }
 
@@ -855,7 +853,7 @@ func (s *storageDir) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
-	logger.Debugf("Creating DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -899,11 +897,11 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 	if sourceContainer.IsRunning() {
 		// This is done to ensure consistency when snapshotting. But we
 		// probably shouldn't fail just because of that.
-		logger.Debugf("Trying to freeze and rsync again to ensure consistency.")
+		logger.Debugf("Trying to freeze and rsync again to ensure consistency")
 
 		err := sourceContainer.Freeze()
 		if err != nil {
-			logger.Errorf("Trying to freeze and rsync again failed.")
+			logger.Errorf("Trying to freeze and rsync again failed")
 			goto onSuccess
 		}
 		defer sourceContainer.Unfreeze()
@@ -916,7 +914,7 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 
 onSuccess:
 	// Check if the symlink
-	// ${LXD_DIR}/snapshots/<source_container_name> -> ${POOL_PATH}/snapshots/<source_container_name>
+	// ${LXD_DIR}/snapshots/<source_container_name> to ${POOL_PATH}/snapshots/<source_container_name>
 	// exists and if not create it.
 	sourceContainerSymlink := shared.VarPath("snapshots", sourceContainerName)
 	sourceContainerSymlinkTarget := getSnapshotMountPoint(sourcePool, sourceContainerName)
@@ -927,12 +925,12 @@ onSuccess:
 		}
 	}
 
-	logger.Debugf("Created DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	logger.Debugf("Creating empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -955,7 +953,7 @@ func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 	}()
 
 	// Check if the symlink
-	// ${LXD_DIR}/snapshots/<source_container_name> -> ${POOL_PATH}/snapshots/<source_container_name>
+	// ${LXD_DIR}/snapshots/<source_container_name> to ${POOL_PATH}/snapshots/<source_container_name>
 	// exists and if not create it.
 	targetContainerMntPoint = getSnapshotMountPoint(s.pool.Name,
 		targetContainerName)
@@ -971,7 +969,7 @@ func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 
 	revert = false
 
-	logger.Debugf("Created empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -1006,7 +1004,7 @@ func dirSnapshotDeleteInternal(poolName string, snapshotName string) error {
 }
 
 func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error {
-	logger.Debugf("Deleting DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1024,12 +1022,12 @@ func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error 
 		return err
 	}
 
-	logger.Debugf("Deleted DIR storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newName string) error {
-	logger.Debugf("Renaming DIR storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming DIR storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -1045,7 +1043,7 @@ func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newNam
 		return err
 	}
 
-	logger.Debugf("Renamed DIR storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed DIR storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
@@ -1058,7 +1056,7 @@ func (s *storageDir) ContainerSnapshotStop(container container) (bool, error) {
 }
 
 func (s *storageDir) ContainerBackupCreate(backup backup, sourceContainer container) error {
-	logger.Debugf("Creating DIR storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Creating DIR storage volume for backup \"%s\" on storage pool \"%s\"",
 		backup.Name(), s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1115,11 +1113,11 @@ func (s *storageDir) ContainerBackupCreate(backup backup, sourceContainer contai
 	if sourceContainer.IsRunning() {
 		// This is done to ensure consistency when snapshotting. But we
 		// probably shouldn't fail just because of that.
-		logger.Debugf("Trying to freeze and rsync again to ensure consistency.")
+		logger.Debugf("Trying to freeze and rsync again to ensure consistency")
 
 		err := sourceContainer.Freeze()
 		if err != nil {
-			logger.Errorf("Trying to freeze and rsync again failed.")
+			logger.Errorf("Trying to freeze and rsync again failed")
 		}
 		defer sourceContainer.Unfreeze()
 
@@ -1148,13 +1146,13 @@ func (s *storageDir) ContainerBackupCreate(backup backup, sourceContainer contai
 		}
 	}
 
-	logger.Debugf("Created DIR storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Created DIR storage volume for backup \"%s\" on storage pool \"%s\"",
 		backup.Name(), s.pool.Name)
 	return nil
 }
 
 func (s *storageDir) ContainerBackupDelete(name string) error {
-	logger.Debugf("Deleting DIR storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Deleting DIR storage volume for backup \"%s\" on storage pool \"%s\"",
 		name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1172,7 +1170,7 @@ func (s *storageDir) ContainerBackupDelete(name string) error {
 		return err
 	}
 
-	logger.Debugf("Deleted DIR storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Deleted DIR storage volume for backup \"%s\" on storage pool \"%s\"",
 		name, s.pool.Name)
 	return nil
 }
@@ -1200,7 +1198,7 @@ func dirBackupDeleteInternal(poolName string, backupName string) error {
 }
 
 func (s *storageDir) ContainerBackupRename(backup backup, newName string) error {
-	logger.Debugf("Renaming DIR storage volume for backup \"%s\" from %s -> %s.",
+	logger.Debugf("Renaming DIR storage volume for backup \"%s\" from %s to %s",
 		backup.Name(), backup.Name(), newName)
 
 	_, err := s.StoragePoolMount()
@@ -1224,7 +1222,7 @@ func (s *storageDir) ContainerBackupRename(backup backup, newName string) error 
 		}
 	}
 
-	logger.Debugf("Renamed DIR storage volume for backup \"%s\" from %s -> %s.",
+	logger.Debugf("Renamed DIR storage volume for backup \"%s\" from %s to %s",
 		backup.Name(), backup.Name(), newName)
 	return nil
 }

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -55,7 +55,7 @@ func (s *storageLvm) StorageCoreInit() error {
 		s.sTypeVersion += strings.TrimSpace(fields[1])
 	}
 
-	logger.Debugf("Initializing an LVM driver.")
+	logger.Debugf("Initializing an LVM driver")
 	return nil
 }
 
@@ -89,7 +89,7 @@ func (s *storageLvm) StoragePoolInit() error {
 }
 
 func (s *storageLvm) StoragePoolCheck() error {
-	logger.Debugf("Checking LVM storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checking LVM storage pool \"%s\"", s.pool.Name)
 
 	_, err := s.StoragePoolMount()
 	if err != nil {
@@ -106,12 +106,12 @@ func (s *storageLvm) StoragePoolCheck() error {
 		return err
 	}
 
-	logger.Debugf("Checked LVM storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checked LVM storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolCreate() error {
-	logger.Infof("Creating LVM storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Creating LVM storage pool \"%s\"", s.pool.Name)
 
 	s.pool.Config["volatile.initial_source"] = s.pool.Config["source"]
 
@@ -245,7 +245,7 @@ func (s *storageLvm) StoragePoolCreate() error {
 		// This is an internal error condition which should never be
 		// hit.
 		if pvName == "" {
-			logger.Errorf("no name for physical volume detected")
+			logger.Errorf("No name for physical volume detected")
 		}
 
 		output, err := shared.TryRunCommand("pvcreate", pvName)
@@ -264,7 +264,7 @@ func (s *storageLvm) StoragePoolCreate() error {
 		// Otherwise we will refuse to use it.
 		count, err := lvmGetLVCount(poolName)
 		if err != nil {
-			logger.Errorf("failed to determine whether the volume group \"%s\" is empty", poolName)
+			logger.Errorf("Failed to determine whether the volume group \"%s\" is empty", poolName)
 			return err
 		}
 
@@ -276,7 +276,7 @@ func (s *storageLvm) StoragePoolCreate() error {
 		if count > 0 && s.useThinpool {
 			ok, err := storageLVMThinpoolExists(poolName, s.thinPoolName)
 			if err != nil {
-				logger.Errorf("failed to determine whether thinpool \"%s\" exists in volume group \"%s\": %s", poolName, s.thinPoolName, err)
+				logger.Errorf("Failed to determine whether thinpool \"%s\" exists in volume group \"%s\": %s", poolName, s.thinPoolName, err)
 				return err
 			}
 			empty = ok
@@ -314,12 +314,12 @@ func (s *storageLvm) StoragePoolCreate() error {
 	// Deregister cleanup.
 	tryUndo = false
 
-	logger.Infof("Created LVM storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Created LVM storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolDelete() error {
-	logger.Infof("Deleting LVM storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleting LVM storage pool \"%s\"", s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -348,7 +348,7 @@ func (s *storageLvm) StoragePoolDelete() error {
 		if ok {
 			msg, err := shared.TryRunCommand("lvremove", "-f", devPath)
 			if err != nil {
-				logger.Errorf("failed to delete thinpool \"%s\" from volume group \"%s\": %s", s.thinPoolName, poolName, msg)
+				logger.Errorf("Failed to delete thinpool \"%s\" from volume group \"%s\": %s", s.thinPoolName, poolName, msg)
 				return err
 			}
 		}
@@ -367,7 +367,7 @@ func (s *storageLvm) StoragePoolDelete() error {
 	if count == 0 && poolExists {
 		output, err := shared.TryRunCommand("vgremove", "-f", poolName)
 		if err != nil {
-			logger.Errorf("failed to destroy the volume group for the lvm storage pool: %s", output)
+			logger.Errorf("Failed to destroy the volume group for the lvm storage pool: %s", output)
 			return err
 		}
 	}
@@ -377,7 +377,7 @@ func (s *storageLvm) StoragePoolDelete() error {
 		// otherwise we will get EBADF.
 		err = setAutoclearOnLoopDev(int(s.loopInfo.Fd()))
 		if err != nil {
-			logger.Warnf("Failed to set LO_FLAGS_AUTOCLEAR on loop device: %s. Manual cleanup needed.", err)
+			logger.Warnf("Failed to set LO_FLAGS_AUTOCLEAR on loop device: %s, manual cleanup needed", err)
 		}
 	}
 
@@ -397,7 +397,7 @@ func (s *storageLvm) StoragePoolDelete() error {
 		return err
 	}
 
-	logger.Infof("Deleted LVM storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleted LVM storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
@@ -419,7 +419,7 @@ func (s *storageLvm) StoragePoolMount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[poolMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage pool.
@@ -462,7 +462,7 @@ func (s *storageLvm) StoragePoolUmount() (bool, error) {
 }
 
 func (s *storageLvm) StoragePoolVolumeCreate() error {
-	logger.Infof("Creating LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Creating LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	tryUndo := true
 
 	poolName := s.getOnDiskPoolName()
@@ -516,12 +516,12 @@ func (s *storageLvm) StoragePoolVolumeCreate() error {
 
 	tryUndo = false
 
-	logger.Infof("Created LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Created LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolVolumeDelete() error {
-	logger.Infof("Deleting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleting LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	customLvmDevPath := getLvmDevPath(poolName,
@@ -560,17 +560,15 @@ func (s *storageLvm) StoragePoolVolumeDelete() error {
 		storagePoolVolumeTypeCustom,
 		s.poolID)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for LVM `+
-			`storage volume "%s" on storage pool "%s"`,
-			s.volume.Name, s.pool.Name)
+		logger.Errorf(`Failed to delete database entry for LVM storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	}
 
-	logger.Infof("Deleted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleted LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
-	logger.Debugf("Mounting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 	poolName := s.getOnDiskPoolName()
@@ -586,7 +584,7 @@ func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
@@ -615,12 +613,12 @@ func (s *storageLvm) StoragePoolVolumeMount() (bool, error) {
 		return false, customerr
 	}
 
-	logger.Debugf("Mounted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
-	logger.Debugf("Unmounting LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounting LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
 
@@ -629,7 +627,7 @@ func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
@@ -657,7 +655,7 @@ func (s *storageLvm) StoragePoolVolumeUmount() (bool, error) {
 		return false, customerr
 	}
 
-	logger.Debugf("Unmounted LVM storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounted LVM storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -735,10 +733,7 @@ func (s *storageLvm) StoragePoolUpdate(writable *api.StoragePoolPut, changedConf
 
 			err = lvmLVRename(poolName, newThinpoolName, oldThinpoolName)
 			if err != nil {
-				logger.Warnf(`Failed to rename LVM thinpool `+
-					`from "%s" to "%s": %s. Manual `+
-					`intervention needed`, newThinpoolName,
-					oldThinpoolName, err)
+				logger.Warnf(`Failed to rename LVM thinpool from "%s" to "%s": %s. Manual intervention needed`, newThinpoolName, oldThinpoolName, err)
 			}
 			s.setLvmThinpoolName(oldThinpoolName)
 		}()
@@ -862,7 +857,7 @@ func (s *storageLvm) ContainerStorageReady(name string) bool {
 }
 
 func (s *storageLvm) ContainerCreate(container container) error {
-	logger.Debugf("Creating empty LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	tryUndo := true
 
@@ -921,12 +916,12 @@ func (s *storageLvm) ContainerCreate(container container) error {
 
 	tryUndo = false
 
-	logger.Debugf("Created empty LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string) error {
-	logger.Debugf("Creating LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	tryUndo := true
 
@@ -940,13 +935,10 @@ func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint s
 		err = s.containerCreateFromImageLv(container, fingerprint)
 	}
 	if err != nil {
-		logger.Errorf(`Failed to create LVM storage volume for `+
-			`container "%s" on storage pool "%s": %s`, containerName,
-			s.pool.Name, err)
+		logger.Errorf(`Failed to create LVM storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created LVM storage volume for container "%s" on `+
-		`storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Created LVM storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 	defer func() {
 		if tryUndo {
 			s.ContainerDelete(container)
@@ -1000,13 +992,13 @@ func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint s
 
 	err = container.TemplateApply("create")
 	if err != nil {
-		logger.Errorf("Error in create template during ContainerCreateFromImage, continuing to unmount: %s.", err)
+		logger.Errorf("Error in create template during ContainerCreateFromImage, continuing to unmount: %s", err)
 		return err
 	}
 
 	tryUndo = false
 
-	logger.Debugf("Created LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -1059,7 +1051,7 @@ func lvmContainerDeleteInternal(poolName string, ctName string, isSnapshot bool,
 }
 
 func (s *storageLvm) ContainerDelete(container container) error {
-	logger.Debugf("Deleting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerName := container.Name()
 	poolName := s.getOnDiskPoolName()
@@ -1130,12 +1122,12 @@ func (s *storageLvm) ContainerDelete(container container) error {
 		}
 	}
 
-	logger.Debugf("Deleted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerCopy(target container, source container, containerOnly bool) error {
-	logger.Debugf("Copying LVM container storage for container %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copying LVM container storage for container %s to %s", source.Name(), target.Name())
 
 	ourStart, err := source.StorageStart()
 	if err != nil {
@@ -1177,7 +1169,7 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 	}
 
 	if containerOnly {
-		logger.Debugf("Copied LVM container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied LVM container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -1187,7 +1179,7 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 	}
 
 	if len(snapshots) == 0 {
-		logger.Debugf("Copied LVM container storage %s -> %s.", source.Name(), target.Name())
+		logger.Debugf("Copied LVM container storage %s to %s", source.Name(), target.Name())
 		return nil
 	}
 
@@ -1195,7 +1187,7 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 		_, snapOnlyName, _ := containerGetParentAndSnapshotName(snap.Name())
 		newSnapName := fmt.Sprintf("%s/%s", target.Name(), snapOnlyName)
 
-		logger.Debugf("Copying LVM container storage for snapshot %s -> %s.", snap.Name(), newSnapName)
+		logger.Debugf("Copying LVM container storage for snapshot %s to %s", snap.Name(), newSnapName)
 
 		sourceSnapshot, err := containerLoadByName(srcState, snap.Name())
 		if err != nil {
@@ -1212,10 +1204,10 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 			return err
 		}
 
-		logger.Debugf("Copied LVM container storage for snapshot %s -> %s.", snap.Name(), newSnapName)
+		logger.Debugf("Copied LVM container storage for snapshot %s to %s", snap.Name(), newSnapName)
 	}
 
-	logger.Debugf("Copied LVM container storage for container %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copied LVM container storage for container %s to %s", source.Name(), target.Name())
 	return nil
 }
 
@@ -1224,7 +1216,7 @@ func (s *storageLvm) ContainerMount(c container) (bool, error) {
 }
 
 func (s *storageLvm) doContainerMount(name string) (bool, error) {
-	logger.Debugf("Mounting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerLvmName := containerNameToLVName(name)
 	lvFsType := s.getLvmFilesystem()
@@ -1240,7 +1232,7 @@ func (s *storageLvm) doContainerMount(name string) (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
@@ -1269,12 +1261,12 @@ func (s *storageLvm) doContainerMount(name string) (bool, error) {
 		return false, mounterr
 	}
 
-	logger.Debugf("Mounted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
-	logger.Debugf("Unmounting LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounting LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerMntPoint := getContainerMountPoint(s.pool.Name, name)
 	if shared.IsSnapshot(name) {
@@ -1286,7 +1278,7 @@ func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
@@ -1314,12 +1306,12 @@ func (s *storageLvm) ContainerUmount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
-	logger.Debugf("Unmounted LVM storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounted LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
 func (s *storageLvm) ContainerRename(container container, newContainerName string) error {
-	logger.Debugf("Renaming LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+	logger.Debugf("Renaming LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 
 	tryUndo := true
 
@@ -1418,12 +1410,12 @@ func (s *storageLvm) ContainerRename(container container, newContainerName strin
 
 	tryUndo = false
 
-	logger.Debugf("Renamed LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+	logger.Debugf("Renamed LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 	return nil
 }
 
 func (s *storageLvm) ContainerRestore(target container, source container) error {
-	logger.Debugf("Restoring LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, source.Name(), target.Name())
+	logger.Debugf("Restoring LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, source.Name(), target.Name())
 
 	ourStart, err := source.StorageStart()
 	if err != nil {
@@ -1499,7 +1491,7 @@ func (s *storageLvm) ContainerRestore(target container, source container) error 
 		}
 	}
 
-	logger.Debugf("Restored LVM storage volume for container \"%s\" from %s -> %s.", s.volume.Name, sourceName, targetName)
+	logger.Debugf("Restored LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceName, targetName)
 	return nil
 }
 
@@ -1508,31 +1500,31 @@ func (s *storageLvm) ContainerGetUsage(container container) (int64, error) {
 }
 
 func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
-	logger.Debugf("Creating LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("Created LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer container) error {
-	logger.Debugf("Deleting LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.ContainerDelete(snapshotContainer)
 	if err != nil {
 		return fmt.Errorf("Error deleting snapshot %s: %s", snapshotContainer.Name(), err)
 	}
 
-	logger.Debugf("Deleted LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newContainerName string) error {
-	logger.Debugf("Renaming LVM storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+	logger.Debugf("Renaming LVM storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 
 	tryUndo := true
 
@@ -1559,13 +1551,12 @@ func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newCon
 
 	tryUndo = false
 
-	logger.Debugf("Renamed LVM storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newContainerName)
+	logger.Debugf("Renamed LVM storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 	return nil
 }
 
 func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
-	logger.Debugf(`Initializing LVM storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Initializing LVM storage volume for snapshot "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	containerName := container.Name()
@@ -1580,7 +1571,7 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 	if !wasWritableAtCheck {
 		output, err := shared.TryRunCommand("lvchange", "-prw", fmt.Sprintf("%s/%s_%s", poolName, storagePoolVolumeAPIEndpointContainers, containerLvmName))
 		if err != nil {
-			logger.Errorf("Failed to make LVM snapshot \"%s\" read-write: %s.", containerName, output)
+			logger.Errorf("Failed to make LVM snapshot \"%s\" read-write: %s", containerName, output)
 			return false, err
 		}
 	}
@@ -1600,16 +1591,12 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 
 		err = tryMount(containerLvmPath, containerMntPoint, lvFsType, mountFlags, mountOptions)
 		if err != nil {
-			logger.Errorf(`Failed to mount LVM snapshot "%s" with `+
-				`filesystem "%s" options "%s" onto "%s": %s`,
-				s.volume.Name, lvFsType, mntOptString,
-				containerMntPoint, err)
+			logger.Errorf(`Failed to mount LVM snapshot "%s" with filesystem "%s" options "%s" onto "%s": %s`, s.volume.Name, lvFsType, mntOptString, containerMntPoint, err)
 			return false, err
 		}
 	}
 
-	logger.Debugf(`Initialized LVM storage volume for snapshot "%s" on `+
-		`storage pool "%s"`, s.volume.Name, s.pool.Name)
+	logger.Debugf(`Initialized LVM storage volume for snapshot "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	if wasWritableAtCheck {
 		return false, nil
@@ -1619,7 +1606,7 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 }
 
 func (s *storageLvm) ContainerSnapshotStop(container container) (bool, error) {
-	logger.Debugf("Stopping LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopping LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerName := container.Name()
 	snapshotMntPoint := getSnapshotMountPoint(s.pool.Name, containerName)
@@ -1643,12 +1630,12 @@ func (s *storageLvm) ContainerSnapshotStop(container container) (bool, error) {
 	if wasWritableAtCheck {
 		output, err := shared.TryRunCommand("lvchange", "-pr", fmt.Sprintf("%s/%s_%s", poolName, storagePoolVolumeAPIEndpointContainers, containerLvmName))
 		if err != nil {
-			logger.Errorf("Failed to make LVM snapshot read-only: %s.", output)
+			logger.Errorf("Failed to make LVM snapshot read-only: %s", output)
 			return false, err
 		}
 	}
 
-	logger.Debugf("Stopped LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopped LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	if wasWritableAtCheck {
 		return false, nil
@@ -1658,19 +1645,19 @@ func (s *storageLvm) ContainerSnapshotStop(container container) (bool, error) {
 }
 
 func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
-	logger.Debugf("Creating empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.ContainerCreate(snapshotContainer)
 	if err != nil {
 		return err
 	}
 
-	logger.Debugf("Created empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerBackupCreate(backup backup, sourceContainer container) error {
-	logger.Debugf("Creating LVM storage volume for backup \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating LVM storage volume for backup \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	// mount storage
 	ourStart, err := sourceContainer.StorageStart()
@@ -1760,12 +1747,12 @@ func (s *storageLvm) ContainerBackupCreate(backup backup, sourceContainer contai
 		return err
 	}
 
-	logger.Debugf("Created LVM storage volume for backup \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created LVM storage volume for backup \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ContainerBackupDelete(name string) error {
-	logger.Debugf("Deleting LVM storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Deleting LVM storage volume for backup \"%s\" on storage pool \"%s\"",
 		name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1783,7 +1770,7 @@ func (s *storageLvm) ContainerBackupDelete(name string) error {
 		return err
 	}
 
-	logger.Debugf("Deleted LVM storage volume for backup \"%s\" on storage pool \"%s\".",
+	logger.Debugf("Deleted LVM storage volume for backup \"%s\" on storage pool \"%s\"",
 		name, s.pool.Name)
 	return nil
 }
@@ -1810,7 +1797,7 @@ func lvmBackupDeleteInternal(poolName string, backupName string) error {
 	return nil
 }
 func (s *storageLvm) ContainerBackupRename(backup backup, newName string) error {
-	logger.Debugf("Renaming LVM storage volume for backup \"%s\" from %s -> %s.",
+	logger.Debugf("Renaming LVM storage volume for backup \"%s\" from %s to %s",
 		backup.Name(), backup.Name(), newName)
 
 	_, err := s.StoragePoolMount()
@@ -1834,7 +1821,7 @@ func (s *storageLvm) ContainerBackupRename(backup backup, newName string) error 
 		}
 	}
 
-	logger.Debugf("Renamed LVM storage volume for backup \"%s\" from %s -> %s.",
+	logger.Debugf("Renamed LVM storage volume for backup \"%s\" from %s to %s",
 		backup.Name(), backup.Name(), newName)
 	return nil
 }
@@ -1973,7 +1960,7 @@ func (s *storageLvm) doContainerBackupLoad(containerName string, privileged bool
 }
 
 func (s *storageLvm) ImageCreate(fingerprint string) error {
-	logger.Debugf("Creating LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Creating LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	tryUndo := true
 	trySubUndo := true
@@ -1996,7 +1983,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 		}
 		err := s.deleteImageDbPoolVolume(fingerprint)
 		if err != nil {
-			logger.Warnf("Could not delete image \"%s\" from storage volume database. Manual intervention needed.", fingerprint)
+			logger.Warnf("Could not delete image \"%s\" from storage volume database, manual intervention needed", fingerprint)
 		}
 	}()
 
@@ -2008,7 +1995,6 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 
 		err = lvmCreateLv(poolName, thinPoolName, fingerprint, lvFsType, lvSize, storagePoolVolumeAPIEndpointImages, true)
 		if err != nil {
-			logger.Errorf("lvmCreateLv: %s.", err)
 			return fmt.Errorf("Error Creating LVM LV for new image: %v", err)
 		}
 		defer func() {
@@ -2045,12 +2031,12 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 
 	tryUndo = false
 
-	logger.Debugf("Created LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Created LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ImageDelete(fingerprint string) error {
-	logger.Debugf("Deleting LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleting LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	if s.useThinpool {
 		poolName := s.getOnDiskPoolName()
@@ -2084,12 +2070,12 @@ func (s *storageLvm) ImageDelete(fingerprint string) error {
 		}
 	}
 
-	logger.Debugf("Deleted LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleted LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageLvm) ImageMount(fingerprint string) (bool, error) {
-	logger.Debugf("Mounting LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounting LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if shared.IsMountPoint(imageMntPoint) {
@@ -2111,12 +2097,12 @@ func (s *storageLvm) ImageMount(fingerprint string) (bool, error) {
 		return false, fmt.Errorf("Error mounting image LV: %v", err)
 	}
 
-	logger.Debugf("Mounted LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Mounted LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageLvm) ImageUmount(fingerprint string) (bool, error) {
-	logger.Debugf("Unmounting LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Unmounting LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
 	if !shared.IsMountPoint(imageMntPoint) {
@@ -2128,7 +2114,7 @@ func (s *storageLvm) ImageUmount(fingerprint string) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Unmounted LVM storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Unmounted LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return true, nil
 }
 

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -30,7 +30,7 @@ func (s *storageLvm) lvExtend(lvPath string, lvSize int64, fsType string, fsMntP
 		"-f",
 		lvPath)
 	if err != nil {
-		logger.Errorf("could not extend LV \"%s\": %s", lvPath, msg)
+		logger.Errorf("Could not extend LV \"%s\": %s", lvPath, msg)
 		return fmt.Errorf("could not extend LV \"%s\": %s", lvPath, msg)
 	}
 
@@ -85,11 +85,11 @@ func (s *storageLvm) lvReduce(lvPath string, lvSize int64, fsType string, fsMntP
 		"-f",
 		lvPath)
 	if err != nil {
-		logger.Errorf("could not reduce LV \"%s\": %s", lvPath, msg)
+		logger.Errorf("Could not reduce LV \"%s\": %s", lvPath, msg)
 		return fmt.Errorf("could not reduce LV \"%s\": %s", lvPath, msg)
 	}
 
-	logger.Debugf("reduce underlying %s filesystem for LV \"%s\"", fsType, lvPath)
+	logger.Debugf("Reduced underlying %s filesystem for LV \"%s\"", fsType, lvPath)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func removeLV(vgName string, volumeType string, lvName string) error {
 	output, err := shared.TryRunCommand("lvremove", "-f", lvmVolumePath)
 
 	if err != nil {
-		logger.Errorf("Could not remove LV \"%s\": %s.", lvName, output)
+		logger.Errorf("Could not remove LV \"%s\": %s", lvName, output)
 		return fmt.Errorf("Could not remove LV named %s", lvName)
 	}
 
@@ -186,7 +186,6 @@ func removeLV(vgName string, volumeType string, lvName string) error {
 
 func (s *storageLvm) createSnapshotLV(vgName string, origLvName string, origVolumeType string, lvName string, volumeType string, readonly bool, makeThinLv bool) (string, error) {
 	sourceLvmVolumePath := getLvmDevPath(vgName, origVolumeType, origLvName)
-	logger.Debugf("in createSnapshotLV: %s.", sourceLvmVolumePath)
 	isRecent, err := lvmVersionIsAtLeast(s.sTypeVersion, "2.02.99")
 	if err != nil {
 		return "", fmt.Errorf("Error checking LVM version: %v", err)
@@ -219,7 +218,7 @@ func (s *storageLvm) createSnapshotLV(vgName string, origLvName string, origVolu
 
 	output, err = shared.TryRunCommand("lvcreate", args...)
 	if err != nil {
-		logger.Errorf("Could not create LV snapshot: %s -> %s: %s.", origLvName, lvName, output)
+		logger.Errorf("Could not create LV snapshot: %s to %s: %s", origLvName, lvName, output)
 		return "", fmt.Errorf("Could not create snapshot LV named %s", lvName)
 	}
 
@@ -245,7 +244,7 @@ func (s *storageLvm) createSnapshotContainer(snapshotContainer container, source
 	targetContainerName := snapshotContainer.Name()
 	sourceContainerLvmName := containerNameToLVName(sourceContainerName)
 	targetContainerLvmName := containerNameToLVName(targetContainerName)
-	logger.Debugf("Creating snapshot: %s -> %s.", sourceContainerName, targetContainerName)
+	logger.Debugf("Creating snapshot: %s to %s", sourceContainerName, targetContainerName)
 
 	poolName := s.getOnDiskPoolName()
 	_, err := s.createSnapshotLV(poolName, sourceContainerLvmName, storagePoolVolumeAPIEndpointContainers, targetContainerLvmName, storagePoolVolumeAPIEndpointContainers, readonly, s.useThinpool)
@@ -320,7 +319,7 @@ func (s *storageLvm) createContainerBackup(backup backup, sourceContainer contai
 func (s *storageLvm) copyContainerThinpool(target container, source container, readonly bool) error {
 	err := s.createSnapshotContainer(target, source, readonly)
 	if err != nil {
-		logger.Errorf("Error creating snapshot LV for copy: %s.", err)
+		logger.Errorf("Error creating snapshot LV for copy: %s", err)
 		return err
 	}
 
@@ -374,7 +373,7 @@ func (s *storageLvm) copySnapshot(target container, source container) error {
 		err = s.copyContainerLv(target, source, true)
 	}
 	if err != nil {
-		logger.Errorf("Error creating snapshot LV for copy: %s.", err)
+		logger.Errorf("Error creating snapshot LV for copy: %s", err)
 		return err
 	}
 
@@ -439,7 +438,7 @@ func (s *storageLvm) copyContainerLv(target container, source container, readonl
 		poolName := s.getOnDiskPoolName()
 		output, err := shared.TryRunCommand("lvchange", "-pr", fmt.Sprintf("%s/%s_%s", poolName, storagePoolVolumeAPIEndpointContainers, targetLvmName))
 		if err != nil {
-			logger.Errorf("Failed to make LVM snapshot \"%s\" read-write: %s.", targetName, output)
+			logger.Errorf("Failed to make LVM snapshot \"%s\" read-write: %s", targetName, output)
 			return err
 		}
 	}
@@ -496,38 +495,27 @@ func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
 
 	err := s.ContainerCreate(c)
 	if err != nil {
-		logger.Errorf(`Failed to create non-thinpool LVM storage `+
-			`volume for container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to create non-thinpool LVM storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Created non-thinpool LVM storage volume for container `+
-		`"%s" on storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Created non-thinpool LVM storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	containerPath := c.Path()
 	_, err = s.ContainerMount(c)
 	if err != nil {
-		logger.Errorf(`Failed to mount non-thinpool LVM storage `+
-			`volume for container "%s" on storage pool "%s": %s`,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to mount non-thinpool LVM storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Mounted non-thinpool LVM storage volume for container `+
-		`"%s" on storage pool "%s"`, containerName, s.pool.Name)
+	logger.Debugf(`Mounted non-thinpool LVM storage volume for container "%s" on storage pool "%s"`, containerName, s.pool.Name)
 
 	imagePath := shared.VarPath("images", fp)
 	containerMntPoint := getContainerMountPoint(s.pool.Name, containerName)
 	err = unpackImage(imagePath, containerMntPoint, storageTypeLvm, s.s.OS.RunningInUserNS)
 	if err != nil {
-		logger.Errorf(`Failed to unpack image "%s" into non-thinpool `+
-			`LVM storage volume "%s" for container "%s" on `+
-			`storage pool "%s": %s`, imagePath, containerMntPoint,
-			containerName, s.pool.Name, err)
+		logger.Errorf(`Failed to unpack image "%s" into non-thinpool LVM storage volume "%s" for container "%s" on storage pool "%s": %s`, imagePath, containerMntPoint, containerName, s.pool.Name, err)
 		return err
 	}
-	logger.Debugf(`Unpacked image "%s" into non-thinpool LVM storage `+
-		`volume "%s" for container "%s" on storage pool "%s"`,
-		imagePath, containerMntPoint, containerName, s.pool.Name)
+	logger.Debugf(`Unpacked image "%s" into non-thinpool LVM storage volume "%s" for container "%s" on storage pool "%s"`, imagePath, containerMntPoint, containerName, s.pool.Name)
 
 	s.ContainerUmount(containerName, containerPath)
 
@@ -544,7 +532,7 @@ func (s *storageLvm) containerCreateFromImageThinLv(c container, fp string) erro
 	if waitChannel, ok := lxdStorageOngoingOperationMap[imageStoragePoolLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 	} else {
 		lxdStorageOngoingOperationMap[imageStoragePoolLockID] = make(chan bool)
@@ -856,7 +844,7 @@ func lvmCreateLv(vgName string, thinPoolName string, lvName string, lvFsType str
 		output, err = shared.TryRunCommand("lvcreate", "-n", lvmPoolVolumeName, "--size", lvSize+"B", vgName)
 	}
 	if err != nil {
-		logger.Errorf("Could not create LV \"%s\": %s.", lvmPoolVolumeName, output)
+		logger.Errorf("Could not create LV \"%s\": %s", lvmPoolVolumeName, output)
 		return fmt.Errorf("Could not create thin LV named %s", lvmPoolVolumeName)
 	}
 
@@ -864,7 +852,7 @@ func lvmCreateLv(vgName string, thinPoolName string, lvName string, lvFsType str
 
 	output, err = makeFSType(fsPath, lvFsType, nil)
 	if err != nil {
-		logger.Errorf("Filesystem creation failed: %s.", output)
+		logger.Errorf("Filesystem creation failed: %s", output)
 		return fmt.Errorf("Error making filesystem on image LV: %v", err)
 	}
 
@@ -888,7 +876,7 @@ func lvmCreateThinpool(s *state.State, sTypeVersion string, vgName string, thinP
 
 	err = storageLVMValidateThinPoolName(s, vgName, thinPoolName)
 	if err != nil {
-		logger.Errorf("Setting thin pool name: %s.", err)
+		logger.Errorf("Setting thin pool name: %s", err)
 		return fmt.Errorf("Error setting LVM thin pool config: %v", err)
 	}
 
@@ -919,7 +907,7 @@ func createDefaultThinPool(sTypeVersion string, vgName string, thinPoolName stri
 	}
 
 	if err != nil {
-		logger.Errorf("Could not create thin pool \"%s\": %s.", thinPoolName, string(output))
+		logger.Errorf("Could not create thin pool \"%s\": %s", thinPoolName, string(output))
 		return fmt.Errorf("Could not create LVM thin pool named %s", thinPoolName)
 	}
 
@@ -928,7 +916,7 @@ func createDefaultThinPool(sTypeVersion string, vgName string, thinPoolName stri
 		output, err = shared.TryRunCommand("lvextend", "--alloc", "anywhere", "-l", "100%FREE", lvmThinPool)
 
 		if err != nil {
-			logger.Errorf("Could not grow thin pool: \"%s\": %s.", thinPoolName, string(output))
+			logger.Errorf("Could not grow thin pool: \"%s\": %s", thinPoolName, string(output))
 			return fmt.Errorf("Could not grow LVM thin pool named %s", thinPoolName)
 		}
 	}

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -25,7 +25,7 @@ func (s *storageMock) StorageCoreInit() error {
 	}
 	s.sTypeName = typeName
 
-	logger.Debugf("Initializing a MOCK driver.")
+	logger.Debugf("Initializing a MOCK driver")
 	return nil
 }
 
@@ -39,19 +39,19 @@ func (s *storageMock) StoragePoolInit() error {
 }
 
 func (s *storageMock) StoragePoolCheck() error {
-	logger.Debugf("Checking MOCK storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checking MOCK storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageMock) StoragePoolCreate() error {
-	logger.Infof("Creating MOCK storage pool \"%s\".", s.pool.Name)
-	logger.Infof("Created MOCK storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Creating MOCK storage pool \"%s\"", s.pool.Name)
+	logger.Infof("Created MOCK storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
 func (s *storageMock) StoragePoolDelete() error {
-	logger.Infof("Deleting MOCK storage pool \"%s\".", s.pool.Name)
-	logger.Infof("Deleted MOCK storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleting MOCK storage pool \"%s\"", s.pool.Name)
+	logger.Infof("Deleted MOCK storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 

--- a/lxd/storage_shared.go
+++ b/lxd/storage_shared.go
@@ -38,7 +38,7 @@ func (s *storageShared) shiftRootfs(c container) error {
 	dpath := c.Path()
 	rpath := c.RootfsPath()
 
-	logger.Debugf("Shifting root filesystem \"%s\" for \"%s\".", rpath, c.Name())
+	logger.Debugf("Shifting root filesystem \"%s\" for \"%s\"", rpath, c.Name())
 
 	idmapset, err := c.IdmapSet()
 	if err != nil {

--- a/lxd/storage_utils.go
+++ b/lxd/storage_utils.go
@@ -309,7 +309,7 @@ func shrinkVolumeFilesystem(s storage, volumeType int, fsType string, devPath st
 	var cleanupFunc func() (bool, error)
 	switch fsType {
 	case "xfs":
-		logger.Errorf("xfs filesystems cannot be shrunk: dump, mkfs, and restore are required")
+		logger.Errorf("XFS filesystems cannot be shrunk: dump, mkfs, and restore are required")
 		return nil, fmt.Errorf("xfs filesystems cannot be shrunk: dump, mkfs, and restore are required")
 	case "btrfs":
 		fallthrough

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -60,7 +60,7 @@ func (s *storageZfs) StorageCoreInit() error {
 		return err
 	}
 
-	logger.Debugf("Initializing a ZFS driver.")
+	logger.Debugf("Initializing a ZFS driver")
 	return nil
 }
 
@@ -80,7 +80,7 @@ func (s *storageZfs) StoragePoolInit() error {
 }
 
 func (s *storageZfs) StoragePoolCheck() error {
-	logger.Debugf("Checking ZFS storage pool \"%s\".", s.pool.Name)
+	logger.Debugf("Checking ZFS storage pool \"%s\"", s.pool.Name)
 
 	source := s.pool.Config["source"]
 	if source == "" {
@@ -94,7 +94,7 @@ func (s *storageZfs) StoragePoolCheck() error {
 		return nil
 	}
 
-	logger.Debugf("ZFS storage pool \"%s\" does not exist. Trying to import it.", poolName)
+	logger.Debugf("ZFS storage pool \"%s\" does not exist, trying to import it", poolName)
 
 	var err error
 	var msg string
@@ -109,12 +109,12 @@ func (s *storageZfs) StoragePoolCheck() error {
 		return fmt.Errorf("ZFS storage pool \"%s\" could not be imported: %s", poolName, msg)
 	}
 
-	logger.Debugf("ZFS storage pool \"%s\" successfully imported.", poolName)
+	logger.Debugf("ZFS storage pool \"%s\" successfully imported", poolName)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolCreate() error {
-	logger.Infof("Creating ZFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Creating ZFS storage pool \"%s\"", s.pool.Name)
 
 	err := s.zfsPoolCreate()
 	if err != nil {
@@ -141,7 +141,7 @@ func (s *storageZfs) StoragePoolCreate() error {
 
 	revert = false
 
-	logger.Infof("Created ZFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Created ZFS storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
@@ -261,7 +261,7 @@ func (s *storageZfs) zfsPoolCreate() error {
 	dataset := fmt.Sprintf("%s/containers", poolName)
 	msg, err := zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create containers dataset: %s", msg)
+		logger.Errorf("Failed to create containers dataset: %s", msg)
 		return err
 	}
 
@@ -273,13 +273,13 @@ func (s *storageZfs) zfsPoolCreate() error {
 
 	err = os.Chmod(fixperms, containersDirMode)
 	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(containersDirMode), 8), err)
+		logger.Warnf("Failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(containersDirMode), 8), err)
 	}
 
 	dataset = fmt.Sprintf("%s/images", poolName)
 	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create images dataset: %s", msg)
+		logger.Errorf("Failed to create images dataset: %s", msg)
 		return err
 	}
 
@@ -290,13 +290,13 @@ func (s *storageZfs) zfsPoolCreate() error {
 	}
 	err = os.Chmod(fixperms, imagesDirMode)
 	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(imagesDirMode), 8), err)
+		logger.Warnf("Failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(imagesDirMode), 8), err)
 	}
 
 	dataset = fmt.Sprintf("%s/custom", poolName)
 	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create custom dataset: %s", msg)
+		logger.Errorf("Failed to create custom dataset: %s", msg)
 		return err
 	}
 
@@ -307,20 +307,20 @@ func (s *storageZfs) zfsPoolCreate() error {
 	}
 	err = os.Chmod(fixperms, customDirMode)
 	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(customDirMode), 8), err)
+		logger.Warnf("Failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(customDirMode), 8), err)
 	}
 
 	dataset = fmt.Sprintf("%s/deleted", poolName)
 	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create deleted dataset: %s", msg)
+		logger.Errorf("Failed to create deleted dataset: %s", msg)
 		return err
 	}
 
 	dataset = fmt.Sprintf("%s/snapshots", poolName)
 	msg, err = zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create snapshots dataset: %s", msg)
+		logger.Errorf("Failed to create snapshots dataset: %s", msg)
 		return err
 	}
 
@@ -331,14 +331,14 @@ func (s *storageZfs) zfsPoolCreate() error {
 	}
 	err = os.Chmod(fixperms, snapshotsDirMode)
 	if err != nil {
-		logger.Warnf("failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(snapshotsDirMode), 8), err)
+		logger.Warnf("Failed to chmod \"%s\" to \"0%s\": %s", fixperms, strconv.FormatInt(int64(snapshotsDirMode), 8), err)
 	}
 
 	return nil
 }
 
 func (s *storageZfs) StoragePoolDelete() error {
-	logger.Infof("Deleting ZFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleting ZFS storage pool \"%s\"", s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	if zfsFilesystemEntityExists(poolName, "") {
@@ -356,7 +356,7 @@ func (s *storageZfs) StoragePoolDelete() error {
 		}
 	}
 
-	logger.Infof("Deleted ZFS storage pool \"%s\".", s.pool.Name)
+	logger.Infof("Deleted ZFS storage pool \"%s\"", s.pool.Name)
 	return nil
 }
 
@@ -369,7 +369,7 @@ func (s *storageZfs) StoragePoolUmount() (bool, error) {
 }
 
 func (s *storageZfs) StoragePoolVolumeCreate() error {
-	logger.Infof("Creating ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Creating ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	poolName := s.getOnDiskPoolName()
@@ -378,7 +378,7 @@ func (s *storageZfs) StoragePoolVolumeCreate() error {
 
 	msg, err := zfsPoolVolumeCreate(dataset, "mountpoint=none", "canmount=noauto")
 	if err != nil {
-		logger.Errorf("failed to create ZFS storage volume \"%s\" on storage pool \"%s\": %s", s.volume.Name, s.pool.Name, msg)
+		logger.Errorf("Failed to create ZFS storage volume \"%s\" on storage pool \"%s\": %s", s.volume.Name, s.pool.Name, msg)
 		return err
 	}
 	revert := true
@@ -417,12 +417,12 @@ func (s *storageZfs) StoragePoolVolumeCreate() error {
 
 	revert = false
 
-	logger.Infof("Created ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Created ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolVolumeDelete() error {
-	logger.Infof("Deleting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleting ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
@@ -489,17 +489,15 @@ func (s *storageZfs) StoragePoolVolumeDelete() error {
 		storagePoolVolumeTypeCustom,
 		s.poolID)
 	if err != nil {
-		logger.Errorf(`Failed to delete database entry for ZFS `+
-			`storage volume "%s" on storage pool "%s"`,
-			s.volume.Name, s.pool.Name)
+		logger.Errorf(`Failed to delete database entry for ZFS storage volume "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 	}
 
-	logger.Infof("Deleted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Infof("Deleted ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
-	logger.Debugf("Mounting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounting ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
@@ -509,7 +507,7 @@ func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
@@ -537,12 +535,12 @@ func (s *storageZfs) StoragePoolVolumeMount() (bool, error) {
 		return false, customerr
 	}
 
-	logger.Debugf("Mounted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Mounted ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourMount, nil
 }
 
 func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
-	logger.Debugf("Unmounting ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounting ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("custom/%s", s.volume.Name)
 	customPoolVolumeMntPoint := getStoragePoolVolumeMountPoint(s.pool.Name, s.volume.Name)
@@ -552,7 +550,7 @@ func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[customUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
@@ -580,7 +578,7 @@ func (s *storageZfs) StoragePoolVolumeUmount() (bool, error) {
 		return false, customerr
 	}
 
-	logger.Debugf("Unmounted ZFS storage volume \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounted ZFS storage volume \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -698,7 +696,7 @@ func (s *storageZfs) ContainerMount(c container) (bool, error) {
 }
 
 func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
-	logger.Debugf("Unmounting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounting ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	fs := fmt.Sprintf("containers/%s", name)
 	containerPoolVolumeMntPoint := getContainerMountPoint(s.pool.Name, name)
@@ -708,7 +706,7 @@ func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerUmountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in unmounting the storage volume.
@@ -736,7 +734,7 @@ func (s *storageZfs) ContainerUmount(name string, path string) (bool, error) {
 		return false, imgerr
 	}
 
-	logger.Debugf("Unmounted ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Unmounted ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return ourUmount, nil
 }
 
@@ -770,7 +768,7 @@ func (s *storageZfs) ContainerCreate(container container) error {
 }
 
 func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint string) error {
-	logger.Debugf("Creating ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerPath := container.Path()
 	containerName := container.Name()
@@ -785,7 +783,7 @@ func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint s
 	if waitChannel, ok := lxdStorageOngoingOperationMap[imageStoragePoolLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 	} else {
 		lxdStorageOngoingOperationMap[imageStoragePoolLockID] = make(chan bool)
@@ -849,7 +847,7 @@ func (s *storageZfs) ContainerCreateFromImage(container container, fingerprint s
 
 	revert = false
 
-	logger.Debugf("Created ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
@@ -998,7 +996,7 @@ func (s *storageZfs) copyWithoutSnapshotsSparse(target container, source contain
 }
 
 func (s *storageZfs) copyWithoutSnapshotFull(target container, source container) error {
-	logger.Debugf("Creating full ZFS copy \"%s\" -> \"%s\".", source.Name(), target.Name())
+	logger.Debugf("Creating full ZFS copy \"%s\" to \"%s\"", source.Name(), target.Name())
 
 	sourceIsSnapshot := source.IsSnapshot()
 	poolName := s.getOnDiskPoolName()
@@ -1029,7 +1027,7 @@ func (s *storageZfs) copyWithoutSnapshotFull(target container, source container)
 		defer func() {
 			err := zfsPoolVolumeSnapshotDestroy(poolName, fs, snapshotSuffix)
 			if err != nil {
-				logger.Warnf("Failed to delete temporary ZFS snapshot \"%s\". Manual cleanup needed.", sourceDataset)
+				logger.Warnf("Failed to delete temporary ZFS snapshot \"%s\", manual cleanup needed", sourceDataset)
 			}
 		}()
 	}
@@ -1059,7 +1057,7 @@ func (s *storageZfs) copyWithoutSnapshotFull(target container, source container)
 
 	msg, err := shared.RunCommand("zfs", "rollback", "-r", "-R", targetSnapshotDataset)
 	if err != nil {
-		logger.Errorf("Failed to rollback ZFS dataset: %s.", msg)
+		logger.Errorf("Failed to rollback ZFS dataset: %s", msg)
 		return err
 	}
 
@@ -1094,7 +1092,7 @@ func (s *storageZfs) copyWithoutSnapshotFull(target container, source container)
 		return err
 	}
 
-	logger.Debugf("Created full ZFS copy \"%s\" -> \"%s\".", source.Name(), target.Name())
+	logger.Debugf("Created full ZFS copy \"%s\" to \"%s\"", source.Name(), target.Name())
 	return nil
 }
 
@@ -1218,7 +1216,7 @@ func (s *storageZfs) doCrossPoolContainerCopy(target container, source container
 }
 
 func (s *storageZfs) ContainerCopy(target container, source container, containerOnly bool) error {
-	logger.Debugf("Copying ZFS container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copying ZFS container storage %s to %s", source.Name(), target.Name())
 
 	ourStart, err := source.StorageStart()
 	if err != nil {
@@ -1341,12 +1339,12 @@ func (s *storageZfs) ContainerCopy(target container, source container, container
 
 	}
 
-	logger.Debugf("Copied ZFS container storage %s -> %s.", source.Name(), target.Name())
+	logger.Debugf("Copied ZFS container storage %s to %s", source.Name(), target.Name())
 	return nil
 }
 
 func (s *storageZfs) ContainerRename(container container, newName string) error {
-	logger.Debugf("Renaming ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming ZFS storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	poolName := s.getOnDiskPoolName()
 	oldName := container.Name()
@@ -1435,12 +1433,12 @@ func (s *storageZfs) ContainerRename(container container, newName string) error 
 
 	revert = false
 
-	logger.Debugf("Renamed ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed ZFS storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageZfs) ContainerRestore(target container, source container) error {
-	logger.Debugf("Restoring ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, source.Name(), target.Name())
+	logger.Debugf("Restoring ZFS storage volume for container \"%s\" from %s to %s", s.volume.Name, source.Name(), target.Name())
 
 	// Start storage for source container
 	ourSourceStart, err := source.StorageStart()
@@ -1486,7 +1484,7 @@ func (s *storageZfs) ContainerRestore(target container, source container) error 
 		return err
 	}
 
-	logger.Debugf("Restored ZFS storage volume for container \"%s\" from %s -> %s.", s.volume.Name, source.Name(), target.Name())
+	logger.Debugf("Restored ZFS storage volume for container \"%s\" from %s to %s", s.volume.Name, source.Name(), target.Name())
 	return nil
 }
 
@@ -1523,7 +1521,7 @@ func (s *storageZfs) ContainerGetUsage(container container) (int64, error) {
 
 func (s *storageZfs) doContainerSnapshotCreate(targetName string, sourceName string) error {
 	snapshotContainerName := targetName
-	logger.Debugf("Creating ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", snapshotContainerName, s.pool.Name)
+	logger.Debugf("Creating ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", snapshotContainerName, s.pool.Name)
 
 	sourceContainerName := sourceName
 
@@ -1553,7 +1551,7 @@ func (s *storageZfs) doContainerSnapshotCreate(targetName string, sourceName str
 		}
 	}
 
-	logger.Debugf("Created ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", snapshotContainerName, s.pool.Name)
+	logger.Debugf("Created ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", snapshotContainerName, s.pool.Name)
 	return nil
 }
 
@@ -1609,7 +1607,7 @@ func zfsSnapshotDeleteInternal(poolName string, ctName string, onDiskPoolName st
 	}
 
 	// Check if we can remove the snapshot symlink:
-	// ${LXD_DIR}/snapshots/<container_name> -> ${POOL}/snapshots/<container_name>
+	// ${LXD_DIR}/snapshots/<container_name> to ${POOL}/snapshots/<container_name>
 	// by checking if the directory is empty.
 	snapshotContainerPath := getSnapshotMountPoint(poolName, sourceContainerName)
 	empty, _ := shared.PathIsEmpty(snapshotContainerPath)
@@ -1652,7 +1650,7 @@ func zfsSnapshotDeleteInternal(poolName string, ctName string, onDiskPoolName st
 }
 
 func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error {
-	logger.Debugf("Deleting ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	err := zfsSnapshotDeleteInternal(s.pool.Name, snapshotContainer.Name(),
@@ -1661,12 +1659,12 @@ func (s *storageZfs) ContainerSnapshotDelete(snapshotContainer container) error 
 		return err
 	}
 
-	logger.Debugf("Deleted ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
-	logger.Debugf("Renaming ZFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renaming ZFS storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	oldName := snapshotContainer.Name()
 
@@ -1726,12 +1724,12 @@ func (s *storageZfs) ContainerSnapshotRename(snapshotContainer container, newNam
 
 	revert = false
 
-	logger.Debugf("Renamed ZFS storage volume for snapshot \"%s\" from %s -> %s.", s.volume.Name, s.volume.Name, newName)
+	logger.Debugf("Renamed ZFS storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 	return nil
 }
 
 func (s *storageZfs) ContainerSnapshotStart(container container) (bool, error) {
-	logger.Debugf("Initializing ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Initializing ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	cName, sName, _ := containerGetParentAndSnapshotName(container.Name())
 	sourceFs := fmt.Sprintf("containers/%s", cName)
@@ -1750,12 +1748,12 @@ func (s *storageZfs) ContainerSnapshotStart(container container) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Initialized ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Initialized ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
 func (s *storageZfs) ContainerSnapshotStop(container container) (bool, error) {
-	logger.Debugf("Stopping ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopping ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	cName, sName, _ := containerGetParentAndSnapshotName(container.Name())
 	destFs := fmt.Sprintf("snapshots/%s/%s", cName, sName)
@@ -1765,7 +1763,7 @@ func (s *storageZfs) ContainerSnapshotStop(container container) (bool, error) {
 		return false, err
 	}
 
-	logger.Debugf("Stopped ZFS storage volume for snapshot \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Stopped ZFS storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return true, nil
 }
 
@@ -1801,7 +1799,7 @@ func (s *storageZfs) doContainerOnlyBackup(backup backup, source container) erro
 		defer func() {
 			err := zfsPoolVolumeSnapshotDestroy(poolName, fs, snapshotSuffix)
 			if err != nil {
-				logger.Warnf("Failed to delete temporary ZFS snapshot \"%s\". Manual cleanup needed.", sourceDataset)
+				logger.Warnf("Failed to delete temporary ZFS snapshot \"%s\", manual cleanup needed", sourceDataset)
 			}
 		}()
 	}
@@ -2055,7 +2053,7 @@ func (s *storageZfs) ContainerBackupCreate(backup backup, source container) erro
 }
 
 func (s *storageZfs) ContainerBackupDelete(name string) error {
-	logger.Debugf("Deleting ZFS storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleting ZFS storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	backupContainerMntPoint := getBackupMountPoint(s.pool.Name, name)
 	if shared.PathExists(backupContainerMntPoint) {
 		err := os.RemoveAll(backupContainerMntPoint)
@@ -2074,12 +2072,12 @@ func (s *storageZfs) ContainerBackupDelete(name string) error {
 		}
 	}
 
-	logger.Debugf("Deleted ZFS storage volume for backup \"%s\" on storage pool \"%s\".", name, s.pool.Name)
+	logger.Debugf("Deleted ZFS storage volume for backup \"%s\" on storage pool \"%s\"", name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ContainerBackupRename(backup backup, newName string) error {
-	logger.Debugf("Renaming ZFS storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renaming ZFS storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	oldBackupMntPoint := getBackupMountPoint(s.pool.Name, backup.Name())
 	newBackupMntPoint := getBackupMountPoint(s.pool.Name, newName)
 
@@ -2091,7 +2089,7 @@ func (s *storageZfs) ContainerBackupRename(backup backup, newName string) error 
 		}
 	}
 
-	logger.Debugf("Renamed ZFS storage volume for backup \"%s\" from %s -> %s.", backup.Name(), backup.Name(), newName)
+	logger.Debugf("Renamed ZFS storage volume for backup \"%s\" from %s to %s", backup.Name(), backup.Name(), newName)
 	return nil
 }
 
@@ -2266,7 +2264,7 @@ func (s *storageZfs) doContainerBackupLoadVanilla(info backupInfo, data io.ReadS
 }
 
 func (s *storageZfs) ContainerBackupLoad(info backupInfo, data io.ReadSeeker) error {
-	logger.Debugf("Loading ZFS storage volume for backup \"%s\" on storage pool \"%s\".", info.Name, s.pool.Name)
+	logger.Debugf("Loading ZFS storage volume for backup \"%s\" on storage pool \"%s\"", info.Name, s.pool.Name)
 
 	if info.HasBinaryFormat {
 		return s.doContainerBackupLoadOptimized(info, data)
@@ -2283,7 +2281,7 @@ func (s *storageZfs) ContainerBackupLoad(info backupInfo, data io.ReadSeeker) er
 // - remove mountpoint property from zfs volume images/<fingerprint>
 // - create read-write snapshot from zfs volume images/<fingerprint>
 func (s *storageZfs) ImageCreate(fingerprint string) error {
-	logger.Debugf("Creating ZFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Creating ZFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	imageMntPoint := getImageMountPoint(s.pool.Name, fingerprint)
@@ -2354,7 +2352,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 	dataset := fmt.Sprintf("%s/%s", poolName, fs)
 	msg, err := zfsPoolVolumeCreate(dataset, "mountpoint=none")
 	if err != nil {
-		logger.Errorf("failed to create ZFS dataset \"%s\" on storage pool \"%s\": %s", dataset, s.pool.Name, msg)
+		logger.Errorf("Failed to create ZFS dataset \"%s\" on storage pool \"%s\": %s", dataset, s.pool.Name, msg)
 		return err
 	}
 	subrevert = false
@@ -2406,12 +2404,12 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 
 	revert = false
 
-	logger.Debugf("Created ZFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Created ZFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) ImageDelete(fingerprint string) error {
-	logger.Debugf("Deleting ZFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleting ZFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	fs := fmt.Sprintf("images/%s", fingerprint)
@@ -2458,7 +2456,7 @@ func (s *storageZfs) ImageDelete(fingerprint string) error {
 		}
 	}
 
-	logger.Debugf("Deleted ZFS storage volume for image \"%s\" on storage pool \"%s\".", fingerprint, s.pool.Name)
+	logger.Debugf("Deleted ZFS storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 	return nil
 }
 
@@ -2516,12 +2514,12 @@ func (s *zfsMigrationSourceDriver) send(conn *websocket.Conn, zfsName string, zf
 
 	output, err := ioutil.ReadAll(stderr)
 	if err != nil {
-		logger.Errorf("Problem reading zfs send stderr: %s.", err)
+		logger.Errorf("Problem reading zfs send stderr: %s", err)
 	}
 
 	err = cmd.Wait()
 	if err != nil {
-		logger.Errorf("Problem with zfs send: %s.", string(output))
+		logger.Errorf("Problem with zfs send: %s", string(output))
 	}
 
 	return err
@@ -2677,12 +2675,12 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 
 		output, err := ioutil.ReadAll(stderr)
 		if err != nil {
-			logger.Debugf("problem reading zfs recv stderr %s.", err)
+			logger.Debugf("Problem reading zfs recv stderr %s", err)
 		}
 
 		err = cmd.Wait()
 		if err != nil {
-			logger.Errorf("problem with zfs recv: %s.", string(output))
+			logger.Errorf("Problem with zfs recv: %s", string(output))
 		}
 		return err
 	}
@@ -2766,7 +2764,7 @@ func (s *storageZfs) MigrationSink(live bool, container container, snapshots []*
 		/* clean up our migration-send snapshots that we got from recv. */
 		zfsSnapshots, err := zfsPoolListSnapshots(poolName, fmt.Sprintf("containers/%s", container.Name()))
 		if err != nil {
-			logger.Errorf("failed listing snapshots post migration: %s.", err)
+			logger.Errorf("Failed listing snapshots post migration: %s", err)
 			return
 		}
 

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -71,14 +71,14 @@ func zfsPoolCreate(pool string, vdev string) error {
 		output, err := shared.RunCommand(
 			"zfs", "create", "-p", "-o", "mountpoint=none", vdev)
 		if err != nil {
-			logger.Errorf("zfs create failed: %s.", output)
+			logger.Errorf("zfs create failed: %s", output)
 			return fmt.Errorf("Failed to create ZFS filesystem: %s", output)
 		}
 	} else {
 		output, err = shared.RunCommand(
 			"zpool", "create", "-f", "-m", "none", "-O", "compression=on", pool, vdev)
 		if err != nil {
-			logger.Errorf("zfs create failed: %s.", output)
+			logger.Errorf("zfs create failed: %s", output)
 			return fmt.Errorf("Failed to create the ZFS pool: %s", output)
 		}
 	}
@@ -96,7 +96,7 @@ func zfsPoolVolumeClone(pool string, source string, name string, dest string, mo
 		fmt.Sprintf("%s/%s@%s", pool, source, name),
 		fmt.Sprintf("%s/%s", pool, dest))
 	if err != nil {
-		logger.Errorf("zfs clone failed: %s.", output)
+		logger.Errorf("zfs clone failed: %s", output)
 		return fmt.Errorf("Failed to clone the filesystem: %s", output)
 	}
 
@@ -127,7 +127,7 @@ func zfsPoolVolumeClone(pool string, source string, name string, dest string, mo
 			fmt.Sprintf("%s/%s@%s", pool, sub, name),
 			fmt.Sprintf("%s/%s", pool, destSubvol))
 		if err != nil {
-			logger.Errorf("zfs clone failed: %s.", output)
+			logger.Errorf("zfs clone failed: %s", output)
 			return fmt.Errorf("Failed to clone the sub-volume: %s", output)
 		}
 	}
@@ -166,7 +166,7 @@ func zfsPoolVolumeDestroy(pool string, path string) error {
 	if mountpoint != "none" && shared.IsMountPoint(mountpoint) {
 		err := syscall.Unmount(mountpoint, syscall.MNT_DETACH)
 		if err != nil {
-			logger.Errorf("umount failed: %s.", err)
+			logger.Errorf("umount failed: %s", err)
 			return err
 		}
 	}
@@ -179,7 +179,7 @@ func zfsPoolVolumeDestroy(pool string, path string) error {
 		fmt.Sprintf("%s/%s", pool, path))
 
 	if err != nil {
-		logger.Errorf("zfs destroy failed: %s.", output)
+		logger.Errorf("zfs destroy failed: %s", output)
 		return fmt.Errorf("Failed to destroy ZFS filesystem: %s", output)
 	}
 
@@ -297,7 +297,7 @@ func zfsPoolVolumeRename(pool string, source string, dest string) error {
 	}
 
 	// Timeout
-	logger.Errorf("zfs rename failed: %s.", output)
+	logger.Errorf("zfs rename failed: %s", output)
 	return fmt.Errorf("Failed to rename ZFS filesystem: %s", output)
 }
 
@@ -312,7 +312,7 @@ func zfsPoolVolumeSet(pool string, path string, key string, value string) error 
 		fmt.Sprintf("%s=%s", key, value),
 		vdev)
 	if err != nil {
-		logger.Errorf("zfs set failed: %s.", output)
+		logger.Errorf("zfs set failed: %s", output)
 		return fmt.Errorf("Failed to set ZFS config: %s", output)
 	}
 
@@ -326,7 +326,7 @@ func zfsPoolVolumeSnapshotCreate(pool string, path string, name string) error {
 		"-r",
 		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
-		logger.Errorf("zfs snapshot failed: %s.", output)
+		logger.Errorf("zfs snapshot failed: %s", output)
 		return fmt.Errorf("Failed to create ZFS snapshot: %s", output)
 	}
 
@@ -340,7 +340,7 @@ func zfsPoolVolumeSnapshotDestroy(pool, path string, name string) error {
 		"-r",
 		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
-		logger.Errorf("zfs destroy failed: %s.", output)
+		logger.Errorf("zfs destroy failed: %s", output)
 		return fmt.Errorf("Failed to destroy ZFS snapshot: %s", output)
 	}
 
@@ -353,7 +353,7 @@ func zfsPoolVolumeSnapshotRestore(pool string, path string, name string) error {
 		"rollback",
 		fmt.Sprintf("%s/%s@%s", pool, path, name))
 	if err != nil {
-		logger.Errorf("zfs rollback failed: %s.", output)
+		logger.Errorf("zfs rollback failed: %s", output)
 		return fmt.Errorf("Failed to restore ZFS snapshot: %s", output)
 	}
 
@@ -377,7 +377,7 @@ func zfsPoolVolumeSnapshotRestore(pool string, path string, name string) error {
 			"rollback",
 			fmt.Sprintf("%s/%s@%s", pool, sub, name))
 		if err != nil {
-			logger.Errorf("zfs rollback failed: %s.", output)
+			logger.Errorf("zfs rollback failed: %s", output)
 			return fmt.Errorf("Failed to restore ZFS sub-volume snapshot: %s", output)
 		}
 	}
@@ -393,7 +393,7 @@ func zfsPoolVolumeSnapshotRename(pool string, path string, oldName string, newNa
 		fmt.Sprintf("%s/%s@%s", pool, path, oldName),
 		fmt.Sprintf("%s/%s@%s", pool, path, newName))
 	if err != nil {
-		logger.Errorf("zfs snapshot rename failed: %s.", output)
+		logger.Errorf("zfs snapshot rename failed: %s", output)
 		return fmt.Errorf("Failed to rename ZFS snapshot: %s", output)
 	}
 
@@ -438,7 +438,7 @@ func zfsPoolListSubvolumes(pool string, path string) ([]string, error) {
 		"-H",
 		"-r", path)
 	if err != nil {
-		logger.Errorf("zfs list failed: %s.", output)
+		logger.Errorf("zfs list failed: %s", output)
 		return []string{}, fmt.Errorf("Failed to list ZFS filesystems: %s", output)
 	}
 
@@ -475,7 +475,7 @@ func zfsPoolListSnapshots(pool string, path string) ([]string, error) {
 		"-s", "creation",
 		"-r", fullPath)
 	if err != nil {
-		logger.Errorf("zfs list failed: %s.", output)
+		logger.Errorf("zfs list failed: %s", output)
 		return []string{}, fmt.Errorf("Failed to list ZFS snapshots: %s", output)
 	}
 
@@ -547,7 +547,7 @@ func (s *storageZfs) doContainerMount(name string, privileged bool) (bool, error
 	if waitChannel, ok := lxdStorageOngoingOperationMap[containerMountLockID]; ok {
 		lxdStorageMapLock.Unlock()
 		if _, ok := <-waitChannel; ok {
-			logger.Warnf("Received value over semaphore. This should not have happened.")
+			logger.Warnf("Received value over semaphore, this should not have happened")
 		}
 		// Give the benefit of the doubt and assume that the other
 		// thread actually succeeded in mounting the storage volume.
@@ -584,13 +584,13 @@ func (s *storageZfs) doContainerMount(name string, privileged bool) (bool, error
 		mounterr := tryMount(source, containerPoolVolumeMntPoint, "zfs", 0, zfsMountOptions)
 		if mounterr != nil {
 			if mounterr != syscall.EBUSY {
-				logger.Errorf("Failed to mount ZFS dataset \"%s\" onto \"%s\".", source, containerPoolVolumeMntPoint)
+				logger.Errorf("Failed to mount ZFS dataset \"%s\" onto \"%s\"", source, containerPoolVolumeMntPoint)
 				return false, mounterr
 			}
 			// EBUSY error in zfs are related to a bug we're
 			// tracking. So ignore them for now, report back that
 			// the mount isn't ours and proceed.
-			logger.Warnf("ZFS returned EBUSY while \"%s\" is actually not a mountpoint.", containerPoolVolumeMntPoint)
+			logger.Warnf("ZFS returned EBUSY while \"%s\" is actually not a mountpoint", containerPoolVolumeMntPoint)
 			return false, mounterr
 		}
 		ourMount = true
@@ -601,7 +601,7 @@ func (s *storageZfs) doContainerMount(name string, privileged bool) (bool, error
 }
 
 func (s *storageZfs) doContainerDelete(name string) error {
-	logger.Debugf("Deleting ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleting ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
 	containerName := name
@@ -675,7 +675,7 @@ func (s *storageZfs) doContainerDelete(name string) error {
 	}
 
 	// Delete potential leftover snapshot symlinks:
-	// ${LXD_DIR}/snapshots/<container_name> -> ${POOL}/snapshots/<container_name>
+	// ${LXD_DIR}/snapshots/<container_name> to ${POOL}/snapshots/<container_name>
 	snapshotSymlink := shared.VarPath("snapshots", containerName)
 	if shared.PathExists(snapshotSymlink) {
 		err := os.Remove(snapshotSymlink)
@@ -684,12 +684,12 @@ func (s *storageZfs) doContainerDelete(name string) error {
 		}
 	}
 
-	logger.Debugf("Deleted ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Deleted ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }
 
 func (s *storageZfs) doContainerCreate(name string, privileged bool) error {
-	logger.Debugf("Creating empty ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Creating empty ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerPath := shared.VarPath("containers", name)
 	containerName := name
@@ -701,7 +701,7 @@ func (s *storageZfs) doContainerCreate(name string, privileged bool) error {
 	// Create volume.
 	msg, err := zfsPoolVolumeCreate(dataset, "mountpoint=none", "canmount=noauto")
 	if err != nil {
-		logger.Errorf("failed to create ZFS storage volume for container \"%s\" on storage pool \"%s\": %s", s.volume.Name, s.pool.Name, msg)
+		logger.Errorf("Failed to create ZFS storage volume for container \"%s\" on storage pool \"%s\": %s", s.volume.Name, s.pool.Name, msg)
 		return err
 	}
 
@@ -716,6 +716,6 @@ func (s *storageZfs) doContainerCreate(name string, privileged bool) error {
 		return err
 	}
 
-	logger.Debugf("Created empty ZFS storage volume for container \"%s\" on storage pool \"%s\".", s.volume.Name, s.pool.Name)
+	logger.Debugf("Created empty ZFS storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 	return nil
 }

--- a/lxd/sys/apparmor.go
+++ b/lxd/sys/apparmor.go
@@ -43,11 +43,11 @@ func (s *OS) initAppArmor() {
 	/* Detect AppArmor admin support */
 	if !haveMacAdmin() {
 		if s.AppArmorAvailable {
-			logger.Warnf("Per-container AppArmor profiles are disabled because the mac_admin capability is missing.")
+			logger.Warnf("Per-container AppArmor profiles are disabled because the mac_admin capability is missing")
 		}
 	} else if s.RunningInUserNS && !s.AppArmorStacked {
 		if s.AppArmorAvailable {
-			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is running in an unprivileged container without stacking.")
+			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is running in an unprivileged container without stacking")
 		}
 	} else {
 		s.AppArmorAdmin = true
@@ -57,7 +57,7 @@ func (s *OS) initAppArmor() {
 	profile := util.AppArmorProfile()
 	if profile != "unconfined" && profile != "" {
 		if s.AppArmorAvailable {
-			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor.")
+			logger.Warnf("Per-container AppArmor profiles are disabled because LXD is already protected by AppArmor")
 		}
 		s.AppArmorConfined = true
 	}
@@ -95,13 +95,13 @@ func appArmorCanStack() bool {
 	parts := strings.Split(strings.TrimSpace(content), ".")
 
 	if len(parts) == 0 {
-		logger.Warn("unknown apparmor domain version", log.Ctx{"version": content})
+		logger.Warn("Unknown apparmor domain version", log.Ctx{"version": content})
 		return false
 	}
 
 	major, err := strconv.Atoi(parts[0])
 	if err != nil {
-		logger.Warn("unknown apparmor domain version", log.Ctx{"version": content})
+		logger.Warn("Unknown apparmor domain version", log.Ctx{"version": content})
 		return false
 	}
 
@@ -109,7 +109,7 @@ func appArmorCanStack() bool {
 	if len(parts) == 2 {
 		minor, err = strconv.Atoi(parts[1])
 		if err != nil {
-			logger.Warn("unknown apparmor domain version", log.Ctx{"version": content})
+			logger.Warn("Unknown apparmor domain version", log.Ctx{"version": content})
 			return false
 		}
 	}

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -50,7 +51,7 @@ func GetIdmapSet() *idmap.IdmapSet {
 		if err == nil {
 			logger.Infof("Kernel uid/gid map:")
 			for _, lxcmap := range kernelIdmapSet.ToLxcString() {
-				logger.Infof(" - " + lxcmap)
+				logger.Infof(fmt.Sprintf(" - %s", lxcmap))
 			}
 		}
 


### PR DESCRIPTION
This does a few things:

 - Ensure that no log entries end with a period
 - Ensure all log entries start with a capital (with some minor exceptions)
 - Ensure all log entries are greppable (no split text)

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>