### PR TITLE
allow uidmaps to be parsed from alternate roots

### DIFF
--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -85,7 +85,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Load the idmap for unprivileged containers
-	d.os.IdmapSet, err = idmap.DefaultIdmapSet("")
+	d.os.IdmapSet, err = idmap.DefaultIdmapSet("", "")
 	if err != nil {
 		return err
 	}

--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -586,7 +586,7 @@ your Linux distribution and run "lxd init" again afterwards.
 
 func (c *cmdInit) askDaemon(config *initData, d lxd.ContainerServer) error {
 	// Detect lack of uid/gid
-	idmapset, err := idmap.DefaultIdmapSet("")
+	idmapset, err := idmap.DefaultIdmapSet("", "")
 	if (err != nil || len(idmapset.Idmap) == 0 || idmapset.Usable() != nil) && shared.RunningInUserNS() {
 		fmt.Printf(`
 We detected that you are running inside an unprivileged container.

--- a/lxd/util/sys.go
+++ b/lxd/util/sys.go
@@ -40,7 +40,7 @@ func GetArchitectures() ([]int, error) {
 
 // GetIdmapSet reads the uid/gid allocation.
 func GetIdmapSet() *idmap.IdmapSet {
-	idmapSet, err := idmap.DefaultIdmapSet("")
+	idmapSet, err := idmap.DefaultIdmapSet("", "")
 	if err != nil {
 		logger.Warn("Error reading default uid/gid map", log.Ctx{"err": err.Error()})
 		logger.Warnf("Only privileged containers will be able to run")

--- a/shared/idmap/idmapset_linux.go
+++ b/shared/idmap/idmapset_linux.go
@@ -660,7 +660,7 @@ func getFromProc(fname string) ([][]int64, error) {
 /*
  * Create a new default idmap
  */
-func DefaultIdmapSet(username string) (*IdmapSet, error) {
+func DefaultIdmapSet(rootfs string, username string) (*IdmapSet, error) {
 	idmapset := new(IdmapSet)
 
 	if username == "" {
@@ -672,9 +672,12 @@ func DefaultIdmapSet(username string) (*IdmapSet, error) {
 		username = currentUser.Username
 	}
 
-	if shared.PathExists("/etc/subuid") && shared.PathExists("/etc/subgid") {
+	// Check if shadow's uidmap tools are installed
+	subuidPath := path.Join(rootfs, "/etc/subuid")
+	subgidPath := path.Join(rootfs, "/etc/subgid")
+	if shared.PathExists(subuidPath) && shared.PathExists(subgidPath) {
 		// Parse the shadow uidmap
-		entries, err := getFromShadow("/etc/subuid", username)
+		entries, err := getFromShadow(subuidPath, username)
 		if err != nil {
 			return nil, err
 		}
@@ -693,7 +696,7 @@ func DefaultIdmapSet(username string) (*IdmapSet, error) {
 		}
 
 		// Parse the shadow gidmap
-		entries, err = getFromShadow("/etc/subgid", username)
+		entries, err = getFromShadow(subgidPath, username)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Since this code is handy, let's allow it to parse other roots on the
filesystem than just /.

Signed-off-by: Tycho Andersen <tycho@tycho.ws>