### PR TITLE
Allow identity mappings for unprivileged containers

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -243,7 +243,7 @@ func containerValidDeviceConfigKey(t, k string) bool {
 	}
 }
 
-func validateRawIdmap(rawIdmap string) error {
+func allowedUnprivilegedOnlyMap(rawIdmap string) error {
 	rawMaps, err := parseRawIdmap(rawIdmap)
 	if err != nil {
 		return err
@@ -252,10 +252,6 @@ func validateRawIdmap(rawIdmap string) error {
 	for _, ent := range rawMaps {
 		if ent.Hostid == 0 {
 			return fmt.Errorf("Cannot map root user into container as LXD was configured to only allow unprivileged containers")
-		}
-
-		if ent.Hostid != ent.Nsid {
-			return fmt.Errorf("Cannot create non-identity mapping for container as LXD was configured to only allow unprivileged containers")
 		}
 	}
 
@@ -303,7 +299,8 @@ func containerValidConfig(sysOS *sys.OS, config map[string]string, profile bool,
 	unprivOnly := os.Getenv("LXD_UNPRIVILEGED_ONLY")
 	if shared.IsTrue(unprivOnly) {
 		if config["raw.idmap"] != "" {
-			if err := validateRawIdmap(config["raw.idmap"]); err != nil {
+			err := allowedUnprivilegedOnlyMap(config["raw.idmap"])
+			if err != nil {
 				return err
 			}
 		}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -243,6 +243,25 @@ func containerValidDeviceConfigKey(t, k string) bool {
 	}
 }
 
+func validateRawIdmap(rawIdmap string) error {
+	rawMaps, err := parseRawIdmap(rawIdmap)
+	if err != nil {
+		return err
+	}
+
+	for _, ent := range rawMaps {
+		if ent.Hostid == 0 {
+			return fmt.Errorf("Cannot map root user into container as LXD was configured to only allow unprivileged containers")
+		}
+
+		if ent.Hostid != ent.Nsid {
+			return fmt.Errorf("Cannot create non-identity mapping for container as LXD was configured to only allow unprivileged containers")
+		}
+	}
+
+	return nil
+}
+
 func containerValidConfig(sysOS *sys.OS, config map[string]string, profile bool, expanded bool) error {
 	if config == nil {
 		return nil
@@ -284,7 +303,9 @@ func containerValidConfig(sysOS *sys.OS, config map[string]string, profile bool,
 	unprivOnly := os.Getenv("LXD_UNPRIVILEGED_ONLY")
 	if shared.IsTrue(unprivOnly) {
 		if config["raw.idmap"] != "" {
-			return fmt.Errorf("raw.idmap can't be set as LXD was configured to only allow unprivileged containers")
+			if err := validateRawIdmap(config["raw.idmap"]); err != nil {
+				return err
+			}
 		}
 
 		if shared.IsTrue(config["security.privileged"]) {


### PR DESCRIPTION
Allow identity mapped uid/gid ranges in the raw.idmap config even if the
LXD_UNPRIVILEGED_ONLY environment variable is set.  Make sure that this
also prevents the root user in the parent namespace from being mapped
into the child namespace.

This is useful for mapping the uid of the user into the child namespace
so that they can still access files in their home directory.


I tried running the tests locally but they complained about not being able to find "golang.org/x/tools/go/gcimporter".  From what I can see the path is actually "golang.org/x/tools/go/internal/gcimporter" but I'm not sure where it's getting the incorrect path.

I did test this specific behavior locally:

```bash
(termina) chronos@localhost ~ $ lxc config set penguin raw.idmap "both 1000 0"
error: Cannot create non-identity mapping for container as LXD was configured to only allow unprivileged containers 
(termina) chronos@localhost ~ $ lxc config set penguin raw.idmap "both 0 1000"
error: Cannot map root user into container as LXD was configured to only allow unprivileged containers
(termina) chronos@localhost ~ $ lxc config set penguin raw.idmap "both 0 0" 
error: Cannot map root user into container as LXD was configured to only allow unprivileged containers 
(termina) chronos@localhost ~ $ lxc config set penguin raw.idmap "both 1000 1001" 
error: Cannot create non-identity mapping for container as LXD was configured to only allow unprivileged containers 
(termina) chronos@localhost ~ $ lxc config set penguin raw.idmap "both 1000 1000" 
(termina) chronos@localhost ~ $ lxc start penguin
(termina) chronos@localhost ~ $ pstree -p
init(1)-+-dnsmasq(189)
        |-lxd(138)-+-{lxd}(141)
        |          |-{lxd}(142)
        |          |-{lxd}(145)
        |          |-{lxd}(148)
        |          |-{lxd}(149)
        |          |-{lxd}(150)
        |          |-{lxd}(180)
        |          |-{lxd}(191)
        |          |-{lxd}(192)
        |          |-{lxd}(193)
        |          |-{lxd}(194)
        |          |-{lxd}(195)
        |          |-{lxd}(196)
        |          |-{lxd}(279)
        |          |-{lxd}(298)
        |          `-{lxd}(299)
        |-lxd(558)---systemd(569)-+-agetty(651)
        |                         |-dbus-daemon(614)
        |                         |-dhclient(632)
        |                         |-sshd(652)
        |                         |-sshd(653)
        |                         |-systemd(650)-+-(sd-pam)(654)
        |                         |              |-ld-linux-x86-64(658)
        |                         |              `-ld-linux-x86-64(659)---ld-linux-x86-64(663)-+-{llvmpipe-0}(666)
        |                         |                                                            |-{llvmpipe-1}(667)
        |                         |                                                            |-{llvmpipe-2}(668)
        |                         |                                                            `-{llvmpipe-3}(669)
        |                         |-systemd-journal(583)
        |                         `-systemd-logind(612)
        |-vm_syslog(102)
        |-vshd(103)---vshd(251)---bash(252)---pstree(694)
        |-{init worker thr}(101)
        |-{init}(104)
        |-{init}(107)
        `-{shutdown thread}(105)
(termina) chronos@localhost ~ $ cat /proc/569/uid_map
         0    1000000       1000
      1000       1000          1
      1001    1001001  999998999
```