### PR TITLE
shared: Dereference directory symlinks

### DIFF
--- a/shared/util.go
+++ b/shared/util.go
@@ -89,7 +89,7 @@ func PathIsEmpty(path string) (bool, error) {
 
 // IsDir returns true if the given path is a directory.
 func IsDir(name string) bool {
-	stat, err := os.Lstat(name)
+	stat, err := os.Stat(name)
 	if err != nil {
 		return false
 	}


### PR DESCRIPTION
This change prevents failure when adding disk devices to containers
where the source is a symlinked directory.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>