### PR TITLE
container: use lxcSetConfigItem() for lxc.log.file

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -909,8 +909,7 @@ func (c *containerLXC) initLXC(config bool) error {
 
 	// Setup logging
 	logfile := c.LogFilePath()
-
-	err = cc.SetLogFile(logfile)
+	err = lxcSetConfigItem(cc, "lxc.log.file", logfile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
So far we've been using the go-lxc SetLogFile() function. The problem is that
the go-lxc shared library might have been linked against an older liblxc than
LXD. In that case SetLogFile() will check:

if VersionAtLeast(2, 1, 0) {
        err = c.setConfigItem("lxc.log.file", filename)
} else {
        err = c.setConfigItem("lxc.logfile", filename)
}

but VersionAtLeast() will not check the runtime but the linked liblxc version
and thus set the wrong config item.
Fix this by using lxcSetConfigItem() which will check against the runtime
liblxc version.

Closes #4713.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>