### PR TITLE
tests: Add sleep when getting TCP port

### DIFF
--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -7,8 +7,7 @@ local_tcp_port() {
 
     while true; do
         port=$(shuf -i 10000-32768 -n 1)
-        nc -l 127.0.0.1 "${port}" >/dev/null 2>&1 &
-        sleep 1
+        socat TCP-LISTEN:"${port}" >/dev/null 2>&1 &
         pid=$!
         kill "${pid}" >/dev/null 2>&1 || continue
         wait "${pid}" || true

--- a/test/includes/net.sh
+++ b/test/includes/net.sh
@@ -8,6 +8,7 @@ local_tcp_port() {
     while true; do
         port=$(shuf -i 10000-32768 -n 1)
         nc -l 127.0.0.1 "${port}" >/dev/null 2>&1 &
+        sleep 1
         pid=$!
         kill "${pid}" >/dev/null 2>&1 || continue
         wait "${pid}" || true


### PR DESCRIPTION
This fixes random hangs when running the test suite.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>