### PR TITLE
Convert mode from string to octal (not to decimal)

### DIFF
--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -497,7 +497,7 @@ func (c *cmdForkproxy) Run(cmd *cobra.Command, args []string) error {
 
 			var listenAddrMode os.FileMode
 			if args[8] != "" {
-				tmp, err := strconv.Atoi(args[8])
+				tmp, err := strconv.ParseUint(args[8], 8, 0)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Currently, the mode (Unix file permissions) is converted from string to decimal using `Atoi()`.
The mode is traditionally provided as octal, therefore the conversion should be from string to octal, with `strconv.ParseUint()`.