### PR TITLE
network: do not print writer struct on error

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -325,7 +325,7 @@ func defaultWriter(conn *websocket.Conn, w io.WriteCloser, writeDone chan<- bool
 	for {
 		mt, r, err := conn.NextReader()
 		if err != nil {
-			logger.Debugf("Got error getting next reader %s, %s", err, w)
+			logger.Debugf("Got error getting next reader %s", err)
 			break
 		}
 


### PR DESCRIPTION
This string

&{%!s(*os.file=&{{{1 0 0} -1 {0} <nil> 1 true true true true} master <nil> false false})}

is not helpful at all so stop dumping it to the log. It is just irritating.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>