### PR TITLE
Reduce the frequency of raft snapshots

### DIFF
--- a/lxd/cluster/raft.go
+++ b/lxd/cluster/raft.go
@@ -406,7 +406,7 @@ func raftConfig(latency float64) *raft.Config {
 	//             number of uncompacted raft logs low, and workaround slow
 	//             log replay when the LXD daemon starts (see #4485). A more
 	//             proper fix should be probably implemented in dqlite.
-	config.SnapshotThreshold = 64
+	config.SnapshotThreshold = 512
 	config.TrailingLogs = 128
 
 	return config


### PR DESCRIPTION
We have been taking raft snapshots agressively for a while now, in order
to mitigate #4485.

This change makes the frequency less aggressive. It shouldn't really make a
difference regarding #4485, since we take a raft snapshot at daemon shutdown
anyways, so the net effect is virtually the same (except in case of hard
crashes).

It seems snapshots might have some impact on #4769, so this should help.

The snapshots trick will go away altogether in the new dqlite implementation.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>