### PR TITLE
lxd/networks: Improve dnsmasq leases cleanup

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3367,7 +3367,7 @@ func (c *containerLXC) Delete() error {
 	// Update network files
 	networkUpdateStatic(c.state, "")
 	for k, m := range c.expandedDevices {
-		if (m["type"] != "nic" && m["type"] != "infiniband") || m["nictype"] != "bridged" || (m["ipv4.address"] == "" && m["ipv6.address"] == "") {
+		if m["type"] != "nic" || m["nictype"] != "bridged" {
 			continue
 		}
 
@@ -3376,7 +3376,7 @@ func (c *containerLXC) Delete() error {
 			continue
 		}
 
-		networkClearLease(c.state, m["parent"], m["hwaddr"])
+		networkClearLease(c.state, c.name, m["parent"], m["hwaddr"])
 	}
 
 	logger.Info("Deleted container", ctxMap)

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -934,7 +934,7 @@ func networkGetMacSlice(hwaddr string) []string {
 	return buf
 }
 
-func networkClearLease(s *state.State, network string, hwaddr string) error {
+func networkClearLease(s *state.State, name string, network string, hwaddr string) error {
 	leaseFile := shared.VarPath("networks", network, "dnsmasq.leases")
 
 	// Check that we are in fact running a dnsmasq for the network
@@ -966,6 +966,7 @@ func networkClearLease(s *state.State, network string, hwaddr string) error {
 		return err
 	}
 
+	knownMac := networkGetMacSlice(hwaddr)
 	for _, lease := range strings.Split(string(leases), "\n") {
 		if lease == "" {
 			continue
@@ -973,12 +974,16 @@ func networkClearLease(s *state.State, network string, hwaddr string) error {
 
 		fields := strings.Fields(lease)
 		if len(fields) > 2 {
-			leaseMac := networkGetMacSlice(fields[1])
-			leaseMacStr := strings.Join(leaseMac, ":")
-			knownMac := networkGetMacSlice(hwaddr)
-			knownMacStr := strings.Join(
-				knownMac[len(knownMac)-len(leaseMac):], ":")
-			if knownMacStr == leaseMacStr {
+			if strings.Contains(fields[1], ":") {
+				leaseMac := networkGetMacSlice(fields[1])
+				leaseMacStr := strings.Join(leaseMac, ":")
+
+				knownMacStr := strings.Join(knownMac[len(knownMac)-len(leaseMac):], ":")
+				if knownMacStr == leaseMacStr {
+					continue
+				}
+			} else if len(fields) > 3 && fields[3] == name {
+				// Mostly IPv6 leases which don't contain a MAC address...
 				continue
 			}
 		}


### PR DESCRIPTION
dnsmasq doesn't record the MAC address for IPv6 leases, so add logic to
detect that case and then cleanup base on the container name.

This isn't perfect as there's no guarantee that the reported name over
DHCP matches the container's LXD name, but there's really nothing else
to match against.

Closes #4635

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>