### PR TITLE
Allow NAT rule to be appended to POSTROUTING table

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -561,3 +561,7 @@ Adds a bridge.hwaddr key to control the MAC address of the bridge.
 ## proxy\_nat
 This adds optimized UDP/TCP proxying. If the configuration allows, proxying
 will be done via iptables instead of proxy devices.
+
+## network\_nat\_order
+This introduces the `ipv4.nat.order` and `ipv6.nat.order` configuration keys for LXD bridges.
+Those keys control whether to put the LXD rules before or after any pre-existing rules in the chain.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -38,6 +38,7 @@ ipv4.dhcp.gateway               | string    | ipv4 dhcp             | ipv4.addre
 ipv4.dhcp.ranges                | string    | ipv4 dhcp             | all addresses             | Comma separated list of IP ranges to use for DHCP (FIRST-LAST format)
 ipv4.firewall                   | boolean   | ipv4 address          | true                      | Whether to generate filtering firewall rules for this network
 ipv4.nat                        | boolean   | ipv4 address          | false                     | Whether to NAT (will default to true if unset and a random ipv4.address is generated)
+ipv4.nat.order                  | string    | ipv4 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv4.routes                     | string    | ipv4 address          | -                         | Comma separated list of additional IPv4 CIDR subnets to route to the bridge
 ipv4.routing                    | boolean   | ipv4 address          | true                      | Whether to route traffic in and out of the bridge
 ipv6.address                    | string    | standard mode         | random unused subnet      | IPv6 address for the bridge (CIDR notation). Use "none" to turn off IPv6 or "auto" to generate a new one
@@ -47,6 +48,7 @@ ipv6.dhcp.ranges                | string    | ipv6 stateful dhcp    | all addres
 ipv6.dhcp.stateful              | boolean   | ipv6 dhcp             | false                     | Whether to allocate addresses using DHCP
 ipv6.firewall                   | boolean   | ipv6 address          | true                      | Whether to generate filtering firewall rules for this network
 ipv6.nat                        | boolean   | ipv6 address          | false                     | Whether to NAT (will default to true if unset and a random ipv6.address is generated)
+ipv6.nat.order                  | string    | ipv6 address          | before                    | Whether to add the required NAT rules before or after any pre-existing rules
 ipv6.routes                     | string    | ipv6 address          | -                         | Comma separated list of additional IPv6 CIDR subnets to route to the bridge
 ipv6.routing                    | boolean   | ipv6 address          | true                      | Whether to route traffic in and out of the bridge
 raw.dnsmasq                     | string    | -                     | -                         | Additional dnsmasq configuration to append to the configuration

--- a/lxd/iptables.go
+++ b/lxd/iptables.go
@@ -8,7 +8,7 @@ import (
 	"github.com/lxc/lxd/shared"
 )
 
-func iptablesPrepend(protocol string, comment string, table string, chain string,
+func iptablesConfig(protocol string, comment string, table string, method string, chain string,
 	rule ...string) error {
 	cmd := "iptables"
 	if protocol == "ipv6" {
@@ -35,8 +35,7 @@ func iptablesPrepend(protocol string, comment string, table string, chain string
 		return nil
 	}
 
-	// Add the rule
-	args = append(baseArgs, []string{"-I", chain}...)
+	args = append(baseArgs, []string{method, chain}...)
 	args = append(args, rule...)
 	args = append(args, "-m", "comment", "--comment", fmt.Sprintf("generated for %s", comment))
 
@@ -46,6 +45,14 @@ func iptablesPrepend(protocol string, comment string, table string, chain string
 	}
 
 	return nil
+}
+
+func iptablesAppend(protocol string, comment string, table string, chain string, rule ...string) error {
+	return iptablesConfig(protocol, comment, table, "-A", chain, rule...)
+}
+
+func iptablesPrepend(protocol string, comment string, table string, chain string, rule ...string) error {
+	return iptablesConfig(protocol, comment, table, "-I", chain, rule...)
 }
 
 func iptablesClear(protocol string, comment string, table string) error {
@@ -94,6 +101,12 @@ func iptablesClear(protocol string, comment string, table string) error {
 	}
 
 	return nil
+}
+
+func networkIptablesAppend(protocol string, comment string, table string, chain string,
+	rule ...string) error {
+	return iptablesAppend(protocol, fmt.Sprintf("LXD network %s", comment),
+		table, chain, rule...)
 }
 
 func networkIptablesPrepend(protocol string, comment string, table string, chain string,

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1235,9 +1235,16 @@ func (n *network) Start() error {
 
 		// Configure NAT
 		if shared.IsTrue(n.config["ipv4.nat"]) {
-			err = networkIptablesPrepend("ipv4", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
-			if err != nil {
-				return err
+			if n.config["ipv4.nat.order"] == "after" {
+				err = networkIptablesAppend("ipv4", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				if err != nil {
+					return err
+				}
+			} else {
+				err = networkIptablesPrepend("ipv4", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				if err != nil {
+					return err
+				}
 			}
 		}
 
@@ -1397,9 +1404,16 @@ func (n *network) Start() error {
 
 		// Configure NAT
 		if shared.IsTrue(n.config["ipv6.nat"]) {
-			err = networkIptablesPrepend("ipv6", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
-			if err != nil {
-				return err
+			if n.config["ipv6.nat.order"] == "after" {
+				err = networkIptablesAppend("ipv6", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				if err != nil {
+					return err
+				}
+			} else {
+				err = networkIptablesPrepend("ipv6", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/lxd/networks_config.go
+++ b/lxd/networks_config.go
@@ -61,8 +61,11 @@ var networkConfigKeys = map[string]func(value string) error{
 
 		return networkValidAddressCIDRV4(value)
 	},
-	"ipv4.firewall":     shared.IsBool,
-	"ipv4.nat":          shared.IsBool,
+	"ipv4.firewall": shared.IsBool,
+	"ipv4.nat":      shared.IsBool,
+	"ipv4.nat.order": func(value string) error {
+		return shared.IsOneOf(value, []string{"before", "after"})
+	},
 	"ipv4.dhcp":         shared.IsBool,
 	"ipv4.dhcp.gateway": networkValidAddressV4,
 	"ipv4.dhcp.expiry":  shared.IsAny,
@@ -77,8 +80,11 @@ var networkConfigKeys = map[string]func(value string) error{
 
 		return networkValidAddressCIDRV6(value)
 	},
-	"ipv6.firewall":      shared.IsBool,
-	"ipv6.nat":           shared.IsBool,
+	"ipv6.firewall": shared.IsBool,
+	"ipv6.nat":      shared.IsBool,
+	"ipv6.nat.order": func(value string) error {
+		return shared.IsOneOf(value, []string{"before", "after"})
+	},
 	"ipv6.dhcp":          shared.IsBool,
 	"ipv6.dhcp.expiry":   shared.IsAny,
 	"ipv6.dhcp.stateful": shared.IsBool,

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -118,6 +118,7 @@ var APIExtensions = []string{
 	"proxy_haproxy_protocol",
 	"network_hwaddr",
 	"proxy_nat",
+	"network_nat_order",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
The current implementation of the NAT feature in LXD causes some
issues when it should collaborate with firewall/IPsec packages. This
patch adds therefor some flexibility within LXD on how firewall
rules are handled. This espacially comes into play during restarts
of lxd(8).

The ipv[46].nat configuration options are advanced to accept the
following options:
- true|insert: the firewall rule is insert at the beginning of the
  POSTROUTING table
- false: no rule is added
- append: the iptables rule is appended at the end of the POSTROUTING
  table

To keep the configuration options backwards compatible the old value
"true" and "false" are kept.