### PR TITLE
Support downloading through host LXD

### DIFF
--- a/client/lxd.go
+++ b/client/lxd.go
@@ -121,7 +121,7 @@ func (r *ProtocolLXD) RawOperation(method string, path string, data interface{},
 }
 
 // Internal functions
-func (r *ProtocolLXD) parseResponse(resp *http.Response) (*api.Response, string, error) {
+func lxdParseResponse(resp *http.Response) (*api.Response, string, error) {
 	// Get the ETag
 	etag := resp.Header.Get("ETag")
 
@@ -221,7 +221,7 @@ func (r *ProtocolLXD) rawQuery(method string, url string, data interface{}, ETag
 	}
 	defer resp.Body.Close()
 
-	return r.parseResponse(resp)
+	return lxdParseResponse(resp)
 }
 
 func (r *ProtocolLXD) query(method string, path string, data interface{}, ETag string) (*api.Response, string, error) {

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -762,7 +762,7 @@ func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.Re
 
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(resp)
+		_, _, err := lxdParseResponse(resp)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -861,7 +861,7 @@ func (r *ProtocolLXD) CreateContainerFile(containerName string, path string, arg
 	}
 
 	// Check the return value for a cleaner error
-	_, _, err = r.parseResponse(resp)
+	_, _, err = lxdParseResponse(resp)
 	if err != nil {
 		return err
 	}
@@ -1287,7 +1287,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(resp)
+		_, _, err := lxdParseResponse(resp)
 		if err != nil {
 			return nil, err
 		}
@@ -1381,7 +1381,7 @@ func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateNam
 
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(resp)
+		_, _, err := lxdParseResponse(resp)
 		if err != nil {
 			return nil, err
 		}
@@ -1421,7 +1421,7 @@ func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateNam
 	resp, err := r.http.Do(req)
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(resp)
+		_, _, err := lxdParseResponse(resp)
 		if err != nil {
 			return err
 		}
@@ -1536,7 +1536,7 @@ func (r *ProtocolLXD) GetContainerConsoleLog(containerName string, args *Contain
 
 	// Check the return value for a cleaner error
 	if resp.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(resp)
+		_, _, err := lxdParseResponse(resp)
 		if err != nil {
 			return nil, err
 		}
@@ -1695,7 +1695,7 @@ func (r *ProtocolLXD) GetContainerBackupFile(containerName string, name string, 
 	defer close(doneCh)
 
 	if response.StatusCode != http.StatusOK {
-		_, _, err := r.parseResponse(response)
+		_, _, err := lxdParseResponse(response)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds the needed logic in the client to look for and use /dev/lxd/sock, attempting to download the image binaries through the host when possible.

@tvansteenburgh sorry it took 3 months :)
This should let you reduce your bandwidth usage quite a bit once host and containers run a version of LXD that supports it AND you have the needed security flags enabled (`security.devlxd` and `security.devlxd.images`).