### PR TITLE
Forward dqlite logging

### DIFF
--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -52,7 +52,7 @@ func TestGateway_Single(t *testing.T) {
 
 	leader, err := gateway.LeaderAddress()
 	assert.Equal(t, "", leader)
-	assert.EqualError(t, err, "node is not clustered")
+	assert.EqualError(t, err, "Node is not clustered")
 }
 
 // If there's a network address configured, we expose the gRPC endpoint with

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -478,6 +478,7 @@ func (d *Daemon) init() error {
 			dqlite.WithDialFunc(d.gateway.DialFunc()),
 			dqlite.WithContext(d.gateway.Context()),
 			dqlite.WithConnectionTimeout(d.config.DqliteSetupTimeout),
+			dqlite.WithLogFunc(cluster.DqliteLog),
 		)
 		if err == nil {
 			break


### PR DESCRIPTION
This branch configures dqlite to use lxd's logger instead of its default one (from the stdlib)