### PR TITLE
Make use of the new cluster join API in lxd init

### DIFF
--- a/client/lxd_cluster.go
+++ b/client/lxd_cluster.go
@@ -23,7 +23,7 @@ func (r *ProtocolLXD) GetCluster() (*api.Cluster, string, error) {
 	return cluster, etag, nil
 }
 
-// UpdateCluster requests to bootstrap a new cluster
+// UpdateCluster requests to bootstrap a new cluster or join an existing one.
 func (r *ProtocolLXD) UpdateCluster(cluster api.ClusterPut, ETag string) (Operation, error) {
 	if !r.HasExtension("clustering") {
 		return nil, fmt.Errorf("The server is missing the required \"clustering\" API extension")

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -87,42 +87,22 @@ cluster:
 Then run `cat <preseed-file> | lxd init --preseed` and your first node
 should be bootstrapped.
 
-Now create a bootstrap file for another node. Be sure to specify the
-address and certificate of the target bootstrap node. To create a
-YAML-compatible entry for the `<cert>` key you can use a command like
-`sed ':a;N;$!ba;s/\n/\n\n/g' /var/lib/lxd/server.crt`, which you have to
-run on the bootstrap node.
+Now create a bootstrap file for another node. You only need to fill in the
+``cluster`` section with data and config values that are specific to the joining
+node.
+
+Be sure to include the address and certificate of the target bootstrap node. To
+create a YAML-compatible entry for the ``cluster_certificate`` key you can use a
+command like `sed ':a;N;$!ba;s/\n/\n\n/g' /var/lib/lxd/server.crt`, which you
+have to run on the bootstrap node.
 
 For example:
 
 ```yaml
-config:
-  core.https_address: 10.55.60.155:8443
-  images.auto_update_interval: 15
-storage_pools:
-- name: default
-  driver: dir
-networks:
-- name: lxdbr0
-  type: bridge
-  config:
-    ipv4.address: 192.168.100.14/24
-    ipv6.address: none
-profiles:
-- name: default
-  devices:
-    root:
-      path: /
-      pool: default
-      type: disk
-    eth0:
-      name: eth0
-      nictype: bridged
-      parent: lxdbr0
-      type: nic
 cluster:
-  server_name: node2
   enabled: true
+  server_name: node2
+  server_address: 10.55.60.155:8443
   cluster_address: 10.55.60.171:8443
   cluster_certificate: "-----BEGIN CERTIFICATE-----
 
@@ -135,6 +115,11 @@ opyQ1VRpAg2sV2C4W8irbNqeUsTeZZxhLqp4vNOXXBBrSqUCdPu1JXADV0kavg1l
 -----END CERTIFICATE-----
 "
   cluster_password: sekret
+  member_config:
+  - entity: storage-pool
+    name: default
+    key: source
+    value: ""
 ```
 
 ## Managing a cluster

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -274,13 +274,13 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) Response {
 			return err
 		}
 
-		// If node-specific configuration values are provided, it means
-		// the user wants to also initialize storage pools and
-		// networks.
-		if len(req.MemberConfig) > 0 {
+		// If the ServerAddress field is set it means that we're using
+		// the new join API introduced with the 'clustering_join'
+		// extension.
+		if req.ServerAddress != "" {
 			// Connect to ourselves to initialize storage pools and
 			// networks using the API.
-			d, err := lxd.ConnectLXDUnix("", nil)
+			d, err := lxd.ConnectLXDUnix(d.UnixSocket(), nil)
 			if err != nil {
 				return errors.Wrap(err, "Failed to connect to local LXD")
 			}

--- a/lxd/main_init.go
+++ b/lxd/main_init.go
@@ -124,6 +124,20 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Detect if the user has chosen to join a cluster using the new
+	// cluster join API format, and use the dedicated API if so.
+	if config.Cluster != nil && config.Cluster.ClusterAddress != "" && config.Cluster.ServerAddress != "" {
+		op, err := d.UpdateCluster(config.Cluster.ClusterPut, "")
+		if err != nil {
+			return errors.Wrap(err, "Failed to join cluster")
+		}
+		err = op.Wait()
+		if err != nil {
+			return errors.Wrap(err, "Failed to join cluster")
+		}
+		return nil
+	}
+
 	revert, err := initDataNodeApply(d, config.Node)
 	if err != nil {
 		revert()


### PR DESCRIPTION
This changes the format of the YAML, but the code handling the old format is
still there so it will continue to work (although we now print the new format
when you dump the YAML config at the end of interactive mode).

Fixes #4830.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>