### PR TITLE
fscaps: translate from big to little endian

### DIFF
--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -13,6 +13,7 @@ import (
 // #cgo LDFLAGS: -lacl
 /*
 #define _GNU_SOURCE
+#include <byteswap.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
@@ -48,6 +49,11 @@ struct vfs_ns_cap_data {
 };
 #endif
 
+#if __BYTE_ORDER == __BIG_ENDIAN
+#define BE32_TO_LE32(x) bswap_32(x)
+#else
+#define BE32_TO_LE32(x) (x)
+#endif
 
 int set_vfs_ns_caps(char *path, char *caps, ssize_t len, uint32_t uid)
 {
@@ -59,7 +65,7 @@ int set_vfs_ns_caps(char *path, char *caps, ssize_t len, uint32_t uid)
 	memcpy(&ns_xattr, caps, len);
 	ns_xattr.magic_etc &= ~(VFS_CAP_REVISION_1 | VFS_CAP_REVISION_2);
 	ns_xattr.magic_etc |= VFS_CAP_REVISION_3;
-	ns_xattr.rootid = uid;
+	ns_xattr.rootid = BE32_TO_LE32(uid);
 
 	return setxattr(path, "security.capability", &ns_xattr, sizeof(ns_xattr), 0);
 }

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -48,10 +48,9 @@ struct vfs_ns_cap_data {
 };
 #endif
 
-int set_caps(char *path, char *caps, ssize_t len, uint32_t uid)
-{
-	ssize_t ret;
 
+int set_vfs_ns_caps(char *path, char *caps, ssize_t len, uint32_t uid)
+{
 	// Works because vfs_ns_cap_data is a superset of vfs_cap_data (rootid
 	// field added to the end)
 	struct vfs_ns_cap_data ns_xattr;
@@ -62,12 +61,7 @@ int set_caps(char *path, char *caps, ssize_t len, uint32_t uid)
 	ns_xattr.magic_etc |= VFS_CAP_REVISION_3;
 	ns_xattr.rootid = uid;
 
-	ret = setxattr(path, "security.capability", &ns_xattr, sizeof(ns_xattr), 0);
-	if (ret < 0) {
-		return -1;
-	}
-
-	return 0;
+	return setxattr(path, "security.capability", &ns_xattr, sizeof(ns_xattr), 0);
 }
 
 int shiftowner(char *basepath, char *path, int uid, int gid)
@@ -176,7 +170,7 @@ func SetCaps(path string, caps []byte, uid int64) error {
 	ccaps := C.CString(string(caps))
 	defer C.free(unsafe.Pointer(ccaps))
 
-	r := C.set_caps(cpath, ccaps, C.ssize_t(len(caps)), C.uint32_t(uid))
+	r := C.set_vfs_ns_caps(cpath, ccaps, C.ssize_t(len(caps)), C.uint32_t(uid))
 	if r != 0 {
 		return fmt.Errorf("Failed to apply capabilities to: %s", path)
 	}


### PR DESCRIPTION
When I suggested the `memcpy()` between ` vfs_cap_data` to `vfs_ns_cap_data` in order
to copy fscaps I forgot to mention that we need to ensure that all fields are
passed as 32 bit little endian integers. This commit makes sure to convert from
big to little endian when passing the uid down.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>