### PR TITLE
Fix "no transaction is active" error during database updates

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -213,13 +213,13 @@ func patchStorageApi(name string, d *Daemon) error {
 	// Check if this LXD instace currently has any containers, snapshots, or
 	// images configured. If so, we create a default storage pool in the
 	// database. Otherwise, the user will have to run LXD init.
-	cRegular, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cRegular, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing snapshots.
-	cSnapshots, err := d.cluster.ContainersNodeList(db.CTypeSnapshot)
+	cSnapshots, err := d.cluster.ContainersList(db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
@@ -1881,13 +1881,13 @@ func patchStorageApiV1(name string, d *Daemon) error {
 		return nil
 	}
 
-	cRegular, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cRegular, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		return err
 	}
 
 	// Get list of existing snapshots.
-	cSnapshots, err := d.cluster.ContainersNodeList(db.CTypeSnapshot)
+	cSnapshots, err := d.cluster.ContainersList(db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
@@ -1902,7 +1902,7 @@ func patchStorageApiV1(name string, d *Daemon) error {
 }
 
 func patchContainerConfigRegen(name string, d *Daemon) error {
-	cts, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cts, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -2651,7 +2651,7 @@ func patchStorageApiCephSizeRemove(name string, d *Daemon) error {
 }
 
 func patchDevicesNewNamingScheme(name string, d *Daemon) error {
-	cts, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cts, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		logger.Errorf("Failed to retrieve containers from database")
 		return err
@@ -2905,7 +2905,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 		}
 	}
 
-	cRegular, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cRegular, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		return err
 	}
@@ -2978,7 +2978,7 @@ func patchUpdateFromV10(d *Daemon) error {
 }
 
 func patchUpdateFromV11(d *Daemon) error {
-	cNames, err := d.cluster.ContainersNodeList(db.CTypeSnapshot)
+	cNames, err := d.cluster.ContainersList(db.CTypeSnapshot)
 	if err != nil {
 		return err
 	}
@@ -3049,7 +3049,7 @@ func patchUpdateFromV15(d *Daemon) error {
 	// munge all LVM-backed containers' LV names to match what is
 	// required for snapshot support
 
-	cNames, err := d.cluster.ContainersNodeList(db.CTypeRegular)
+	cNames, err := d.cluster.ContainersList(db.CTypeRegular)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Daemon patches were recently changed (PR #4881) to use the new
ContainersNodeList API instead of the older ContainersList one. Unfortunately
the newer API requires the "node_id" column to be present, which is not the case
when those patches are triggered during an upgrade from a pre-clustering
version.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>