### PR TITLE
lxc/remote: Fix crash on bad remote name

### DIFF
--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -653,7 +653,7 @@ func (c *cmdRemoteSwitch) Run(cmd *cobra.Command, args []string) error {
 	// Set the default remote
 	_, ok := conf.Remotes[args[0]]
 	if !ok {
-		return fmt.Errorf(i18n.G("Remote %s doesn't exist"), args[1])
+		return fmt.Errorf(i18n.G("Remote %s doesn't exist"), args[0])
 	}
 
 	conf.DefaultRemote = args[0]


### PR DESCRIPTION
Closes #4894

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>