### PR TITLE
lxd/images: Cleanup any leftovers on startup

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -573,6 +573,9 @@ func (d *Daemon) init() error {
 	/* Log expiry */
 	d.tasks.Add(expireLogsTask(d.State()))
 
+	// Cleanup leftover images
+	pruneLeftoverImages(d)
+
 	/* Setup the proxy handler, external authentication and MAAS */
 	macaroonEndpoint := ""
 	maasAPIURL := ""


### PR DESCRIPTION
As LXD may have been downloading or publishing an image as it got
restarted or crashed, it's not that unusual for there to be leftovers in
the images directory.

This adds a function which compares the content of the images directory
with what's expected to be there according to the database and deletes
any file that shouldn't be there.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>