### PR TITLE
shallow clone for deps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ deps:
 		cd "$(GOPATH)/deps/sqlite"; \
 		git pull; \
 	else \
-		git clone "https://github.com/CanonicalLtd/sqlite" "$(GOPATH)/deps/sqlite"; \
+		git clone --depth=1 "https://github.com/CanonicalLtd/sqlite" "$(GOPATH)/deps/sqlite"; \
 	fi
 
 	cd "$(GOPATH)/deps/sqlite" && \
@@ -46,7 +46,7 @@ deps:
 		cd "$(GOPATH)/deps/dqlite"; \
 		git pull; \
 	else \
-		git clone "https://github.com/CanonicalLtd/dqlite" "$(GOPATH)/deps/dqlite"; \
+		git clone --depth=1 "https://github.com/CanonicalLtd/dqlite" "$(GOPATH)/deps/dqlite"; \
 	fi
 
 	cd "$(GOPATH)/deps/dqlite" && \

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,8 @@ dist:
 	cd $(TMP)/lxd-$(VERSION) && GOPATH=$(TMP)/dist go get -t -v -d ./...
 
 	# Download the cluster-enabled sqlite/dqlite
-	git clone https://github.com/CanonicalLtd/dqlite $(TMP)/dist/dqlite
-	git clone https://github.com/CanonicalLtd/sqlite $(TMP)/dist/sqlite
+	git clone --depth=1 https://github.com/CanonicalLtd/dqlite $(TMP)/dist/dqlite
+	git clone --depth=1 https://github.com/CanonicalLtd/sqlite $(TMP)/dist/sqlite
 	cd $(TMP)/dist/sqlite && git log -1 --format="format:%ci%n" | sed -e 's/ [-+].*$$//;s/ /T/;s/^/D /' > manifest
 	cd $(TMP)/dist/sqlite && git log -1 --format="format:%H" > manifest.uuid
 


### PR DESCRIPTION
The complete clone of sqlite repo is about 89 MB while the shallow copy is just about 9 MB. There is a significant gain primary in bandwidth saving and consequently in compilation speed.