### PR TITLE
lxd/task: Add support from cron expressions

### DIFF
--- a/lxd/task/group.go
+++ b/lxd/task/group.go
@@ -23,11 +23,21 @@ type Group struct {
 
 // Add a new task to the group, returning its index.
 func (g *Group) Add(f Func, schedule Schedule) *Task {
+	return g.add(f, schedule, false)
+}
+
+// AddCron adds a new cron task to the group, returning its index.
+func (g *Group) AddCron(f Func, schedule Schedule) *Task {
+	return g.add(f, schedule, true)
+}
+
+func (g *Group) add(f Func, schedule Schedule, cron bool) *Task {
 	i := len(g.tasks)
 	g.tasks = append(g.tasks, Task{
 		f:        f,
 		schedule: schedule,
 		reset:    make(chan struct{}, 16), // Buffered to not block senders
+		cron:     cron,
 	})
 	return &g.tasks[i]
 }

--- a/lxd/task/start.go
+++ b/lxd/task/start.go
@@ -19,3 +19,22 @@ func Start(f Func, schedule Schedule) (func(time.Duration) error, func()) {
 
 	return stop, reset
 }
+
+// StartCron starts a single cron task executing the given function with the
+// given schedule.
+//
+// This is a convenience around Group and it returns two functions that can be
+// used to control the task. The first is a "stop" function trying to terminate
+// the task gracefully within the given timeout and the second is a "reset"
+// function to reset the task's state. See Group.Stop() and Group.Reset() for
+// more details.
+func StartCron(f Func, schedule Schedule) (func(time.Duration) error, func()) {
+	group := Group{}
+	task := group.AddCron(f, schedule)
+	group.Start()
+
+	stop := group.Stop
+	reset := task.Reset
+
+	return stop, reset
+}


### PR DESCRIPTION
Cron expressions will be needed for the snapshot scheduling (#2610).

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>