### PR TITLE
Container scheduling honors pending operations

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -189,7 +189,7 @@ func clusterPutBootstrap(d *Daemon, req api.ClusterPut) Response {
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Creating bootstrap node", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -426,7 +426,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) Response {
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Joining cluster", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationClusterJoin, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -253,7 +253,7 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 	// /cluster/nodes request which triggered this code.
 	var pools map[string]map[string]string
 	var networks map[string]map[string]string
-	var operations []string
+	var operations []db.Operation
 	err = state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		pools, err = tx.StoragePoolsNodeConfig()
 		if err != nil {
@@ -263,7 +263,7 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 		if err != nil {
 			return err
 		}
-		operations, err = tx.OperationsUUIDs()
+		operations, err = tx.Operations()
 		if err != nil {
 			return err
 		}
@@ -396,10 +396,10 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 		}
 
 		// Migrate outstanding operations.
-		for _, uuid := range operations {
-			_, err := tx.OperationAdd(uuid)
+		for _, operation := range operations {
+			_, err := tx.OperationAdd(operation.UUID, operation.Type)
 			if err != nil {
-				return errors.Wrapf(err, "failed to migrate operation %s", uuid)
+				return errors.Wrapf(err, "failed to migrate operation %s", operation.UUID)
 			}
 		}
 

--- a/lxd/container_backup.go
+++ b/lxd/container_backup.go
@@ -153,7 +153,7 @@ func containerBackupsPost(d *Daemon, r *http.Request) Response {
 	resources["backups"] = []string{req.Name}
 
 	op, err := operationCreate(d.cluster, operationClassTask,
-		"Backing up container", resources, nil, backup, nil, nil)
+		db.OperationBackupCreate, resources, nil, backup, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -228,7 +228,7 @@ func containerBackupPost(d *Daemon, r *http.Request) Response {
 	resources["containers"] = []string{name}
 
 	op, err := operationCreate(d.cluster, operationClassTask,
-		"Renaming container backup", resources, nil, rename, nil, nil)
+		db.OperationBackupRename, resources, nil, rename, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -268,7 +268,7 @@ func containerBackupDelete(d *Daemon, r *http.Request) Response {
 	resources["container"] = []string{name}
 
 	op, err := operationCreate(d.cluster, operationClassTask,
-		"Removing container backup", resources, nil, remove, nil, nil)
+		db.OperationBackupRemove, resources, nil, remove, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_console.go
+++ b/lxd/container_console.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/lxc/go-lxc.v2"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -330,7 +331,7 @@ func containerConsolePost(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{ws.container.Name()}
 
-	op, err := operationCreate(d.cluster, operationClassWebsocket, "Showing console",
+	op, err := operationCreate(d.cluster, operationClassWebsocket, db.OperationConsoleShow,
 		resources, ws.Metadata(), ws.Do, nil, ws.Connect)
 	if err != nil {
 		return InternalError(err)

--- a/lxd/container_delete.go
+++ b/lxd/container_delete.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gorilla/mux"
+	"github.com/lxc/lxd/lxd/db"
 )
 
 func containerDelete(d *Daemon, r *http.Request) Response {
@@ -35,7 +36,7 @@ func containerDelete(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Deleting container", resources, nil, rmct, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerDelete, resources, nil, rmct, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -17,6 +17,7 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -455,7 +456,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 		resources := map[string][]string{}
 		resources["containers"] = []string{ws.container.Name()}
 
-		op, err := operationCreate(d.cluster, operationClassWebsocket, "Executing command", resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+		op, err := operationCreate(d.cluster, operationClassWebsocket, db.OperationCommandExec, resources, ws.Metadata(), ws.Do, nil, ws.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -507,7 +508,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Executing command", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationCommandExec, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -207,7 +207,7 @@ func containerPost(d *Daemon, r *http.Request) Response {
 				return InternalError(err)
 			}
 
-			op, err := operationCreate(d.cluster, operationClassTask, "Migrating container", resources, nil, ws.Do, nil, nil)
+			op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerMigrate, resources, nil, ws.Do, nil, nil)
 			if err != nil {
 				return InternalError(err)
 			}
@@ -216,7 +216,7 @@ func containerPost(d *Daemon, r *http.Request) Response {
 		}
 
 		// Pull mode
-		op, err := operationCreate(d.cluster, operationClassWebsocket, "Migrating container", resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+		op, err := operationCreate(d.cluster, operationClassWebsocket, db.OperationContainerMigrate, resources, ws.Metadata(), ws.Do, nil, ws.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -237,7 +237,7 @@ func containerPost(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Renaming container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerRename, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -380,7 +380,7 @@ func containerPostClusteringMigrate(d *Daemon, c container, oldName, newName, ne
 
 	resources := map[string][]string{}
 	resources["containers"] = []string{oldName}
-	op, err := operationCreate(d.cluster, operationClassTask, "Moving container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerMigrate, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -487,7 +487,7 @@ func containerPostClusteringMigrateWithCeph(d *Daemon, c container, oldName, new
 
 	resources := map[string][]string{}
 	resources["containers"] = []string{oldName}
-	op, err := operationCreate(d.cluster, operationClassTask, "Moving container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerMigrate, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -56,7 +56,7 @@ func containerPut(d *Daemon, r *http.Request) Response {
 	}
 
 	var do func(*operation) error
-	var opDescription string
+	var opType db.OperationType
 	if configRaw.Restore == "" {
 		// Update container configuration
 		do = func(op *operation) error {
@@ -78,20 +78,20 @@ func containerPut(d *Daemon, r *http.Request) Response {
 			return nil
 		}
 
-		opDescription = "Updating container"
+		opType = db.OperationSnapshotUpdate
 	} else {
 		// Snapshot Restore
 		do = func(op *operation) error {
 			return containerSnapRestore(d.State(), name, configRaw.Restore, configRaw.Stateful)
 		}
 
-		opDescription = "Restoring snapshot"
+		opType = db.OperationSnapshotRestore
 	}
 
 	resources := map[string][]string{}
 	resources["containers"] = []string{name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, opDescription, resources, nil, do, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, opType, resources, nil, do, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_snapshot.go
+++ b/lxd/container_snapshot.go
@@ -141,7 +141,7 @@ func containerSnapshotsPost(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Snapshotting container", resources, nil, snapshot, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationSnapshotCreate, resources, nil, snapshot, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -255,7 +255,7 @@ func snapshotPost(d *Daemon, r *http.Request, sc container, containerName string
 				return InternalError(err)
 			}
 
-			op, err := operationCreate(d.cluster, operationClassTask, "Transferring snapshot", resources, nil, ws.Do, nil, nil)
+			op, err := operationCreate(d.cluster, operationClassTask, db.OperationSnapshotTransfer, resources, nil, ws.Do, nil, nil)
 			if err != nil {
 				return InternalError(err)
 			}
@@ -264,7 +264,7 @@ func snapshotPost(d *Daemon, r *http.Request, sc container, containerName string
 		}
 
 		// Pull mode
-		op, err := operationCreate(d.cluster, operationClassWebsocket, "Transferring snapshot", resources, ws.Metadata(), ws.Do, nil, ws.Connect)
+		op, err := operationCreate(d.cluster, operationClassWebsocket, db.OperationSnapshotTransfer, resources, ws.Metadata(), ws.Do, nil, ws.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -297,7 +297,7 @@ func snapshotPost(d *Daemon, r *http.Request, sc container, containerName string
 	resources := map[string][]string{}
 	resources["containers"] = []string{containerName}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Renaming snapshot", resources, nil, rename, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationSnapshotRename, resources, nil, rename, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -313,7 +313,7 @@ func snapshotDelete(sc container, name string) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{sc.Name()}
 
-	op, err := operationCreate(sc.DaemonState().Cluster, operationClassTask, "Deleting snapshot", resources, nil, remove, nil, nil)
+	op, err := operationCreate(sc.DaemonState().Cluster, operationClassTask, db.OperationSnapshotDelete, resources, nil, remove, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -133,7 +133,7 @@ func createFromImage(d *Daemon, req *api.ContainersPost) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{req.Name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Creating container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -168,7 +168,7 @@ func createFromNone(d *Daemon, req *api.ContainersPost) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{req.Name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Creating container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -428,12 +428,12 @@ func createFromMigration(d *Daemon, req *api.ContainersPost) Response {
 
 	var op *operation
 	if push {
-		op, err = operationCreate(d.cluster, operationClassWebsocket, "Creating container", resources, sink.Metadata(), run, nil, sink.Connect)
+		op, err = operationCreate(d.cluster, operationClassWebsocket, db.OperationContainerCreate, resources, sink.Metadata(), run, nil, sink.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
 	} else {
-		op, err = operationCreate(d.cluster, operationClassTask, "Creating container", resources, nil, run, nil, nil)
+		op, err = operationCreate(d.cluster, operationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -529,7 +529,7 @@ func createFromCopy(d *Daemon, req *api.ContainersPost) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{req.Name, req.Source.Source}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Creating container", resources, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -597,7 +597,7 @@ func createFromBackup(d *Daemon, data io.Reader) Response {
 	resources := map[string][]string{}
 	resources["containers"] = []string{bInfo.Name}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Restoring backup",
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationBackupRestore,
 		resources, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)

--- a/lxd/daemon_images_test.go
+++ b/lxd/daemon_images_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/stretchr/testify/suite"
 )
@@ -39,7 +40,7 @@ func (suite *daemonImagesTestSuite) TestUseCachedImagesIfAvailable() {
 
 	// Request an image with alias "test" and check that it's the
 	// one we created above.
-	op, err := operationCreate(suite.d.cluster, operationClassTask, "Downloading image", map[string][]string{}, nil, nil, nil, nil)
+	op, err := operationCreate(suite.d.cluster, operationClassTask, db.OperationImageDownload, map[string][]string{}, nil, nil, nil, nil)
 	suite.Req.Nil(err)
 	image, err := suite.d.ImageDownload(op, "img.srv", "simplestreams", "", "", "test", false, false, "", true)
 	suite.Req.Nil(err)

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -167,6 +167,7 @@ CREATE TABLE operations (
     id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
     uuid TEXT NOT NULL,
     node_id TEXT NOT NULL,
+    type INTEGER NOT NULL DEFAULT 0,
     UNIQUE (uuid),
     FOREIGN KEY (node_id) REFERENCES nodes (id) ON DELETE CASCADE
 );
@@ -246,5 +247,5 @@ CREATE TABLE storage_volumes_config (
     FOREIGN KEY (storage_volume_id) REFERENCES storage_volumes (id) ON DELETE CASCADE
 );
 
-INSERT INTO schema (version, updated_at) VALUES (9, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (10, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -30,15 +30,26 @@ func SchemaDotGo() error {
 var SchemaVersion = len(updates)
 
 var updates = map[int]schema.Update{
-	1: updateFromV0,
-	2: updateFromV1,
-	3: updateFromV2,
-	4: updateFromV3,
-	5: updateFromV4,
-	6: updateFromV5,
-	7: updateFromV6,
-	8: updateFromV7,
-	9: updateFromV8,
+	1:  updateFromV0,
+	2:  updateFromV1,
+	3:  updateFromV2,
+	4:  updateFromV3,
+	5:  updateFromV4,
+	6:  updateFromV5,
+	7:  updateFromV6,
+	8:  updateFromV7,
+	9:  updateFromV8,
+	10: updateFromV9,
+}
+
+// Add a new 'type' column to the operations table.
+func updateFromV9(tx *sql.Tx) error {
+	stmts := `
+	ALTER TABLE operations ADD COLUMN type INTEGER NOT NULL DEFAULT 0;
+        UPDATE operations SET type = 0;
+`
+	_, err := tx.Exec(stmts)
+	return err
 }
 
 // The lvm.thinpool_name and lvm.vg_name config keys are node-specific and need

--- a/lxd/db/operations_test.go
+++ b/lxd/db/operations_test.go
@@ -13,13 +13,19 @@ func TestOperation(t *testing.T) {
 	tx, cleanup := db.NewTestClusterTx(t)
 	defer cleanup()
 
-	id, err := tx.OperationAdd("abcd")
+	id, err := tx.OperationAdd("abcd", db.OperationContainerCreate)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), id)
+
+	operations, err := tx.Operations()
+	require.NoError(t, err)
+	assert.Len(t, operations, 1)
+	assert.Equal(t, operations[0].UUID, "abcd")
 
 	operation, err := tx.OperationByUUID("abcd")
 	require.NoError(t, err)
 	assert.Equal(t, id, operation.ID)
+	assert.Equal(t, db.OperationContainerCreate, operation.Type)
 
 	uuids, err := tx.OperationsUUIDs()
 	require.NoError(t, err)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -726,7 +726,7 @@ func imagesPost(d *Daemon, r *http.Request) Response {
 		return nil
 	}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Downloading image", nil, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationImageDownload, nil, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -1263,7 +1263,7 @@ func imageDelete(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["images"] = []string{fingerprint}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Deleting image", resources, nil, rmimg, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationImageDelete, resources, nil, rmimg, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -1745,7 +1745,7 @@ func imageSecret(d *Daemon, r *http.Request) Response {
 	resources := map[string][]string{}
 	resources["images"] = []string{imgInfo.Fingerprint}
 
-	op, err := operationCreate(d.cluster, operationClassToken, "Image download token", resources, meta, nil, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassToken, db.OperationImageToken, resources, meta, nil, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -1821,7 +1821,7 @@ func imageRefresh(d *Daemon, r *http.Request) Response {
 		return autoUpdateImage(d, op, imageId, imageInfo)
 	}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Refreshing image", nil, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationImageRefresh, nil, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/websocket"
 	"gopkg.in/lxc/go-lxc.v2"
 
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -488,7 +489,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 			actionScriptOp, err := operationCreate(
 				state.Cluster,
 				operationClassWebsocket,
-				"Live-migrating container",
+				db.OperationContainerLiveMigrate,
 				nil,
 				nil,
 				func(op *operation) error {

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -397,11 +397,11 @@ func (op *operation) UpdateMetadata(opMetadata interface{}) error {
 	return nil
 }
 
-func operationCreate(cluster *db.Cluster, opClass operationClass, description string, opResources map[string][]string, opMetadata interface{}, onRun func(*operation) error, onCancel func(*operation) error, onConnect func(*operation, *http.Request, http.ResponseWriter) error) (*operation, error) {
+func operationCreate(cluster *db.Cluster, opClass operationClass, opType db.OperationType, opResources map[string][]string, opMetadata interface{}, onRun func(*operation) error, onCancel func(*operation) error, onConnect func(*operation, *http.Request, http.ResponseWriter) error) (*operation, error) {
 	// Main attributes
 	op := operation{}
 	op.id = uuid.NewRandom().String()
-	op.description = description
+	op.description = opType.Description()
 	op.class = opClass
 	op.createdAt = time.Now()
 	op.updatedAt = op.createdAt
@@ -444,7 +444,7 @@ func operationCreate(cluster *db.Cluster, opClass operationClass, description st
 	operationsLock.Unlock()
 
 	err = op.cluster.Transaction(func(tx *db.ClusterTx) error {
-		_, err := tx.OperationAdd(op.id)
+		_, err := tx.OperationAdd(op.id, opType)
 		return err
 	})
 	if err != nil {

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -227,7 +227,7 @@ func doVolumeCreateOrCopy(d *Daemon, poolName string, req *api.StorageVolumesPos
 		return doWork()
 	}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Copying storage volume", nil, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationVolumeCopy, nil, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}
@@ -355,12 +355,12 @@ func doVolumeMigration(d *Daemon, poolName string, req *api.StorageVolumesPost) 
 
 	var op *operation
 	if push {
-		op, err = operationCreate(d.cluster, operationClassWebsocket, "Creating storage volume", resources, sink.Metadata(), run, nil, sink.Connect)
+		op, err = operationCreate(d.cluster, operationClassWebsocket, db.OperationVolumeCreate, resources, sink.Metadata(), run, nil, sink.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
 	} else {
-		op, err = operationCreate(d.cluster, operationClassTask, "Copying storage volume", resources, nil, run, nil, nil)
+		op, err = operationCreate(d.cluster, operationClassTask, db.OperationVolumeCopy, resources, nil, run, nil, nil)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -465,7 +465,7 @@ func storagePoolVolumeTypePost(d *Daemon, r *http.Request) Response {
 				return InternalError(err)
 			}
 
-			op, err := operationCreate(d.cluster, operationClassTask, "Migrating storage volume", resources, nil, ws.DoStorage, nil, nil)
+			op, err := operationCreate(d.cluster, operationClassTask, db.OperationVolumeMigrate, resources, nil, ws.DoStorage, nil, nil)
 			if err != nil {
 				return InternalError(err)
 			}
@@ -474,7 +474,7 @@ func storagePoolVolumeTypePost(d *Daemon, r *http.Request) Response {
 		}
 
 		// Pull mode
-		op, err := operationCreate(d.cluster, operationClassWebsocket, "Migrating storage volume", resources, ws.Metadata(), ws.DoStorage, nil, ws.Connect)
+		op, err := operationCreate(d.cluster, operationClassWebsocket, db.OperationVolumeMigrate, resources, ws.Metadata(), ws.DoStorage, nil, ws.Connect)
 		if err != nil {
 			return InternalError(err)
 		}
@@ -544,7 +544,7 @@ func storagePoolVolumeTypePost(d *Daemon, r *http.Request) Response {
 		return doWork()
 	}
 
-	op, err := operationCreate(d.cluster, operationClassTask, "Moving storage volume", nil, nil, run, nil, nil)
+	op, err := operationCreate(d.cluster, operationClassTask, db.OperationVolumeMove, nil, nil, run, nil, nil)
 	if err != nil {
 		return InternalError(err)
 	}


### PR DESCRIPTION
Add a new "type" column to the operations table, which identifies the type of the operation being performed, and associates a description with it. All call sites creating an operation have been modified to pass the operation type code, rather than a description.

Change the scheduling logic for picking a cluster node when no target is specified: pending operations for creating a container are taken into account when calculating the number of containers on a node.

There's no integration test since there's no way to reliably submit a create container request during the time window between creating an operation and completing it.

Closes #4884.
