### PR TITLE
lxc: Only target if --target is passed

### DIFF
--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -100,7 +100,6 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 			return err
 		}
 	}
-
 	// Confirm that --target is only used with a cluster
 	if c.flagTarget != "" && !dest.IsClustered() {
 		return fmt.Errorf(i18n.G("To use --target, the destination remote must be a cluster"))
@@ -214,7 +213,10 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 		}
 
 		// Do the actual copy
-		dest = dest.UseTarget(c.flagTarget)
+		if c.flagTarget != "" {
+			dest = dest.UseTarget(c.flagTarget)
+		}
+
 		op, err = dest.CopyContainerSnapshot(source, srcFields[0], *entry, &args)
 		if err != nil {
 			return err
@@ -298,7 +300,10 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 		}
 
 		// Do the actual copy
-		dest = dest.UseTarget(c.flagTarget)
+		if c.flagTarget != "" {
+			dest = dest.UseTarget(c.flagTarget)
+		}
+
 		op, err = dest.CopyContainer(source, *entry, &args)
 		if err != nil {
 			return err

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -86,7 +86,10 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 	if err != nil {
 		return nil, "", err
 	}
-	d = d.UseTarget(c.flagTarget)
+
+	if c.flagTarget != "" {
+		d = d.UseTarget(c.flagTarget)
+	}
 
 	profiles := []string{}
 	for _, p := range c.flagProfile {


### PR DESCRIPTION
Otherwise we end up with differing structs pointing to the same server,
bypassing handling for copy/move within the same server.

Closes #4956

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>