### PR TITLE
bash completion for 'lxc network info'

### DIFF
--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -203,11 +203,11 @@ _have lxc && {
       "network")
         case $pos in
           2)
-            COMPREPLY=( $(compgen -W "list show create get set unset delete edit rename attach attach-profile detach detach-profile" -- $cur) )
+            COMPREPLY=( $(compgen -W "list show create get set unset delete edit rename attach attach-profile detach detach-profile info" -- $cur) )
             ;;
           3)
             case ${no_dashargs[2]} in
-              "show"|"get"|"set"|"unset"|"delete"|"edit"|"rename"|"attach"|"attach-profile"|"detach"|"detach-profile")
+              "show"|"get"|"set"|"unset"|"delete"|"edit"|"rename"|"attach"|"attach-profile"|"detach"|"detach-profile"|"info")
                 _lxd_networks
                 ;;
             esac


### PR DESCRIPTION
Bash autocomplete is missing 'lxc network info'

Signed-off-by: Asterios Dimitriou <asterios@pci.gr>