### PR TITLE
Support lxd cluster update env var

### DIFF
--- a/lxd/cluster/upgrade.go
+++ b/lxd/cluster/upgrade.go
@@ -3,11 +3,17 @@ package cluster
 import (
 	"fmt"
 	"net/http"
+	"os"
+	"time"
 
 	lxd "github.com/lxc/lxd/client"
+	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
 	"github.com/pkg/errors"
+	"golang.org/x/net/context"
 )
 
 // NotifyUpgradeCompleted sends a notification to all other nodes in the
@@ -47,4 +53,76 @@ func NotifyUpgradeCompleted(state *state.State, cert *shared.CertInfo) error {
 
 		return nil
 	})
+}
+
+// KeepUpdated is a task that continuously monitor this node's version to see it
+// it's out of date with respect to other nodes. In the node is out of date,
+// and the LXD_CLUSTER_UPDATE environment variable is set, then the task
+// executes the executable that the variable is pointing at.
+func KeepUpdated(state *state.State) (task.Func, task.Schedule) {
+	f := func(ctx context.Context) {
+		ch := make(chan struct{})
+		go func() {
+			maybeUpdate(state)
+			close(ch)
+		}()
+		select {
+		case <-ctx.Done():
+		case <-ch:
+		}
+	}
+
+	schedule := task.Every(5 * time.Minute)
+
+	return f, schedule
+}
+
+// Check this node's version and possibly run LXD_CLUSTER_UPDATE.
+func maybeUpdate(state *state.State) {
+	shouldUpdate := false
+
+	enabled, err := Enabled(state.Node)
+	if err != nil {
+		logger.Errorf("Failed to check clustering is enabled: %v", err)
+		return
+	}
+	if !enabled {
+		return
+	}
+
+	err = state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		outdated, err := tx.NodeIsOutdated()
+		if err != nil {
+			return err
+		}
+		shouldUpdate = outdated
+		return nil
+	})
+
+	if err != nil {
+		// Just log the error and return.
+		logger.Errorf("Failed to check if this node is out-of-date: %v", err)
+		return
+	}
+
+	if !shouldUpdate {
+		logger.Debugf("Cluster node is up-to-date")
+		return
+	}
+
+	logger.Infof("Node is out-of-date with respect to other cluster nodes")
+
+	updateExecutable := os.Getenv("LXD_CLUSTER_UPDATE")
+	if updateExecutable == "" {
+		logger.Debug("No LXD_CLUSTER_UPDATE variable set, skipping auto-update")
+		return
+	}
+
+	logger.Infof("Triggering cluster update using: %s", updateExecutable)
+
+	_, err = shared.RunCommand(updateExecutable)
+	if err != nil {
+		logger.Errorf("Cluster upgrade failed: '%v'", err.Error())
+		return
+	}
 }

--- a/lxd/cluster/upgrade_test.go
+++ b/lxd/cluster/upgrade_test.go
@@ -1,10 +1,17 @@
 package cluster_test
 
 import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
 )
 
 // A node can unblock other nodes that were waiting for a cluster upgrade to
@@ -23,4 +30,85 @@ func TestNotifyUpgradeCompleted(t *testing.T) {
 	require.NoError(t, err)
 
 	gateway1.WaitUpgradeNotification()
+}
+
+// The task function checks if the node is out of date and runs whatever is in
+// LXD_CLUSTER_UPDATE if so.
+func TestKeepUpdated_Upgrade(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	// Create a stub upgrade script that just touches a stamp file.
+	stamp := filepath.Join(dir, "stamp")
+	script := filepath.Join(dir, "cluster-upgrade")
+	data := []byte(fmt.Sprintf("#!/bin/sh\ntouch %s\n", stamp))
+	err = ioutil.WriteFile(script, data, 0755)
+	require.NoError(t, err)
+
+	state, cleanup := state.NewTestState(t)
+	defer cleanup()
+
+	state.Node.Transaction(func(tx *db.NodeTx) error {
+		nodes := []db.RaftNode{
+			{ID: 1, Address: "0.0.0.0:666"},
+			{ID: 2, Address: "1.2.3.4:666"},
+		}
+		err := tx.RaftNodesReplace(nodes)
+		require.NoError(t, err)
+		return nil
+	})
+
+	state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+		id, err := tx.NodeAdd("buzz", "1.2.3.4:666")
+		require.NoError(t, err)
+
+		node, err := tx.NodeByName("buzz")
+		require.NoError(t, err)
+
+		version := node.Version()
+		version[0]++
+
+		err = tx.NodeUpdateVersion(id, version)
+		require.NoError(t, err)
+
+		return nil
+	})
+
+	os.Setenv("LXD_CLUSTER_UPDATE", script)
+	defer os.Unsetenv("LXD_CLUSTER_UPDATE")
+
+	f, _ := cluster.KeepUpdated(state)
+	f(context.Background())
+
+	_, err = os.Stat(stamp)
+	require.NoError(t, err)
+}
+
+// If the node is up-to-date, nothing is done.
+func TestKeepUpdated_NothingToDo(t *testing.T) {
+	dir, err := ioutil.TempDir("", "")
+	require.NoError(t, err)
+
+	defer os.RemoveAll(dir)
+
+	// Create a stub upgrade script that just touches a stamp file.
+	stamp := filepath.Join(dir, "stamp")
+	script := filepath.Join(dir, "cluster-upgrade")
+	data := []byte(fmt.Sprintf("#!/bin/sh\ntouch %s\n", stamp))
+	err = ioutil.WriteFile(script, data, 0755)
+	require.NoError(t, err)
+
+	state, cleanup := state.NewTestState(t)
+	defer cleanup()
+
+	os.Setenv("LXD_CLUSTER_UPDATE", script)
+	defer os.Unsetenv("LXD_CLUSTER_UPDATE")
+
+	f, _ := cluster.KeepUpdated(state)
+	f(context.Background())
+
+	_, err = os.Stat(stamp)
+	require.True(t, os.IsNotExist(err))
 }

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -667,6 +667,9 @@ func (d *Daemon) Ready() error {
 	/* Events */
 	d.tasks.Add(cluster.Events(d.endpoints, d.cluster, eventForward))
 
+	/* Cluster update trigger */
+	d.tasks.Add(cluster.KeepUpdated(d.State()))
+
 	// FIXME: There's no hard reason for which we should not run these
 	//        tasks in mock mode. However it requires that we tweak them so
 	//        they exit gracefully without blocking (something we should do

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/pkg/errors"
 )
@@ -118,6 +119,44 @@ func (c *ClusterTx) NodeAddress() (string, error) {
 	default:
 		return "", fmt.Errorf("inconsistency: non-unique node ID")
 	}
+}
+
+// NodeIsOutdated returns true if there's some cluster node having an API or
+// schema version greater than the node this method is invoked on.
+func (c *ClusterTx) NodeIsOutdated() (bool, error) {
+	nodes, err := c.nodes(false /* not pending */, "")
+	if err != nil {
+		return false, errors.Wrap(err, "Failed to fetch nodes")
+	}
+
+	// Figure our own version.
+	version := [2]int{}
+	for _, node := range nodes {
+		if node.ID == c.nodeID {
+			version = node.Version()
+		}
+	}
+	if version[0] == 0 || version[1] == 0 {
+		return false, fmt.Errorf("Inconsistency: local node not found")
+	}
+
+	// Check if any of the other nodes is greater than us.
+	for _, node := range nodes {
+		if node.ID == c.nodeID {
+			continue
+		}
+		n, err := util.CompareVersions(node.Version(), version)
+		if err != nil {
+			errors.Wrapf(err, "Failed to compare with version of node %s", node.Name)
+		}
+
+		if n == 1 {
+			// The other node's version is greater than ours.
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // Nodes returns all LXD nodes part of the cluster.
@@ -431,6 +470,28 @@ func (c *ClusterTx) NodeWithLeastContainers() (string, error) {
 		}
 	}
 	return name, nil
+}
+
+// NodeUpdateVersion updates the schema and API version of the node with the
+// given id. This is used only in tests.
+func (c *ClusterTx) NodeUpdateVersion(id int64, version [2]int) error {
+	stmt := "UPDATE nodes SET schema=?, api_extensions=? WHERE id=?"
+
+	result, err := c.tx.Exec(stmt, version[0], version[1], id)
+	if err != nil {
+		return errors.Wrap(err, "Failed to update nodes table")
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return errors.Wrap(err, "Failed to get affected rows")
+	}
+
+	if n != 1 {
+		return fmt.Errorf("Expected exactly one row to be updated")
+	}
+
+	return nil
 }
 
 func nodeIsOffline(threshold time.Duration, heartbeat time.Time) bool {


### PR DESCRIPTION
When clustered, a task will check every 5 minutes if the node is out
of date with respect to other nodes in the cluster, and, if so trigger
an upgrade using the LXD_CLUSTER_UPDATE environment variable.

Fixes #4942.