### PR TITLE
Make database queries timeout after 10s if cluster db is unavail

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -63,7 +63,9 @@ func (s *lxdHttpServer) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 			return nil
 		})
 		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
+			response := SmartError(err)
+			response.Render(rw)
+			return
 		}
 	}
 

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -477,6 +477,7 @@ func clusterPutDisable(d *Daemon) Response {
 	store := d.gateway.ServerStore()
 	d.cluster, err = db.OpenCluster(
 		"db.bin", store, address, "/unused/db/dir",
+		d.config.DqliteSetupTimeout,
 		dqlite.WithDialFunc(d.gateway.DialFunc()),
 		dqlite.WithContext(d.gateway.Context()),
 	)

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -253,7 +253,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	store := gateway.ServerStore()
 	dial := gateway.DialFunc()
 	state.Cluster, err = db.OpenCluster(
-		"db.bin", store, address, "/unused/db/dir", dqlite.WithDialFunc(dial))
+		"db.bin", store, address, "/unused/db/dir", 5*time.Second, dqlite.WithDialFunc(dial))
 	require.NoError(f.t, err)
 
 	f.gateways[len(f.gateways)] = gateway

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/CanonicalLtd/go-dqlite"
 	"github.com/lxc/lxd/lxd/cluster"
@@ -258,6 +259,7 @@ func TestJoin(t *testing.T) {
 	var err error
 	targetState.Cluster, err = db.OpenCluster(
 		"db.bin", targetStore, targetAddress, "/unused/db/dir",
+		10*time.Second,
 		dqlite.WithDialFunc(targetDialFunc))
 	require.NoError(t, err)
 
@@ -294,7 +296,7 @@ func TestJoin(t *testing.T) {
 	dialFunc := gateway.DialFunc()
 
 	state.Cluster, err = db.OpenCluster(
-		"db.bin", store, address, "/unused/db/dir", dqlite.WithDialFunc(dialFunc))
+		"db.bin", store, address, "/unused/db/dir", 5*time.Second, dqlite.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 
 	f := &membershipFixtures{t: t, state: state}
@@ -382,7 +384,7 @@ func FLAKY_TestPromote(t *testing.T) {
 	store := targetGateway.ServerStore()
 	dialFunc := targetGateway.DialFunc()
 	targetState.Cluster, err = db.OpenCluster(
-		"db.bin", store, targetAddress, "/unused/db/dir", dqlite.WithDialFunc(dialFunc))
+		"db.bin", store, targetAddress, "/unused/db/dir", 5*time.Second, dqlite.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 	targetF := &membershipFixtures{t: t, state: targetState}
 	targetF.NetworkAddress(targetAddress)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -475,9 +475,10 @@ func (d *Daemon) init() error {
 		store := d.gateway.ServerStore()
 		d.cluster, err = db.OpenCluster(
 			"db.bin", store, address, dir,
+			d.config.DqliteSetupTimeout,
 			dqlite.WithDialFunc(d.gateway.DialFunc()),
 			dqlite.WithContext(d.gateway.Context()),
-			dqlite.WithConnectionTimeout(d.config.DqliteSetupTimeout),
+			dqlite.WithConnectionTimeout(10*time.Second),
 			dqlite.WithLogFunc(cluster.DqliteLog),
 		)
 		if err == nil {

--- a/lxd/db/query/retry.go
+++ b/lxd/db/query/retry.go
@@ -16,7 +16,7 @@ import (
 func Retry(f func() error) error {
 	// TODO: the retry loop should be configurable.
 	var err error
-	for i := 0; i < 20; i++ {
+	for i := 0; i < 5; i++ {
 		err = f()
 		if err != nil {
 			logger.Debugf("Database error: %#v", err)

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/CanonicalLtd/go-dqlite"
 	"github.com/CanonicalLtd/raft-test"
@@ -63,7 +64,7 @@ func NewTestCluster(t *testing.T) (*Cluster, func()) {
 	}
 
 	cluster, err := OpenCluster(
-		"test.db", store, "1", "/unused/db/dir",
+		"test.db", store, "1", "/unused/db/dir", 5*time.Second,
 		dqlite.WithLogFunc(log), dqlite.WithDialFunc(dial))
 	require.NoError(t, err)
 

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -11,7 +11,9 @@ import (
 	"os"
 	"time"
 
+	dqlite "github.com/CanonicalLtd/go-dqlite"
 	"github.com/mattn/go-sqlite3"
+	"github.com/pkg/errors"
 
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
@@ -509,7 +511,7 @@ func PreconditionFailed(err error) Response {
  * SmartError returns the right error message based on err.
  */
 func SmartError(err error) Response {
-	switch err {
+	switch errors.Cause(err) {
 	case nil:
 		return EmptySyncResponse
 	case os.ErrNotExist:
@@ -524,6 +526,8 @@ func SmartError(err error) Response {
 		return Conflict(nil)
 	case sqlite3.ErrConstraintUnique:
 		return Conflict(nil)
+	case dqlite.ErrNoAvailableLeader:
+		return Unavailable(err)
 	default:
 		return InternalError(err)
 	}


### PR DESCRIPTION
This makes database queries timeout after 10 seconds if quorum is lost **after** the node had initially started fine (e.g. cluster was up but a majority of db nodes were shutdown), which is probably the most common case we want to address.

What it does **not** do is trying to make the node minimally operational (e.g. server responding to "lxc info" without hanging forever) in the case where the daemon is still going through its startup sequence and it's stuck waiting for other nodes to be upgraded, since it found that its own version is more recent. That information is of course present in the logs of the daemon tho, so it should be pretty obvious to figure what's wrong with the stuck client.

Given that we're going to trigger snap refreshes explicitly when we detect that one node has upgraded, probably it's not worth too much polishing the UX for that window of time. It desired, that can be done in a separate branch.

(partially) Fixes #4479.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>