### PR TITLE
network: add netns_getifaddrs()

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -431,6 +431,14 @@ func (d *Daemon) init() error {
 		return err
 	}
 
+	/* Check if Netlink RTM_GET{ADDR,LINK} requests are fully netnsid aware. */
+	d.os.NetnsGetifaddrs = CanUseNetnsGetifaddrs()
+	if d.os.NetnsGetifaddrs {
+		logger.Debugf("Running kernel supports netnsid-based network retrieval")
+	} else {
+		logger.Debugf("Running kernel does not support netnsid-based network retrieval")
+	}
+
 	/* Initialize the database */
 	dump, err := initializeDbObject(d)
 	if err != nil {

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -1,0 +1,120 @@
+package main
+
+/*
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/types.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "../shared/netns_getifaddrs.c"
+
+bool netnsid_aware = false;
+
+static int netns_set_nsid(int fd)
+{
+	int sockfd, ret;
+	char buf[NLMSG_ALIGN(sizeof(struct nlmsghdr)) +
+		 NLMSG_ALIGN(sizeof(struct rtgenmsg)) +
+		 NLMSG_ALIGN(1024)];
+	struct nlmsghdr *hdr;
+	struct rtgenmsg *msg;
+	int saved_errno;
+	__s32 ns_id = -1;
+	__u32 netns_fd = fd;
+
+	sockfd = netlink_open(NETLINK_ROUTE);
+	if (sockfd < 0)
+		return -1;
+
+	memset(buf, 0, sizeof(buf));
+	hdr = (struct nlmsghdr *)buf;
+	msg = (struct rtgenmsg *)NLMSG_DATA(hdr);
+
+	hdr->nlmsg_len = NLMSG_LENGTH(sizeof(*msg));
+	hdr->nlmsg_type = RTM_NEWNSID;
+	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = RTM_NEWNSID;
+	msg->rtgen_family = AF_UNSPEC;
+
+	addattr(hdr, 1024, __LXC_NETNSA_FD, &netns_fd, sizeof(netns_fd));
+	addattr(hdr, 1024, __LXC_NETNSA_NSID, &ns_id, sizeof(ns_id));
+
+	ret = netlink_transaction(sockfd, hdr, hdr);
+	saved_errno = errno;
+	close(sockfd);
+	errno = saved_errno;
+	if (ret < 0)
+		return -1;
+
+	return 0;
+}
+
+void checkfeature() {
+	int netnsid, ret;
+	struct netns_ifaddrs *ifaddrs;
+	int hostnetns_fd = -1, newnetns_fd = -1;
+
+	hostnetns_fd = open("/proc/self/ns/net", O_RDONLY | O_CLOEXEC);
+	if (hostnetns_fd < 0) {
+		fprintf(stderr, "Failed to preserve host network namespace\n");
+		goto on_error;
+	}
+
+	ret = unshare(CLONE_NEWNET);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to unshare network namespace\n");
+		goto on_error;
+	}
+
+	newnetns_fd = open("/proc/self/ns/net", O_RDONLY | O_CLOEXEC);
+	if (newnetns_fd < 0) {
+		fprintf(stderr, "Failed to preserve new network namespace\n");
+		goto on_error;
+	}
+
+	ret = setns(hostnetns_fd, CLONE_NEWNET);
+	if (ret < 0) {
+		fprintf(stderr, "Failed to attach to host network namespace\n");
+		goto on_error;
+	}
+
+	ret = netns_set_nsid(newnetns_fd);
+	if (ret < 0) {
+		fprintf(stderr, "failed to set network namespace identifier\n");
+		goto on_error;
+	}
+
+	netnsid = netns_get_nsid(newnetns_fd);
+	if (netnsid < 0) {
+		fprintf(stderr, "Failed to get network namespace identifier\n");
+		goto on_error;
+	}
+
+	ret = netns_getifaddrs(&ifaddrs, netnsid, &netnsid_aware);
+	netns_freeifaddrs(ifaddrs);
+	if (ret < 0)
+		fprintf(stderr, "Netlink is not fully network namespace id aware\n");
+
+on_error:
+	if (hostnetns_fd >= 0)
+		close(hostnetns_fd);
+
+	if (newnetns_fd >= 0)
+		close(newnetns_fd);
+}
+*/
+import "C"
+
+func CanUseNetnsGetifaddrs() bool {
+	return bool(C.netnsid_aware)
+}

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -3,11 +3,10 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 
 	"github.com/spf13/cobra"
 
-	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared"
 )
 
 /*
@@ -93,15 +92,9 @@ func (c *cmdForknet) Command() *cobra.Command {
 }
 
 func (c *cmdForknet) RunInfo(cmd *cobra.Command, args []string) error {
-	networks := map[string]api.NetworkState{}
-
-	interfaces, err := net.Interfaces()
+	networks, err := shared.NetnsGetifaddrs(-1)
 	if err != nil {
 		return err
-	}
-
-	for _, iface := range interfaces {
-		networks[iface.Name] = networkGetState(iface)
 	}
 
 	buf, err := json.Marshal(networks)

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -34,6 +34,7 @@ package main
 #include <unistd.h>
 
 // External functions
+extern void checkfeature();
 extern void forkfile();
 extern void forkmount();
 extern void forknet();
@@ -231,19 +232,22 @@ __attribute__((constructor)) void init(void) {
 	while (*cmdline_cur != 0)
 		cmdline_cur++;
 	cmdline_cur++;
-	if (cmdline_size <= cmdline_cur - cmdline_buf)
+	if (cmdline_size <= cmdline_cur - cmdline_buf) {
+		checkfeature();
 		return;
+	}
 
 	// Intercepts some subcommands
-	if (strcmp(cmdline_cur, "forkfile") == 0) {
+	if (strcmp(cmdline_cur, "forkfile") == 0)
 		forkfile();
-	} else if (strcmp(cmdline_cur, "forkmount") == 0) {
+	else if (strcmp(cmdline_cur, "forkmount") == 0)
 		forkmount();
-	} else if (strcmp(cmdline_cur, "forknet") == 0) {
+	else if (strcmp(cmdline_cur, "forknet") == 0)
 		forknet();
-	} else if (strcmp(cmdline_cur, "forkproxy") == 0) {
+	else if (strcmp(cmdline_cur, "forkproxy") == 0)
 		forkproxy();
-	}
+	else if (strncmp(cmdline_cur, "-", 1) == 0 || strcmp(cmdline_cur, "daemon") == 0)
+		checkfeature();
 }
 */
 import "C"

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1129,47 +1129,6 @@ func networkGetState(netIf net.Interface) api.NetworkState {
 	}
 
 	// Get counters
-	content, err := ioutil.ReadFile("/proc/net/dev")
-	if err == nil {
-		for _, line := range strings.Split(string(content), "\n") {
-			fields := strings.Fields(line)
-
-			if len(fields) != 17 {
-				continue
-			}
-
-			intName := strings.TrimSuffix(fields[0], ":")
-			if intName != netIf.Name {
-				continue
-			}
-
-			rxBytes, err := strconv.ParseInt(fields[1], 10, 64)
-			if err != nil {
-				continue
-			}
-
-			rxPackets, err := strconv.ParseInt(fields[2], 10, 64)
-			if err != nil {
-				continue
-			}
-
-			txBytes, err := strconv.ParseInt(fields[9], 10, 64)
-			if err != nil {
-				continue
-			}
-
-			txPackets, err := strconv.ParseInt(fields[10], 10, 64)
-			if err != nil {
-				continue
-			}
-
-			network.Counters.BytesSent = txBytes
-			network.Counters.BytesReceived = rxBytes
-			network.Counters.PacketsSent = txPackets
-			network.Counters.PacketsReceived = rxPackets
-			break
-		}
-	}
-
+	network.Counters = shared.NetworkGetCounters(netIf.Name)
 	return network
 }

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -57,6 +57,7 @@ type OS struct {
 	CGroupPidsController    bool
 	CGroupSwapAccounting    bool
 	InotifyWatch            InotifyInfo
+	NetnsGetifaddrs         bool
 
 	MockMode bool // If true some APIs will be mocked (for testing)
 }

--- a/shared/netns_getifaddrs.c
+++ b/shared/netns_getifaddrs.c
@@ -1,0 +1,502 @@
+// +build none
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/if.h>
+#include <linux/if_addr.h>
+#include <linux/if_link.h>
+#include <linux/if_packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/types.h>
+#include <net/ethernet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "network.c"
+
+struct netns_ifaddrs {
+	struct netns_ifaddrs *ifa_next;
+
+	// Can - but shouldn't be - NULL.
+	char *ifa_name;
+
+	// This field is not present struct ifaddrs
+	int ifa_ifindex;
+
+	unsigned ifa_flags;
+
+	// This field is not present struct ifaddrs
+	int ifa_mtu;
+
+	// This field is not present struct ifaddrs
+	int ifa_prefixlen;
+
+	struct sockaddr *ifa_addr;
+	struct sockaddr *ifa_netmask;
+	union {
+		struct sockaddr *ifu_broadaddr;
+		struct sockaddr *ifu_dstaddr;
+	} ifa_ifu;
+
+	// If you don't know what this is for don't touch it.
+	void *ifa_data;
+};
+
+#define __ifa_broadaddr ifa_ifu.ifu_broadaddr
+#define __ifa_dstaddr ifa_ifu.ifu_dstaddr
+
+// getifaddrs() reports hardware addresses with PF_PACKET that implies
+// struct sockaddr_ll.  But e.g. Infiniband socket address length is
+// longer than sockaddr_ll.ssl_addr[8] can hold. Use this hack struct
+// to extend ssl_addr - callers should be able to still use it.
+struct sockaddr_ll_hack {
+	unsigned short sll_family, sll_protocol;
+	int sll_ifindex;
+	unsigned short sll_hatype;
+	unsigned char sll_pkttype, sll_halen;
+	unsigned char sll_addr[24];
+};
+
+union sockany {
+	struct sockaddr sa;
+	struct sockaddr_ll_hack ll;
+	struct sockaddr_in v4;
+	struct sockaddr_in6 v6;
+};
+
+struct ifaddrs_storage {
+	struct netns_ifaddrs ifa;
+	struct ifaddrs_storage *hash_next;
+	union sockany addr, netmask, ifu;
+	unsigned int index;
+	char name[IFNAMSIZ + 1];
+};
+
+struct ifaddrs_ctx {
+	struct ifaddrs_storage *first;
+	struct ifaddrs_storage *last;
+	struct ifaddrs_storage *hash[IFADDRS_HASH_SIZE];
+};
+
+static void netns_freeifaddrs(struct netns_ifaddrs *ifp)
+{
+	struct netns_ifaddrs *n;
+
+	while (ifp) {
+		n = ifp->ifa_next;
+		free(ifp);
+		ifp = n;
+	}
+}
+
+static void copy_addr(struct sockaddr **r, int af, union sockany *sa,
+		      void *addr, size_t addrlen, int ifindex)
+{
+	uint8_t *dst;
+	size_t len;
+
+	switch (af) {
+	case AF_INET:
+		dst = (uint8_t *)&sa->v4.sin_addr;
+		len = 4;
+		break;
+	case AF_INET6:
+		dst = (uint8_t *)&sa->v6.sin6_addr;
+		len = 16;
+		if (__IN6_IS_ADDR_LINKLOCAL(addr) ||
+		    __IN6_IS_ADDR_MC_LINKLOCAL(addr))
+			sa->v6.sin6_scope_id = ifindex;
+		break;
+	default:
+		return;
+	}
+
+	if (addrlen < len)
+		return;
+
+	sa->sa.sa_family = af;
+
+	memcpy(dst, addr, len);
+
+	*r = &sa->sa;
+}
+
+static void gen_netmask(struct sockaddr **r, int af, union sockany *sa,
+			int prefixlen)
+{
+	uint8_t addr[16] = {0};
+	int i;
+
+	if ((size_t)prefixlen > 8 * sizeof(addr))
+		prefixlen = 8 * sizeof(addr);
+
+	i = prefixlen / 8;
+
+	memset(addr, 0xff, i);
+
+	if ((size_t)i < sizeof(addr))
+		addr[i++] = 0xff << (8 - (prefixlen % 8));
+
+	copy_addr(r, af, sa, addr, sizeof(addr), 0);
+}
+
+static void copy_lladdr(struct sockaddr **r, union sockany *sa, void *addr,
+			size_t addrlen, int ifindex, unsigned short hatype)
+{
+	if (addrlen > sizeof(sa->ll.sll_addr))
+		return;
+
+	sa->ll.sll_family = AF_PACKET;
+	sa->ll.sll_ifindex = ifindex;
+	sa->ll.sll_hatype = hatype;
+	sa->ll.sll_halen = addrlen;
+
+	memcpy(sa->ll.sll_addr, addr, addrlen);
+
+	*r = &sa->sa;
+}
+
+static int nl_msg_to_ifaddr(void *pctx, bool *netnsid_aware, struct nlmsghdr *h)
+{
+	struct ifaddrs_storage *ifs, *ifs0;
+	struct rtattr *rta;
+	int stats_len = 0;
+	struct ifinfomsg *ifi = __NLMSG_DATA(h);
+	struct ifaddrmsg *ifa = __NLMSG_DATA(h);
+	struct ifaddrs_ctx *ctx = pctx;
+
+	if (h->nlmsg_type == RTM_NEWLINK) {
+		for (rta = __NLMSG_RTA(h, sizeof(*ifi)); __NLMSG_RTAOK(rta, h);
+		     rta = __RTA_NEXT(rta)) {
+			if (rta->rta_type != IFLA_STATS)
+				continue;
+
+			stats_len = __RTA_DATALEN(rta);
+			break;
+		}
+	} else {
+		for (ifs0 = ctx->hash[ifa->ifa_index % IFADDRS_HASH_SIZE]; ifs0;
+		     ifs0 = ifs0->hash_next)
+			if (ifs0->index == ifa->ifa_index)
+				break;
+		if (!ifs0)
+			return 0;
+	}
+
+	ifs = calloc(1, sizeof(struct ifaddrs_storage) + stats_len);
+	if (!ifs) {
+		errno = ENOMEM;
+		return -1;
+	}
+
+	if (h->nlmsg_type == RTM_NEWLINK) {
+		ifs->index = ifi->ifi_index;
+		ifs->ifa.ifa_ifindex = ifi->ifi_index;
+		ifs->ifa.ifa_flags = ifi->ifi_flags;
+
+		for (rta = __NLMSG_RTA(h, sizeof(*ifi)); __NLMSG_RTAOK(rta, h);
+		     rta = __RTA_NEXT(rta)) {
+			switch (rta->rta_type) {
+			case IFLA_IFNAME:
+				if (__RTA_DATALEN(rta) < sizeof(ifs->name)) {
+					memcpy(ifs->name, __RTA_DATA(rta),
+					       __RTA_DATALEN(rta));
+					ifs->ifa.ifa_name = ifs->name;
+				}
+				break;
+			case IFLA_ADDRESS:
+				copy_lladdr(&ifs->ifa.ifa_addr, &ifs->addr,
+					    __RTA_DATA(rta), __RTA_DATALEN(rta),
+					    ifi->ifi_index, ifi->ifi_type);
+				break;
+			case IFLA_BROADCAST:
+				copy_lladdr(&ifs->ifa.__ifa_broadaddr, &ifs->ifu,
+					    __RTA_DATA(rta), __RTA_DATALEN(rta),
+					    ifi->ifi_index, ifi->ifi_type);
+				break;
+			case IFLA_STATS:
+				ifs->ifa.ifa_data = (void *)(ifs + 1);
+				memcpy(ifs->ifa.ifa_data, __RTA_DATA(rta),
+				       __RTA_DATALEN(rta));
+				break;
+			case IFLA_MTU:
+				memcpy(&ifs->ifa.ifa_mtu, __RTA_DATA(rta),
+				       sizeof(int));
+				printf("%d\n", ifs->ifa.ifa_mtu);
+				break;
+			case IFLA_TARGET_NETNSID:
+				*netnsid_aware = true;
+				break;
+			}
+		}
+
+		if (ifs->ifa.ifa_name) {
+			unsigned int bucket = ifs->index % IFADDRS_HASH_SIZE;
+			ifs->hash_next = ctx->hash[bucket];
+			ctx->hash[bucket] = ifs;
+		}
+	} else {
+		ifs->ifa.ifa_name = ifs0->ifa.ifa_name;
+		ifs->ifa.ifa_mtu = ifs0->ifa.ifa_mtu;
+		ifs->ifa.ifa_ifindex = ifs0->ifa.ifa_ifindex;
+		ifs->ifa.ifa_flags = ifs0->ifa.ifa_flags;
+
+		for (rta = __NLMSG_RTA(h, sizeof(*ifa)); __NLMSG_RTAOK(rta, h);
+		     rta = __RTA_NEXT(rta)) {
+			switch (rta->rta_type) {
+			case IFA_ADDRESS:
+				// If ifa_addr is already set we, received an
+				// IFA_LOCAL before so treat this as destination
+				// address.
+				if (ifs->ifa.ifa_addr)
+					copy_addr(&ifs->ifa.__ifa_dstaddr,
+						  ifa->ifa_family, &ifs->ifu,
+						  __RTA_DATA(rta),
+						  __RTA_DATALEN(rta),
+						  ifa->ifa_index);
+				else
+					copy_addr(&ifs->ifa.ifa_addr,
+						  ifa->ifa_family, &ifs->addr,
+						  __RTA_DATA(rta),
+						  __RTA_DATALEN(rta),
+						  ifa->ifa_index);
+				break;
+			case IFA_BROADCAST:
+				copy_addr(&ifs->ifa.__ifa_broadaddr,
+					  ifa->ifa_family, &ifs->ifu,
+					  __RTA_DATA(rta), __RTA_DATALEN(rta),
+					  ifa->ifa_index);
+				break;
+			case IFA_LOCAL:
+				// If ifa_addr is set and we get IFA_LOCAL,
+				// assume we have a point-to-point network. Move
+				// address to correct field.
+				if (ifs->ifa.ifa_addr) {
+					ifs->ifu = ifs->addr;
+					ifs->ifa.__ifa_dstaddr = &ifs->ifu.sa;
+
+					memset(&ifs->addr, 0, sizeof(ifs->addr));
+				}
+
+				copy_addr(&ifs->ifa.ifa_addr, ifa->ifa_family,
+					  &ifs->addr, __RTA_DATA(rta),
+					  __RTA_DATALEN(rta), ifa->ifa_index);
+				break;
+			case IFA_LABEL:
+				if (__RTA_DATALEN(rta) < sizeof(ifs->name)) {
+					memcpy(ifs->name, __RTA_DATA(rta),
+					       __RTA_DATALEN(rta));
+					ifs->ifa.ifa_name = ifs->name;
+				}
+				break;
+			case IFA_TARGET_NETNSID:
+				*netnsid_aware = true;
+				break;
+			}
+		}
+
+		if (ifs->ifa.ifa_addr) {
+			gen_netmask(&ifs->ifa.ifa_netmask, ifa->ifa_family,
+				    &ifs->netmask, ifa->ifa_prefixlen);
+			ifs->ifa.ifa_prefixlen = ifa->ifa_prefixlen;
+		}
+	}
+
+	if (ifs->ifa.ifa_name) {
+		if (!ctx->first)
+			ctx->first = ifs;
+
+		if (ctx->last)
+			ctx->last->ifa.ifa_next = &ifs->ifa;
+
+		ctx->last = ifs;
+	} else {
+		free(ifs);
+	}
+
+	return 0;
+}
+
+#define NLMSG_TAIL(nmsg)                      \
+	((struct rtattr *)(((void *)(nmsg)) + \
+			   __NETLINK_ALIGN((nmsg)->nlmsg_len)))
+
+static int __netlink_recv(int fd, unsigned int seq, int type, int af,
+			  __s32 netns_id, bool *netnsid_aware,
+			  int (*cb)(void *ctx, bool *netnsid_aware, struct nlmsghdr *h),
+			  void *ctx)
+{
+	char getlink_buf[__NETLINK_ALIGN(sizeof(struct nlmsghdr)) +
+			 __NETLINK_ALIGN(sizeof(struct ifinfomsg)) +
+			 __NETLINK_ALIGN(1024)];
+	char getaddr_buf[__NETLINK_ALIGN(sizeof(struct nlmsghdr)) +
+			 __NETLINK_ALIGN(sizeof(struct ifaddrmsg)) +
+			 __NETLINK_ALIGN(1024)];
+	char *buf;
+	struct nlmsghdr *hdr;
+	struct ifinfomsg *ifi_msg;
+	struct ifaddrmsg *ifa_msg;
+	union {
+		uint8_t buf[8192];
+		struct {
+			struct nlmsghdr nlh;
+			struct rtgenmsg g;
+		} req;
+		struct nlmsghdr reply;
+	} u;
+	int r, property, ret;
+
+	if (type == RTM_GETLINK)
+		buf = getlink_buf;
+	else if (type == RTM_GETADDR)
+		buf = getaddr_buf;
+	else
+		return -1;
+
+	memset(buf, 0, sizeof(*buf));
+	hdr = (struct nlmsghdr *)buf;
+	if (type == RTM_GETLINK)
+		ifi_msg = (struct ifinfomsg *)__NLMSG_DATA(hdr);
+	else
+		ifa_msg = (struct ifaddrmsg *)__NLMSG_DATA(hdr);
+
+	if (type == RTM_GETLINK)
+		hdr->nlmsg_len = NLMSG_LENGTH(sizeof(*ifi_msg));
+	else
+		hdr->nlmsg_len = NLMSG_LENGTH(sizeof(*ifa_msg));
+
+	hdr->nlmsg_type = type;
+	hdr->nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = seq;
+	if (type == RTM_GETLINK)
+		ifi_msg->ifi_family = af;
+	else
+		ifa_msg->ifa_family = af;
+
+	errno = EINVAL;
+	if (type == RTM_GETLINK)
+		property = IFLA_TARGET_NETNSID;
+	else if (type == RTM_GETADDR)
+		property = IFA_TARGET_NETNSID;
+	else
+		return -1;
+
+	if (netns_id >= 0)
+		addattr(hdr, 1024, property, &netns_id, sizeof(netns_id));
+
+	r = __netlink_send(fd, hdr);
+	if (r < 0)
+		return -1;
+
+	for (;;) {
+		r = recv(fd, u.buf, sizeof(u.buf), MSG_DONTWAIT);
+		if (r <= 0)
+			return -1;
+
+		for (hdr = &u.reply; __NLMSG_OK(hdr, (void *)&u.buf[r]);
+		     hdr = __NLMSG_NEXT(hdr)) {
+			if (hdr->nlmsg_type == NLMSG_DONE)
+				return 0;
+
+			if (hdr->nlmsg_type == NLMSG_ERROR) {
+				errno = EINVAL;
+				return -1;
+			}
+
+			ret = cb(ctx, netnsid_aware, hdr);
+			if (ret)
+				return ret;
+		}
+	}
+}
+
+static int __rtnl_enumerate(int link_af, int addr_af, __s32 netns_id,
+			    bool *netnsid_aware,
+			    int (*cb)(void *ctx, bool *netnsid_aware, struct nlmsghdr *h),
+			    void *ctx)
+{
+	int fd, r, saved_errno;
+	bool getaddr_netnsid_aware = false, getlink_netnsid_aware = false;
+
+	fd = socket(PF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+	if (fd < 0)
+		return -1;
+
+	r = __netlink_recv(fd, 1, RTM_GETLINK, link_af, netns_id,
+			   &getlink_netnsid_aware, cb, ctx);
+	if (!r)
+		r = __netlink_recv(fd, 2, RTM_GETADDR, netns_id, addr_af,
+				   &getaddr_netnsid_aware, cb, ctx);
+
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+
+	if (getaddr_netnsid_aware && getlink_netnsid_aware)
+		*netnsid_aware = true;
+	else
+		*netnsid_aware = false;
+
+	return r;
+}
+
+static int netns_getifaddrs(struct netns_ifaddrs **ifap, __s32 netns_id,
+			    bool *netnsid_aware)
+{
+	int r, saved_errno;
+	struct ifaddrs_ctx _ctx;
+	struct ifaddrs_ctx *ctx = &_ctx;
+
+	memset(ctx, 0, sizeof *ctx);
+
+	r = __rtnl_enumerate(AF_UNSPEC, AF_UNSPEC, netns_id, netnsid_aware,
+			     nl_msg_to_ifaddr, ctx);
+	saved_errno = errno;
+	if (r < 0)
+		netns_freeifaddrs(&ctx->first->ifa);
+	else
+		*ifap = &ctx->first->ifa;
+	errno = saved_errno;
+
+	return r;
+}
+
+// Get a pointer to the address structure from a sockaddr.
+static void *get_addr_ptr(struct sockaddr *sockaddr_ptr)
+{
+	if (sockaddr_ptr->sa_family == AF_INET)
+		return &((struct sockaddr_in *)sockaddr_ptr)->sin_addr;
+
+	if (sockaddr_ptr->sa_family == AF_INET6)
+		return &((struct sockaddr_in6 *)sockaddr_ptr)->sin6_addr;
+
+	return NULL;
+}
+
+static char *get_packet_address(struct sockaddr *sockaddr_ptr, char *buf, size_t buflen)
+{
+	char *slider = buf;
+	unsigned char *m = ((struct sockaddr_ll *)sockaddr_ptr)->sll_addr;
+	unsigned char n = ((struct sockaddr_ll *)sockaddr_ptr)->sll_halen;
+
+	for (unsigned char i = 0; i < n; i++) {
+		int ret;
+
+		ret = snprintf(slider, buflen, "%02x%s", m[i], (i + 1) < n ? ":" : "");
+		if (ret < 0 || (size_t)ret >= buflen)
+			return NULL;
+
+		buflen -= ret;
+		slider = (slider + ret);
+	}
+
+	return buf;
+}

--- a/shared/network.c
+++ b/shared/network.c
@@ -1,0 +1,316 @@
+// +build none
+
+#define _GNU_SOURCE
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/if.h>
+#include <linux/if_addr.h>
+#include <linux/if_link.h>
+#include <linux/if_packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/types.h>
+#include <net/ethernet.h>
+#include <netinet/in.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#ifndef NETNS_RTA
+#define NETNS_RTA(r) \
+	((struct rtattr *)(((char *)(r)) + NLMSG_ALIGN(sizeof(struct rtgenmsg))))
+#endif
+
+#ifdef IFLA_IF_NETNSID
+#ifndef IFLA_TARGET_NETNSID
+#define IFLA_TARGET_NETNSID = IFLA_IF_NETNSID
+#endif
+#else
+#define IFLA_IF_NETNSID 46
+#define IFLA_TARGET_NETNSID 46
+#endif
+
+#ifndef IFA_TARGET_NETNSID
+#define IFA_TARGET_NETNSID 10
+#endif
+
+#define IFADDRS_HASH_SIZE 64
+
+#define __NETLINK_ALIGN(len) (((len) + 3) & ~3)
+
+#define __NLMSG_OK(nlh, end) \
+	((char *)(end) - (char *)(nlh) >= sizeof(struct nlmsghdr))
+
+#define __NLMSG_NEXT(nlh) \
+	(struct nlmsghdr *)((char *)(nlh) + __NETLINK_ALIGN((nlh)->nlmsg_len))
+
+#define __NLMSG_DATA(nlh) ((void *)((char *)(nlh) + sizeof(struct nlmsghdr)))
+
+#define __NLMSG_DATAEND(nlh) ((char *)(nlh) + (nlh)->nlmsg_len)
+
+#define __NLMSG_RTA(nlh, len)                               \
+	((void *)((char *)(nlh) + sizeof(struct nlmsghdr) + \
+		  __NETLINK_ALIGN(len)))
+
+#define __RTA_DATALEN(rta) ((rta)->rta_len - sizeof(struct rtattr))
+
+#define __RTA_NEXT(rta) \
+	(struct rtattr *)((char *)(rta) + __NETLINK_ALIGN((rta)->rta_len))
+
+#define __RTA_OK(nlh, end) \
+	((char *)(end) - (char *)(rta) >= sizeof(struct rtattr))
+
+#define __NLMSG_RTAOK(rta, nlh) __RTA_OK(rta, __NLMSG_DATAEND(nlh))
+
+#define __IN6_IS_ADDR_LINKLOCAL(a) \
+	((((uint8_t *)(a))[0]) == 0xfe && (((uint8_t *)(a))[1] & 0xc0) == 0x80)
+
+#define __IN6_IS_ADDR_MC_LINKLOCAL(a) \
+	(IN6_IS_ADDR_MULTICAST(a) && ((((uint8_t *)(a))[1] & 0xf) == 0x2))
+
+#define __RTA_DATA(rta) ((void *)((char *)(rta) + sizeof(struct rtattr)))
+
+
+#define NLMSG_TAIL(nmsg)                      \
+	((struct rtattr *)(((void *)(nmsg)) + \
+			   __NETLINK_ALIGN((nmsg)->nlmsg_len)))
+
+enum {
+	__LXC_NETNSA_NONE,
+#define __LXC_NETNSA_NSID_NOT_ASSIGNED -1
+	__LXC_NETNSA_NSID,
+	__LXC_NETNSA_PID,
+	__LXC_NETNSA_FD,
+	__LXC_NETNSA_MAX,
+};
+
+static int netlink_open(int protocol)
+{
+	int fd, ret;
+	socklen_t socklen;
+	struct sockaddr_nl local;
+	int sndbuf = 32768;
+	int rcvbuf = 32768;
+	int err = -1;
+
+	fd = socket(AF_NETLINK, SOCK_RAW, protocol);
+	if (fd < 0)
+		return -1;
+
+	ret = setsockopt(fd, SOL_SOCKET, SO_SNDBUF, &sndbuf, sizeof(sndbuf));
+	if (ret < 0)
+		goto out;
+
+	ret = setsockopt(fd, SOL_SOCKET, SO_RCVBUF, &rcvbuf, sizeof(rcvbuf));
+	if (ret < 0)
+		goto out;
+
+	memset(&local, 0, sizeof(local));
+	local.nl_family = AF_NETLINK;
+	local.nl_groups = 0;
+
+	ret = bind(fd, (struct sockaddr *)&local, sizeof(local));
+	if (ret < 0)
+		goto out;
+
+	socklen = sizeof(local);
+	ret = getsockname(fd, (struct sockaddr *)&local, &socklen);
+	if (ret < 0)
+		goto out;
+
+	errno = -EINVAL;
+	if (socklen != sizeof(local))
+		goto out;
+
+	errno = -EINVAL;
+	if (local.nl_family != AF_NETLINK)
+		goto out;
+
+	return fd;
+
+out:
+	close(fd);
+	return err;
+}
+
+static int netlink_recv(int fd, struct nlmsghdr *nlmsghdr)
+{
+	int ret;
+	struct sockaddr_nl nladdr;
+	struct iovec iov = {
+	    .iov_base = nlmsghdr,
+	    .iov_len = nlmsghdr->nlmsg_len,
+	};
+
+	struct msghdr msg = {
+	    .msg_name = &nladdr,
+	    .msg_namelen = sizeof(nladdr),
+	    .msg_iov = &iov,
+	    .msg_iovlen = 1,
+	};
+
+	memset(&nladdr, 0, sizeof(nladdr));
+	nladdr.nl_family = AF_NETLINK;
+	nladdr.nl_pid = 0;
+	nladdr.nl_groups = 0;
+
+again:
+	ret = recvmsg(fd, &msg, 0);
+	if (ret < 0) {
+		if (errno == EINTR)
+			goto again;
+
+		return -1;
+	}
+
+	if (!ret)
+		return 0;
+
+	if (msg.msg_flags & MSG_TRUNC && ((__u32)ret == nlmsghdr->nlmsg_len)) {
+		errno = EMSGSIZE;
+		ret = -1;
+	}
+
+	return ret;
+}
+
+static int __netlink_send(int fd, struct nlmsghdr *nlmsghdr)
+{
+	int ret;
+	struct sockaddr_nl nladdr;
+	struct iovec iov = {
+	    .iov_base = nlmsghdr,
+	    .iov_len = nlmsghdr->nlmsg_len,
+	};
+	struct msghdr msg = {
+	    .msg_name = &nladdr,
+	    .msg_namelen = sizeof(nladdr),
+	    .msg_iov = &iov,
+	    .msg_iovlen = 1,
+	};
+
+	memset(&nladdr, 0, sizeof(nladdr));
+	nladdr.nl_family = AF_NETLINK;
+	nladdr.nl_pid = 0;
+	nladdr.nl_groups = 0;
+
+	ret = sendmsg(fd, &msg, MSG_NOSIGNAL);
+	if (ret < 0)
+		return -1;
+
+	return ret;
+}
+
+static int netlink_transaction(int fd, struct nlmsghdr *request,
+			       struct nlmsghdr *answer)
+{
+	int ret;
+
+	ret = __netlink_send(fd, request);
+	if (ret < 0)
+		return -1;
+
+	ret = netlink_recv(fd, answer);
+	if (ret < 0)
+		return -1;
+
+	ret = 0;
+	if (answer->nlmsg_type == NLMSG_ERROR) {
+		struct nlmsgerr *err = (struct nlmsgerr *)__NLMSG_DATA(answer);
+		errno = -err->error;
+		if (err->error < 0)
+			ret = -1;
+	}
+
+	return ret;
+}
+
+static int parse_rtattr(struct rtattr *tb[], int max, struct rtattr *rta, int len)
+{
+	memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
+
+	while (RTA_OK(rta, len)) {
+		unsigned short type = rta->rta_type;
+
+		if ((type <= max) && (!tb[type]))
+			tb[type] = rta;
+
+		rta = RTA_NEXT(rta, len);
+	}
+
+	return 0;
+}
+
+static __s32 rta_getattr_s32(const struct rtattr *rta)
+{
+	return *(__s32 *)RTA_DATA(rta);
+}
+
+static int addattr(struct nlmsghdr *n, size_t maxlen, int type,
+		   const void *data, size_t alen)
+{
+	int len = RTA_LENGTH(alen);
+	struct rtattr *rta;
+
+	if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > maxlen)
+		return -1;
+
+	rta = NLMSG_TAIL(n);
+	rta->rta_type = type;
+	rta->rta_len = len;
+	if (alen)
+		memcpy(RTA_DATA(rta), data, alen);
+	n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
+
+	return 0;
+}
+
+static __s32 netns_get_nsid(int netns_fd)
+{
+	int fd, ret;
+	ssize_t len;
+	char buf[NLMSG_ALIGN(sizeof(struct nlmsghdr)) +
+		 NLMSG_ALIGN(sizeof(struct rtgenmsg)) + NLMSG_ALIGN(1024)];
+	struct rtattr *tb[__LXC_NETNSA_MAX + 1];
+	struct nlmsghdr *hdr;
+	struct rtgenmsg *msg;
+	int saved_errno;
+
+	fd = netlink_open(NETLINK_ROUTE);
+	if (fd < 0)
+		return -1;
+
+	memset(buf, 0, sizeof(buf));
+	hdr = (struct nlmsghdr *)buf;
+	msg = (struct rtgenmsg *)__NLMSG_DATA(hdr);
+
+	hdr->nlmsg_len = NLMSG_LENGTH(sizeof(*msg));
+	hdr->nlmsg_type = RTM_GETNSID;
+	hdr->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+	hdr->nlmsg_pid = 0;
+	hdr->nlmsg_seq = RTM_GETNSID;
+	msg->rtgen_family = AF_UNSPEC;
+
+	addattr(hdr, 1024, __LXC_NETNSA_FD, &netns_fd, sizeof(__s32));
+
+	ret = netlink_transaction(fd, hdr, hdr);
+	saved_errno = errno;
+	close(fd);
+	errno = saved_errno;
+	if (ret < 0)
+		return -1;
+
+	msg = __NLMSG_DATA(hdr);
+	len = hdr->nlmsg_len - NLMSG_SPACE(sizeof(*msg));
+	if (len < 0)
+		return -1;
+
+	parse_rtattr(tb, __LXC_NETNSA_MAX, NETNS_RTA(msg), len);
+	if (tb[__LXC_NETNSA_NSID])
+		return rta_getattr_s32(tb[__LXC_NETNSA_NSID]);
+
+	return -1;
+}

--- a/shared/network_linux.go
+++ b/shared/network_linux.go
@@ -1,14 +1,164 @@
 // +build linux
+// +build cgo
 
 package shared
 
 import (
+	"fmt"
 	"io"
+	"os"
+	"strings"
 
 	"github.com/gorilla/websocket"
 
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 )
+
+/*
+#include "../shared/netns_getifaddrs.c"
+*/
+import "C"
+
+func NetnsGetifaddrs(initPID int32) (map[string]api.ContainerStateNetwork, error) {
+	var netnsid_aware C.bool
+	var ifaddrs *C.struct_netns_ifaddrs
+	var netnsID C.__s32
+
+	if initPID > 0 {
+		f, err := os.Open(fmt.Sprintf("/proc/%d/ns/net", initPID))
+		if err != nil {
+			return nil, err
+		}
+		defer f.Close()
+
+		netnsID = C.netns_get_nsid(C.__s32(f.Fd()))
+		if netnsID < 0 {
+			return nil, fmt.Errorf("Failed to retrieve network namespace id")
+		}
+	} else {
+		netnsID = -1
+	}
+
+	ret := C.netns_getifaddrs(&ifaddrs, netnsID, &netnsid_aware)
+	if ret < 0 {
+		return nil, fmt.Errorf("Failed to retrieve network interfaces and addresses")
+	}
+	defer C.netns_freeifaddrs(ifaddrs)
+
+	if netnsID >= 0 && !netnsid_aware {
+		return nil, fmt.Errorf("Netlink requests are not fully network namespace id aware")
+	}
+
+	// We're using the interface name as key here but we should really
+	// switch to the ifindex at some point to handle ip aliasing correctly.
+	networks := map[string]api.ContainerStateNetwork{}
+
+	for addr := ifaddrs; addr != nil; addr = addr.ifa_next {
+		var address [C.INET6_ADDRSTRLEN]C.char
+		addNetwork, networkExists := networks[C.GoString(addr.ifa_name)]
+		if !networkExists {
+			addNetwork = api.ContainerStateNetwork{
+				Addresses: []api.ContainerStateNetworkAddress{},
+				Counters:  api.ContainerStateNetworkCounters{},
+			}
+		}
+
+		if addr.ifa_addr.sa_family == C.AF_INET || addr.ifa_addr.sa_family == C.AF_INET6 {
+			netState := "down"
+			netType := "unknown"
+
+			if (addr.ifa_flags & C.IFF_BROADCAST) > 0 {
+				netType = "broadcast"
+			}
+
+			if (addr.ifa_flags & C.IFF_LOOPBACK) > 0 {
+				netType = "loopback"
+			}
+
+			if (addr.ifa_flags & C.IFF_POINTOPOINT) > 0 {
+				netType = "point-to-point"
+			}
+
+			if (addr.ifa_flags & C.IFF_UP) > 0 {
+				netState = "up"
+			}
+
+			family := "inet"
+			if addr.ifa_addr.sa_family == C.AF_INET6 {
+				family = "inet6"
+			}
+
+			addr_ptr := C.get_addr_ptr(addr.ifa_addr)
+			if addr_ptr == nil {
+				return nil, fmt.Errorf("Failed to retrieve valid address pointer")
+			}
+
+			address_str := C.inet_ntop(C.int(addr.ifa_addr.sa_family), addr_ptr, &address[0], C.INET6_ADDRSTRLEN)
+			if address_str == nil {
+				return nil, fmt.Errorf("Failed to retrieve address string")
+			}
+
+			if addNetwork.Addresses == nil {
+				addNetwork.Addresses = []api.ContainerStateNetworkAddress{}
+			}
+
+			goAddrString := C.GoString(address_str)
+			scope := "global"
+			if strings.HasPrefix(goAddrString, "127") {
+				scope = "local"
+			}
+
+			if goAddrString == "::1" {
+				scope = "local"
+			}
+
+			if strings.HasPrefix(goAddrString, "169.254") {
+				scope = "link"
+			}
+
+			if strings.HasPrefix(goAddrString, "fe80:") {
+				scope = "link"
+			}
+
+			address := api.ContainerStateNetworkAddress{}
+			address.Family = family
+			address.Address = goAddrString
+			address.Netmask = fmt.Sprintf("%d", int(addr.ifa_prefixlen))
+			address.Scope = scope
+
+			addNetwork.Addresses = append(addNetwork.Addresses, address)
+			addNetwork.State = netState
+			addNetwork.Type = netType
+			addNetwork.Mtu = int(addr.ifa_mtu)
+		} else if addr.ifa_addr.sa_family == C.AF_PACKET {
+
+			if (addr.ifa_flags & C.IFF_LOOPBACK) == 0 {
+				var buf [1024]C.char
+
+				hwaddr := C.get_packet_address(addr.ifa_addr, &buf[0], 1024)
+				if hwaddr == nil {
+					return nil, fmt.Errorf("Failed to retrieve hardware address")
+				}
+
+				addNetwork.Hwaddr = C.GoString(hwaddr)
+			}
+
+			stats := (*C.struct_rtnl_link_stats)(addr.ifa_data)
+			if stats != nil {
+				addNetwork.Counters.BytesReceived = int64(stats.rx_bytes)
+				addNetwork.Counters.BytesSent = int64(stats.tx_bytes)
+				addNetwork.Counters.PacketsReceived = int64(stats.rx_packets)
+				addNetwork.Counters.PacketsSent = int64(stats.tx_packets)
+			}
+		}
+		ifName := C.GoString(addr.ifa_name)
+
+		networks[ifName] = addNetwork
+	}
+
+	return networks, nil
+}
 
 func WebsocketExecMirror(conn *websocket.Conn, w io.WriteCloser, r io.ReadCloser, exited chan bool, fd int) (chan bool, chan bool) {
 	readDone := make(chan bool, 1)


### PR DESCRIPTION
This commit introduces my concept of a network namespace aware
getifaddrs(), i.e. `netns_getifaddrs()`.
This presupposes a kernel that supports IF{L}A_TARGET_NETNSID.

I am also introducing:

```C
struct netns_ifaddrs {
	struct netns_ifaddrs *ifa_next;

	// Can - but shouldn't be - NULL.
	char *ifa_name;

	// This field is not present struct ifaddrs
	int ifa_ifindex;
	unsigned ifa_flags;

	// This field is not present struct ifaddrs
	int ifa_mtu;
	struct sockaddr *ifa_addr;
	struct sockaddr *ifa_netmask;
	union {
		struct sockaddr *ifu_broadaddr;
		struct sockaddr *ifu_dstaddr;
	} ifa_ifu;

	// If you don't know what this is for don't touch it.
	void *ifa_data;
};
```

which is a superset of struct ifaddrs. It contains additional
information such as the mtu and ifindex of the corresponding network
devices. Note though that the field ordering is not is different too. So
don't get any ideas of using memcpy() to copy from an old struct ifaddrs
into a struct netns_ifaddrs.
I would suggest using to either use a custom struct + map:

```go
type NetnsGetifaddrs struct {
	// Sensible fields for general stuff we need
}

var ifaddrs map[int]NetnsGetifaddrs
```

where the map keys are the ifindices of the interfaces or to translate
it into the standard GO struct for this type of information.

This commits also adds dumping infrastructure. It is not needed for LXD
and once the implemenation is complete it can be removed. But it is very
useful to debug the returned C struct itself and might be worth keeping.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>