### PR TITLE
lxd/containers: Force bring up of SRIOV parent

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7369,6 +7369,12 @@ func (c *containerLXC) fillSriovNetworkDevice(name string, m types.Device, reser
 		return nil, err
 	}
 
+	// Ensure parent is up (needed for Intel at least)
+	_, err = shared.RunCommand("ip", "link", "set", "dev", m["parent"], "up")
+	if err != nil {
+		return nil, err
+	}
+
 	// Check if any VFs are already enabled
 	nicName := ""
 	for i := 0; i < sriovNum; i++ {


### PR DESCRIPTION
Closes #5041

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>