### PR TITLE
nvidia: Default to compute,utility

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -34,50 +34,50 @@ currently supported:
 
 The currently supported keys are:
 
-Key                                     | Type      | Default       | Live update   | API extension                        | Description
-:--                                     | :---      | :------       | :----------   | :------------                        | :----------
-boot.autostart                          | boolean   | -             | n/a           | -                                    | Always start the container when LXD starts (if not set, restore last state)
-boot.autostart.delay                    | integer   | 0             | n/a           | -                                    | Number of seconds to wait after the container started before starting the next one
-boot.autostart.priority                 | integer   | 0             | n/a           | -                                    | What order to start the containers in (starting with highest)
-boot.host\_shutdown\_timeout            | integer   | 30            | yes           | container\_host\_shutdown\_timeout   | Seconds to wait for container to shutdown before it is force stopped
-boot.stop.priority                      | integer   | 0             | n/a           | container\_stop\_priority            | What order to shutdown the containers (starting with highest)
-environment.\*                          | string    | -             | yes (exec)    | -                                    | key/value environment variables to export to the container and set on exec
-limits.cpu                              | string    | - (all)       | yes           | -                                    | Number or range of CPUs to expose to the container
-limits.cpu.allowance                    | string    | 100%          | yes           | -                                    | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
-limits.cpu.priority                     | integer   | 10 (maximum)  | yes           | -                                    | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit) (integer between 0 and 10)
-limits.disk.priority                    | integer   | 5 (medium)    | yes           | -                                    | When under load, how much priority to give to the container's I/O requests (integer between 0 and 10)
-limits.kernel.\*                        | string    | -             | no            | kernel\_limits                       | This limits kernel resources per container (e.g. number of open files)
-limits.memory                           | string    | - (all)       | yes           | -                                    | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
-limits.memory.enforce                   | string    | hard          | yes           | -                                    | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
-limits.memory.swap                      | boolean   | true          | yes           | -                                    | Whether to allow some of the container's memory to be swapped out to disk
-limits.memory.swap.priority             | integer   | 10 (maximum)  | yes           | -                                    | The higher this is set, the least likely the container is to be swapped to disk (integer between 0 and 10)
-limits.network.priority                 | integer   | 0 (minimum)   | yes           | -                                    | When under load, how much priority to give to the container's network requests (integer between 0 and 10)
-limits.processes                        | integer   | - (max)       | yes           | -                                    | Maximum number of processes that can run in the container
-linux.kernel\_modules                   | string    | -             | yes           | -                                    | Comma separated list of kernel modules to load before starting the container
-migration.incremental.memory            | boolean   | false         | yes           | migration\_pre\_copy                 | Incremental memory transfer of the container's memory to reduce downtime.
-migration.incremental.memory.goal       | integer   | 70            | yes           | migration\_pre\_copy                 | Percentage of memory to have in sync before stopping the container.
-migration.incremental.memory.iterations | integer   | 10            | yes           | migration\_pre\_copy                 | Maximum number of transfer operations to go through before stopping the container.
-nvidia.driver.capabilities              | string    | all           | no            | nvidia\_runtime\_config              | What driver capabilities the container needs (sets libnvidia-container NVIDIA\_DRIVER\_CAPABILITIES)
-nvidia.runtime                          | boolean   | false         | no            | nvidia\_runtime                      | Pass the host NVIDIA and CUDA runtime libraries into the container
-nvidia.require.cuda                     | string    | -             | no            | nvidia\_runtime\_config              | Version expression for the required CUDA version (sets libnvidia-container NVIDIA\_REQUIRE\_CUDA)
-nvidia.require.driver                   | string    | -             | no            | nvidia\_runtime\_config              | Version expression for the required driver version (sets libnvidia-container NVIDIA\_REQUIRE\_DRIVER)
-raw.apparmor                            | blob      | -             | yes           | -                                    | Apparmor profile entries to be appended to the generated profile
-raw.idmap                               | blob      | -             | no            | id\_map                              | Raw idmap configuration (e.g. "both 1000 1000")
-raw.lxc                                 | blob      | -             | no            | -                                    | Raw LXC configuration to be appended to the generated one
-raw.seccomp                             | blob      | -             | no            | container\_syscall\_filtering        | Raw Seccomp configuration
-security.devlxd                         | boolean   | true          | no            | restrict\_devlxd                     | Controls the presence of /dev/lxd in the container
-security.devlxd.images                  | boolean   | false         | no            | devlxd\_images                       | Controls the availability of the /1.0/images API over devlxd
-security.idmap.base                     | integer   | -             | no            | id\_map\_base                        | The base host ID to use for the allocation (overrides auto-detection)
-security.idmap.isolated                 | boolean   | false         | no            | id\_map                              | Use an idmap for this container that is unique among containers with isolated set.
-security.idmap.size                     | integer   | -             | no            | id\_map                              | The size of the idmap to use
-security.nesting                        | boolean   | false         | yes           | -                                    | Support running lxd (nested) inside the container
-security.privileged                     | boolean   | false         | no            | -                                    | Runs the container in privileged mode
-security.protection.delete              | boolean   | false         | yes           | container\_protection\_delete        | Prevents the container from being deleted
-security.syscalls.blacklist             | string    | -             | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to blacklist
-security.syscalls.blacklist\_compat     | boolean   | false         | no            | container\_syscall\_filtering        | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
-security.syscalls.blacklist\_default    | boolean   | true          | no            | container\_syscall\_filtering        | Enables the default syscall blacklist
-security.syscalls.whitelist             | string    | -             | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to whitelist (mutually exclusive with security.syscalls.blacklist\*)
-user.\*                                 | string    | -             | n/a           | -                                    | Free form user key/value storage (can be used in search)
+Key                                     | Type      | Default           | Live update   | API extension                        | Description
+:--                                     | :---      | :------           | :----------   | :------------                        | :----------
+boot.autostart                          | boolean   | -                 | n/a           | -                                    | Always start the container when LXD starts (if not set, restore last state)
+boot.autostart.delay                    | integer   | 0                 | n/a           | -                                    | Number of seconds to wait after the container started before starting the next one
+boot.autostart.priority                 | integer   | 0                 | n/a           | -                                    | What order to start the containers in (starting with highest)
+boot.host\_shutdown\_timeout            | integer   | 30                | yes           | container\_host\_shutdown\_timeout   | Seconds to wait for container to shutdown before it is force stopped
+boot.stop.priority                      | integer   | 0                 | n/a           | container\_stop\_priority            | What order to shutdown the containers (starting with highest)
+environment.\*                          | string    | -                 | yes (exec)    | -                                    | key/value environment variables to export to the container and set on exec
+limits.cpu                              | string    | - (all)           | yes           | -                                    | Number or range of CPUs to expose to the container
+limits.cpu.allowance                    | string    | 100%              | yes           | -                                    | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
+limits.cpu.priority                     | integer   | 10 (maximum)      | yes           | -                                    | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit) (integer between 0 and 10)
+limits.disk.priority                    | integer   | 5 (medium)        | yes           | -                                    | When under load, how much priority to give to the container's I/O requests (integer between 0 and 10)
+limits.kernel.\*                        | string    | -                 | no            | kernel\_limits                       | This limits kernel resources per container (e.g. number of open files)
+limits.memory                           | string    | - (all)           | yes           | -                                    | Percentage of the host's memory or fixed value in bytes (supports kB, MB, GB, TB, PB and EB suffixes)
+limits.memory.enforce                   | string    | hard              | yes           | -                                    | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
+limits.memory.swap                      | boolean   | true              | yes           | -                                    | Whether to allow some of the container's memory to be swapped out to disk
+limits.memory.swap.priority             | integer   | 10 (maximum)      | yes           | -                                    | The higher this is set, the least likely the container is to be swapped to disk (integer between 0 and 10)
+limits.network.priority                 | integer   | 0 (minimum)       | yes           | -                                    | When under load, how much priority to give to the container's network requests (integer between 0 and 10)
+limits.processes                        | integer   | - (max)           | yes           | -                                    | Maximum number of processes that can run in the container
+linux.kernel\_modules                   | string    | -                 | yes           | -                                    | Comma separated list of kernel modules to load before starting the container
+migration.incremental.memory            | boolean   | false             | yes           | migration\_pre\_copy                 | Incremental memory transfer of the container's memory to reduce downtime.
+migration.incremental.memory.goal       | integer   | 70                | yes           | migration\_pre\_copy                 | Percentage of memory to have in sync before stopping the container.
+migration.incremental.memory.iterations | integer   | 10                | yes           | migration\_pre\_copy                 | Maximum number of transfer operations to go through before stopping the container.
+nvidia.driver.capabilities              | string    | compute,utility   | no            | nvidia\_runtime\_config              | What driver capabilities the container needs (sets libnvidia-container NVIDIA\_DRIVER\_CAPABILITIES)
+nvidia.runtime                          | boolean   | false             | no            | nvidia\_runtime                      | Pass the host NVIDIA and CUDA runtime libraries into the container
+nvidia.require.cuda                     | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required CUDA version (sets libnvidia-container NVIDIA\_REQUIRE\_CUDA)
+nvidia.require.driver                   | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required driver version (sets libnvidia-container NVIDIA\_REQUIRE\_DRIVER)
+raw.apparmor                            | blob      | -                 | yes           | -                                    | Apparmor profile entries to be appended to the generated profile
+raw.idmap                               | blob      | -                 | no            | id\_map                              | Raw idmap configuration (e.g. "both 1000 1000")
+raw.lxc                                 | blob      | -                 | no            | -                                    | Raw LXC configuration to be appended to the generated one
+raw.seccomp                             | blob      | -                 | no            | container\_syscall\_filtering        | Raw Seccomp configuration
+security.devlxd                         | boolean   | true              | no            | restrict\_devlxd                     | Controls the presence of /dev/lxd in the container
+security.devlxd.images                  | boolean   | false             | no            | devlxd\_images                       | Controls the availability of the /1.0/images API over devlxd
+security.idmap.base                     | integer   | -                 | no            | id\_map\_base                        | The base host ID to use for the allocation (overrides auto-detection)
+security.idmap.isolated                 | boolean   | false             | no            | id\_map                              | Use an idmap for this container that is unique among containers with isolated set.
+security.idmap.size                     | integer   | -                 | no            | id\_map                              | The size of the idmap to use
+security.nesting                        | boolean   | false             | yes           | -                                    | Support running lxd (nested) inside the container
+security.privileged                     | boolean   | false             | no            | -                                    | Runs the container in privileged mode
+security.protection.delete              | boolean   | false             | yes           | container\_protection\_delete        | Prevents the container from being deleted
+security.syscalls.blacklist             | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to blacklist
+security.syscalls.blacklist\_compat     | boolean   | false             | no            | container\_syscall\_filtering        | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
+security.syscalls.blacklist\_default    | boolean   | true              | no            | container\_syscall\_filtering        | Enables the default syscall blacklist
+security.syscalls.whitelist             | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to whitelist (mutually exclusive with security.syscalls.blacklist\*)
+user.\*                                 | string    | -                 | n/a           | -                                    | Free form user key/value storage (can be used in search)
 
 The following volatile keys are currently internally used by LXD:
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1231,7 +1231,7 @@ func (c *containerLXC) initLXC(config bool) error {
 
 		nvidiaDriver := c.expandedConfig["nvidia.driver.capabilities"]
 		if nvidiaDriver == "" {
-			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_DRIVER_CAPABILITIES=all")
+			err = lxcSetConfigItem(cc, "lxc.environment", "NVIDIA_DRIVER_CAPABILITIES=compute,utility")
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This matches the behavior prior to the introduction of
nvidia.driver.capabilities.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>