### PR TITLE
lxc/image: add new column shorthand char 'F' that displays the full image hash/fingerprint

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -915,7 +915,8 @@ Column shorthand chars:
 
     l - Shortest image alias (and optionally number of other aliases)
     L - Newline-separated list of all image aliases
-    f - Fingerprint
+    f - Fingerprint (short)
+    F - Fingerprint (long)
     p - Whether image is public
     d - Description
     a - Architecture
@@ -933,6 +934,7 @@ func (c *cmdImageList) parseColumns() ([]imageColumn, error) {
 		'l': {i18n.G("ALIAS"), c.aliasColumnData},
 		'L': {i18n.G("ALIASES"), c.aliasesColumnData},
 		'f': {i18n.G("FINGERPRINT"), c.fingerprintColumnData},
+		'F': {i18n.G("FINGERPRINT"), c.fingerprintFullColumnData},
 		'p': {i18n.G("PUBLIC"), c.publicColumnData},
 		'd': {i18n.G("DESCRIPTION"), c.descriptionColumnData},
 		'a': {i18n.G("ARCH"), c.architectureColumnData},
@@ -980,6 +982,10 @@ func (c *cmdImageList) aliasesColumnData(image api.Image) string {
 
 func (c *cmdImageList) fingerprintColumnData(image api.Image) string {
 	return image.Fingerprint[0:12]
+}
+
+func (c *cmdImageList) fingerprintFullColumnData(image api.Image) string {
+	return image.Fingerprint
 }
 
 func (c *cmdImageList) publicColumnData(image api.Image) string {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-09-02 14:16+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -253,7 +253,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
@@ -277,15 +277,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -553,7 +553,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "Spalten"
 
@@ -744,7 +744,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -818,7 +818,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -952,7 +952,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1060,7 +1060,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
@@ -1126,7 +1127,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1202,7 +1203,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1214,7 +1215,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1228,7 +1229,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Image imported with fingerprint: %s"
 msgstr "Abbild mit Fingerabdruck %s importiert\n"
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1285,7 +1286,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
@@ -1511,7 +1512,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1945,7 +1947,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -2096,11 +2098,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2264,7 +2266,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2400,7 +2402,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2729,7 +2731,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2747,7 +2749,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3480,7 +3482,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3546,7 +3548,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 #, fuzzy
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -3687,7 +3689,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3834,7 +3836,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -170,15 +170,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -436,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -613,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -684,7 +684,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -816,7 +816,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -918,7 +918,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -978,7 +979,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1052,7 +1053,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1064,7 +1065,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1078,7 +1079,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1133,7 +1134,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1339,7 +1340,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1750,7 +1752,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1894,11 +1896,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2050,7 +2052,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2179,7 +2181,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2492,7 +2494,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2510,7 +2512,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3188,7 +3190,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3238,7 +3240,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3356,7 +3358,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3485,6 +3487,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-02-10 11:39+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -203,7 +203,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -227,15 +227,15 @@ msgstr "%s no es un tipo de archivo soportado."
 msgid "(none)"
 msgstr "(ninguno)"
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr "ALIASES"
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -494,7 +494,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "Columnas"
 
@@ -672,7 +672,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -743,7 +743,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -874,7 +874,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -978,7 +978,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1038,7 +1039,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1112,7 +1113,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1124,7 +1125,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1138,7 +1139,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1194,7 +1195,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1401,7 +1402,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1812,7 +1814,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1956,11 +1958,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2112,7 +2114,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2241,7 +2243,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2554,7 +2556,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2572,7 +2574,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3251,7 +3253,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3301,7 +3303,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3419,7 +3421,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3549,7 +3551,7 @@ msgstr "Columnas"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-03-06 13:50+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -242,7 +242,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
@@ -266,16 +266,16 @@ msgstr "'%s' n'est pas un format de fichier pris en charge."
 msgid "(none)"
 msgstr "(aucun)"
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 #, fuzzy
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr "ARCH"
 
@@ -542,7 +542,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -752,7 +752,7 @@ msgstr "Création du conteneur"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -827,7 +827,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -961,7 +961,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1076,7 +1076,8 @@ msgstr "Import de l'image : %s"
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
@@ -1140,7 +1141,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1223,7 +1224,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1236,7 +1237,7 @@ msgstr "Image copiée avec succès !"
 msgid "Image exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1250,7 +1251,7 @@ msgstr "Image importée avec l'empreinte : %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "Image importée avec l'empreinte : %s"
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 #, fuzzy
 msgid "Image refreshed successfully!"
 msgstr "Image copiée avec succès !"
@@ -1308,7 +1309,7 @@ msgstr "Clé de configuration invalide"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
@@ -1579,7 +1580,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -2020,7 +2022,7 @@ msgstr "PROFILS"
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
@@ -2170,12 +2172,12 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 #, fuzzy
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
@@ -2339,7 +2341,7 @@ msgstr "Récupération de l'image : %s"
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr "TAILLE"
 
@@ -2481,7 +2483,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2818,7 +2820,7 @@ msgstr "Type : éphémère"
 msgid "Type: persistent"
 msgstr "Type : persistant"
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
@@ -2836,7 +2838,7 @@ msgstr "UTILISÉ PAR"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3613,7 +3615,7 @@ msgstr ""
 msgid "network"
 msgstr "Nom du réseau"
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr "non"
 
@@ -3686,7 +3688,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 #, fuzzy
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -3837,7 +3839,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3992,7 +3994,7 @@ msgstr "Colonnes"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr "oui"
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -168,7 +168,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
@@ -192,15 +192,15 @@ msgstr "'%s' non è un tipo di file supportato."
 msgid "(none)"
 msgstr "(nessuno)"
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr "ALIAS"
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr "ARCH"
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "Colonne"
 
@@ -638,7 +638,7 @@ msgstr "Creazione del container in corso"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -709,7 +709,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -840,7 +840,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -944,7 +944,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1005,7 +1006,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1080,7 +1081,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr "Creazione del container in corso"
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1092,7 +1093,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1106,7 +1107,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1162,7 +1163,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
@@ -1371,7 +1372,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1783,7 +1785,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1928,11 +1930,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2085,7 +2087,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2214,7 +2216,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2530,7 +2532,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2548,7 +2550,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3229,7 +3231,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr "no"
 
@@ -3279,7 +3281,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3397,7 +3399,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3527,7 +3529,7 @@ msgstr "Colonne"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-09-06 08:20+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
@@ -171,15 +171,15 @@ msgstr "'%s' はサポートされないタイプのファイルです"
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -443,7 +443,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -633,7 +633,7 @@ msgstr "コンテナを作成中"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -704,7 +704,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -835,7 +835,7 @@ msgstr "ストレージプールの設定をYAMLで編集します"
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -952,7 +952,8 @@ msgstr "イメージのエクスポート中: %s"
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1012,7 +1013,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -1086,7 +1087,7 @@ msgstr "初めてこのマシンで LXD を使う場合、lxd init と実行す�
 msgid "Ignore the container state"
 msgstr "コンテナの状態を無視します"
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr "イメージは更新済みです。"
 
@@ -1098,7 +1099,7 @@ msgstr "イメージのコピーが成功しました!"
 msgid "Image exported successfully!"
 msgstr "イメージのエクスポートが成功しました!"
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr "イメージ名を指定してください"
 
@@ -1112,7 +1113,7 @@ msgstr "イメージ名を指定してください: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr "イメージは以下のフィンガープリントでインポートされました: %s"
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr "イメージの更新が成功しました!"
 
@@ -1172,7 +1173,7 @@ msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %q"
@@ -1423,6 +1424,7 @@ msgid "List images"
 msgstr "イメージを一覧表示します"
 
 #: lxc/image.go:902
+#, fuzzy
 msgid ""
 "List images\n"
 "\n"
@@ -1439,7 +1441,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1892,7 +1895,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -2036,11 +2039,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
@@ -2200,7 +2203,7 @@ msgstr "イメージの取得中: %s"
 msgid "Run command against all containers"
 msgstr "すべてのコンテナに対してコマンドを実行します"
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2329,7 +2332,7 @@ msgstr "バックグラウンド操作の詳細を表示します"
 msgid "Show full device configuration for containers or profiles"
 msgstr "コンテナもしくはプロファイルのデバイス設定をすべて表示します"
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
@@ -2654,7 +2657,7 @@ msgstr "タイプ: ephemeral"
 msgid "Type: persistent"
 msgstr "タイプ: persistent"
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2672,7 +2675,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -3465,7 +3468,7 @@ msgstr "名前"
 msgid "network"
 msgstr "network"
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3521,7 +3524,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 
@@ -3641,7 +3644,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3772,7 +3775,7 @@ msgstr "volume"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2018-09-21 09:33+0200\n"
+        "POT-Creation-Date: 2018-09-24 15:22-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -136,7 +136,7 @@ msgid   "### This is a yaml representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid   "%s (%d more)"
 msgstr  ""
@@ -160,15 +160,15 @@ msgstr  ""
 msgid   "(none)"
 msgstr  ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid   "ALIAS"
 msgstr  ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid   "ALIASES"
 msgstr  ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid   "ARCH"
 msgstr  ""
 
@@ -414,7 +414,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid   "Columns"
 msgstr  ""
 
@@ -586,7 +586,7 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861 lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861 lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -638,7 +638,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:37 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:30 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788 lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:36 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:165 lxc/profile.go:245 lxc/profile.go:301 lxc/profile.go:355 lxc/profile.go:405 lxc/profile.go:529 lxc/profile.go:577 lxc/profile.go:641 lxc/profile.go:717 lxc/profile.go:767 lxc/profile.go:826 lxc/profile.go:880 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:40 lxc/remote.go:91 lxc/remote.go:404 lxc/remote.go:440 lxc/remote.go:545 lxc/remote.go:607 lxc/remote.go:657 lxc/remote.go:695 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:463 lxc/storage_volume.go:540 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:29 lxc/config.go:88 lxc/config.go:289 lxc/config.go:355 lxc/config.go:452 lxc/config.go:560 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:37 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:30 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788 lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:36 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:30 lxc/profile.go:102 lxc/profile.go:165 lxc/profile.go:245 lxc/profile.go:301 lxc/profile.go:355 lxc/profile.go:405 lxc/profile.go:529 lxc/profile.go:577 lxc/profile.go:641 lxc/profile.go:717 lxc/profile.go:767 lxc/profile.go:826 lxc/profile.go:880 lxc/publish.go:34 lxc/query.go:30 lxc/remote.go:40 lxc/remote.go:91 lxc/remote.go:404 lxc/remote.go:440 lxc/remote.go:545 lxc/remote.go:607 lxc/remote.go:657 lxc/remote.go:695 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:21 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:463 lxc/storage_volume.go:540 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -742,7 +742,7 @@ msgstr  ""
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -837,7 +837,7 @@ msgstr  ""
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937 lxc/image_alias.go:229
 msgid   "FINGERPRINT"
 msgstr  ""
 
@@ -897,7 +897,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -969,7 +969,7 @@ msgstr  ""
 msgid   "Ignore the container state"
 msgstr  ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid   "Image already up to date."
 msgstr  ""
 
@@ -981,7 +981,7 @@ msgstr  ""
 msgid   "Image exported successfully!"
 msgstr  ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid   "Image identifier missing"
 msgstr  ""
 
@@ -995,7 +995,7 @@ msgstr  ""
 msgid   "Image imported with fingerprint: %s"
 msgstr  ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid   "Image refreshed successfully!"
 msgstr  ""
 
@@ -1049,7 +1049,7 @@ msgstr  ""
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
@@ -1248,7 +1248,8 @@ msgid   "List images\n"
         "\n"
         "    l - Shortest image alias (and optionally number of other aliases)\n"
         "    L - Newline-separated list of all image aliases\n"
-        "    f - Fingerprint\n"
+        "    f - Fingerprint (short)\n"
+        "    F - Fingerprint (long)\n"
         "    p - Whether image is public\n"
         "    d - Description\n"
         "    a - Architecture\n"
@@ -1634,7 +1635,7 @@ msgstr  ""
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid   "PUBLIC"
 msgstr  ""
 
@@ -1776,11 +1777,11 @@ msgstr  ""
 msgid   "Recursively transfer files"
 msgstr  ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid   "Refreshing the image: %s"
 msgstr  ""
@@ -1929,7 +1930,7 @@ msgstr  ""
 msgid   "Run command against all containers"
 msgstr  ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid   "SIZE"
 msgstr  ""
 
@@ -2058,7 +2059,7 @@ msgstr  ""
 msgid   "Show full device configuration for containers or profiles"
 msgstr  ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid   "Show image properties"
 msgstr  ""
 
@@ -2366,7 +2367,7 @@ msgstr  ""
 msgid   "Type: persistent"
 msgstr  ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid   "UPLOAD DATE"
 msgstr  ""
 
@@ -2383,7 +2384,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -3011,7 +3012,7 @@ msgstr  ""
 msgid   "network"
 msgstr  ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid   "no"
 msgstr  ""
 
@@ -3055,7 +3056,7 @@ msgstr  ""
 msgid   "query [<remote>:]<API path>"
 msgstr  ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid   "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
@@ -3171,7 +3172,7 @@ msgstr  ""
 msgid   "show [<remote>:]<container|profile>"
 msgstr  ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid   "show [<remote>:]<image>"
 msgstr  ""
 
@@ -3300,7 +3301,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid   "yes"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -174,7 +174,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -198,15 +198,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -640,7 +640,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -711,7 +711,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -842,7 +842,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -944,7 +944,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1004,7 +1005,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1078,7 +1079,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1090,7 +1091,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1104,7 +1105,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1159,7 +1160,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1365,7 +1366,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1774,7 +1776,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1918,11 +1920,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2074,7 +2076,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2203,7 +2205,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2516,7 +2518,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2534,7 +2536,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3212,7 +3214,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3262,7 +3264,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3380,7 +3382,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3509,6 +3511,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-08-06 22:13+0000\n"
 "Last-Translator: Renato dos Santos <shazaum@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -171,7 +171,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -195,15 +195,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -708,7 +708,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -839,7 +839,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +941,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1001,7 +1002,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1075,7 +1076,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1087,7 +1088,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr "Imagem exportada com sucesso!"
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr "Falta o identificador da imagem"
 
@@ -1101,7 +1102,7 @@ msgstr "Falta o identificador da imagem: %s"
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1156,7 +1157,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1362,7 +1363,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1771,7 +1773,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1915,11 +1917,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2071,7 +2073,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2200,7 +2202,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2513,7 +2515,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2531,7 +2533,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3209,7 +3211,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3259,7 +3261,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3377,7 +3379,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3506,6 +3508,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -235,7 +235,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -259,16 +259,16 @@ msgstr ""
 msgid "(none)"
 msgstr "(пусто)"
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 #, fuzzy
 msgid "ALIASES"
 msgstr "ПСЕВДОНИМ"
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr "ARCH"
 
@@ -528,7 +528,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -711,7 +711,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -785,7 +785,7 @@ msgstr "Копирование образа: %s"
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1023,7 +1023,8 @@ msgstr "Копирование образа: %s"
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -1083,7 +1084,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1158,7 +1159,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1170,7 +1171,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1184,7 +1185,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1241,7 +1242,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1449,7 +1450,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1868,7 +1870,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -2012,12 +2014,12 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 #, fuzzy
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, fuzzy, c-format
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
@@ -2174,7 +2176,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2305,7 +2307,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2621,7 +2623,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2639,7 +2641,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3354,7 +3356,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3416,7 +3418,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 #, fuzzy
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
@@ -3554,7 +3556,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3700,7 +3702,7 @@ msgstr "Столбцы"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr "да"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -170,15 +170,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -435,7 +435,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -612,7 +612,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -683,7 +683,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -814,7 +814,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -916,7 +916,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -976,7 +977,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1050,7 +1051,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1062,7 +1063,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1076,7 +1077,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1131,7 +1132,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1337,7 +1338,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1746,7 +1748,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1890,11 +1892,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2046,7 +2048,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2175,7 +2177,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2488,7 +2490,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2506,7 +2508,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3184,7 +3186,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3234,7 +3236,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3352,7 +3354,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3481,6 +3483,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-21 09:33+0200\n"
+"POT-Creation-Date: 2018-09-24 15:22-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/image.go:966
+#: lxc/image.go:968
 #, c-format
 msgid "%s (%d more)"
 msgstr ""
@@ -167,15 +167,15 @@ msgstr ""
 msgid "(none)"
 msgstr ""
 
-#: lxc/alias.go:127 lxc/image.go:933 lxc/image_alias.go:228
+#: lxc/alias.go:127 lxc/image.go:934 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
 
-#: lxc/image.go:934
+#: lxc/image.go:935
 msgid "ALIASES"
 msgstr ""
 
-#: lxc/image.go:938
+#: lxc/image.go:940
 msgid "ARCH"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:924 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:112
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +609,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:937 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -680,7 +680,7 @@ msgstr ""
 #: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
 #: lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:788
-#: lxc/image.go:902 lxc/image.go:1225 lxc/image.go:1302 lxc/image_alias.go:26
+#: lxc/image.go:902 lxc/image.go:1231 lxc/image.go:1308 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:25 lxc/info.go:29 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:48 lxc/manpage.go:19
@@ -811,7 +811,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:948 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:496
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -913,7 +913,8 @@ msgstr ""
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:174 lxc/image.go:935 lxc/image_alias.go:229
+#: lxc/config_trust.go:174 lxc/image.go:936 lxc/image.go:937
+#: lxc/image_alias.go:229
 msgid "FINGERPRINT"
 msgstr ""
 
@@ -973,7 +974,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1047,7 +1048,7 @@ msgstr ""
 msgid "Ignore the container state"
 msgstr ""
 
-#: lxc/image.go:1285
+#: lxc/image.go:1291
 msgid "Image already up to date."
 msgstr ""
 
@@ -1059,7 +1060,7 @@ msgstr ""
 msgid "Image exported successfully!"
 msgstr ""
 
-#: lxc/image.go:288 lxc/image.go:1248
+#: lxc/image.go:288 lxc/image.go:1254
 msgid "Image identifier missing"
 msgstr ""
 
@@ -1073,7 +1074,7 @@ msgstr ""
 msgid "Image imported with fingerprint: %s"
 msgstr ""
 
-#: lxc/image.go:1283
+#: lxc/image.go:1289
 msgid "Image refreshed successfully!"
 msgstr ""
 
@@ -1128,7 +1129,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1209 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
@@ -1334,7 +1335,8 @@ msgid ""
 "\n"
 "    l - Shortest image alias (and optionally number of other aliases)\n"
 "    L - Newline-separated list of all image aliases\n"
-"    f - Fingerprint\n"
+"    f - Fingerprint (short)\n"
+"    F - Fingerprint (long)\n"
 "    p - Whether image is public\n"
 "    d - Description\n"
 "    a - Architecture\n"
@@ -1743,7 +1745,7 @@ msgstr ""
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:936 lxc/remote.go:490
+#: lxc/image.go:938 lxc/remote.go:490
 msgid "PUBLIC"
 msgstr ""
 
@@ -1887,11 +1889,11 @@ msgstr ""
 msgid "Recursively transfer files"
 msgstr ""
 
-#: lxc/image.go:1224 lxc/image.go:1225
+#: lxc/image.go:1230 lxc/image.go:1231
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/image.go:1253
+#: lxc/image.go:1259
 #, c-format
 msgid "Refreshing the image: %s"
 msgstr ""
@@ -2043,7 +2045,7 @@ msgstr ""
 msgid "Run command against all containers"
 msgstr ""
 
-#: lxc/image.go:939
+#: lxc/image.go:941
 msgid "SIZE"
 msgstr ""
 
@@ -2172,7 +2174,7 @@ msgstr ""
 msgid "Show full device configuration for containers or profiles"
 msgstr ""
 
-#: lxc/image.go:1301 lxc/image.go:1302
+#: lxc/image.go:1307 lxc/image.go:1308
 msgid "Show image properties"
 msgstr ""
 
@@ -2485,7 +2487,7 @@ msgstr ""
 msgid "Type: persistent"
 msgstr ""
 
-#: lxc/image.go:940
+#: lxc/image.go:942
 msgid "UPLOAD DATE"
 msgstr ""
 
@@ -2503,7 +2505,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:955 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:510
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3181,7 +3183,7 @@ msgstr ""
 msgid "network"
 msgstr ""
 
-#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:989
+#: lxc/image.go:821 lxc/image.go:826 lxc/image.go:995
 msgid "no"
 msgstr ""
 
@@ -3231,7 +3233,7 @@ msgstr ""
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
-#: lxc/image.go:1223
+#: lxc/image.go:1229
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
@@ -3349,7 +3351,7 @@ msgstr ""
 msgid "show [<remote>:]<container|profile>"
 msgstr ""
 
-#: lxc/image.go:1300
+#: lxc/image.go:1306
 msgid "show [<remote>:]<image>"
 msgstr ""
 
@@ -3478,6 +3480,6 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:987
+#: lxc/delete.go:46 lxc/image.go:823 lxc/image.go:828 lxc/image.go:993
 msgid "yes"
 msgstr ""


### PR DESCRIPTION
```sh
  $ lxc image list -clF
  +---------------------+------------------------------------------------------------------+
  |        ALIAS        |                           FINGERPRINT                            |
  +---------------------+------------------------------------------------------------------+
  | alpine/3.4 (3 more) | cc8b580121227c92e05123e00cc52046b0139253db2c7a034234915f05a43eeb |
  +---------------------+------------------------------------------------------------------+
```
  * This is useful for shell scripts wanting the full image hash from csv output.
```sh
  $ lxc image list -clF --format=csv
  alpine/3.4 (3 more),cc8b580121227c92e05123e00cc52046b0139253db2c7a034234915f05a43eeb
```
Signed-off-by: fqbuild <TerraTech@users.noreply.github.com>