### PR TITLE
lxc/list: add three new columns for "IMAGE ALIAS", "BASE IMAGE" (short and long hash)

### DIFF
--- a/lxc/image.go
+++ b/lxc/image.go
@@ -1005,7 +1005,7 @@ func (c *cmdImageList) uploadDateColumnData(image api.Image) string {
 	return image.UploadedAt.UTC().Format("Jan 2, 2006 at 3:04pm (MST)")
 }
 
-func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {
+func imageShortestAlias(list []api.ImageAlias) string {
 	shortest := ""
 	for _, l := range list {
 		if shortest == "" {
@@ -1018,6 +1018,10 @@ func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {
 	}
 
 	return shortest
+}
+
+func (c *cmdImageList) shortestAlias(list []api.ImageAlias) string {
+	return imageShortestAlias(list)
 }
 
 func (c *cmdImageList) findDescription(props map[string]string) string {

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,7 +52,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46abcdlnNpPsStL"
+const shorthand = "46abcdfFIlnNpPsStL"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {


### PR DESCRIPTION
```sh
  $ lxc list -c nIfF
  +-------------+---------------+--------------+------------------------------------------------------------------+
  |    NAME     |  IMAGE ALIAS  |  BASE IMAGE  |                            BASE IMAGE                            |
  +-------------+---------------+--------------+------------------------------------------------------------------+
  | gentoo-lc   | gentoo-201809 | 6131070a4f44 | 6131070a4f44b4e48b5f34fc6093b9cb52c7d2c34fad85068a1f404322d02bc6 |
  +-------------+---------------+--------------+------------------------------------------------------------------+
```
  *NOTE: "IMAGE ALIAS" currently only does lookups on the "local" image server.

Signed-off-by: fqbuild <TerraTech@users.noreply.github.com>