### PR TITLE
lxc/list: define list column arguments via LXC_LIST_COLUMNS environment variable

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -71,7 +71,7 @@ which container attributes to output when displaying in table or csv
 format.
 
 Column arguments are either pre-defined shorthand chars (see below),
-or (extended) config keys.
+(extended) config keys, or by setting the LXC_LIST_COLUMNS environment variable.
 
 Commas between consecutive shorthand chars are optional.
 
@@ -473,6 +473,10 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		}
 
 		c.flagColumns = "nsacPt"
+	}
+
+	if envFlagColumns := os.Getenv("LXC_LIST_COLUMNS"); envFlagColumns != "" {
+		c.flagColumns = envFlagColumns
 	}
 
 	if clustered {


### PR DESCRIPTION
```sh
  $ LXC_LIST_COLUMNS=nsl lxc list
  +-------------+---------+----------------------+
  |    NAME     |  STATE  |     LAST USED AT     |
  +-------------+---------+----------------------+
  | gentoo-lc   | RUNNING | 2018/09/20 21:10 UTC |
  +-------------+---------+----------------------+
```
Signed-off-by: fqbuild <TerraTech@users.noreply.github.com>