### PR TITLE
compiler warnings on CentOS 7

### DIFF
--- a/shared/netns_getifaddrs.c
+++ b/shared/netns_getifaddrs.c
@@ -485,8 +485,9 @@ static char *get_packet_address(struct sockaddr *sockaddr_ptr, char *buf, size_t
 	char *slider = buf;
 	unsigned char *m = ((struct sockaddr_ll *)sockaddr_ptr)->sll_addr;
 	unsigned char n = ((struct sockaddr_ll *)sockaddr_ptr)->sll_halen;
+	unsigned char i = 0;
 
-	for (unsigned char i = 0; i < n; i++) {
+	for (i = 0; i < n; i++) {
 		int ret;
 
 		ret = snprintf(slider, buflen, "%02x%s", m[i], (i + 1) < n ? ":" : "");


### PR DESCRIPTION
When building another project (Gobetween LoadBalancer), I hit this issue:
```
# github.com/lxc/lxd/shared
In file included from vendor/src/github.com/lxc/lxd/shared/network_linux.go:19:0:
./../shared/netns_getifaddrs.c: In function 'get_packet_address':
./../shared/netns_getifaddrs.c:489:2: error: 'for' loop initial declarations are only allowed in C99 mode
  for (unsigned char i = 0; i < n; i++) {
  ^
./../shared/netns_getifaddrs.c:489:2: note: use option -std=c99 or -std=gnu99 to compile your code
```

My build machine is CentOS 7 with the stock packages
```
# gcc --version
gcc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-28)
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```