### PR TITLE
lxc/list: add new column "BASE IMAGE" for both short and long image fingerprint variants

### DIFF
--- a/lxc/list.go
+++ b/lxc/list.go
@@ -91,6 +91,8 @@ Pre-defined column shorthand chars:
   S - Number of snapshots
   t - Type (persistent or ephemeral)
   L - Location of the container (e.g. its cluster member)
+  f - Base Image Fingerprint (short)
+  F - Base Image Fingerprint (long)
 
 Custom columns are defined with "key[:name][:maxWidth]":
   KEY: The (extended) config key to display
@@ -101,7 +103,7 @@ Custom columns are defined with "key[:name][:maxWidth]":
   Defaults to -1 (unlimited). Use 0 to limit to the column header size.`))
 
 	cmd.Example = cli.FormatSection("", i18n.G(
-		`lxc list -c n,volatile.base_image:"BASE IMAGE":0,s46,volatile.eth0.hwaddr:MAC
+		`lxc list -c nFs46,volatile.eth0.hwaddr:MAC
   Show containers using the "NAME", "BASE IMAGE", "STATE", "IPV4", "IPV6" and "MAC" columns.
   "BASE IMAGE" and "MAC" are custom columns generated from container configuration keys.
 
@@ -464,6 +466,8 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 		's': {i18n.G("STATE"), c.statusColumnData, false, false},
 		't': {i18n.G("TYPE"), c.typeColumnData, false, false},
 		'b': {i18n.G("STORAGE POOL"), c.StoragePoolColumnData, false, false},
+		'f': {i18n.G("BASE IMAGE"), c.baseImageColumnData, false, false},
+		'F': {i18n.G("BASE IMAGE"), c.baseImageFullColumnData, false, false},
 	}
 
 	if c.flagFast {
@@ -568,6 +572,27 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	}
 
 	return columns, needsData, nil
+}
+
+func (c *cmdList) getBaseImage(cInfo api.ContainerFull, long bool) string {
+	v, ok := cInfo.Config["volatile.base_image"]
+	if !ok {
+		return ""
+	}
+
+	if !long && len(v) >= 12 {
+		v = v[:12]
+	}
+
+	return v
+}
+
+func (c *cmdList) baseImageColumnData(cInfo api.ContainerFull) string {
+	return c.getBaseImage(cInfo, false)
+}
+
+func (c *cmdList) baseImageFullColumnData(cInfo api.ContainerFull) string {
+	return c.getBaseImage(cInfo, true)
 }
 
 func (c *cmdList) nameColumnData(cInfo api.ContainerFull) string {

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -52,7 +52,7 @@ func TestShouldShow(t *testing.T) {
 }
 
 // Used by TestColumns and TestInvalidColumns
-const shorthand = "46abcdlnNpPsStL"
+const shorthand = "46abcdfFlnNpPsStL"
 const alphanum = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
 
 func TestColumns(t *testing.T) {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-09-02 14:16+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -289,7 +289,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
@@ -403,6 +403,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 #, fuzzy
 msgid "Backup exported successfully!"
@@ -463,7 +467,7 @@ msgstr " Prozessorauslastung:"
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -498,7 +502,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -506,7 +510,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -553,7 +557,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "Spalten"
 
@@ -744,7 +748,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
@@ -906,7 +910,7 @@ msgstr " Prozessorauslastung:"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -952,7 +956,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1090,7 +1094,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1127,7 +1131,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1180,11 +1184,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1276,32 +1280,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1340,11 +1344,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1456,6 +1460,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1819,7 +1825,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1927,19 +1933,19 @@ msgstr "Profil %s gelöscht\n"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2270,7 +2276,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2278,7 +2284,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2290,7 +2296,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2590,7 +2596,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2749,7 +2755,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3336,10 +3342,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -292,6 +292,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -350,7 +354,7 @@ msgstr "  Χρήση CPU:"
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -381,7 +385,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -389,7 +393,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -436,7 +440,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -613,7 +617,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -772,7 +776,7 @@ msgstr "  Χρήση CPU:"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -816,7 +820,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -946,7 +950,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -979,7 +983,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1031,11 +1035,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1124,32 +1128,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1187,11 +1191,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1298,6 +1302,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1627,7 +1633,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1732,19 +1738,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2056,7 +2062,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2064,7 +2070,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2076,7 +2082,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2360,7 +2366,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2512,7 +2518,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3053,10 +3059,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-02-10 11:39+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -239,7 +239,7 @@ msgstr "ALIASES"
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
@@ -350,6 +350,10 @@ msgstr "Tipo de autenticación %s no está soportada por el servidor"
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -407,7 +411,7 @@ msgstr "Uso de CPU:"
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -438,7 +442,7 @@ msgstr "No se peude leer desde stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -447,7 +451,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -494,7 +498,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "Columnas"
 
@@ -672,7 +676,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -830,7 +834,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -874,7 +878,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1006,7 +1010,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1039,7 +1043,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1091,11 +1095,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1185,32 +1189,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1248,11 +1252,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1360,6 +1364,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1690,7 +1696,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1794,19 +1800,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2118,7 +2124,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2126,7 +2132,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2138,7 +2144,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2422,7 +2428,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2574,7 +2580,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3116,10 +3122,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-03-06 13:50+0000\n"
 "Last-Translator: Alban Vidal <alban.vidal@zordhak.fr>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -279,7 +279,7 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
@@ -393,6 +393,10 @@ msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 #, fuzzy
 msgid "Backup exported successfully!"
@@ -452,7 +456,7 @@ msgstr "CPU utilisé :"
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -485,7 +489,7 @@ msgstr "Impossible de lire depuis stdin : %s"
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -493,7 +497,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -542,7 +546,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -752,7 +756,7 @@ msgstr "Création du conteneur"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
@@ -915,7 +919,7 @@ msgstr "  Disque utilisé :"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -961,7 +965,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1106,7 +1110,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
@@ -1141,7 +1145,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1198,11 +1202,11 @@ msgstr "PID"
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr "IPv6"
 
@@ -1299,32 +1303,32 @@ msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1363,11 +1367,11 @@ msgstr "IPs :"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1479,6 +1483,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1888,7 +1894,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr "NOM"
@@ -2002,19 +2008,19 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr "PERSISTANT"
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr "PROFILS"
 
@@ -2345,7 +2351,7 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
@@ -2353,7 +2359,7 @@ msgstr "INSTANTANÉS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -2366,7 +2372,7 @@ msgstr "STATIQUE"
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
@@ -2676,7 +2682,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr "TYPE"
@@ -2838,7 +2844,7 @@ msgstr "UTILISÉ PAR"
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3457,10 +3463,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -204,7 +204,7 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
@@ -315,6 +315,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -373,7 +377,7 @@ msgstr "Utilizzo CPU:"
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -404,7 +408,7 @@ msgstr "Impossible leggere da stdin: %s"
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -412,7 +416,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -459,7 +463,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "Colonne"
 
@@ -638,7 +642,7 @@ msgstr "Creazione del container in corso"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
@@ -796,7 +800,7 @@ msgstr "Utilizzo disco:"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -840,7 +844,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -972,7 +976,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1006,7 +1010,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1058,11 +1062,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1153,32 +1157,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1217,11 +1221,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1330,6 +1334,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1661,7 +1667,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1765,19 +1771,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2091,7 +2097,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2099,7 +2105,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2111,7 +2117,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2397,7 +2403,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2550,7 +2556,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3094,10 +3100,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-09-06 08:20+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -297,6 +297,10 @@ msgstr "認証タイプ '%s' はサーバではサポートされていません
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
@@ -354,7 +358,7 @@ msgstr "CPU使用量:"
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -387,7 +391,7 @@ msgstr "標準入力から読み込めません: %s"
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
@@ -395,7 +399,7 @@ msgstr "--fast と --columns は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -443,7 +447,7 @@ msgstr "クラスタメンバ名"
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -633,7 +637,7 @@ msgstr "コンテナを作成中"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -791,7 +795,7 @@ msgstr "ディスク使用量:"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -835,7 +839,7 @@ msgstr "ストレージプールの設定をYAMLで編集します"
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -980,7 +984,7 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
@@ -1013,7 +1017,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
 
@@ -1065,11 +1069,11 @@ msgstr "ID"
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr "IPV6"
 
@@ -1162,35 +1166,35 @@ msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %q"
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1229,11 +1233,11 @@ msgstr "IPアドレス:"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1291,6 +1295,7 @@ msgid "List containers"
 msgstr "コンテナを一覧表示します"
 
 #: lxc/list.go:48
+#, fuzzy
 msgid ""
 "List containers\n"
 "\n"
@@ -1340,6 +1345,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1770,7 +1777,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1875,19 +1882,19 @@ msgstr "バックグラウンド操作 %s を削除しました"
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr "ターミナルモードを上書きします (auto, interactive, non-interactive)"
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2207,7 +2214,7 @@ msgstr "すべてのコンテナに対してコマンドを実行します"
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2215,7 +2222,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2227,7 +2234,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2512,7 +2519,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2675,7 +2682,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -3269,10 +3276,10 @@ msgstr "lxc init ubuntu:16.04 u1"
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr "lxc launch ubuntu:16.04 u1"
 
-#: lxc/list.go:103
+#: lxc/list.go:105
+#, fuzzy
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2018-09-24 15:22-0400\n"
+        "POT-Creation-Date: 2018-09-25 11:38-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -172,7 +172,7 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid   "ARCHITECTURE"
 msgstr  ""
 
@@ -281,6 +281,10 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid   "BASE IMAGE"
+msgstr  ""
+
 #: lxc/export.go:126
 msgid   "Backup exported successfully!"
 msgstr  ""
@@ -337,7 +341,7 @@ msgstr  ""
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -367,7 +371,7 @@ msgstr  ""
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
@@ -375,7 +379,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -414,7 +418,7 @@ msgstr  ""
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid   "Columns"
 msgstr  ""
 
@@ -586,7 +590,7 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861 lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861 lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid   "DESCRIPTION"
 msgstr  ""
 
@@ -698,7 +702,7 @@ msgstr  ""
 msgid   "Don't show progress information"
 msgstr  ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -742,7 +746,7 @@ msgstr  ""
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
@@ -864,7 +868,7 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
@@ -897,7 +901,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -949,11 +953,11 @@ msgstr  ""
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid   "IPV6"
 msgstr  ""
 
@@ -1039,32 +1043,32 @@ msgstr  ""
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -1101,11 +1105,11 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1208,6 +1212,8 @@ msgid   "List containers\n"
         "  S - Number of snapshots\n"
         "  t - Type (persistent or ephemeral)\n"
         "  L - Location of the container (e.g. its cluster member)\n"
+        "  f - Base Image Fingerprint (short)\n"
+        "  F - Base Image Fingerprint (long)\n"
         "\n"
         "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
         "  KEY: The (extended) config key to display\n"
@@ -1512,7 +1518,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622 lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622 lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid   "NAME"
 msgstr  ""
 
@@ -1615,19 +1621,19 @@ msgstr  ""
 msgid   "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr  ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid   "PERSISTENT"
 msgstr  ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid   "PROFILES"
 msgstr  ""
 
@@ -1934,7 +1940,7 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid   "SNAPSHOTS"
 msgstr  ""
 
@@ -1942,7 +1948,7 @@ msgstr  ""
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid   "STATE"
 msgstr  ""
 
@@ -1954,7 +1960,7 @@ msgstr  ""
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid   "STORAGE POOL"
 msgstr  ""
 
@@ -2238,7 +2244,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155 lxc/storage_volume.go:1119
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155 lxc/storage_volume.go:1119
 msgid   "TYPE"
 msgstr  ""
 
@@ -2384,7 +2390,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -2896,8 +2902,8 @@ msgstr  ""
 msgid   "lxc launch ubuntu:16.04 u1"
 msgstr  ""
 
-#: lxc/list.go:103
-msgid   "lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:MAC\n"
+#: lxc/list.go:105
+msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
         "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container configuration keys.\n"
         "\n"

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -210,7 +210,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -320,6 +320,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -377,7 +381,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -408,7 +412,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -416,7 +420,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -463,7 +467,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -640,7 +644,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -798,7 +802,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -842,7 +846,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -972,7 +976,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1005,7 +1009,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1057,11 +1061,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1150,32 +1154,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1213,11 +1217,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1324,6 +1328,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1652,7 +1658,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1756,19 +1762,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2080,7 +2086,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2088,7 +2094,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2100,7 +2106,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2384,7 +2390,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2536,7 +2542,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3077,10 +3083,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-08-06 22:13+0000\n"
 "Last-Translator: Renato dos Santos <shazaum@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -207,7 +207,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -317,6 +317,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -374,7 +378,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -405,7 +409,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -413,7 +417,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -460,7 +464,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -637,7 +641,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -795,7 +799,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -839,7 +843,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -969,7 +973,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1002,7 +1006,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1054,11 +1058,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1147,32 +1151,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1210,11 +1214,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1321,6 +1325,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1649,7 +1655,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1753,19 +1759,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2077,7 +2083,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2085,7 +2091,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2097,7 +2103,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2381,7 +2387,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2533,7 +2539,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3074,10 +3080,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -272,7 +272,7 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
@@ -383,6 +383,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -442,7 +446,7 @@ msgstr " Использование ЦП:"
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -473,7 +477,7 @@ msgstr "Невозможно прочитать из стандартного в
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -481,7 +485,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -528,7 +532,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -711,7 +715,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -873,7 +877,7 @@ msgstr " Использование диска:"
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -918,7 +922,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -1051,7 +1055,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -1084,7 +1088,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1136,11 +1140,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1232,32 +1236,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1295,11 +1299,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1408,6 +1412,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1744,7 +1750,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1850,19 +1856,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2180,7 +2186,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2188,7 +2194,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2200,7 +2206,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2489,7 +2495,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2641,7 +2647,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3215,10 +3221,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/zh.po
+++ b/po/zh.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -292,6 +292,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -349,7 +353,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -380,7 +384,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -388,7 +392,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -435,7 +439,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -612,7 +616,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -770,7 +774,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -814,7 +818,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -944,7 +948,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -977,7 +981,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1029,11 +1033,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1122,32 +1126,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1185,11 +1189,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1296,6 +1300,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1624,7 +1630,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1728,19 +1734,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2052,7 +2058,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2060,7 +2066,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2072,7 +2078,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2356,7 +2362,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2508,7 +2514,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3049,10 +3055,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2018-09-24 15:22-0400\n"
+"POT-Creation-Date: 2018-09-25 11:38-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -179,7 +179,7 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:455
+#: lxc/list.go:457
 msgid "ARCHITECTURE"
 msgstr ""
 
@@ -289,6 +289,10 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
+#: lxc/list.go:469 lxc/list.go:470
+msgid "BASE IMAGE"
+msgstr ""
+
 #: lxc/export.go:126
 msgid "Backup exported successfully!"
 msgstr ""
@@ -346,7 +350,7 @@ msgstr ""
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:456
+#: lxc/list.go:458
 msgid "CREATED AT"
 msgstr ""
 
@@ -377,7 +381,7 @@ msgstr ""
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:472
+#: lxc/list.go:476
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -385,7 +389,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:484
+#: lxc/list.go:488
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -432,7 +436,7 @@ msgstr ""
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:925 lxc/list.go:112
+#: lxc/image.go:925 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -609,7 +613,7 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:457 lxc/network.go:861
+#: lxc/image.go:939 lxc/image_alias.go:230 lxc/list.go:459 lxc/network.go:861
 #: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
@@ -767,7 +771,7 @@ msgstr ""
 msgid "Don't show progress information"
 msgstr ""
 
-#: lxc/list.go:637
+#: lxc/list.go:662
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -811,7 +815,7 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:950 lxc/list.go:496
+#: lxc/image.go:950 lxc/list.go:500
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
@@ -941,7 +945,7 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:114
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
@@ -974,7 +978,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/image.go:926 lxc/list.go:113 lxc/network.go:803 lxc/remote.go:444
+#: lxc/image.go:926 lxc/list.go:115 lxc/network.go:803 lxc/remote.go:444
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
 
@@ -1026,11 +1030,11 @@ msgstr ""
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:455
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:454
+#: lxc/list.go:456
 msgid "IPV6"
 msgstr ""
 
@@ -1119,32 +1123,32 @@ msgstr ""
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:521
+#: lxc/list.go:525
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:520
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1215 lxc/list.go:366 lxc/network.go:903 lxc/remote.go:528
+#: lxc/image.go:1215 lxc/list.go:368 lxc/network.go:903 lxc/remote.go:528
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:539
+#: lxc/list.go:543
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:536
+#: lxc/list.go:540
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:527
+#: lxc/list.go:531
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1182,11 +1186,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:458
+#: lxc/list.go:460
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:480 lxc/storage_volume.go:1125
+#: lxc/list.go:484 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1293,6 +1297,8 @@ msgid ""
 "  S - Number of snapshots\n"
 "  t - Type (persistent or ephemeral)\n"
 "  L - Location of the container (e.g. its cluster member)\n"
+"  f - Base Image Fingerprint (short)\n"
+"  F - Base Image Fingerprint (long)\n"
 "\n"
 "Custom columns are defined with \"key[:name][:maxWidth]\":\n"
 "  KEY: The (extended) config key to display\n"
@@ -1621,7 +1627,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:459 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:124 lxc/list.go:461 lxc/network.go:858 lxc/profile.go:622
 #: lxc/remote.go:486 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
@@ -1725,19 +1731,19 @@ msgstr ""
 msgid "Override the terminal mode (auto, interactive or non-interactive)"
 msgstr ""
 
-#: lxc/list.go:640
+#: lxc/list.go:665
 msgid "PERSISTENT"
 msgstr ""
 
-#: lxc/list.go:461
+#: lxc/list.go:463
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:460
+#: lxc/list.go:462
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:462
+#: lxc/list.go:464
 msgid "PROFILES"
 msgstr ""
 
@@ -2049,7 +2055,7 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:463
+#: lxc/list.go:465
 msgid "SNAPSHOTS"
 msgstr ""
 
@@ -2057,7 +2063,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:464 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:127 lxc/list.go:466 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2069,7 +2075,7 @@ msgstr ""
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:466
+#: lxc/list.go:468
 msgid "STORAGE POOL"
 msgstr ""
 
@@ -2353,7 +2359,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:465 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:467 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2505,7 +2511,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:957 lxc/list.go:510
+#: lxc/image.go:957 lxc/list.go:514
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3046,10 +3052,9 @@ msgstr ""
 msgid "lxc launch ubuntu:16.04 u1"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:105
 msgid ""
-"lxc list -c n,volatile.base_image:\"BASE IMAGE\":0,s46,volatile.eth0.hwaddr:"
-"MAC\n"
+"lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
 "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", "
 "\"IPV6\" and \"MAC\" columns.\n"
 "  \"BASE IMAGE\" and \"MAC\" are custom columns generated from container "


### PR DESCRIPTION
  Supercedes: #5057
```sh
  $ lxc list alpine-34 -cnfF
  +-----------+--------------+------------------------------------------------------------------+
  |   NAME    |  BASE IMAGE  |                            BASE IMAGE                            |
  +-----------+--------------+------------------------------------------------------------------+
  | alpine-34 | cc8b58012122 | cc8b580121227c92e05123e00cc52046b0139253db2c7a034234915f05a43eeb |
  +-----------+--------------+------------------------------------------------------------------+
```
Signed-off-by: fqbuild <TerraTech@users.noreply.github.com>
