### PR TITLE
tree-wide: pass -std=gnu11 -Wvla

### DIFF
--- a/lxd-p2c/setns.go
+++ b/lxd-p2c/setns.go
@@ -30,4 +30,5 @@ __attribute__((constructor)) void init(void) {
 	// We're done, jump back to Go
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"

--- a/lxd/devlxd_gccgo.go
+++ b/lxd/devlxd_gccgo.go
@@ -33,6 +33,7 @@ void getucred(int sock, uint *uid, uint *gid, int *pid) {
 	return;
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 func getUcred(fd int) (uint32, uint32, int32, error) {

--- a/lxd/main_checkfeature.go
+++ b/lxd/main_checkfeature.go
@@ -123,6 +123,7 @@ static bool is_empty_string(char *s)
 	return (errbuf[0] == '\0');
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 func CanUseNetnsGetifaddrs() bool {

--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -440,6 +440,7 @@ void forkfile() {
 	}
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 type cmdForkfile struct {

--- a/lxd/main_forkmount.go
+++ b/lxd/main_forkmount.go
@@ -215,6 +215,7 @@ void forkmount() {
 	}
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 type cmdForkmount struct {

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -62,6 +62,7 @@ void forknet() {
 	}
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 type cmdForknet struct {

--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -282,6 +282,7 @@ void forkproxy()
 	}
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 const forkproxyUDSSockFDNum int = C.FORKPROXY_UDS_SOCK_FD_NUM

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -250,4 +250,5 @@ __attribute__((constructor)) void init(void) {
 		checkfeature();
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"

--- a/lxd/storage_cgo.go
+++ b/lxd/storage_cgo.go
@@ -268,6 +268,7 @@ int unset_autoclear_loop_device(int fd_loop)
 	return ioctl(fd_loop, LOOP_SET_STATUS64, &lo64);
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 import (

--- a/shared/idmap/shift_linux.go
+++ b/shared/idmap/shift_linux.go
@@ -153,6 +153,7 @@ int shiftowner(char *basepath, char *path, int uid, int gid)
 	return 0;
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 // ShiftOwner updates uid and gid for a file when entering/exiting a namespace

--- a/shared/network_linux.go
+++ b/shared/network_linux.go
@@ -18,6 +18,7 @@ import (
 /*
 #include "../shared/netns_getifaddrs.c"
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 func NetnsGetifaddrs(initPID int32) (map[string]api.ContainerStateNetwork, error) {

--- a/shared/termios/termios_unix.go
+++ b/shared/termios/termios_unix.go
@@ -10,6 +10,7 @@ import (
 )
 
 // #include <termios.h>
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 // State contains the state of a terminal.

--- a/shared/util_linux.go
+++ b/shared/util_linux.go
@@ -238,6 +238,7 @@ out:
 	return ret;
 }
 */
+// #cgo CFLAGS: -std=gnu11 -Wvla
 import "C"
 
 const ABSTRACT_UNIX_SOCK_LEN int = C.ABSTRACT_UNIX_SOCK_LEN


### PR DESCRIPTION
In LXC I've introduced the policy that the minimum supported compiler
version will be the same as for the kernel. This is currently gcc 4.8.
As such we can support the niceties that the C11 standard provides and
also disable the crazyness that are VLAs that have been marked optional
from C11 onwards. So always pass -std=gnu11 and -Wvla.

Closes #5066.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>