### PR TITLE
Added optional ?target=<member> to /containers POST documentation

### DIFF
--- a/doc/rest-api.md
+++ b/doc/rest-api.md
@@ -423,7 +423,7 @@ Return value:
         "/1.0/containers/blah1"
     ]
 
-### POST
+### POST (optional `?target=<member>`)
  * Description: Create a new container
  * Authentication: trusted
  * Operation: async


### PR DESCRIPTION
it was not obvious how to specify a target through the api. 

Thanks to @stgraber for his quick irc support.