### PR TITLE
doc: Add configuration for readthedocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,2 @@
+site_name: "LXD - system container manager"
+theme: readthedocs


### PR DESCRIPTION
The documentation of LXD is converted and published on readthedocs.org.
In this conversion, mkdocs is used. When this conversion, mkdocs uses
"mkdocs" theme by default.

With the mkdocs theme, the menu at the top of each page is too large,
and contents of a page will be hidden.

So add mkdocs.yml, and set it to use the "readthedocs" theme. Current
configuration is minium.

Signed-off-by: KATOH Yasufumi <karma@jazz.email.ne.jp>