### PR TITLE
Add symbol if not defined

### DIFF
--- a/shared/network.c
+++ b/shared/network.c
@@ -37,6 +37,10 @@
 #define IFA_TARGET_NETNSID 10
 #endif
 
+#ifndef RTM_GETNSID
+#define RTM_GETNSID 90
+#endif
+
 #define IFADDRS_HASH_SIZE 64
 
 #define __NETLINK_ALIGN(len) (((len) + 3) & ~3)


### PR DESCRIPTION
This defines the symbol RTM_GETNSID if it is not defined

This fixes compilation of the terraform lxd plugin on travis for the architecture linux/amd64.
The split of cgo and non-cgo code is still required to compile for linux/arm ( #5090 )