### PR TITLE
Document LVM support for storage quotas

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -69,7 +69,7 @@ Block based                                 | no        | no    | yes   | no   |
 Instant cloning                             | no        | yes   | yes   | yes  | yes
 Storage driver usable inside a container    | yes       | yes   | no    | no   | no
 Restore from older snapshots (not latest)   | yes       | yes   | yes   | no   | yes
-Storage quotas                              | no        | yes   | no    | yes  | no
+Storage quotas                              | no        | yes   | yes   | yes  | no
 
 ## Recommended setup
 The two best options for use with LXD are ZFS and btrfs.  


### PR DESCRIPTION
LVM backend supports storage quotas while the documentation still refers
to this feature as being unsupported:

ac1740d7092bf0dfb5e70cc66330e60b68e95613
f88e381d2d7c63c3a35f82691cd3627bf029c2b8
https://github.com/lxc/lxd/issues/1205

Signed-off-by: Dmitrii Shcherbakov <dmitrii.shcherbakov@canonical.com>