### PR TITLE
client: Fix potential event race condition

### DIFF
--- a/client/operations.go
+++ b/client/operations.go
@@ -152,15 +152,15 @@ func (op *operation) setupListener() error {
 	_, err := op.listener.AddHandler([]string{"operation"}, func(data interface{}) {
 		<-chReady
 
+		// We don't want concurrency while processing events
+		op.handlerLock.Lock()
+		defer op.handlerLock.Unlock()
+
 		// Get an operation struct out of this data
 		newOp := op.extractOperation(data)
 		if newOp == nil {
 			return
 		}
-
-		// We don't want concurrency while processing events
-		op.handlerLock.Lock()
-		defer op.handlerLock.Unlock()
 
 		// Check if we're done already (because of another event)
 		if op.listener == nil {


### PR DESCRIPTION
This commit fixes a potential race condition when listening
for events and extracting operations by moving the lock
to before the operation struct is created.

For #5117 