### PR TITLE
candid: Improve domain validation and pubkey

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -622,3 +622,8 @@ Add a new project API, supporting creation, update and deletion of projects.
 
 Projects can hold containers, profiles or images at this point and let
 you get a separate view of your LXD resources by switching to it.
+
+## candid\_config\_key
+This introduces a new `candid.api.key` option which allows for setting
+the expected public key for the endpoint, allowing for safe use of a
+HTTP-only candid server.

--- a/doc/server.md
+++ b/doc/server.md
@@ -11,6 +11,7 @@ currently supported:
 Key                             | Type      | Default   | API extension            | Description
 :--                             | :---      | :------   | :------------            | :----------
 backups.compression\_algorithm  | string    | gzip      | backup\_compression      | Compression algorithm to use for new images (bzip2, gzip, lzma, xz or none)
+candid.api.key                  | string    | -         | candid\_config\_key      | Public key of the candid server (required for HTTP-only servers)
 candid.api.url                  | string    | -         | candid\_authentication   | URL of the the external authentication endpoint using Candid
 candid.expiry                   | integer   | 3600      | candid\_config           | Candid macaroon expiry in seconds
 candid.domains                  | string    | -         | candid\_config           | Comma-separated list of allowed Candid domains (empty string means all domains are valid)

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -396,6 +396,8 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 			fallthrough
 		case "candid.expiry":
 			fallthrough
+		case "candid.api.key":
+			fallthrough
 		case "candid.api.url":
 			candidChanged = true
 		case "images.auto_update_interval":
@@ -435,10 +437,11 @@ func doApi10UpdateTriggers(d *Daemon, nodeChanged, clusterChanged map[string]str
 
 	if candidChanged {
 		endpoint := clusterConfig.CandidEndpoint()
+		endpointKey := clusterConfig.CandidEndpointKey()
 		expiry := clusterConfig.CandidExpiry()
 		domains := clusterConfig.CandidDomains()
 
-		err := d.setupExternalAuthentication(endpoint, expiry, domains)
+		err := d.setupExternalAuthentication(endpoint, endpointKey, expiry, domains)
 		if err != nil {
 			return err
 		}

--- a/lxd/cluster/config.go
+++ b/lxd/cluster/config.go
@@ -70,6 +70,11 @@ func (c *Config) CandidEndpoint() string {
 	return c.m.GetString("candid.api.url")
 }
 
+// CandidEndpointKey returns the public key for the API endpoint
+func (c *Config) CandidEndpointKey() string {
+	return c.m.GetString("candid.api.key")
+}
+
 // CandidExpiry returns the cookie expiry of the macaroon.
 func (c *Config) CandidExpiry() int64 {
 	return c.m.GetInt64("candid.expiry")
@@ -221,6 +226,7 @@ var ConfigSchema = config.Schema{
 	"core.proxy_https":               {},
 	"core.proxy_ignore_hosts":        {},
 	"core.trust_password":            {Hidden: true, Setter: passwordSetter},
+	"candid.api.key":                 {},
 	"candid.api.url":                 {},
 	"candid.domains":                 {},
 	"candid.expiry":                  {Type: config.Int64, Default: "3600"},

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -67,7 +67,8 @@ _have lxc && {
     global_keys="backups.compression_algorithm,
       core.https_address core.https_allowed_credentials \
       core.https_allowed_headers core.https_allowed_methods \
-      core.https_allowed_origin candid.api.url candid.expiry candid.domains \
+      core.https_allowed_origin candid.api.url candid.api.key candid.expiry \
+      candid.domains \
       core.proxy_https core.proxy_http core.proxy_ignore_hosts \
       core.trust_password core.debug_address cluster.offline_threshold \
       images.auto_update_cached images.auto_update_interval \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -127,6 +127,7 @@ var APIExtensions = []string{
 	"storage_api_volume_snapshots",
 	"storage_unmapped",
 	"projects",
+	"candid_config_key",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/suites/external_auth.sh
+++ b/test/suites/external_auth.sh
@@ -7,6 +7,8 @@ test_macaroon_auth() {
     ensure_has_localhost_remote "$LXD_ADDR"
 
     lxc config set candid.api.url "$identity_endpoint"
+    key=$(curl -s "${identity_endpoint}/discharge/info" | jq .PublicKey)
+    lxc config set candid.api.key "${key}"
 
     # invalid credentials make the remote add fail
     # shellcheck disable=SC2039


### PR DESCRIPTION
This introduces a new "candid.api.key" option which can be set to the
expected public key for the candid server.

Setting this key is effectively required if using a non-HTTPs server.
When using HTTPs, this is optional as LXD can fetch the key directly
from the candid server.

An issue with validation of domains is also fixed, effectively
preventing a candid token which doesn't include a domain for being
considered valid when a list of valid domains is set.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>