### PR TITLE
Typo in french PO

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -68,7 +68,7 @@ msgstr ""
 "### Ceci est une représentation yaml des propriétés de l'image.\n"
 "### Toute ligne commençant par un '# sera ignorée.\n"
 "###\n"
-"### Caque propriété est représentée par une ligne unique :\n"
+"### Chaque propriété est représentée par une ligne unique :\n"
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 


### PR DESCRIPTION
"Caque" instead of "Chaque"

Signed-off-by: Fridolin Somers <fridobox@gmail.com>