### PR TITLE
Fix remote images in projects

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -112,7 +112,7 @@ func createFromImage(d *Daemon, project string, req *api.ContainersPost) Respons
 			}
 			info, err = d.ImageDownload(
 				op, req.Source.Server, req.Source.Protocol, req.Source.Certificate,
-				req.Source.Secret, hash, true, autoUpdate, "", true)
+				req.Source.Secret, hash, true, autoUpdate, "", true, project)
 			if err != nil {
 				return err
 			}

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -96,7 +96,7 @@ func imageLoadStreamCache(d *Daemon) error {
 }
 
 // ImageDownload resolves the image fingerprint and if not in the database, downloads it
-func (d *Daemon) ImageDownload(op *operation, server string, protocol string, certificate string, secret string, alias string, forContainer bool, autoUpdate bool, storagePool string, preferCached bool) (*api.Image, error) {
+func (d *Daemon) ImageDownload(op *operation, server string, protocol string, certificate string, secret string, alias string, forContainer bool, autoUpdate bool, storagePool string, preferCached bool, project string) (*api.Image, error) {
 	var err error
 	var ctxMap log.Ctx
 
@@ -244,7 +244,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	}
 
 	// Check if the image already exists (partial hash match)
-	_, imgInfo, err := d.cluster.ImageGet("default", fp, false, true)
+	_, imgInfo, err := d.cluster.ImageGet(project, fp, false, true)
 	if err == nil {
 		logger.Debug("Image already exists in the db", log.Ctx{"image": fp})
 		info = imgInfo
@@ -298,7 +298,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		<-waitChannel
 
 		// Grab the database entry
-		_, imgInfo, err := d.cluster.ImageGet("default", fp, false, true)
+		_, imgInfo, err := d.cluster.ImageGet(project, fp, false, true)
 		if err != nil {
 			// Other download failed, lets try again
 			logger.Error("Other image download didn't succeed", log.Ctx{"image": fp})
@@ -519,7 +519,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 	}
 
 	// Create the database entry
-	err = d.cluster.ImageInsert("default", info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties)
+	err = d.cluster.ImageInsert(project, info.Fingerprint, info.Filename, info.Size, info.Public, info.AutoUpdate, info.Architecture, info.CreatedAt, info.ExpiresAt, info.Properties)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +545,7 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 
 	// Record the image source
 	if alias != fp {
-		id, _, err := d.cluster.ImageGet("default", fp, false, true)
+		id, _, err := d.cluster.ImageGet(project, fp, false, true)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/daemon_images_test.go
+++ b/lxd/daemon_images_test.go
@@ -42,7 +42,7 @@ func (suite *daemonImagesTestSuite) TestUseCachedImagesIfAvailable() {
 	// one we created above.
 	op, err := operationCreate(suite.d.cluster, "default", operationClassTask, db.OperationImageDownload, map[string][]string{}, nil, nil, nil, nil)
 	suite.Req.Nil(err)
-	image, err := suite.d.ImageDownload(op, "img.srv", "simplestreams", "", "", "test", false, false, "", true)
+	image, err := suite.d.ImageDownload(op, "img.srv", "simplestreams", "", "", "test", false, false, "", true, "default")
 	suite.Req.Nil(err)
 	suite.Req.Equal("abcd", image.Fingerprint)
 }


### PR DESCRIPTION
There were a few issues with remote images and projects:

1) When creating a container from a remote image, the image was correctly downloaded but unconditionally linked to the the "default" project.

2) No check was performed before downloading to see if an image is already available in another project (no need to download in that case).

3) Image auto-update logic was only considering images in the "default" project.
 
Fixes #5136.