### PR TITLE
lxd: Add an additional VXLAN TTL configuration key

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -627,3 +627,7 @@ you get a separate view of your LXD resources by switching to it.
 This introduces a new `candid.api.key` option which allows for setting
 the expected public key for the endpoint, allowing for safe use of a
 HTTP-only candid server.
+
+## network\_vxlan\_ttl
+This adds a new `tunnel.NAME.ttl` network configuration option which
+makes it possible to raise the ttl on VXLAN tunnels.

--- a/doc/networks.md
+++ b/doc/networks.md
@@ -59,6 +59,7 @@ tunnel.NAME.local               | string    | gre or vxlan          | -         
 tunnel.NAME.port                | integer   | vxlan                 | 0                         | Specific port to use for the vxlan tunnel
 tunnel.NAME.protocol            | string    | standard mode         | -                         | Tunneling protocol ("vxlan" or "gre")
 tunnel.NAME.remote              | string    | gre or vxlan          | -                         | Remote address for the tunnel (not necessary for multicast vxlan)
+tunnel.NAME.ttl                 | integer   | vxlan                 | 1                         | Specific TTL to use for multicast routing topologies
 
 
 Those keys can be set using the lxc tool with:

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1629,6 +1629,12 @@ func (n *network) Start() error {
 				tunId = "1"
 			}
 			cmd = append(cmd, []string{"id", tunId}...)
+
+			tunTtl := getConfig("ttl")
+			if tunTtl == "" {
+				tunTtl = "1"
+			}
+			cmd = append(cmd, []string{"ttl", tunTtl}...)
 		}
 
 		// Create the interface

--- a/lxd/networks_config.go
+++ b/lxd/networks_config.go
@@ -53,6 +53,7 @@ var networkConfigKeys = map[string]func(value string) error{
 	"tunnel.TARGET.group":     networkValidAddressV4,
 	"tunnel.TARGET.id":        shared.IsInt64,
 	"tunnel.TARGET.interface": networkValidName,
+	"tunnel.TARGET.ttl":       shared.IsUint8,
 
 	"ipv4.address": func(value string) error {
 		if shared.IsOneOf(value, []string{"none", "auto"}) == nil {

--- a/shared/container.go
+++ b/shared/container.go
@@ -29,6 +29,19 @@ func IsInt64(value string) error {
 	return nil
 }
 
+func IsUint8(value string) error {
+	if value == "" {
+		return nil
+	}
+
+	_, err := strconv.ParseUint(value, 10, 8)
+	if err != nil {
+		return fmt.Errorf("Invalid value for an integer: %s. Must be between 0 and 255", value)
+	}
+
+	return nil
+}
+
 func IsUint32(value string) error {
 	if value == "" {
 		return nil

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -128,6 +128,7 @@ var APIExtensions = []string{
 	"storage_unmapped",
 	"projects",
 	"candid_config_key",
+	"network_vxlan_ttl",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is mandatory in multicast routing scenarios.

Signed-off-by: Julian Pelizäus <jp@adformc.de>