### PR TITLE
Fix lxc exec when using a container inside a project

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5983,7 +5983,8 @@ func (c *containerLXC) Exec(command []string, env map[string]string, stdin *os.F
 	}
 
 	// Prepare the subcommand
-	args := []string{c.state.OS.ExecPath, "forkexec", c.name, c.state.OS.LxcPath, filepath.Join(c.LogPath(), "lxc.conf")}
+	cname := projectPrefix(c.Project(), c.Name())
+	args := []string{c.state.OS.ExecPath, "forkexec", cname, c.state.OS.LxcPath, filepath.Join(c.LogPath(), "lxc.conf")}
 
 	args = append(args, "--")
 	args = append(args, "env")

--- a/test/suites/projects.sh
+++ b/test/suites/projects.sh
@@ -91,6 +91,7 @@ test_projects_containers() {
   # Start the container
   lxc start c1
   lxc list | grep c1 | grep -q RUNNING
+  echo "abc" | lxc exec c1 cat | grep -q abc
 
   # The container can't be managed when using the default project
   lxc project switch default


### PR DESCRIPTION
Fixes #5188.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>