### PR TITLE
Prefix the container name with the project name when invoking forkconsole

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5943,7 +5943,7 @@ func (c *containerLXC) Console(terminal *os.File) *exec.Cmd {
 	args := []string{
 		c.state.OS.ExecPath,
 		"forkconsole",
-		c.name,
+		projectPrefix(c.Project(), c.Name()),
 		c.state.OS.LxcPath,
 		filepath.Join(c.LogPath(), "lxc.conf"),
 		"tty=0",


### PR DESCRIPTION
Fixes #5192.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>