### PR TITLE
shared/cert: Switch default key to EC384

### DIFF
--- a/shared/cert_test.go
+++ b/shared/cert_test.go
@@ -81,7 +81,7 @@ func TestGenerateMemCert(t *testing.T) {
 	if len(rest) != 0 {
 		t.Errorf("GenerateMemCert returned a key with trailing content: %q", string(rest))
 	}
-	if block.Type != "RSA PRIVATE KEY" {
-		t.Errorf("GenerateMemCert returned a cert with Type %q not \"RSA PRIVATE KEY\"", block.Type)
+	if block.Type != "EC PRIVATE KEY" {
+		t.Errorf("GenerateMemCert returned a cert with Type %q not \"EC PRIVATE KEY\"", block.Type)
 	}
 }


### PR DESCRIPTION
This switches the key generation code to using an EC384 private key
rather than RSA4096.

This significantly speeds up key generation on some architectures.

Note that existing installations will keep using whatever client or
server key they have, this only affects certification generation on
first use.

If you want a newer installation to use RSA rather than EC, you can
generate a normal x509 cert/key pair using RSA4096 with tools like
openssl and put them in place.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>