### PR TITLE
lxd/migration: Use current idmap instead of next

### DIFF
--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -336,7 +336,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 
 	idmaps := make([]*migration.IDMapType, 0)
 
-	idmapset, err := s.container.IdmapSet()
+	idmapset, err := s.container.LastIdmapSet()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Doesn't do us any good advertising what the map should be instead of
what it actually is, so let's use the right one instead.

Closes #5205

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>