### PR TITLE
exec: Expose command, env and mode in metadata

### DIFF
--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -53,7 +53,12 @@ func (s *execWs) Metadata() interface{} {
 		}
 	}
 
-	return shared.Jmap{"fds": fds}
+	return shared.Jmap{
+		"fds":         fds,
+		"command":     s.command,
+		"environment": s.env,
+		"interactive": s.interactive,
+	}
 }
 
 func (s *execWs) Connect(op *operation, r *http.Request, w http.ResponseWriter) error {


### PR DESCRIPTION
Closes #5231

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>