### PR TITLE
Increase go-dqlite client timeout when not-clustered

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"time"
 
 	"github.com/CanonicalLtd/go-dqlite"
 	"github.com/gorilla/mux"
@@ -184,7 +185,20 @@ func clusterPut(d *Daemon, r *http.Request) Response {
 
 func clusterPutBootstrap(d *Daemon, req api.ClusterPut) Response {
 	run := func(op *operation) error {
-		return cluster.Bootstrap(d.State(), d.gateway, req.ServerName)
+		// The default timeout when non-clustered is one minute, let's
+		// lower it down now that we'll likely have to make requests
+		// over the network.
+		//
+		// FIXME: this is a workaround for #5234.
+		d.cluster.SetDefaultTimeout(5 * time.Second)
+
+		err := cluster.Bootstrap(d.State(), d.gateway, req.ServerName)
+		if err != nil {
+			d.cluster.SetDefaultTimeout(time.Minute)
+			return err
+		}
+
+		return nil
 	}
 	resources := map[string][]string{}
 	resources["cluster"] = []string{}
@@ -348,8 +362,16 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) Response {
 			nodes[i].Address = node.Address
 		}
 
+		// The default timeout when non-clustered is one minute, let's
+		// lower it down now that we'll likely have to make requests
+		// over the network.
+		//
+		// FIXME: this is a workaround for #5234.
+		d.cluster.SetDefaultTimeout(5 * time.Second)
+
 		err = cluster.Join(d.State(), d.gateway, cert, req.ServerName, nodes)
 		if err != nil {
+			d.cluster.SetDefaultTimeout(time.Minute)
 			return err
 		}
 

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -279,6 +279,12 @@ func ForLocalInspectionWithPreparedStmts(db *sql.DB) (*Cluster, error) {
 	return c, nil
 }
 
+// SetDefaultTimeout sets the default go-dqlite driver timeout.
+func (c *Cluster) SetDefaultTimeout(timeout time.Duration) {
+	driver := c.db.Driver().(*dqlite.Driver)
+	driver.SetContextTimeout(timeout)
+}
+
 // Transaction creates a new ClusterTx object and transactionally executes the
 // cluster database interactions invoked by the given function. If the function
 // returns no error, all database changes are committed to the cluster database


### PR DESCRIPTION
This is a workaround for #5234. Later down the road we'll want to implement a
proper fix in dqlite, as described in the issue.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>