### PR TITLE
lxd: fix starting container with missing optional disk

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1862,7 +1862,7 @@ func (c *containerLXC) startCommon() (string, error) {
 			// the storage volume, not the path where it is mounted.
 			// So do only check for the existence of m["source"]
 			// when m["pool"] is empty.
-			if m["pool"] == "" && m["source"] != "" && !shared.PathExists(shared.HostPath(m["source"])) {
+			if m["pool"] == "" && m["source"] != "" && !shared.PathExists(shared.HostPath(m["source"])) && !shared.IsTrue(m["optional"]) {
 				return "", fmt.Errorf("Missing source '%s' for disk '%s'", m["source"], name)
 			}
 		case "nic":


### PR DESCRIPTION
This PR should to fix #5281 for lxd 3.0 (e.g. works on my machine).