### PR TITLE
lxd/db: Avoid un-needed query on container move

### DIFF
--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -441,6 +441,11 @@ func (c *ClusterTx) ContainerNodeMove(oldName, newName, newNode string) error {
 		}
 	}
 
+	// No need to update storage_volumes if the name is identical
+	if newName == oldName {
+		return nil
+	}
+
 	// Update the container's and snapshots' storage volume name (since this is ceph,
 	// there's a clone of the volume for each node).
 	count, err := c.NodesCount()


### PR DESCRIPTION
Closes #5297

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>