### PR TITLE
lxd/storage: user_subvol_rm_allowed for btrfs

### DIFF
--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -696,6 +696,10 @@ func (s *storageCeph) getRBDMountOptions() string {
 		return s.pool.Config["volume.block.mount_options"]
 	}
 
+	if s.getRBDFilesystem() == "btrfs" {
+		return "user_subvol_rm_allowed,discard"
+	}
+
 	return "discard"
 }
 

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -95,6 +95,10 @@ func (s *storageLvm) getLvmMountOptions() string {
 		return s.pool.Config["volume.block.mount_options"]
 	}
 
+	if s.getLvmFilesystem() == "btrfs" {
+		return "user_subvol_rm_allowed,discard"
+	}
+
 	return "discard"
 }
 


### PR DESCRIPTION
This sets user_subvol_rm_allowed for btrfs on block storage, matching
the default behavior on the btrfs backend.

block mount options overrides will still override this default.

Closes #5301

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>