### PR TITLE
client: convert EventListener to use api.Event

### DIFF
--- a/client/events.go
+++ b/client/events.go
@@ -3,6 +3,8 @@ package lxd
 import (
 	"fmt"
 	"sync"
+
+	"github.com/lxc/lxd/shared/api"
 )
 
 // The EventListener struct is used to interact with a LXD event stream
@@ -18,12 +20,12 @@ type EventListener struct {
 
 // The EventTarget struct is returned to the caller of AddHandler and used in RemoveHandler
 type EventTarget struct {
-	function func(interface{})
+	function func(api.Event)
 	types    []string
 }
 
 // AddHandler adds a function to be called whenever an event is received
-func (e *EventListener) AddHandler(types []string, function func(interface{})) (*EventTarget, error) {
+func (e *EventListener) AddHandler(types []string, function func(api.Event)) (*EventTarget, error) {
 	if function == nil {
 		return nil, fmt.Errorf("A valid function must be provided")
 	}

--- a/client/lxd_events.go
+++ b/client/lxd_events.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
 
 // Event handling functions
@@ -90,29 +91,27 @@ func (r *ProtocolLXD) GetEvents() (*EventListener, error) {
 			}
 
 			// Attempt to unpack the message
-			message := make(map[string]interface{})
-			err = json.Unmarshal(data, &message)
+			event := api.Event{}
+			err = json.Unmarshal(data, &event)
 			if err != nil {
 				continue
 			}
 
 			// Extract the message type
-			_, ok := message["type"]
-			if !ok {
+			if event.Type == "" {
 				continue
 			}
-			messageType := message["type"].(string)
 
 			// Send the message to all handlers
 			r.eventListenersLock.Lock()
 			for _, listener := range r.eventListeners {
 				listener.targetsLock.Lock()
 				for _, target := range listener.targets {
-					if target.types != nil && !shared.StringInSlice(messageType, target.types) {
+					if target.types != nil && !shared.StringInSlice(event.Type, target.types) {
 						continue
 					}
 
-					go target.function(message)
+					go target.function(event)
 				}
 				listener.targetsLock.Unlock()
 			}

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -93,22 +93,9 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	handler := func(message interface{}) {
+	handler := func(event api.Event) {
 		// Special handling for logging only output
 		if c.flagPretty && len(c.flagType) == 1 && shared.StringInSlice("logging", c.flagType) {
-			render, err := json.Marshal(&message)
-			if err != nil {
-				fmt.Printf("error: %s\n", err)
-				os.Exit(1)
-			}
-
-			event := api.Event{}
-			err = json.Unmarshal(render, &event)
-			if err != nil {
-				fmt.Printf("error: %s\n", err)
-				os.Exit(1)
-			}
-
 			logEntry := api.EventLogging{}
 			err = json.Unmarshal(event.Metadata, &logEntry)
 			if err != nil {
@@ -144,7 +131,7 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		render, err := yaml.Marshal(&message)
+		render, err := yaml.Marshal(&event)
 		if err != nil {
 			fmt.Printf("error: %s\n", err)
 			os.Exit(1)

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -18,7 +18,7 @@ import (
 // get notified about events.
 //
 // Whenever an event is received the given callback is invoked.
-func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, interface{})) (task.Func, task.Schedule) {
+func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, api.Event)) (task.Func, task.Schedule) {
 	listeners := map[int64]*lxd.EventListener{}
 
 	// Update our pool of event listeners. Since database queries are
@@ -42,7 +42,7 @@ func Events(endpoints *endpoints.Endpoints, cluster *db.Cluster, f func(int64, i
 	return update, schedule
 }
 
-func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, listeners map[int64]*lxd.EventListener, f func(int64, interface{})) {
+func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, listeners map[int64]*lxd.EventListener, f func(int64, api.Event)) {
 	// Get the current cluster nodes.
 	var nodes []db.NodeInfo
 	var offlineThreshold time.Duration

--- a/lxd/cluster/events.go
+++ b/lxd/cluster/events.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lxc/lxd/lxd/endpoints"
 	"github.com/lxc/lxd/lxd/task"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"golang.org/x/net/context"
 )
@@ -99,7 +100,7 @@ func eventsUpdateListeners(endpoints *endpoints.Endpoints, cluster *db.Cluster, 
 			continue
 		}
 		logger.Debugf("Listening for events on node %s", node.Address)
-		listener.AddHandler(nil, func(event interface{}) { f(node.ID, event) })
+		listener.AddHandler(nil, func(event api.Event) { f(node.ID, event) })
 		listeners[node.ID] = listener
 	}
 	for id, listener := range listeners {

--- a/lxd/events.go
+++ b/lxd/events.go
@@ -129,26 +129,29 @@ func eventsGet(d *Daemon, r *http.Request) Response {
 }
 
 func eventSend(project, eventType string, eventMessage interface{}) error {
-	event := shared.Jmap{}
-	event["type"] = eventType
-	event["timestamp"] = time.Now()
-	event["metadata"] = eventMessage
-	event["project"] = project
+	encodedMessage, err := json.Marshal(eventMessage)
+	if err != nil {
+		return err
+	}
+	event := api.Event{
+		Type:      eventType,
+		Timestamp: time.Now(),
+		Metadata:  encodedMessage,
+	}
 
-	return eventBroadcast(event)
+	return eventBroadcast(project, event, false)
 }
 
-func eventBroadcast(event shared.Jmap) error {
+func eventBroadcast(project string, event api.Event, isForward bool) error {
 	body, err := json.Marshal(event)
 	if err != nil {
 		return err
 	}
 
-	_, isForward := event["node"]
 	eventsLock.Lock()
 	listeners := eventListeners
 	for _, listener := range listeners {
-		if event["project"] != "" && listener.project != "*" && event["project"] != listener.project {
+		if project != "" && listener.project != "*" && project != listener.project {
 			continue
 		}
 
@@ -156,7 +159,7 @@ func eventBroadcast(event shared.Jmap) error {
 			continue
 		}
 
-		if !shared.StringInSlice(event["type"].(string), listener.messageTypes) {
+		if !shared.StringInSlice(event.Type, listener.messageTypes) {
 			continue
 		}
 
@@ -175,7 +178,7 @@ func eventBroadcast(event shared.Jmap) error {
 				return
 			}
 
-			err = listener.connection.WriteMessage(websocket.TextMessage, body)
+			err := listener.connection.WriteMessage(websocket.TextMessage, body)
 			if err != nil {
 				// Remove the listener from the list
 				eventsLock.Lock()
@@ -196,11 +199,8 @@ func eventBroadcast(event shared.Jmap) error {
 }
 
 // Forward to the local events dispatcher an event received from another node .
-func eventForward(id int64, data interface{}) {
-	event := data.(map[string]interface{})
-	event["node"] = id
-
-	err := eventBroadcast(event)
+func eventForward(id int64, event api.Event) {
+	err := eventBroadcast("", event, true)
 	if err != nil {
 		logger.Warnf("Failed to forward event from node %d: %v", id, err)
 	}


### PR DESCRIPTION
Improve EventListener's AddHandler function to use an api.Event
struct rather than an interface{}.

Fix an asymmetry between the AddHandler functions for
Operation and EventListener, as the former provides an
api.Operation struct to its handler function, but the latter
gives just an interface{} that must be either be teased apart
with type assertions or marshaled back into JSON and
unmarshaled into the appropriate type.

Signed-off-by: Stephen Barber <smbarber@chromium.org>