### PR TITLE
lxd/init: Verify if ZFS pool exists

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -574,7 +574,7 @@ func (c *cmdInit) askStoragePool(config *cmdInitData, d lxd.ContainerServer, poo
 					if err != nil {
 						return err
 					}
-					if poolvolumeexists {
+					if poolvolumeexists == false {
 						return fmt.Errorf("'%s' ZFS pool or dataset does not exist", pool.Name)
 					}
 				}

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -89,6 +89,23 @@ func zfsPoolCheck(pool string) error {
 	return nil
 }
 
+// zfsPoolVolumeExists verifies if a specific ZFS pool or dataset exists.
+func zfsPoolVolumeExists(dataset string) (bool, error) {
+	output, err := shared.RunCommand(
+		"zpool", "list", "-Ho", "name")
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, name := range strings.Split(output, "\n") {
+		if name == dataset {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func zfsPoolCreate(pool string, vdev string) error {
 	var output string
 	var err error


### PR DESCRIPTION
The ZFS pool is only verified at a later stage as soon LXD tries to create it.

This causes some frustration as we need to go through  the whole `lxd init` process only to find out a mistake was made at a later stage.

This PR implements a function to verify if a ZFS pool exists and a check on the `lxd init` interactive process that calls that same function when a user defines the pool setting to have a zfs backend.