### PR TITLE
LXD init: Verify ZFS pool when in interactive mode.

### DIFF
--- a/lxd/main_init_interactive.go
+++ b/lxd/main_init_interactive.go
@@ -486,6 +486,13 @@ func (c *cmdInit) askStoragePool(config *cmdInitData, d lxd.ContainerServer, poo
 		}
 
 		if cli.AskBool(fmt.Sprintf("Create a new %s pool? (yes/no) [default=yes]: ", strings.ToUpper(pool.Driver)), "yes") {
+			if pool.Driver == "zfs" && os.Geteuid() == 0 {
+				poolVolumeExists, err := zfsPoolVolumeExists(pool.Name)
+				if err == nil && poolVolumeExists {
+					return fmt.Errorf("'%s' ZFS pool already exists", pool.Name)
+				}
+			}
+
 			if pool.Driver == "ceph" {
 				// Ask for the name of the cluster
 				pool.Config["ceph.cluster_name"] = cli.AskString("Name of the existing CEPH cluster [default=ceph]: ", "ceph", nil)
@@ -554,6 +561,13 @@ func (c *cmdInit) askStoragePool(config *cmdInitData, d lxd.ContainerServer, poo
 			} else {
 				question := fmt.Sprintf("Name of the existing %s pool or dataset: ", strings.ToUpper(pool.Driver))
 				pool.Config["source"] = cli.AskString(question, "", nil)
+			}
+
+			if pool.Driver == "zfs" && os.Geteuid() == 0 {
+				poolVolumeExists, err := zfsPoolVolumeExists(pool.Config["source"])
+				if err == nil && !poolVolumeExists {
+					return fmt.Errorf("'%s' ZFS pool or dataset does not exist", pool.Config["source"])
+				}
 			}
 		}
 

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -89,6 +89,23 @@ func zfsPoolCheck(pool string) error {
 	return nil
 }
 
+// zfsPoolVolumeExists verifies if a specific ZFS pool or volume exists.
+func zfsPoolVolumeExists(dataset string) (bool, error) {
+	output, err := shared.RunCommand(
+		"zfs", "list", "-Ho", "name")
+
+	if err != nil {
+		return false, err
+	}
+
+	for _, name := range strings.Split(output, "\n") {
+		if name == dataset {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func zfsPoolCreate(pool string, vdev string) error {
 	var output string
 	var err error


### PR DESCRIPTION
Follow up of: https://github.com/lxc/lxd/pull/5345
The ZFS pool is only verified at a later stage as soon LXD tries to create it.

This causes some frustration as we need to go through the whole lxd init process only to find out a mistake was made at a later stage.

This PR implements a function to verify if a ZFS pool exists and a check on the `lxd init` interactive process that calls that same function when a user defines the pool setting to have a ZFS backend.