### PR TITLE
Re-generate the fresh schema, bumping the schema version

### DIFF
--- a/lxd/db/node/schema.go
+++ b/lxd/db/node/schema.go
@@ -24,5 +24,5 @@ CREATE TABLE raft_nodes (
     UNIQUE (address)
 );
 
-INSERT INTO schema (version, updated_at) VALUES (37, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (38, strftime("%s"))
 `


### PR DESCRIPTION
The 'make generate' command was not run when patch 38 was introduced, so newly
installed LXDs are inconsistent: the schema version is effectively 38, but the
one stored in local.db is 37.

Closes #5364.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>