### PR TITLE
shared: Read certificates from host

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -64,14 +64,15 @@ func InitTLSConfig() *tls.Config {
 }
 
 func finalizeTLSConfig(tlsConfig *tls.Config, tlsRemoteCert *x509.Certificate) {
+	// Setup RootCA
+	if tlsConfig.RootCAs == nil {
+		tlsConfig.RootCAs, _ = systemCertPool()
+	}
+
 	// Trusted certificates
 	if tlsRemoteCert != nil {
-		caCertPool := tlsConfig.RootCAs
-		if caCertPool == nil {
-			caCertPool, _ = systemCertPool()
-			if caCertPool == nil {
-				caCertPool = x509.NewCertPool()
-			}
+		if tlsConfig.RootCAs == nil {
+			tlsConfig.RootCAs = x509.NewCertPool()
 		}
 
 		// Make it a valid RootCA
@@ -79,8 +80,7 @@ func finalizeTLSConfig(tlsConfig *tls.Config, tlsRemoteCert *x509.Certificate) {
 		tlsRemoteCert.KeyUsage = x509.KeyUsageCertSign
 
 		// Setup the pool
-		caCertPool.AddCert(tlsRemoteCert)
-		tlsConfig.RootCAs = caCertPool
+		tlsConfig.RootCAs.AddCert(tlsRemoteCert)
 
 		// Set the ServerName
 		if tlsRemoteCert.DNSNames != nil {

--- a/shared/network_unix.go
+++ b/shared/network_unix.go
@@ -4,8 +4,23 @@ package shared
 
 import (
 	"crypto/x509"
+	"io/ioutil"
 )
 
 func systemCertPool() (*x509.CertPool, error) {
-	return x509.SystemCertPool()
+	// Get the system pool
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		return nil, err
+	}
+
+	// Attempt to load the system's pool too (for snaps)
+	if PathExists("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt") {
+		snapCerts, err := ioutil.ReadFile("/var/lib/snapd/hostfs/etc/ssl/certs/ca-certificates.crt")
+		if err == nil {
+			pool.AppendCertsFromPEM(snapCerts)
+		}
+	}
+
+	return pool, nil
 }


### PR DESCRIPTION
This is for snap users, during update of the core snap, the custom mount
namespace setup by LXD may be missing, causing access to the host CA
configuration to be temporarily broken (until the next LXD restart).

With this patch, we directly go look for the CA certificates of the host
and merge those with what's in the snap environment.

Closes https://github.com/lxc/lxd-pkg-snap/issues/28

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>