### PR TITLE
lxd/cluster: Fix schema upgrades

### DIFF
--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -213,6 +213,15 @@ func OpenCluster(name string, store dqlite.ServerStore, address, dir string, tim
 	db.SetMaxOpenConns(1)
 	db.SetMaxIdleConns(1)
 
+	if !nodesVersionsMatch {
+		cluster := &Cluster{
+			db:    db,
+			stmts: map[int]*sql.Stmt{},
+		}
+
+		return cluster, ErrSomeNodesAreBehind
+	}
+
 	stmts, err := cluster.PrepareStmts(db)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to prepare statements")
@@ -244,10 +253,6 @@ func OpenCluster(name string, store dqlite.ServerStore, address, dir string, tim
 	})
 	if err != nil {
 		return nil, err
-	}
-
-	if !nodesVersionsMatch {
-		err = ErrSomeNodesAreBehind
 	}
 
 	return cluster, err


### PR DESCRIPTION
While working on LXD 3.0 deb to LXD 3.8 snap upgrades, I ran into an
issue where loading the prepared statements was erroring out, causing
the daemon to exit.

That happens when the first node upgrades as the rest of the cluster is
still on the older schema version, causing the schema upgrade code to be
skipped. The prepared statements were then loaded regardless, causing
the crash when preparing them.

Instead, as soon as we know that the DB hasn't been upgraded, return and
let the retry logic happen. Once the remaining nodes have upgraded, the
schema update will happen and the prepared statements will be
re-processed.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>