### PR TITLE
image-handling.md: 'release' should be a string and not a list

### DIFF
--- a/doc/image-handling.md
+++ b/doc/image-handling.md
@@ -100,9 +100,7 @@ creation_date: 1424284563
 properties:
   description: Ubuntu 14.04 LTS Intel 64bit
   os: Ubuntu
-  release:
-    - trusty
-    - 14.04
+  release: trusty 14.04
 templates:
   /etc/hosts:
     when:


### PR DESCRIPTION
  During 'lxc image import', yaml.Unmarshal() and is applied to the following struct:

```go
  // ImageMetadata represents LXD image metadata
  type ImageMetadata struct {
	Architecture string                            `json:"architecture" yaml:"architecture"`
	CreationDate int64                             `json:"creation_date" yaml:"creation_date"`
	ExpiryDate   int64                             `json:"expiry_date" yaml:"expiry_date"`
	Properties   map[string]string                 `json:"properties" yaml:"properties"`
	Templates    map[string]*ImageMetadataTemplate `json:"templates" yaml:"templates"`
  }
```
  ImageMetadata.Properties is a map[string]string, and applying any property as a list will
  result in the following error:

  > Error: Could not parse metadata.yaml: yaml: unmarshal errors:
  > line 8: cannot unmarshal !!seq into string

Signed-off-by: fqbuild <TerraTech@users.noreply.github.com>