### PR TITLE
lxc/storage: Fix argument count check for delete

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -549,8 +549,7 @@ func (c *cmdStorageVolumeDelete) Command() *cobra.Command {
 
 func (c *cmdStorageVolumeDelete) Run(cmd *cobra.Command, args []string) error {
 	// Sanity checks
-	// Sanity checks
-	exit, err := c.global.CheckArgs(cmd, args, 2, 3)
+	exit, err := c.global.CheckArgs(cmd, args, 2, 2)
 	if exit {
 		return err
 	}


### PR DESCRIPTION
Closes #5394

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>