### PR TITLE
lxd: Fix possible segfaults in tasks

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -387,6 +387,7 @@ func pruneExpiredContainerBackupsTask(d *Daemon) (task.Func, task.Schedule) {
 		op, err := operationCreate(d.cluster, "", operationClassTask, db.OperationBackupsExpire, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired backups operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Info("Pruning expired container backups")

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1586,6 +1586,7 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		op, err := operationCreate(d.cluster, "", operationClassTask, db.OperationSnapshotCreate, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start create snapshot operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Info("Creating scheduled container snapshots")

--- a/lxd/container_instance_types.go
+++ b/lxd/container_instance_types.go
@@ -94,6 +94,7 @@ func instanceRefreshTypesTask(d *Daemon) (task.Func, task.Schedule) {
 		op, err := operationCreate(d.cluster, "", operationClassTask, db.OperationInstanceTypesUpdate, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start instance types update operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Info("Updating instance types")

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -863,6 +863,7 @@ func autoUpdateImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		op, err := operationCreate(d.cluster, "", operationClassTask, db.OperationImagesUpdate, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start image update operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Infof("Updating images")
@@ -1090,6 +1091,7 @@ func pruneExpiredImagesTask(d *Daemon) (task.Func, task.Schedule) {
 		op, err := operationCreate(d.cluster, "", operationClassTask, db.OperationImagesExpire, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start expired image operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Infof("Pruning expired images")

--- a/lxd/logging.go
+++ b/lxd/logging.go
@@ -26,6 +26,7 @@ func expireLogsTask(state *state.State) (task.Func, task.Schedule) {
 		op, err := operationCreate(state.Cluster, "", operationClassTask, db.OperationLogsExpire, nil, nil, opRun, nil, nil)
 		if err != nil {
 			logger.Error("Failed to start log expiry operation", log.Ctx{"err": err})
+			return
 		}
 
 		logger.Infof("Expiring log files")


### PR DESCRIPTION
Calling op.Run() if operationCreate() has failed will cause a segfault.

This problem is mentioned in #5436.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>