### PR TITLE
lxd: Send metadata in CreateImage error importing image

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -580,7 +580,7 @@ func getImgPostInfo(d *Daemon, r *http.Request, builddir string, project string,
 				return nil, err
 			}
 		} else {
-			return nil, fmt.Errorf("Image with same fingerprint already exists")
+			return &info, fmt.Errorf("Image with same fingerprint already exists")
 		}
 	} else {
 		// Create the database entry


### PR DESCRIPTION
When importing a packed image, send 'fingerprint' and 'size'
in metadata when an error occurs because the image already
exists.

Signed-off-by: Joel Hockey <joelhockey@chromium.org>