### PR TITLE
lxd: change ImageFileRequest to use io.Writer rather than WriteSeeker

### DIFF
--- a/client/interfaces.go
+++ b/client/interfaces.go
@@ -250,7 +250,7 @@ type ContainerBackupArgs struct {
 // The BackupFileRequest struct is used for a backup download request
 type BackupFileRequest struct {
 	// Writer for the backup file
-	BackupFile io.WriteSeeker
+	BackupFile io.Writer
 
 	// Progress handler (called whenever some progress is made)
 	ProgressHandler func(progress ioprogress.ProgressData)
@@ -286,10 +286,10 @@ type ImageCreateArgs struct {
 // The ImageFileRequest struct is used for an image download request
 type ImageFileRequest struct {
 	// Writer for the metadata file
-	MetaFile io.WriteSeeker
+	MetaFile io.Writer
 
 	// Writer for the rootfs file
-	RootfsFile io.WriteSeeker
+	RootfsFile io.Writer
 
 	// Progress handler (called whenever some progress is made)
 	ProgressHandler func(progress ioprogress.ProgressData)

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -79,7 +79,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 	resp := ImageFileResponse{}
 
 	// Download function
-	download := func(path string, filename string, hash string, target io.WriteSeeker) (int64, error) {
+	download := func(path string, filename string, hash string, target io.Writer) (int64, error) {
 		// Try over http
 		url := fmt.Sprintf("http://%s/%s", strings.TrimPrefix(r.httpHost, "https://"), path)
 

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io"
 	"os"
 	"strings"
 	"time"
@@ -112,7 +111,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 	backupFileRequest := lxd.BackupFileRequest{
-		BackupFile:      io.WriteSeeker(target),
+		BackupFile:      target,
 		ProgressHandler: progress.UpdateProgress,
 	}
 

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -501,8 +501,8 @@ func (c *cmdImageExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	req := lxd.ImageFileRequest{
-		MetaFile:        io.WriteSeeker(dest),
-		RootfsFile:      io.WriteSeeker(destRootfs),
+		MetaFile:        dest,
+		RootfsFile:      destRootfs,
 		ProgressHandler: progress.UpdateProgress,
 	}
 

--- a/lxd/daemon_images.go
+++ b/lxd/daemon_images.go
@@ -431,8 +431,8 @@ func (d *Daemon) ImageDownload(op *operation, server string, protocol string, ce
 		// Download the image
 		var resp *lxd.ImageFileResponse
 		request := lxd.ImageFileRequest{
-			MetaFile:        io.WriteSeeker(dest),
-			RootfsFile:      io.WriteSeeker(destRootfs),
+			MetaFile:        dest,
+			RootfsFile:      destRootfs,
 			ProgressHandler: progress,
 			Canceler:        canceler,
 			DeltaSourceRetriever: func(fingerprint string, file string) string {

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1902,8 +1902,8 @@ func imageImportFromNode(imagesDir string, client lxd.ContainerServer, fingerpri
 	defer rootfsFile.Close()
 
 	getReq := lxd.ImageFileRequest{
-		MetaFile:   io.WriteSeeker(metaFile),
-		RootfsFile: io.WriteSeeker(rootfsFile),
+		MetaFile:   metaFile,
+		RootfsFile: rootfsFile,
 	}
 	getResp, err := client.GetImageFile(fingerprint, getReq)
 	if err != nil {

--- a/shared/util.go
+++ b/shared/util.go
@@ -1008,10 +1008,7 @@ func EscapePathFstab(path string) string {
 	return r.Replace(path)
 }
 
-func DownloadFileHash(httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.Canceler, filename string, url string, hash string, hashFunc hash.Hash, target io.WriteSeeker) (int64, error) {
-	// Always seek to the beginning
-	target.Seek(0, 0)
-
+func DownloadFileHash(httpClient *http.Client, useragent string, progress func(progress ioprogress.ProgressData), canceler *cancel.Canceler, filename string, url string, hash string, hashFunc hash.Hash, target io.Writer) (int64, error) {
 	// Prepare the download request
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
Currently shared/util.go DownloadFileHash requires an io.WriteSeeker
since it calls Seek(0, 0).  The call to Seek is unnecessary as all
current calls into this function provide a file newly created
with os.Create.

Allowing io.Writer rather than the more restrictive io.WriteSeeker
allows other writers such as ioprogress.ProgressWriter to be
passed.

Signed-off-by: Joel Hockey <joelhockey@chromium.org>