### PR TITLE
lxd: Send operation progress when creating image or container.

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -353,7 +353,17 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 	}
 
 	if compress != "none" {
-		compressedPath, err := compressFile(backupPath, compress)
+		infile, err := os.Open(backupPath)
+		if err != nil {
+			return err
+		}
+		defer infile.Close()
+		compressed, err := os.Create(backupPath + ".compressed")
+		if err != nil {
+			return err
+		}
+		defer compressed.Close()
+		err = compressFile(compress, infile, compressed)
 		if err != nil {
 			return err
 		}
@@ -363,7 +373,7 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 			return err
 		}
 
-		err = os.Rename(compressedPath, backupPath)
+		err = os.Rename(compressed.Name(), backupPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -358,11 +358,13 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 			return err
 		}
 		defer infile.Close()
+
 		compressed, err := os.Create(backupPath + ".compressed")
 		if err != nil {
 			return err
 		}
 		defer compressed.Close()
+
 		err = compressFile(compress, infile, compressed)
 		if err != nil {
 			return err

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
+	"github.com/lxc/lxd/shared/ioprogress"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
@@ -767,7 +768,7 @@ func containerCreateEmptySnapshot(s *state.State, args db.ContainerArgs) (contai
 	return c, nil
 }
 
-func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (container, error) {
+func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string, tracker *ioprogress.ProgressTracker) (container, error) {
 	s := d.State()
 
 	// Get the image properties
@@ -826,6 +827,7 @@ func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (co
 	}
 
 	// Now create the storage from an image
+	c.Storage().SetProgressTracker(tracker)
 	err = c.Storage().ContainerCreateFromImage(c, hash)
 	if err != nil {
 		c.Delete()

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -205,11 +205,13 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 			},
 		},
 	}
+
 	// Calculate (close estimate of) total size of tarfile
 	sumSize := func(path string, fi os.FileInfo, err error) error {
 		tarfileProgressWriter.Tracker.Length += fi.Size()
 		return nil
 	}
+
 	err = filepath.Walk(c.RootfsPath(), sumSize)
 	if err != nil {
 		return nil, err
@@ -250,10 +252,12 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 			return nil, err
 		}
 		defer tarfile.Close()
+
 		fi, err := tarfile.Stat()
 		if err != nil {
 			return nil, err
 		}
+
 		// Track progress writing gzipped file
 		metadata = make(map[string]string)
 		tarfileProgressReader := &ioprogress.ProgressReader{
@@ -269,14 +273,18 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 			},
 		}
 		compressedPath = tarfile.Name() + ".compressed"
+
 		compressed, err := os.Create(compressedPath)
 		if err != nil {
 			return nil, err
 		}
+
 		defer compressed.Close()
 		defer os.Remove(compressed.Name())
+
 		// Calculate sha256 as we compress
 		writer := io.MultiWriter(compressed, sha256)
+
 		err = compressFile(compress, tarfileProgressReader, writer)
 		if err != nil {
 			return nil, err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3159,11 +3159,13 @@ func patchMoveBackups(name string, d *Daemon) error {
 					return err
 				}
 				defer infile.Close()
+
 				compressed, err := os.Create(backupPath + ".compressed")
 				if err != nil {
 					return err
 				}
 				defer compressed.Close()
+
 				err = compressFile("xz", infile, compressed)
 				if err != nil {
 					return err

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3154,7 +3154,17 @@ func patchMoveBackups(name string, d *Daemon) error {
 				}
 
 				// Compress it
-				compressedPath, err := compressFile(backupPath, "xz")
+				infile, err := os.Open(backupPath)
+				if err != nil {
+					return err
+				}
+				defer infile.Close()
+				compressed, err := os.Create(backupPath + ".compressed")
+				if err != nil {
+					return err
+				}
+				defer compressed.Close()
+				err = compressFile("xz", infile, compressed)
 				if err != nil {
 					return err
 				}
@@ -3164,7 +3174,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 					return err
 				}
 
-				err = os.Rename(compressedPath, backupPath)
+				err = os.Rename(compressed.Name(), backupPath)
 				if err != nil {
 					return err
 				}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -237,6 +237,9 @@ type storage interface {
 
 	StorageMigrationSource(args MigrationSourceArgs) (MigrationStorageSourceDriver, error)
 	StorageMigrationSink(conn *websocket.Conn, op *operation, args MigrationSinkArgs) error
+
+	// For tracking long operations such as unpacking an image.
+	SetProgressTracker(tracker *ioprogress.ProgressTracker)
 }
 
 func storageCoreInit(driver string) (storage, error) {

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -2057,7 +2057,7 @@ func (s *storageBtrfs) ImageCreate(fingerprint string) error {
 
 	// Unpack the image in imageMntPoint.
 	imagePath := shared.VarPath("images", fingerprint)
-	err = unpackImage(imagePath, tmpImageSubvolumeName, storageTypeBtrfs, s.s.OS.RunningInUserNS)
+	err = unpackImage(imagePath, tmpImageSubvolumeName, storageTypeBtrfs, s.s.OS.RunningInUserNS, s.tracker)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -2189,7 +2189,7 @@ func (s *storageCeph) ImageCreate(fingerprint string) error {
 
 		// rsync contents into image
 		imagePath := shared.VarPath("images", fingerprint)
-		err = unpackImage(imagePath, imageMntPoint, storageTypeCeph, s.s.OS.RunningInUserNS)
+		err = unpackImage(imagePath, imageMntPoint, storageTypeCeph, s.s.OS.RunningInUserNS, s.tracker)
 		if err != nil {
 			logger.Errorf(`Failed to unpack image for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -542,7 +542,7 @@ func (s *storageDir) ContainerCreateFromImage(container container, imageFingerpr
 	}()
 
 	imagePath := shared.VarPath("images", imageFingerprint)
-	err = unpackImage(imagePath, containerMntPoint, storageTypeDir, s.s.OS.RunningInUserNS)
+	err = unpackImage(imagePath, containerMntPoint, storageTypeDir, s.s.OS.RunningInUserNS, s.tracker)
 	if err != nil {
 		return errors.Wrap(err, "Unpack image")
 	}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1968,7 +1968,7 @@ func (s *storageLvm) ImageCreate(fingerprint string) error {
 		}
 
 		imagePath := shared.VarPath("images", fingerprint)
-		err = unpackImage(imagePath, imageMntPoint, storageTypeLvm, s.s.OS.RunningInUserNS)
+		err = unpackImage(imagePath, imageMntPoint, storageTypeLvm, s.s.OS.RunningInUserNS, s.tracker)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -502,7 +502,7 @@ func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
 
 	imagePath := shared.VarPath("images", fp)
 	containerMntPoint := getContainerMountPoint(c.Project(), s.pool.Name, containerName)
-	err = unpackImage(imagePath, containerMntPoint, storageTypeLvm, s.s.OS.RunningInUserNS)
+	err = unpackImage(imagePath, containerMntPoint, storageTypeLvm, s.s.OS.RunningInUserNS, s.tracker)
 	if err != nil {
 		logger.Errorf(`Failed to unpack image "%s" into non-thinpool LVM storage volume "%s" for container "%s" on storage pool "%s": %s`, imagePath, containerMntPoint, containerName, s.pool.Name, err)
 		return err

--- a/lxd/storage_shared.go
+++ b/lxd/storage_shared.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/pkg/errors"
 )
@@ -22,6 +23,8 @@ type storageShared struct {
 	pool   *api.StoragePool
 
 	volume *api.StorageVolume
+
+	tracker *ioprogress.ProgressTracker
 }
 
 func (s *storageShared) GetStorageType() storageType {
@@ -34,6 +37,10 @@ func (s *storageShared) GetStorageTypeName() string {
 
 func (s *storageShared) GetStorageTypeVersion() string {
 	return s.sTypeVersion
+}
+
+func (s *storageShared) SetProgressTracker(tracker *ioprogress.ProgressTracker) {
+	s.tracker = tracker
 }
 
 func (s *storageShared) shiftRootfs(c container, skipper func(dir string, absPath string, fi os.FileInfo) bool) error {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -2443,7 +2443,7 @@ func (s *storageZfs) ImageCreate(fingerprint string) error {
 	}
 
 	// Unpack the image into the temporary mountpoint.
-	err = unpackImage(imagePath, tmpImageDir, storageTypeZfs, s.s.OS.RunningInUserNS)
+	err = unpackImage(imagePath, tmpImageDir, storageTypeZfs, s.s.OS.RunningInUserNS, s.tracker)
 	if err != nil {
 		return err
 	}

--- a/shared/archive_linux.go
+++ b/shared/archive_linux.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -54,7 +55,7 @@ func DetectCompressionFile(f io.ReadSeeker) ([]string, string, []string, error) 
 	}
 }
 
-func Unpack(file string, path string, blockBackend bool, runningInUserns bool) error {
+func Unpack(file string, path string, blockBackend bool, runningInUserns bool, tracker *ioprogress.ProgressTracker) error {
 	extractArgs, extension, _, err := DetectCompression(file)
 	if err != nil {
 		return err
@@ -62,6 +63,7 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool) e
 
 	command := ""
 	args := []string{}
+	var reader io.Reader
 	if strings.HasPrefix(extension, ".tar") {
 		command = "tar"
 		if runningInUserns {
@@ -73,8 +75,28 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool) e
 		}
 		args = append(args, "-C", path, "--numeric-owner", "--xattrs-include=*")
 		args = append(args, extractArgs...)
-		args = append(args, file)
+		args = append(args, "-")
+		f, err := os.Open(file)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		reader = f
+		// Attach the ProgressTracker if supplied.
+		if tracker != nil {
+			fsinfo, err := f.Stat()
+			if err != nil {
+				return err
+			}
+			tracker.Length = fsinfo.Size()
+			reader = &ioprogress.ProgressReader{
+				ReadCloser: f,
+				Tracker: tracker,
+			}
+		}
 	} else if strings.HasPrefix(extension, ".squashfs") {
+		// unsquashfs does not support reading from stdin,
+                // so ProgressTracker is not possible.
 		command = "unsquashfs"
 		args = append(args, "-f", "-d", path, "-n")
 
@@ -91,7 +113,7 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool) e
 		return fmt.Errorf("Unsupported image format: %s", extension)
 	}
 
-	output, err := RunCommand(command, args...)
+	err = RunCommandWithFds(reader, nil, command, args...)
 	if err != nil {
 		// Check if we ran out of space
 		fs := syscall.Statfs_t{}
@@ -110,14 +132,9 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool) e
 			}
 		}
 
-		co := output
 		logger.Debugf("Unpacking failed")
-		logger.Debugf(co)
-
-		// Truncate the output to a single line for inclusion in the error
-		// message.  The first line isn't guaranteed to pinpoint the issue,
-		// but it's better than nothing and better than a multi-line message.
-		return fmt.Errorf("Unpack failed, %s.  %s", err, strings.SplitN(co, "\n", 2)[0])
+		logger.Debugf(err.Error())
+		return fmt.Errorf("Unpack failed, %s.", err)
 	}
 
 	return nil

--- a/shared/archive_linux.go
+++ b/shared/archive_linux.go
@@ -76,18 +76,22 @@ func Unpack(file string, path string, blockBackend bool, runningInUserns bool, t
 		args = append(args, "-C", path, "--numeric-owner", "--xattrs-include=*")
 		args = append(args, extractArgs...)
 		args = append(args, "-")
+
 		f, err := os.Open(file)
 		if err != nil {
 			return err
 		}
 		defer f.Close()
+
 		reader = f
+
 		// Attach the ProgressTracker if supplied.
 		if tracker != nil {
 			fsinfo, err := f.Stat()
 			if err != nil {
 				return err
 			}
+
 			tracker.Length = fsinfo.Size()
 			reader = &ioprogress.ProgressReader{
 				ReadCloser: f,


### PR DESCRIPTION
Added metadata fields 'stage', 'percent', 'speed' to track
long running tasks in some operations.

In CreateImage, added stages 'create_image_from_container_tar'
and 'create_image_from_container_compress'.

In CreateContainerFromImage, added stage
'create_container_from_image_unpack'.

Modified images.go compressFile to take io.Reader and io.Writer
rather than a path name to allow imgPostContInfo to
supply an ioprogress.ProgressWriter that can track progress
of image compression.

Refactored imgPostContInfo to not require a separate pass
to determine the fingerprint when publishing an image from
a container.  The sha256 calculation is either done during
tar, or during compression.

Added tracker field in storageShared where callers can set
a ProgressTracker which is used when unpacking an image to
create new container in unpackImage and Unpack

Signed-off-by: Joel Hockey <joelhockey@chromium.org>