### PR TITLE
lxd/images: change compressFile to take io.Reader and io.Writer

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -353,7 +353,19 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 	}
 
 	if compress != "none" {
-		compressedPath, err := compressFile(backupPath, compress)
+		infile, err := os.Open(backupPath)
+		if err != nil {
+			return err
+		}
+		defer infile.Close()
+
+		compressed, err := os.Create(backupPath + ".compressed")
+		if err != nil {
+			return err
+		}
+		defer compressed.Close()
+
+		err = compressFile(compress, infile, compressed)
 		if err != nil {
 			return err
 		}
@@ -363,7 +375,7 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 			return err
 		}
 
-		err = os.Rename(compressedPath, backupPath)
+		err = os.Rename(compressed.Name(), backupPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -129,7 +129,7 @@ func unpackImage(imagefname string, destpath string, sType storageType, runningI
 	return nil
 }
 
-func compressFile(path string, compress string) (string, error) {
+func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 	reproducible := []string{"gzip"}
 
 	args := []string{"-c"}
@@ -137,24 +137,11 @@ func compressFile(path string, compress string) (string, error) {
 		args = append(args, "-n")
 	}
 
-	args = append(args, path)
 	cmd := exec.Command(compress, args...)
-
-	outfile, err := os.Create(path + ".compressed")
-	if err != nil {
-		return "", err
-	}
-
-	defer outfile.Close()
+	cmd.Stdin = infile
 	cmd.Stdout = outfile
 
-	err = cmd.Run()
-	if err != nil {
-		os.Remove(outfile.Name())
-		return "", err
-	}
-
-	return outfile.Name(), nil
+	return cmd.Run()
 }
 
 /*
@@ -223,7 +210,21 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, builddir st
 	}
 
 	if compress != "none" {
-		compressedPath, err = compressFile(tarfile.Name(), compress)
+		tarfile, err = os.Open(tarfile.Name())
+		if err != nil {
+			return nil, err
+		}
+		defer tarfile.Close()
+
+		compressedPath = tarfile.Name() + ".compressed"
+
+		compressed, err := os.Create(compressedPath)
+		if err != nil {
+			return nil, err
+		}
+		defer compressed.Close()
+
+		err = compressFile(compress, tarfile, compressed)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -3154,7 +3154,19 @@ func patchMoveBackups(name string, d *Daemon) error {
 				}
 
 				// Compress it
-				compressedPath, err := compressFile(backupPath, "xz")
+				infile, err := os.Open(backupPath)
+				if err != nil {
+					return err
+				}
+				defer infile.Close()
+
+				compressed, err := os.Create(backupPath + ".compressed")
+				if err != nil {
+					return err
+				}
+				defer compressed.Close()
+
+				err = compressFile("xz", infile, compressed)
 				if err != nil {
 					return err
 				}
@@ -3164,7 +3176,7 @@ func patchMoveBackups(name string, d *Daemon) error {
 					return err
 				}
 
-				err = os.Rename(compressedPath, backupPath)
+				err = os.Rename(compressed.Name(), backupPath)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This is part 1 of a series of patches to add better progress
tracking support for export and import.

By using Reader and Writer rather than filename for compressing
the caller can provide a tracking reader/writer for progress.

Signed-off-by: Joel Hockey <joelhockey@chromium.org>