### PR TITLE
storage: Add ioprogress.ProgressTracker field to storage

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -25,6 +25,7 @@ import (
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/idmap"
+	"github.com/lxc/lxd/shared/ioprogress"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/osarch"
@@ -768,7 +769,7 @@ func containerCreateEmptySnapshot(s *state.State, args db.ContainerArgs) (contai
 	return c, nil
 }
 
-func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (container, error) {
+func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string, tracker *ioprogress.ProgressTracker) (container, error) {
 	s := d.State()
 
 	// Get the image properties
@@ -827,7 +828,7 @@ func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string) (co
 	}
 
 	// Now create the storage from an image
-	err = c.Storage().ContainerCreateFromImage(c, hash)
+	err = c.Storage().ContainerCreateFromImage(c, hash, tracker)
 	if err != nil {
 		c.Delete()
 		return nil, errors.Wrap(err, "Create container from image")

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -128,7 +128,7 @@ func createFromImage(d *Daemon, project string, req *api.ContainersPost) Respons
 			return err
 		}
 
-		_, err = containerCreateFromImage(d, args, info.Fingerprint)
+		_, err = containerCreateFromImage(d, args, info.Fingerprint, nil)
 		return err
 	}
 
@@ -356,7 +356,7 @@ func createFromMigration(d *Daemon, project string, req *api.ContainersPost) Res
 			}
 
 			if ps.MigrationType() == migration.MigrationFSType_RSYNC {
-				c, err = containerCreateFromImage(d, args, req.Source.BaseImage)
+				c, err = containerCreateFromImage(d, args, req.Source.BaseImage, nil)
 				if err != nil {
 					return InternalError(err)
 				}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -618,7 +618,7 @@ func imageCreateInPool(d *Daemon, info *api.Image, storagePool string) error {
 
 	// Create the storage volume for the image on the requested storage
 	// pool.
-	err = s.ImageCreate(info.Fingerprint)
+	err = s.ImageCreate(info.Fingerprint, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -175,7 +175,7 @@ type storage interface {
 	ContainerCreate(container container) error
 
 	// ContainerCreateFromImage creates a container from a image.
-	ContainerCreateFromImage(c container, fingerprint string) error
+	ContainerCreateFromImage(c container, fingerprint string, tracker *ioprogress.ProgressTracker) error
 	ContainerCanRestore(target container, source container) error
 	ContainerDelete(c container) error
 	ContainerCopy(target container, source container, containerOnly bool) error
@@ -201,7 +201,7 @@ type storage interface {
 	ContainerSnapshotCreateEmpty(c container) error
 
 	// Functions dealing with image storage volumes.
-	ImageCreate(fingerprint string) error
+	ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error
 	ImageDelete(fingerprint string) error
 	ImageMount(fingerprint string) (bool, error)
 	ImageUmount(fingerprint string) (bool, error)

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 
 	"github.com/pborman/uuid"
@@ -796,7 +797,7 @@ func (s *storageCeph) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint string) error {
+func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf(`Creating RBD storage volume for container "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	revert := true
@@ -837,7 +838,7 @@ func (s *storageCeph) ContainerCreateFromImage(container container, fingerprint 
 		}
 
 		if !ok {
-			imgerr = s.ImageCreate(fingerprint)
+			imgerr = s.ImageCreate(fingerprint, tracker)
 		}
 
 		lxdStorageMapLock.Lock()
@@ -2083,7 +2084,7 @@ func (s *storageCeph) ContainerBackupLoad(info backupInfo, data io.ReadSeeker, t
 	return nil
 }
 
-func (s *storageCeph) ImageCreate(fingerprint string) error {
+func (s *storageCeph) ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf(`Creating RBD storage volume for image "%s" on storage pool "%s"`, fingerprint, s.pool.Name)
 
 	revert := true

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -16,6 +16,7 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -513,7 +514,7 @@ func (s *storageDir) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageDir) ContainerCreateFromImage(container container, imageFingerprint string) error {
+func (s *storageDir) ContainerCreateFromImage(container container, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf("Creating DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1242,7 +1243,7 @@ func (s *storageDir) ContainerBackupLoad(info backupInfo, data io.ReadSeeker, ta
 	return nil
 }
 
-func (s *storageDir) ImageCreate(fingerprint string) error {
+func (s *storageDir) ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	return nil
 }
 

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -17,6 +17,7 @@ import (
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -995,7 +996,7 @@ func (s *storageLvm) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string) error {
+func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf("Creating LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	tryUndo := true
@@ -1908,7 +1909,7 @@ func (s *storageLvm) doContainerBackupLoad(project, containerName string, privil
 	return containerPath, nil
 }
 
-func (s *storageLvm) ImageCreate(fingerprint string) error {
+func (s *storageLvm) ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf("Creating LVM storage volume for image \"%s\" on storage pool \"%s\"", fingerprint, s.pool.Name)
 
 	tryUndo := true

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -548,7 +548,7 @@ func (s *storageLvm) containerCreateFromImageThinLv(c container, fp string) erro
 		}
 
 		if !ok {
-			imgerr = s.ImageCreate(fp)
+			imgerr = s.ImageCreate(fp, nil)
 		}
 
 		lxdStorageMapLock.Lock()

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -8,6 +8,7 @@ import (
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/ioprogress"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -117,7 +118,7 @@ func (s *storageMock) ContainerCreate(container container) error {
 }
 
 func (s *storageMock) ContainerCreateFromImage(
-	container container, imageFingerprint string) error {
+	container container, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
 
 	return nil
 }
@@ -200,7 +201,7 @@ func (s *storageMock) ContainerBackupLoad(info backupInfo, data io.ReadSeeker, t
 	return nil
 }
 
-func (s *storageMock) ImageCreate(fingerprint string) error {
+func (s *storageMock) ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	return nil
 }
 


### PR DESCRIPTION
This is part 4 of a series of patches to add better progress
tracking support for export and import.

Add a tracker field to ContainerCreateFromImage and ImageCreate
which can be used during Unpack.

Signed-off-by: Joel Hockey <joelhockey@chromium.org>