### PR TITLE
shared: Progress metadata as a map

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -129,7 +129,7 @@ func createFromImage(d *Daemon, project string, req *api.ContainersPost) Respons
 			return err
 		}
 
-		metadata := make(map[string]string)
+		metadata := make(map[string]interface{})
 		_, err = containerCreateFromImage(d, args, info.Fingerprint, &ioprogress.ProgressTracker{
 			Handler: func(percent, speed int64) {
 				shared.SetProgressMetadata(metadata, "create_container_from_image_unpack", "Unpack", percent, speed)

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -207,7 +207,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 	}
 
 	// Track progress writing tarfile
-	metadata := make(map[string]string)
+	metadata := make(map[string]interface{})
 	tarfileProgressWriter := &ioprogress.ProgressWriter{
 		WriteCloser: tarfile,
 		Tracker: &ioprogress.ProgressTracker{
@@ -262,7 +262,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 		}
 
 		// Track progress writing gzipped file
-		metadata = make(map[string]string)
+		metadata = make(map[string]interface{})
 		tarfileProgressReader := &ioprogress.ProgressReader{
 			ReadCloser: tarfile,
 			Tracker: &ioprogress.ProgressTracker{

--- a/shared/util.go
+++ b/shared/util.go
@@ -1008,11 +1008,13 @@ func EscapePathFstab(path string) string {
 	return r.Replace(path)
 }
 
-func SetProgressMetadata(metadata map[string]string, stage, displayPrefix string, percent, speed int64) {
+func SetProgressMetadata(metadata map[string]interface{}, stage, displayPrefix string, percent, speed int64) {
+	progress := make(map[string]string)
 	// stage, percent, speed sent for API callers.
-	metadata["progress_stage"] = stage
-	metadata["progress_percent"] = strconv.FormatInt(percent, 10)
-	metadata["progress_speed"] = strconv.FormatInt(speed, 10)
+	progress["stage"] = stage
+	progress["percent"] = strconv.FormatInt(percent, 10)
+	progress["speed"] = strconv.FormatInt(speed, 10)
+	metadata["progress"] = progress
 	// <stage>_progress with formatted text sent for lxc cli.
 	metadata[stage+"_progress"] = fmt.Sprintf("%s: %d%% (%s/s)", displayPrefix, percent, GetByteSizeString(speed, 2))
 }


### PR DESCRIPTION
Modify the progress metadata to send stage, percent, speed in
a map keyed by 'progress'. Metadata format will now be:
* progress => {stage: <string>, percent: <string>, speed: <string>}
* <stage>_progress => <string>

Signed-off-by: Joel Hockey <joelhockey@chromium.org>