### PR TITLE
client: fix goroutine leak in ExecContainer

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -806,6 +806,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 
 				if fds["0"] != "" {
 					args.Stdin.Close()
+					<-dones[0]
 				}
 
 				for _, conn := range conns {


### PR DESCRIPTION
The stdin channel from WebsocketSendStream needs to be consumed,
otherwise that goroutine will leak.

Signed-off-by: Stephen Barber <smbarber@chromium.org>