### PR TITLE
Revert "lxd: remove /proc/self/cmdline parsing"

### DIFF
--- a/lxd/main_forkfile.go
+++ b/lxd/main_forkfile.go
@@ -409,10 +409,6 @@ void forkfile() {
 
 	// Get the subcommand
 	command = advance_arg(false);
-	if (command)
-		fprintf(stderr, "BBBB: %s\n", command);
-	else
-		fprintf(stderr, "CCCC\n");
 	if (command == NULL || (strcmp(command, "--help") == 0 || strcmp(command, "--version") == 0 || strcmp(command, "-h") == 0)) {
 		return;
 	}


### PR DESCRIPTION
The ELF binary spec doesn specify:

SHT_INIT_ARRAY
This section contains an array of pointers to initialization functions,
as described in ``Initialization and Termination Functions'' in Chapter
5. Each pointer in the array is taken as a parameterless procedure with
a void return.

which means libcs other than glibc might not pass down argc and argv to
constructors.

This reverts commit 2149bdaf895a1145d49e7627b50e0097678de189.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>