### PR TITLE
lxd: Fix duplicate scheduled snapshots

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1584,7 +1584,11 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 			now := time.Now()
 			next := sched.Next(now)
 
-			if now.Add(time.Minute).Before(next) {
+			// Ignore everything that is more precise than minutes.
+			now = now.Truncate(time.Minute)
+			next = next.Truncate(time.Minute)
+
+			if !now.Equal(next) {
 				continue
 			}
 


### PR DESCRIPTION
This fixes scheduled snapshots being created twice after each other.

This fixes #5504.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>