### PR TITLE
Image sync for joined node

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -247,7 +247,7 @@ func isJSONRequest(r *http.Request) bool {
 	return false
 }
 
-// State creates a new State instance liked to our internal db and os.
+// State creates a new State instance linked to our internal db and os.
 func (d *Daemon) State() *state.State {
 	return state.NewState(d.db, d.cluster, d.maas, d.os, d.endpoints)
 }
@@ -824,6 +824,9 @@ func (d *Daemon) Ready() error {
 
 		// Remove expired container snapshots (minutely)
 		d.tasks.Add(pruneExpiredContainerSnapshotsTask(d))
+
+		// Auto-sync images across the cluster (daily)
+		d.tasks.Add(autoSyncImagesTask(d))
 	}
 
 	// Start all background tasks

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -901,8 +901,8 @@ WHERE images.fingerprint = ?
 	return c.getNodesByImageFingerprint(q, fingerprint)
 }
 
-// ImageGetNodesHasNoImage returns the addresses of online nodes which don't have the image.
-func (c *Cluster) ImageGetNodesHasNoImage(fingerprint string) ([]string, error) {
+// ImageGetNodesWithoutImage returns the addresses of online nodes which don't have the image.
+func (c *Cluster) ImageGetNodesWithoutImage(fingerprint string) ([]string, error) {
 	q := `
 SELECT DISTINCT nodes.address FROM nodes WHERE nodes.address NOT IN (
   SELECT DISTINCT nodes.address FROM nodes

--- a/lxd/db/operations.go
+++ b/lxd/db/operations.go
@@ -57,6 +57,7 @@ const (
 	OperationImagesExpire
 	OperationImagesPruneLeftover
 	OperationImagesUpdate
+	OperationImagesSynchronize
 	OperationLogsExpire
 	OperationInstanceTypesUpdate
 	OperationBackupsExpire
@@ -146,6 +147,8 @@ func (t OperationType) Description() string {
 		return "Pruning leftover image files"
 	case OperationImagesUpdate:
 		return "Updating images"
+	case OperationImagesSynchronize:
+		return "Synchronizing images"
 	case OperationLogsExpire:
 		return "Expiring log files"
 	case OperationInstanceTypesUpdate:

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -2032,7 +2032,7 @@ func imageSyncBetweenNodes(d *Daemon, fingerprint string) error {
 		return nil
 	}
 
-	addresses, err := d.cluster.ImageGetNodesHasNoImage(fingerprint)
+	addresses, err := d.cluster.ImageGetNodesWithoutImage(fingerprint)
 	if err != nil {
 		return errors.Wrap(err, "Failed to get nodes for the image synchronization")
 	}

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1166,17 +1166,22 @@ test_clustering_image_replication() {
   [ -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
   [ -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
 
-  # Delete the imported image
-  LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
-  [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
-  [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
-
   # Spawn a third node
   setup_clustering_netns 3
   LXD_THREE_DIR=$(mktemp -d -p "${TEST_DIR}" XXX)
   chmod +x "${LXD_THREE_DIR}"
   ns3="${prefix}3"
   spawn_lxd_and_join_cluster "${ns3}" "${bridge}" "${cert}" 3 1 "${LXD_THREE_DIR}"
+
+  # Wait for the test image to be synced into the joined node on the background
+  sleep 5
+  [ -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
+
+  # Delete the imported image
+  LXD_DIR="${LXD_ONE_DIR}" lxc image delete testimage
+  [ ! -f "${LXD_ONE_DIR}/images/${fingerprint}" ] || false
+  [ ! -f "${LXD_TWO_DIR}/images/${fingerprint}" ] || false
+  [ ! -f "${LXD_THREE_DIR}/images/${fingerprint}" ] || false
 
   # Import the test image on node3
   LXD_DIR="${LXD_THREE_DIR}" ensure_import_testimage


### PR DESCRIPTION
1. Sync all available images to the new node after it's joined
2. Add a daily task that is launched only by the leader node to do image synchronization if an image doesn't get synced successfully across the nodes in the past
3. Minor improvement on image sync between the nodes
