### PR TITLE
Revert "client: fix goroutine leak in ExecContainer"

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -806,7 +806,6 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 
 				if fds["0"] != "" {
 					args.Stdin.Close()
-					<-dones[0]
 				}
 
 				for _, conn := range conns {


### PR DESCRIPTION
This reverts commit e2379cf367ef76f1b42f5a747c475c18cbdf6cac.

This fix ended up causing issues as outlined in #5519

Reverting until we have a better fix.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>