### PR TITLE
lxd: Remove backup directory after creating tarball

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -382,6 +382,11 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 		return err
 	}
 
+	err = os.RemoveAll(path)
+	if err != nil {
+		return err
+	}
+
 	// Compress it
 	compress, err := cluster.ConfigGetString(s.Cluster, "backups.compression_algorithm")
 	if err != nil {

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1819,7 +1819,6 @@ func (s *storageBtrfs) ContainerBackupCreate(backup backup, source container) er
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpPath)
 
 	// Generate the actual backup
 	if backup.optimizedStorage {

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -1987,7 +1987,6 @@ func (s *storageCeph) ContainerBackupCreate(backup backup, source container) err
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpPath)
 
 	// Generate the actual backup
 	if !backup.containerOnly {

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -1106,7 +1106,6 @@ func (s *storageDir) ContainerBackupCreate(backup backup, source container) erro
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpPath)
 
 	// Prepare for rsync
 	rsync := func(oldPath string, newPath string, bwlimit string) error {

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1690,7 +1690,6 @@ func (s *storageLvm) ContainerBackupCreate(backup backup, source container) erro
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpPath)
 
 	// Prepare for rsync
 	rsync := func(oldPath string, newPath string, bwlimit string) error {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -2136,7 +2136,6 @@ func (s *storageZfs) ContainerBackupCreate(backup backup, source container) erro
 	if err != nil {
 		return err
 	}
-	defer os.RemoveAll(tmpPath)
 
 	// Generate the actual backup
 	if backup.optimizedStorage {


### PR DESCRIPTION
Remove the backup backup directory as soon as the tarball has been
created. That way one will hopefully not run out of disk space when
doing backups.

See #5515

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>