### PR TITLE
util_linux_cgo: restore old behavior

### DIFF
--- a/shared/util_linux_cgo.go
+++ b/shared/util_linux_cgo.go
@@ -215,7 +215,7 @@ int lxc_abstract_unix_recv_fds(int fd, int *recvfds, int num_recvfds,
 	ret = recvmsg(fd, &msg, 0);
 	if (ret <= 0) {
 		fprintf(stderr, "%s - Failed to receive file descriptor\n", strerror(errno));
-		return -1;
+		return ret;
 	}
 
 	cmsg = CMSG_FIRSTHDR(&msg);


### PR DESCRIPTION
lxc_abstract_unix_recv_fds() used to return 0 if recvmsg() returned 0
and ret if it return < 0. Let's restore that behavior.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>