### PR TITLE
Stricter node remove checks

### DIFF
--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"sort"
@@ -10,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
@@ -235,7 +237,8 @@ type cmdClusterRemove struct {
 	global  *cmdGlobal
 	cluster *cmdCluster
 
-	flagForce bool
+	flagForce          bool
+	flagNonInteractive bool
 }
 
 func (c *cmdClusterRemove) Command() *cobra.Command {
@@ -248,8 +251,36 @@ func (c *cmdClusterRemove) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, i18n.G("Force removing a member, even if degraded"))
+	cmd.Flags().BoolVarP(&c.flagNonInteractive, "quiet", "q", false, i18n.G("Don't require user confirmation for using --force"))
 
 	return cmd
+}
+
+func (c *cmdClusterRemove) promptConfirmation(name string) error {
+	reader := bufio.NewReader(os.Stdin)
+	fmt.Printf(i18n.G(`Forcefully removing a server from the cluster should only be done as a last
+resort.
+
+The removed server will not be functional after this action and will require a
+full reset of LXD, losing any remaining container, image or storage volume
+that the server may have held.
+
+When possible, a graceful removal should be preferred, this will require you to
+move any affected container, image or storage volume to another server prior to
+the server being cleanly removed from the cluster.
+
+The --force flag should only be used if the server has died, been reinstalled
+or is otherwise never expected to come back up.
+
+Are you really sure you want to force removing %s? (yes/no): `), name)
+	input, _ := reader.ReadString('\n')
+	input = strings.TrimSuffix(input, "\n")
+
+	if !shared.StringInSlice(strings.ToLower(input), []string{i18n.G("yes")}) {
+		return fmt.Errorf(i18n.G("User aborted delete operation"))
+	}
+
+	return nil
 }
 
 func (c *cmdClusterRemove) Run(cmd *cobra.Command, args []string) error {
@@ -266,6 +297,14 @@ func (c *cmdClusterRemove) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	resource := resources[0]
+
+	// Prompt for confiromation if --force is used.
+	if !c.flagNonInteractive && c.flagForce {
+		err := c.promptConfirmation(resource.name)
+		if err != nil {
+			return err
+		}
+	}
 
 	// Delete the cluster member
 	err = resource.server.DeleteClusterMember(resource.name, c.flagForce)

--- a/lxd/api_cluster_test.go
+++ b/lxd/api_cluster_test.go
@@ -480,7 +480,7 @@ func TestCluster_LeaveWithImages(t *testing.T) {
 
 	client := f.ClientUnix(daemons[1])
 	err = client.DeleteClusterMember("rusp-0", false)
-	assert.EqualError(t, err, "node still has the following images: abc")
+	assert.EqualError(t, err, "Node still has the following images: abc")
 
 	// If we now associate the image with the other node as well, leaving
 	// the cluster is fine.

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -328,15 +328,15 @@ func (c *ClusterTx) NodeIsEmpty(id int64) (string, error) {
 	// Check if the node has any containers.
 	containers, err := query.SelectStrings(c.tx, "SELECT name FROM containers WHERE node_id=?", id)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get containers for node %d", id)
+		return "", errors.Wrapf(err, "Failed to get containers for node %d", id)
 	}
 	if len(containers) > 0 {
 		message := fmt.Sprintf(
-			"node still has the following containers: %s", strings.Join(containers, ", "))
+			"Node still has the following containers: %s", strings.Join(containers, ", "))
 		return message, nil
 	}
 
-	// Check if the node has any images available only in.
+	// Check if the node has any images available only in it.
 	images := []struct {
 		fingerprint string
 		nodeID      int64
@@ -357,7 +357,7 @@ SELECT fingerprint, node_id FROM images JOIN images_nodes ON images.id=images_no
 	defer stmt.Close()
 	err = query.SelectObjects(stmt, dest)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get image list for node %d", id)
+		return "", errors.Wrapf(err, "Failed to get image list for node %d", id)
 	}
 	index := map[string][]int64{} // Map fingerprints to IDs of nodes
 	for _, image := range images {
@@ -376,7 +376,7 @@ SELECT fingerprint, node_id FROM images JOIN images_nodes ON images.id=images_no
 
 	if len(fingerprints) > 0 {
 		message := fmt.Sprintf(
-			"node still has the following images: %s", strings.Join(fingerprints, ", "))
+			"Node still has the following images: %s", strings.Join(fingerprints, ", "))
 		return message, nil
 	}
 

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -380,6 +380,19 @@ SELECT fingerprint, node_id FROM images JOIN images_nodes ON images.id=images_no
 		return message, nil
 	}
 
+	// Check if the node has any custom volumes.
+	volumes, err := query.SelectStrings(
+		c.tx, "SELECT name FROM storage_volumes WHERE node_id=? AND type=?",
+		id, StoragePoolVolumeTypeCustom)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to get custom volumes for node %d", id)
+	}
+	if len(volumes) > 0 {
+		message := fmt.Sprintf(
+			"Node still has the following custom volumes: %s", strings.Join(volumes, ", "))
+		return message, nil
+	}
+
 	return "", nil
 }
 

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -232,7 +232,7 @@ INSERT INTO containers (id, node_id, name, architecture, type, project_id) VALUE
 
 	message, err = tx.NodeIsEmpty(id)
 	require.NoError(t, err)
-	assert.Equal(t, "node still has the following containers: foo", message)
+	assert.Equal(t, "Node still has the following containers: foo", message)
 
 	err = tx.NodeClear(id)
 	require.NoError(t, err)
@@ -262,7 +262,7 @@ INSERT INTO images_nodes(image_id, node_id) VALUES(1, ?)`, id)
 
 	message, err := tx.NodeIsEmpty(id)
 	require.NoError(t, err)
-	assert.Equal(t, "node still has the following images: abc", message)
+	assert.Equal(t, "Node still has the following images: abc", message)
 
 	// Insert a new image entry for node 1 (the default node).
 	_, err = tx.Tx().Exec(`

--- a/lxd/db/node_test.go
+++ b/lxd/db/node_test.go
@@ -274,6 +274,28 @@ INSERT INTO images_nodes(image_id, node_id) VALUES(1, 1)`)
 	assert.Equal(t, "", message)
 }
 
+// A node is considered empty only if it has no custom volumes on it.
+func TestNodeIsEmpty_CustomVolumes(t *testing.T) {
+	tx, cleanup := db.NewTestClusterTx(t)
+	defer cleanup()
+
+	id, err := tx.NodeAdd("buzz", "1.2.3.4:666")
+	require.NoError(t, err)
+
+	_, err = tx.Tx().Exec(`
+INSERT INTO storage_pools (id, name, driver) VALUES (1, 'local', 'zfs')`)
+	require.NoError(t, err)
+
+	_, err = tx.Tx().Exec(`
+INSERT INTO storage_volumes(name, storage_pool_id, node_id, type, project_id)
+  VALUES ('data', 1, ?, ?, 1)`, id, db.StoragePoolVolumeTypeCustom)
+	require.NoError(t, err)
+
+	message, err := tx.NodeIsEmpty(id)
+	require.NoError(t, err)
+	assert.Equal(t, "Node still has the following custom volumes: data", message)
+}
+
 // If there are 2 online nodes, return the address of the one with the least
 // number of containers.
 func TestNodeWithLeastContainers(t *testing.T) {

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -596,7 +596,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -801,7 +801,7 @@ msgstr "Erstelle %s"
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -868,8 +868,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -971,6 +971,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -1030,11 +1034,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1183,7 +1187,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1198,6 +1202,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1440,7 +1468,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1462,7 +1490,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1661,7 +1689,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1683,7 +1711,7 @@ msgstr "Veröffentliche Abbild"
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1780,12 +1808,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -1928,7 +1956,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2323,7 +2351,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2433,7 +2461,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2550,7 +2578,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2903,7 +2931,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2972,7 +3000,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3075,7 +3103,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3292,7 +3320,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3414,7 +3442,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3790,7 +3818,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3815,7 +3843,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3915,7 +3943,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -4079,7 +4107,8 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -461,7 +461,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -650,7 +650,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -713,8 +713,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -816,6 +816,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -873,11 +877,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1015,7 +1019,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1029,6 +1033,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1265,7 +1293,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1286,7 +1314,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1466,7 +1494,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1487,7 +1515,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1574,12 +1602,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1712,7 +1740,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2069,7 +2097,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2093,7 +2121,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2194,7 +2222,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2303,7 +2331,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2640,7 +2668,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2706,7 +2734,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2802,7 +2830,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2988,7 +3016,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3097,7 +3125,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3444,7 +3472,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3464,7 +3492,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3546,7 +3574,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3683,6 +3711,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2019-01-28 23:09+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -534,7 +534,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr "Creando %s"
 msgid "Creating the container"
 msgstr "Creando el contenedor"
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -787,8 +787,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -889,6 +889,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -946,11 +950,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1090,7 +1094,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1104,6 +1108,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1341,7 +1369,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1363,7 +1391,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1543,7 +1571,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1564,7 +1592,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1651,12 +1679,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1791,7 +1819,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2147,7 +2175,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2171,7 +2199,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2272,7 +2300,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2381,7 +2409,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2718,7 +2746,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2784,7 +2812,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2881,7 +2909,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3068,7 +3096,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3177,7 +3205,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3524,7 +3552,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3544,7 +3572,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3626,7 +3654,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3765,7 +3793,8 @@ msgstr "Columnas"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -586,7 +586,7 @@ msgstr "Afficher la version du client"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -810,7 +810,7 @@ msgstr "Création de %s"
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -878,8 +878,8 @@ msgstr "Copie de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -981,6 +981,11 @@ msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
 
+#: lxc/cluster.go:254
+#, fuzzy
+msgid "Don't require user confirmation for using --force"
+msgstr "Requérir une confirmation de l'utilisateur"
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -1041,11 +1046,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1199,7 +1204,7 @@ msgstr "Empreinte : %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1215,6 +1220,30 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
 #: lxc/remote.go:425
@@ -1465,7 +1494,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1487,7 +1516,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1731,7 +1760,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1752,7 +1781,7 @@ msgstr "Rendre l'image publique"
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1847,12 +1876,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -1999,7 +2028,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2374,7 +2403,7 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2401,7 +2430,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2511,7 +2540,7 @@ msgstr "INSTANTANÉS"
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -2634,7 +2663,7 @@ msgstr "Afficher des informations supplémentaires"
 msgid "Show content of container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2997,7 +3026,7 @@ msgstr "Type : persistant"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr "URL"
 
@@ -3071,7 +3100,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -3175,7 +3204,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3402,7 +3431,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3528,7 +3557,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3934,7 +3963,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3962,7 +3991,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -4068,7 +4097,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -4244,7 +4273,8 @@ msgstr "Colonnes"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr "oui"
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -690,7 +690,7 @@ msgstr "Creazione di %s in corso"
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -753,8 +753,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -855,6 +855,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -912,11 +916,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1057,7 +1061,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1071,6 +1075,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1310,7 +1338,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1332,7 +1360,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1513,7 +1541,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1534,7 +1562,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1623,12 +1651,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1762,7 +1790,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2119,7 +2147,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2143,7 +2171,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2245,7 +2273,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2354,7 +2382,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2694,7 +2722,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2761,7 +2789,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2859,7 +2887,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3046,7 +3074,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3155,7 +3183,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3502,7 +3530,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3522,7 +3550,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3604,7 +3632,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3743,7 +3771,8 @@ msgstr "Colonne"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr "si"
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2019-01-18 12:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -468,7 +468,7 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
@@ -669,7 +669,7 @@ msgstr "%s を作成中"
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -732,8 +732,8 @@ msgstr "ストレージボリュームを削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -834,6 +834,11 @@ msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
+#: lxc/cluster.go:254
+#, fuzzy
+msgid "Don't require user confirmation for using --force"
+msgstr "ユーザの確認を要求する"
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
@@ -892,12 +897,12 @@ msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 "クラスタリングで動作していないLXDインスタンス上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1058,7 +1063,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -1073,6 +1078,30 @@ msgstr "稼働中のコンテナを強制的に削除します"
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
+msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
 #: lxc/remote.go:425
@@ -1317,7 +1346,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -1338,7 +1367,7 @@ msgstr "DHCP のリースを一覧表示します"
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
@@ -1603,7 +1632,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1624,7 +1653,7 @@ msgstr "イメージを public にする"
 msgid "Manage and attach containers to networks"
 msgstr "ネットワークを管理し、コンテナをネットワークに接続します"
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
@@ -1728,12 +1757,12 @@ msgstr "リモートサーバのリストを管理します"
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -1870,7 +1899,7 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2226,7 +2255,7 @@ msgstr "リモート名: %s"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
@@ -2250,7 +2279,7 @@ msgstr "リモートサーバを削除します"
 msgid "Remove trusted clients"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
@@ -2358,7 +2387,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2467,7 +2496,7 @@ msgstr "コンテナもしくはサーバの情報を表示します"
 msgid "Show content of container file templates"
 msgstr "コンテナのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
@@ -2817,7 +2846,7 @@ msgstr "タイプ: persistent"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2885,7 +2914,7 @@ msgstr ""
 "最適化された形でストレージドライバを使います (同様のプール上にのみリストアで"
 "きます)"
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -2984,7 +3013,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3176,7 +3205,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "restore [<remote>:]<container> <snapshot>"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3287,7 +3316,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3742,7 +3771,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3762,7 +3791,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3846,7 +3875,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3984,7 +4013,8 @@ msgstr "volume"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-02-26 22:22+0100\n"
+        "POT-Creation-Date: 2019-02-27 15:05+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -438,7 +438,7 @@ msgstr  ""
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid   "Clustering enabled"
 msgstr  ""
 
@@ -622,7 +622,7 @@ msgstr  ""
 msgid   "Creating the container"
 msgstr  ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid   "DATABASE"
 msgstr  ""
 
@@ -682,7 +682,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147 lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30 lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520 lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:385 lxc/remote.go:421 lxc/remote.go:537 lxc/remote.go:599 lxc/remote.go:649 lxc/remote.go:687 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149 lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30 lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520 lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:385 lxc/remote.go:421 lxc/remote.go:537 lxc/remote.go:599 lxc/remote.go:649 lxc/remote.go:687 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -736,6 +736,10 @@ msgstr  ""
 
 #: lxc/info.go:183
 msgid   "Disk usage:"
+msgstr  ""
+
+#: lxc/cluster.go:254
+msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
 #: lxc/main.go:60
@@ -795,11 +799,11 @@ msgstr  ""
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid   "Enable clustering on a single non-clustered LXD instance"
 msgstr  ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid   "Enable clustering on a single non-clustered LXD instance\n"
         "\n"
         "  This command turns a non-clustered LXD instance into the first member of a new\n"
@@ -929,7 +933,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -943,6 +947,25 @@ msgstr  ""
 
 #: lxc/main.go:56
 msgid   "Force using the local unix socket"
+msgstr  ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
+        "resort.\n"
+        "\n"
+        "The removed server will not be functional after this action and will require a\n"
+        "full reset of LXD, losing any remaining container, image or storage volume\n"
+        "that the server may have held.\n"
+        "\n"
+        "When possible, a graceful removal should be preferred, this will require you to\n"
+        "move any affected container, image or storage volume to another server prior to\n"
+        "the server being cleanly removed from the cluster.\n"
+        "\n"
+        "The --force flag should only be used if the server has died, been reinstalled\n"
+        "or is otherwise never expected to come back up.\n"
+        "\n"
+        "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584 lxc/remote.go:425
@@ -1173,7 +1196,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -1194,7 +1217,7 @@ msgstr  ""
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid   "List all the cluster members"
 msgstr  ""
 
@@ -1368,7 +1391,7 @@ msgstr  ""
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid   "MESSAGE"
 msgstr  ""
 
@@ -1389,7 +1412,7 @@ msgstr  ""
 msgid   "Manage and attach containers to networks"
 msgstr  ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid   "Manage cluster members"
 msgstr  ""
 
@@ -1473,12 +1496,12 @@ msgstr  ""
 msgid   "Manage trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -1590,7 +1613,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622 lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549 lxc/storage_volume.go:1120
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622 lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549 lxc/storage_volume.go:1120
 msgid   "NAME"
 msgstr  ""
 
@@ -1940,7 +1963,7 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
@@ -1964,7 +1987,7 @@ msgstr  ""
 msgid   "Remove trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid   "Rename a cluster member"
 msgstr  ""
 
@@ -2062,7 +2085,7 @@ msgstr  ""
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid   "STATE"
 msgstr  ""
 
@@ -2171,7 +2194,7 @@ msgstr  ""
 msgid   "Show content of container file templates"
 msgstr  ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid   "Show details of a cluster member"
 msgstr  ""
 
@@ -2503,7 +2526,7 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid   "URL"
 msgstr  ""
 
@@ -2567,7 +2590,7 @@ msgstr  ""
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -2655,7 +2678,7 @@ msgstr  ""
 msgid   "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid   "cluster"
 msgstr  ""
 
@@ -2839,7 +2862,7 @@ msgstr  ""
 msgid   "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid   "enable [<remote>:] <name>"
 msgstr  ""
 
@@ -2944,7 +2967,7 @@ msgstr  ""
 msgid   "list"
 msgstr  ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796 lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796 lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid   "list [<remote>:]"
 msgstr  ""
 
@@ -3249,7 +3272,7 @@ msgstr  ""
 msgid   "remove [<remote>:]<container|profile> <name>..."
 msgstr  ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid   "remove [<remote>:]<member>"
 msgstr  ""
 
@@ -3269,7 +3292,7 @@ msgstr  ""
 msgid   "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid   "rename [<remote>:]<member> <new-name>"
 msgstr  ""
 
@@ -3349,7 +3372,7 @@ msgstr  ""
 msgid   "show [<remote>:]<image>"
 msgstr  ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid   "show [<remote>:]<member>"
 msgstr  ""
 
@@ -3486,7 +3509,7 @@ msgstr  ""
 msgid   "y"
 msgstr  ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
 msgid   "yes"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2018-09-24 23:21+0000\n"
 "Last-Translator: idef1x <sjoerd@sjomar.eu>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -487,7 +487,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -676,7 +676,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -739,8 +739,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -841,6 +841,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -898,11 +902,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1040,7 +1044,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1054,6 +1058,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1290,7 +1318,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1311,7 +1339,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1491,7 +1519,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1512,7 +1540,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1599,12 +1627,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1736,7 +1764,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2092,7 +2120,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2116,7 +2144,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2217,7 +2245,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2326,7 +2354,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2663,7 +2691,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2729,7 +2757,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2825,7 +2853,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3011,7 +3039,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3120,7 +3148,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3467,7 +3495,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3487,7 +3515,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3569,7 +3597,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3706,6 +3734,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -695,7 +695,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -758,8 +758,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -860,6 +860,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -917,11 +921,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1059,7 +1063,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1073,6 +1077,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1309,7 +1337,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1330,7 +1358,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1510,7 +1538,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1531,7 +1559,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1618,12 +1646,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1755,7 +1783,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2111,7 +2139,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2135,7 +2163,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2236,7 +2264,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2345,7 +2373,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2682,7 +2710,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2748,7 +2776,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2844,7 +2872,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3030,7 +3058,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3139,7 +3167,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3486,7 +3514,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3506,7 +3534,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3588,7 +3616,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3725,6 +3753,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2019-01-01 22:06+0000\n"
 "Last-Translator: Renato dos Santos <shazaum@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -577,7 +577,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -829,8 +829,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -931,6 +931,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -989,11 +993,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1131,7 +1135,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1145,6 +1149,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1382,7 +1410,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1403,7 +1431,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1583,7 +1611,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1604,7 +1632,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1691,12 +1719,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1828,7 +1856,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2184,7 +2212,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2208,7 +2236,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2309,7 +2337,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2419,7 +2447,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2756,7 +2784,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2823,7 +2851,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2919,7 +2947,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3105,7 +3133,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3214,7 +3242,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3561,7 +3589,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3581,7 +3609,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3663,7 +3691,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3800,6 +3828,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -571,7 +571,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -766,7 +766,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -832,8 +832,8 @@ msgstr "Копирование образа: %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -935,6 +935,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr " Использование диска:"
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -993,11 +997,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1138,7 +1142,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1152,6 +1156,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1391,7 +1419,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1413,7 +1441,7 @@ msgstr ""
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1595,7 +1623,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1616,7 +1644,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1706,12 +1734,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1848,7 +1876,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2207,7 +2235,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2232,7 +2260,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2337,7 +2365,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2448,7 +2476,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2788,7 +2816,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2854,7 +2882,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2951,7 +2979,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3165,7 +3193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3286,7 +3314,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3653,7 +3681,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3677,7 +3705,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3775,7 +3803,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3937,7 +3965,8 @@ msgstr "Столбцы"
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr "да"
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -457,7 +457,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -646,7 +646,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -709,8 +709,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -811,6 +811,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -868,11 +872,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1010,7 +1014,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1024,6 +1028,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1260,7 +1288,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1281,7 +1309,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1461,7 +1489,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1482,7 +1510,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1569,12 +1597,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1706,7 +1734,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2062,7 +2090,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2086,7 +2114,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2187,7 +2215,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2296,7 +2324,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2633,7 +2661,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2699,7 +2727,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2795,7 +2823,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2981,7 +3009,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3090,7 +3118,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3437,7 +3465,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3457,7 +3485,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3539,7 +3567,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3676,6 +3704,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-26 22:22+0100\n"
+"POT-Creation-Date: 2019-02-27 15:05+0100\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:366
+#: lxc/cluster.go:405
 msgid "Clustering enabled"
 msgstr ""
 
@@ -649,7 +649,7 @@ msgstr ""
 msgid "Creating the container"
 msgstr ""
 
-#: lxc/cluster.go:126
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
@@ -712,8 +712,8 @@ msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
-#: lxc/alias.go:198 lxc/cluster.go:27 lxc/cluster.go:64 lxc/cluster.go:147
-#: lxc/cluster.go:197 lxc/cluster.go:246 lxc/cluster.go:295 lxc/config.go:30
+#: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
 #: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
 #: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
@@ -814,6 +814,10 @@ msgstr ""
 msgid "Disk usage:"
 msgstr ""
 
+#: lxc/cluster.go:254
+msgid "Don't require user confirmation for using --force"
+msgstr ""
+
 #: lxc/main.go:60
 msgid "Don't show progress information"
 msgstr ""
@@ -871,11 +875,11 @@ msgstr ""
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:294
+#: lxc/cluster.go:333
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:295
+#: lxc/cluster.go:334
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1013,7 +1017,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:253
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1027,6 +1031,30 @@ msgstr ""
 
 #: lxc/main.go:56
 msgid "Force using the local unix socket"
+msgstr ""
+
+#: lxc/cluster.go:261
+#, c-format
+msgid ""
+"Forcefully removing a server from the cluster should only be done as a last\n"
+"resort.\n"
+"\n"
+"The removed server will not be functional after this action and will require "
+"a\n"
+"full reset of LXD, losing any remaining container, image or storage volume\n"
+"that the server may have held.\n"
+"\n"
+"When possible, a graceful removal should be preferred, this will require you "
+"to\n"
+"move any affected container, image or storage volume to another server prior "
+"to\n"
+"the server being cleanly removed from the cluster.\n"
+"\n"
+"The --force flag should only be used if the server has died, been "
+"reinstalled\n"
+"or is otherwise never expected to come back up.\n"
+"\n"
+"Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
 #: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
@@ -1263,7 +1291,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:99
+#: lxc/cluster.go:101
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1284,7 +1312,7 @@ msgstr ""
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/cluster.go:64
+#: lxc/cluster.go:65 lxc/cluster.go:66
 msgid "List all the cluster members"
 msgstr ""
 
@@ -1464,7 +1492,7 @@ msgstr ""
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:128
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
@@ -1485,7 +1513,7 @@ msgstr ""
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:26 lxc/cluster.go:27
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
@@ -1572,12 +1600,12 @@ msgstr ""
 msgid "Manage trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:277
+#: lxc/cluster.go:316
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:227
+#: lxc/cluster.go:229
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1709,7 +1737,7 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:124 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
 #: lxc/project.go:450 lxc/remote.go:478 lxc/storage.go:549
 #: lxc/storage_volume.go:1120
 msgid "NAME"
@@ -2065,7 +2093,7 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:245 lxc/cluster.go:246
+#: lxc/cluster.go:248 lxc/cluster.go:249
 msgid "Remove a member from the cluster"
 msgstr ""
 
@@ -2089,7 +2117,7 @@ msgstr ""
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:196 lxc/cluster.go:197
+#: lxc/cluster.go:198 lxc/cluster.go:199
 msgid "Rename a cluster member"
 msgstr ""
 
@@ -2190,7 +2218,7 @@ msgstr ""
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:127 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
 msgid "STATE"
 msgstr ""
 
@@ -2299,7 +2327,7 @@ msgstr ""
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:146 lxc/cluster.go:147
+#: lxc/cluster.go:148 lxc/cluster.go:149
 msgid "Show details of a cluster member"
 msgstr ""
 
@@ -2636,7 +2664,7 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/remote.go:479
+#: lxc/cluster.go:127 lxc/remote.go:479
 msgid "URL"
 msgstr ""
 
@@ -2702,7 +2730,7 @@ msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
 
-#: lxc/delete.go:47
+#: lxc/cluster.go:280 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -2798,7 +2826,7 @@ msgid ""
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:25
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -2984,7 +3012,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:293
+#: lxc/cluster.go:332
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3093,7 +3121,7 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:61 lxc/config_trust.go:112 lxc/network.go:796
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
 #: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
 msgid "list [<remote>:]"
 msgstr ""
@@ -3440,7 +3468,7 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:243
+#: lxc/cluster.go:246
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
@@ -3460,7 +3488,7 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:194
+#: lxc/cluster.go:196
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
@@ -3542,7 +3570,7 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:145
+#: lxc/cluster.go:147
 msgid "show [<remote>:]<member>"
 msgstr ""
 
@@ -3679,6 +3707,7 @@ msgstr ""
 msgid "y"
 msgstr ""
 
-#: lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833 lxc/image.go:999
+#: lxc/cluster.go:279 lxc/delete.go:46 lxc/image.go:828 lxc/image.go:833
+#: lxc/image.go:999
 msgid "yes"
 msgstr ""

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -145,6 +145,11 @@ test_clustering_membership() {
   ! LXD_DIR="${LXD_FOUR_DIR}" lxc cluster remove node3 || false
   LXD_DIR="${LXD_TWO_DIR}" lxc image delete testimage
 
+  # Trying to delete a node which has a custom volume on it results in an error.
+  LXD_DIR="${LXD_FOUR_DIR}" lxc storage volume create data v1
+  ! LXD_DIR="${LXD_FOUR_DIR}" lxc cluster remove node3 || false
+  LXD_DIR="${LXD_FOUR_DIR}" lxc storage volume delete data v1
+
   # The image got deleted from the LXD_DIR tree.
   # shellcheck disable=2086
   [ "$(ls ${LXD_FOUR_DIR}/images)" = "" ] || false

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -125,7 +125,7 @@ test_clustering_membership() {
   ! LXD_DIR="${LXD_TWO_DIR}" lxc network delete "${bridge}" || false
 
   # Force the removal of the degraded node.
-  LXD_DIR="${LXD_TWO_DIR}" lxc cluster remove node3 --force
+  LXD_DIR="${LXD_TWO_DIR}" lxc cluster remove node3 -q --force
 
   # Sleep a bit to let a heartbeat occur and update the list of raft nodes
   # everywhere, showing that node 4 has been promoted to database node.
@@ -507,7 +507,7 @@ test_clustering_storage() {
     LXD_DIR="${LXD_ONE_DIR}" lxc stop bar --force
 
     LXD_DIR="${LXD_ONE_DIR}" lxc config set cluster.offline_threshold 20
-    LXD_DIR="${LXD_ONE_DIR}" lxc cluster remove node3 --force
+    LXD_DIR="${LXD_ONE_DIR}" lxc cluster remove node3 -q --force
 
     LXD_DIR="${LXD_ONE_DIR}" lxc delete bar
 


### PR DESCRIPTION
This is a first pass at mitigating #5434. We check that the node to be removed has no custom volumes and also require confirmation by default when using ```---force```.