### PR TITLE
When starting up, use the cluster.https_address as key for updating the nodes table

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -579,7 +579,7 @@ func (d *Daemon) init() error {
 		}
 
 		d.cluster, err = db.OpenCluster(
-			"db.bin", store, address, dir,
+			"db.bin", store, clusterAddress, dir,
 			d.config.DqliteSetupTimeout,
 			dqlite.WithDialFunc(d.gateway.DialFunc()),
 			dqlite.WithContext(d.gateway.Context()),


### PR DESCRIPTION

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>