### PR TITLE
Don't use Exit() within lxc commands

### DIFF
--- a/lxc/console.go
+++ b/lxc/console.go
@@ -196,16 +196,5 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if oldttystate != nil {
-		/* A bit of a special case here: we want to exit with the same code as
-		 * the process inside the container, so we explicitly exit here
-		 * instead of returning an error.
-		 *
-		 * Additionally, since os.Exit() exits without running deferred
-		 * functions, we restore the terminal explicitly.
-		 */
-		termios.Restore(cfd, oldttystate)
-	}
-
 	return nil
 }

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -240,17 +240,6 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 	// Wait for any remaining I/O to be flushed
 	<-execArgs.DataDone
 
-	if oldttystate != nil {
-		/* A bit of a special case here: we want to exit with the same code as
-		 * the process inside the container, so we explicitly exit here
-		 * instead of returning an error.
-		 *
-		 * Additionally, since os.Exit() exits without running deferred
-		 * functions, we restore the terminal explicitly.
-		 */
-		termios.Restore(stdinFd, oldttystate)
-	}
-
-	os.Exit(int(opAPI.Metadata["return"].(float64)))
+	c.global.ret = int(opAPI.Metadata["return"].(float64))
 	return nil
 }

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -23,6 +23,7 @@ type cmdGlobal struct {
 	conf     *config.Config
 	confPath string
 	cmd      *cobra.Command
+	ret      int
 
 	flagForceLocal bool
 	flagHelp       bool
@@ -236,6 +237,10 @@ For help with any of those, simply call them with --help.`))
 	err = app.Execute()
 	if err != nil {
 		os.Exit(1)
+	}
+
+	if globalCmd.ret != 0 {
+		os.Exit(globalCmd.ret)
 	}
 }
 

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -36,7 +36,11 @@ type cmdGlobal struct {
 
 func main() {
 	// Process aliases
-	execIfAliases()
+	err := execIfAliases()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
 
 	// Setup the parser
 	app := &cobra.Command{}
@@ -218,7 +222,7 @@ For help with any of those, simply call them with --help.`))
 	help.Flags().BoolVar(&globalCmd.flagHelpAll, "all", false, i18n.G("Show less common commands"))
 
 	// Deal with --all flag
-	err := app.ParseFlags(os.Args[1:])
+	err = app.ParseFlags(os.Args[1:])
 	if err == nil {
 		if globalCmd.flagHelpAll {
 			// Show all commands

--- a/lxc/main_aliases.go
+++ b/lxc/main_aliases.go
@@ -77,12 +77,12 @@ func expandAlias(conf *config.Config, origArgs []string) ([]string, bool) {
 	return newArgs, true
 }
 
-func execIfAliases() {
+func execIfAliases() error {
 	args := os.Args
 
 	// Avoid loops
 	if os.Getenv("LXC_ALIASES") == "1" {
-		return
+		return nil
 	}
 
 	// Figure out the config directory and config path
@@ -94,7 +94,7 @@ func execIfAliases() {
 	} else {
 		user, err := user.Current()
 		if err != nil {
-			return
+			return nil
 		}
 
 		configDir = path.Join(user.HomeDir, ".config", "lxc")
@@ -108,7 +108,7 @@ func execIfAliases() {
 	if shared.PathExists(confPath) {
 		conf, err = config.LoadConfig(confPath)
 		if err != nil {
-			return
+			return nil
 		}
 	} else {
 		conf = config.NewConfig(filepath.Dir(confPath), true)
@@ -117,20 +117,18 @@ func execIfAliases() {
 	// Expand the aliases
 	newArgs, expanded := expandAlias(conf, args)
 	if !expanded {
-		return
+		return nil
 	}
 
 	// Look for the executable
 	path, err := exec.LookPath(newArgs[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, i18n.G("Processing aliases failed: %s\n"), err)
-		os.Exit(1)
+		return fmt.Errorf(i18n.G("Processing aliases failed: %s"), err)
 	}
 
 	// Re-exec
 	environ := syscall.Environ()
 	environ = append(environ, "LXC_ALIASES=1")
 	ret := syscall.Exec(path, newArgs, environ)
-	fmt.Fprintf(os.Stderr, i18n.G("Processing aliases failed: %s\n"), ret)
-	os.Exit(1)
+	return fmt.Errorf(i18n.G("Processing aliases failed: %s"), ret)
 }

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -93,20 +92,22 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	chError := make(chan error, 1)
+
 	handler := func(event api.Event) {
 		// Special handling for logging only output
 		if c.flagPretty && len(c.flagType) == 1 && shared.StringInSlice("logging", c.flagType) {
 			logEntry := api.EventLogging{}
 			err = json.Unmarshal(event.Metadata, &logEntry)
 			if err != nil {
-				fmt.Printf("error: %s\n", err)
-				os.Exit(1)
+				chError <- err
+				return
 			}
 
 			lvl, err := log15.LvlFromString(logEntry.Level)
 			if err != nil {
-				fmt.Printf("error: %s\n", err)
-				os.Exit(1)
+				chError <- err
+				return
 			}
 
 			if lvl > logLvl {
@@ -134,23 +135,23 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		// Render as JSON (to expand RawMessage)
 		jsonRender, err := json.Marshal(&event)
 		if err != nil {
-			fmt.Printf("error: %s\n", err)
-			os.Exit(1)
+			chError <- err
+			return
 		}
 
 		// Read back to a clean interface
 		var rawEvent interface{}
 		err = json.Unmarshal(jsonRender, &rawEvent)
 		if err != nil {
-			fmt.Printf("error: %s\n", err)
-			os.Exit(1)
+			chError <- err
+			return
 		}
 
 		// And now print as YAML
 		render, err := yaml.Marshal(&rawEvent)
 		if err != nil {
-			fmt.Printf("error: %s\n", err)
-			os.Exit(1)
+			chError <- err
+			return
 		}
 
 		fmt.Printf("%s\n\n", render)
@@ -161,5 +162,9 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return listener.Wait()
+	go func() {
+		chError <- listener.Wait()
+	}()
+
+	return <-chError
 }

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -604,11 +604,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Spalten"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -887,8 +887,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -975,7 +975,7 @@ msgstr " Prozessorauslastung:"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1066,7 +1066,7 @@ msgstr "Flüchtiger Container"
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1200,7 +1200,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1303,7 +1303,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1423,7 +1423,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
@@ -1838,7 +1838,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1906,11 +1906,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -2062,7 +2062,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Administrator Passwort für %s: "
@@ -2131,11 +2131,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -2143,7 +2143,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -2152,9 +2152,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, fuzzy, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
 #: lxc/profile.go:150
@@ -2552,11 +2552,11 @@ msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2594,7 +2594,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2884,7 +2884,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3577,7 +3577,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3689,7 +3689,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -469,11 +469,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -732,8 +732,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -820,7 +820,7 @@ msgstr "  Χρήση CPU:"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -909,7 +909,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1031,7 +1031,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1132,7 +1132,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1249,7 +1249,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1633,7 +1633,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1695,11 +1695,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1843,7 +1843,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1883,7 +1883,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1911,11 +1911,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1923,7 +1923,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1932,9 +1932,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2307,11 +2307,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2347,7 +2347,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2621,7 +2621,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3260,7 +3260,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3368,7 +3368,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2019-01-28 23:09+0000\n"
 "Last-Translator: Allan Esquivel Sibaja <allan.esquivel.sibaja@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -542,11 +542,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Columnas"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr "Cliente de Linea de Comandos para LXD"
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -806,8 +806,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -893,7 +893,7 @@ msgstr "Uso del disco:"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -982,7 +982,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1106,7 +1106,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1207,7 +1207,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1325,7 +1325,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1709,7 +1709,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1774,11 +1774,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1921,7 +1921,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1961,7 +1961,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Contraseña admin para %s:"
@@ -1989,11 +1989,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -2001,7 +2001,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -2010,9 +2010,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Procesos: %d"
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2385,11 +2385,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2425,7 +2425,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2699,7 +2699,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3340,7 +3340,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3448,7 +3448,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -594,11 +594,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonnes"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 #, fuzzy
 msgid ""
 "Command line client for LXD\n"
@@ -897,8 +897,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -986,7 +986,7 @@ msgstr "  Disque utilisé :"
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1078,7 +1078,7 @@ msgstr "Conteneur éphémère"
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr "Type d'évènements à surveiller"
 
@@ -1217,7 +1217,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Force the removal of running containers"
 msgstr "Forcer la suppression des conteneurs arrêtés"
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
@@ -1324,7 +1324,7 @@ msgstr "IPv6"
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 #, fuzzy
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
@@ -1449,7 +1449,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
@@ -1908,7 +1908,7 @@ msgstr "Échec lors de la migration vers l'hôte source: %s"
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1978,11 +1978,11 @@ msgstr "Copie de l'image : %s"
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -2140,7 +2140,7 @@ msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 #, fuzzy
 msgid "Override the source project"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -2181,7 +2181,7 @@ msgstr "Paquets reçus"
 msgid "Packets sent"
 msgstr "Paquets émis"
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Mot de passe administrateur pour %s : "
@@ -2210,11 +2210,11 @@ msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -2222,7 +2222,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -2231,9 +2231,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr "Processus : %d"
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, fuzzy, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr "l'analyse des alias a échoué %s\n"
 
 #: lxc/profile.go:150
@@ -2635,11 +2635,11 @@ msgstr "Définir les permissions du fichier lors de l'envoi"
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2679,7 +2679,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 #, fuzzy
 msgid "Show less common commands"
 msgstr "Afficher les commandes moins communes"
@@ -2977,7 +2977,7 @@ msgstr "Pour créer un réseau, utiliser : lxc network create"
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 #, fuzzy
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
@@ -3702,7 +3702,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3822,7 +3822,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -507,11 +507,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Colonne"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -772,8 +772,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -859,7 +859,7 @@ msgstr "Utilizzo disco:"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -948,7 +948,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1073,7 +1073,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1293,7 +1293,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 #, fuzzy
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
@@ -1681,7 +1681,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1745,11 +1745,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1892,7 +1892,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1932,7 +1932,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Password amministratore per %s: "
@@ -1961,11 +1961,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1973,7 +1973,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1982,9 +1982,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, fuzzy, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr "errore di processamento degli alias %s\n"
 
 #: lxc/profile.go:150
@@ -2358,11 +2358,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2398,7 +2398,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2675,7 +2675,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3318,7 +3318,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3426,7 +3426,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2019-01-18 12:23+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -476,11 +476,11 @@ msgstr "クラスタリングが有効になりました"
 msgid "Columns"
 msgstr "カラムレイアウト"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr "LXD のコマンドラインクライアント"
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -751,8 +751,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -839,7 +839,7 @@ msgstr "ディスク使用量:"
 msgid "Don't require user confirmation for using --force"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr "進捗情報を表示しません"
 
@@ -939,7 +939,7 @@ msgstr "Ephemeral コンテナ"
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr "Listenするイベントタイプ"
 
@@ -1075,7 +1075,7 @@ msgstr "コンテナを強制シャットダウンします"
 msgid "Force the removal of running containers"
 msgstr "稼働中のコンテナを強制的に削除します"
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
@@ -1176,7 +1176,7 @@ msgstr "IPV6"
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1302,7 +1302,7 @@ msgid ""
 msgstr ""
 "'%s' は不正な名前です。空文字列は maxWidth を指定しているときのみ指定できます"
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
@@ -1787,7 +1787,7 @@ msgstr "マイグレーション API が失敗しました"
 msgid "Migration operation failure"
 msgstr "マイグレーションが失敗しました"
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr "表示するログメッセージの最小レベル"
 
@@ -1849,11 +1849,11 @@ msgstr "コピー元のボリューム名を指定する必要があります"
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr "ローカルもしくはリモートの LXD サーバをモニタリングします"
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -2001,7 +2001,7 @@ msgstr "管理対象のネットワークのみ変更できます"
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr "プロジェクトを指定します"
 
@@ -2041,7 +2041,7 @@ msgstr "受信パケット"
 msgid "Packets sent"
 msgstr "送信パケット"
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr "%s のパスワード: "
@@ -2069,11 +2069,11 @@ msgstr "再度エディタを開くためには Enter キーを押します"
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr "見やすい形 (pretty) で表示します"
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
@@ -2081,7 +2081,7 @@ msgstr "ヘルプを表示します"
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
@@ -2090,9 +2090,9 @@ msgstr "バージョン番号を表示します"
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
-#, c-format
-msgid "Processing aliases failed: %s\n"
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
+#, fuzzy, c-format
+msgid "Processing aliases failed: %s"
 msgstr "エイリアスの処理が失敗しました: %s\n"
 
 #: lxc/profile.go:150
@@ -2472,11 +2472,11 @@ msgstr "プッシュ時にファイルのパーミションを設定します"
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr "デバッグメッセージをすべて表示します"
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr "詳細な情報を出力します"
 
@@ -2512,7 +2512,7 @@ msgstr "コンテナもしくはプロファイルのデバイス設定をすべ
 msgid "Show image properties"
 msgstr "イメージのプロパティを表示します"
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr "全てのコマンドを表示します (主なコマンドだけではなく)"
 
@@ -2795,7 +2795,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr "コンソールから切り離すには <ctrl>+a q を押します"
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 "初めてコンテナを起動するには、\"lxc launch ubuntu:18.04\" と実行してみてくだ"
@@ -3498,7 +3498,7 @@ msgstr ""
 "lxc list -c ns,user.comment:comment\n"
 "  実行状態とユーザコメントとともにコンテナを一覧表示します。"
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3659,7 +3659,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-02-27 15:05+0100\n"
+        "POT-Creation-Date: 2019-02-28 10:30+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -446,11 +446,11 @@ msgstr  ""
 msgid   "Columns"
 msgstr  ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid   "Command line client for LXD"
 msgstr  ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid   "Command line client for LXD\n"
         "\n"
         "All of LXD's features can be driven through the various commands below.\n"
@@ -682,7 +682,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149 lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30 lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520 lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19 lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:385 lxc/remote.go:421 lxc/remote.go:537 lxc/remote.go:599 lxc/remote.go:649 lxc/remote.go:687 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149 lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30 lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520 lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:385 lxc/remote.go:421 lxc/remote.go:537 lxc/remote.go:599 lxc/remote.go:649 lxc/remote.go:687 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -742,7 +742,7 @@ msgstr  ""
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid   "Don't show progress information"
 msgstr  ""
 
@@ -827,7 +827,7 @@ msgstr  ""
 msgid   "Error updating template file: %s"
 msgstr  ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid   "Event type to listen for"
 msgstr  ""
 
@@ -945,7 +945,7 @@ msgstr  ""
 msgid   "Force the removal of running containers"
 msgstr  ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid   "Force using the local unix socket"
 msgstr  ""
 
@@ -1040,7 +1040,7 @@ msgstr  ""
 msgid   "ISSUE DATE"
 msgstr  ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid   "If this is your first time running LXD on this machine, you should also run: lxd init"
 msgstr  ""
 
@@ -1152,7 +1152,7 @@ msgstr  ""
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid   "Invalid number of arguments"
 msgstr  ""
 
@@ -1526,7 +1526,7 @@ msgstr  ""
 msgid   "Migration operation failure"
 msgstr  ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid   "Minimum level for log messages"
 msgstr  ""
 
@@ -1570,11 +1570,11 @@ msgstr  ""
 msgid   "Missing target directory"
 msgstr  ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid   "Monitor a local or remote LXD server"
 msgstr  ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid   "Monitor a local or remote LXD server\n"
         "\n"
         "By default the monitor will listen to all message types."
@@ -1712,7 +1712,7 @@ msgstr  ""
 msgid   "Operation %s deleted"
 msgstr  ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid   "Override the source project"
 msgstr  ""
 
@@ -1752,7 +1752,7 @@ msgstr  ""
 msgid   "Packets sent"
 msgstr  ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid   "Password for %s: "
 msgstr  ""
@@ -1778,11 +1778,11 @@ msgstr  ""
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid   "Pretty rendering"
 msgstr  ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid   "Print help"
 msgstr  ""
 
@@ -1790,7 +1790,7 @@ msgstr  ""
 msgid   "Print the raw response"
 msgstr  ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid   "Print version number"
 msgstr  ""
 
@@ -1799,9 +1799,9 @@ msgstr  ""
 msgid   "Processes: %d"
 msgstr  ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid   "Processing aliases failed: %s\n"
+msgid   "Processing aliases failed: %s"
 msgstr  ""
 
 #: lxc/profile.go:150
@@ -2170,11 +2170,11 @@ msgstr  ""
 msgid   "Set the file's uid on push"
 msgstr  ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid   "Show all debug messages"
 msgstr  ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid   "Show all information messages"
 msgstr  ""
 
@@ -2210,7 +2210,7 @@ msgstr  ""
 msgid   "Show image properties"
 msgstr  ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid   "Show less common commands"
 msgstr  ""
 
@@ -2479,7 +2479,7 @@ msgstr  ""
 msgid   "To detach from the console, press: <ctrl>+a q"
 msgstr  ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid   "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr  ""
 
@@ -3084,7 +3084,7 @@ msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC\n"
         "  List images with their running state and user comment."
 msgstr  ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid   "lxc monitor --type=logging\n"
         "    Only show log messages.\n"
         "\n"
@@ -3176,7 +3176,7 @@ msgstr  ""
 msgid   "metadata"
 msgstr  ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid   "monitor [<remote>:]"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2018-09-24 23:21+0000\n"
 "Last-Translator: idef1x <sjoerd@sjomar.eu>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -495,11 +495,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -758,8 +758,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -845,7 +845,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -934,7 +934,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1056,7 +1056,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1157,7 +1157,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1274,7 +1274,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1657,7 +1657,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1719,11 +1719,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1866,7 +1866,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1906,7 +1906,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1934,11 +1934,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1946,7 +1946,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1955,9 +1955,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2330,11 +2330,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2370,7 +2370,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2644,7 +2644,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3283,7 +3283,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3391,7 +3391,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -514,11 +514,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -777,8 +777,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -864,7 +864,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -953,7 +953,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1075,7 +1075,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1176,7 +1176,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1293,7 +1293,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1676,7 +1676,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1738,11 +1738,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1885,7 +1885,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1925,7 +1925,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1953,11 +1953,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1965,7 +1965,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1974,9 +1974,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2349,11 +2349,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2389,7 +2389,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2663,7 +2663,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3302,7 +3302,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3410,7 +3410,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2019-01-01 22:06+0000\n"
 "Last-Translator: Renato dos Santos <shazaum@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -585,11 +585,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -848,8 +848,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -935,7 +935,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1025,7 +1025,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1147,7 +1147,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1249,7 +1249,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1366,7 +1366,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1749,7 +1749,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1811,11 +1811,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1958,7 +1958,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1998,7 +1998,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -2026,11 +2026,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -2038,7 +2038,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -2047,9 +2047,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2423,11 +2423,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2737,7 +2737,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3377,7 +3377,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3485,7 +3485,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -579,11 +579,11 @@ msgstr ""
 msgid "Columns"
 msgstr "Столбцы"
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -851,8 +851,8 @@ msgstr "Копирование образа: %s"
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -939,7 +939,7 @@ msgstr " Использование диска:"
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1154,7 +1154,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1255,7 +1255,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1375,7 +1375,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1765,7 +1765,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1830,11 +1830,11 @@ msgstr "Копирование образа: %s"
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1980,7 +1980,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -2020,7 +2020,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, fuzzy, c-format
 msgid "Password for %s: "
 msgstr "Пароль администратора для %s: "
@@ -2048,11 +2048,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -2060,7 +2060,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -2069,9 +2069,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, fuzzy, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/profile.go:150
@@ -2450,11 +2450,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2492,7 +2492,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2769,7 +2769,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3449,7 +3449,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3557,7 +3557,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -465,11 +465,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -728,8 +728,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -815,7 +815,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1026,7 +1026,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1127,7 +1127,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1244,7 +1244,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1627,7 +1627,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1689,11 +1689,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1836,7 +1836,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1876,7 +1876,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1904,11 +1904,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1916,7 +1916,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1925,9 +1925,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2300,11 +2300,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2340,7 +2340,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2614,7 +2614,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3253,7 +3253,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3361,7 +3361,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-02-27 15:05+0100\n"
+"POT-Creation-Date: 2019-02-28 10:30+0100\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -468,11 +468,11 @@ msgstr ""
 msgid "Columns"
 msgstr ""
 
-#: lxc/main.go:44
+#: lxc/main.go:49
 msgid "Command line client for LXD"
 msgstr ""
 
-#: lxc/main.go:45
+#: lxc/main.go:50
 msgid ""
 "Command line client for LXD\n"
 "\n"
@@ -731,8 +731,8 @@ msgstr ""
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
 #: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
-#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:45 lxc/manpage.go:19
-#: lxc/monitor.go:31 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
+#: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
+#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
-#: lxc/main.go:60
+#: lxc/main.go:65
 msgid "Don't show progress information"
 msgstr ""
 
@@ -907,7 +907,7 @@ msgstr ""
 msgid "Error updating template file: %s"
 msgstr ""
 
-#: lxc/monitor.go:48
+#: lxc/monitor.go:47
 msgid "Event type to listen for"
 msgstr ""
 
@@ -1029,7 +1029,7 @@ msgstr ""
 msgid "Force the removal of running containers"
 msgstr ""
 
-#: lxc/main.go:56
+#: lxc/main.go:61
 msgid "Force using the local unix socket"
 msgstr ""
 
@@ -1130,7 +1130,7 @@ msgstr ""
 msgid "ISSUE DATE"
 msgstr ""
 
-#: lxc/main.go:313
+#: lxc/main.go:322
 msgid ""
 "If this is your first time running LXD on this machine, you should also run: "
 "lxd init"
@@ -1247,7 +1247,7 @@ msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr ""
 
-#: lxc/main.go:392
+#: lxc/main.go:401
 msgid "Invalid number of arguments"
 msgstr ""
 
@@ -1630,7 +1630,7 @@ msgstr ""
 msgid "Migration operation failure"
 msgstr ""
 
-#: lxc/monitor.go:49
+#: lxc/monitor.go:48
 msgid "Minimum level for log messages"
 msgstr ""
 
@@ -1692,11 +1692,11 @@ msgstr ""
 msgid "Missing target directory"
 msgstr ""
 
-#: lxc/monitor.go:30
+#: lxc/monitor.go:29
 msgid "Monitor a local or remote LXD server"
 msgstr ""
 
-#: lxc/monitor.go:31
+#: lxc/monitor.go:30
 msgid ""
 "Monitor a local or remote LXD server\n"
 "\n"
@@ -1839,7 +1839,7 @@ msgstr ""
 msgid "Operation %s deleted"
 msgstr ""
 
-#: lxc/main.go:57
+#: lxc/main.go:62
 msgid "Override the source project"
 msgstr ""
 
@@ -1879,7 +1879,7 @@ msgstr ""
 msgid "Packets sent"
 msgstr ""
 
-#: lxc/main.go:282
+#: lxc/main.go:291
 #, c-format
 msgid "Password for %s: "
 msgstr ""
@@ -1907,11 +1907,11 @@ msgstr ""
 msgid "Press enter to start the editor again"
 msgstr ""
 
-#: lxc/monitor.go:47
+#: lxc/monitor.go:46
 msgid "Pretty rendering"
 msgstr ""
 
-#: lxc/main.go:55
+#: lxc/main.go:60
 msgid "Print help"
 msgstr ""
 
@@ -1919,7 +1919,7 @@ msgstr ""
 msgid "Print the raw response"
 msgstr ""
 
-#: lxc/main.go:54
+#: lxc/main.go:59
 msgid "Print version number"
 msgstr ""
 
@@ -1928,9 +1928,9 @@ msgstr ""
 msgid "Processes: %d"
 msgstr ""
 
-#: lxc/main_aliases.go:126 lxc/main_aliases.go:134
+#: lxc/main_aliases.go:126 lxc/main_aliases.go:133
 #, c-format
-msgid "Processing aliases failed: %s\n"
+msgid "Processing aliases failed: %s"
 msgstr ""
 
 #: lxc/profile.go:150
@@ -2303,11 +2303,11 @@ msgstr ""
 msgid "Set the file's uid on push"
 msgstr ""
 
-#: lxc/main.go:58
+#: lxc/main.go:63
 msgid "Show all debug messages"
 msgstr ""
 
-#: lxc/main.go:59
+#: lxc/main.go:64
 msgid "Show all information messages"
 msgstr ""
 
@@ -2343,7 +2343,7 @@ msgstr ""
 msgid "Show image properties"
 msgstr ""
 
-#: lxc/main.go:217 lxc/main.go:218
+#: lxc/main.go:222 lxc/main.go:223
 msgid "Show less common commands"
 msgstr ""
 
@@ -2617,7 +2617,7 @@ msgstr ""
 msgid "To detach from the console, press: <ctrl>+a q"
 msgstr ""
 
-#: lxc/main.go:316
+#: lxc/main.go:325
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
@@ -3256,7 +3256,7 @@ msgid ""
 "  List images with their running state and user comment."
 msgstr ""
 
-#: lxc/monitor.go:35
+#: lxc/monitor.go:34
 msgid ""
 "lxc monitor --type=logging\n"
 "    Only show log messages.\n"
@@ -3364,7 +3364,7 @@ msgstr ""
 msgid "metadata"
 msgstr ""
 
-#: lxc/monitor.go:29
+#: lxc/monitor.go:28
 msgid "monitor [<remote>:]"
 msgstr ""
 


### PR DESCRIPTION
Direct calls to Exit() will prevent the global post functions from running, which among other things will prevent the cookie jar from getting saved. This also was preventing a number of defers from ever running, requiring needless code duplication.