### PR TITLE
Improve cluster targeting

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -693,3 +693,8 @@ This adds the following new endpoint (see [RESTful API](rest-api.md) for details
 ## snapshot\_expiry\_creation
 Adds `expires\_at` to container creation, allowing for override of a
 snapshot's expiry at creation time.
+
+## network\_leases\_location
+Introductes a "Location" field in the leases list.
+This is used when querying a cluster to show what node a particular
+lease was found on.

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -729,6 +729,7 @@ func (c *cmdNetworkInfo) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Get runtime information on networks`))
 
+	cmd.Flags().StringVar(&c.network.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
 	return cmd
@@ -752,6 +753,15 @@ func (c *cmdNetworkInfo) Run(cmd *cobra.Command, args []string) error {
 
 	if resource.name == "" {
 		return fmt.Errorf(i18n.G("Missing network name"))
+	}
+
+	// Targeting
+	if c.network.flagTarget != "" {
+		if !client.IsClustered() {
+			return fmt.Errorf(i18n.G("To use --target, the destination remote must be a cluster"))
+		}
+
+		client = client.UseTarget(c.network.flagTarget)
 	}
 
 	state, err := client.GetNetworkState(resource.name)

--- a/lxc/storage.go
+++ b/lxc/storage.go
@@ -389,6 +389,7 @@ func (c *cmdStorageInfo) Command() *cobra.Command {
 		`Show useful information about storage pools`))
 
 	cmd.Flags().BoolVar(&c.flagBytes, "bytes", false, i18n.G("Show the used and free space in bytes"))
+	cmd.Flags().StringVar(&c.storage.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
 	cmd.RunE = c.Run
 
 	return cmd
@@ -411,6 +412,15 @@ func (c *cmdStorageInfo) Run(cmd *cobra.Command, args []string) error {
 
 	if resource.name == "" {
 		return fmt.Errorf(i18n.G("Missing pool name"))
+	}
+
+	// Targeting
+	if c.storage.flagTarget != "" {
+		if !resource.server.IsClustered() {
+			return fmt.Errorf(i18n.G("To use --target, the destination remote must be a cluster"))
+		}
+
+		resource.server = resource.server.UseTarget(c.storage.flagTarget)
 	}
 
 	// Get the pool information

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -114,6 +114,12 @@ func api10Get(d *Daemon, r *http.Request) Response {
 		return SyncResponseETag(true, srv, nil)
 	}
 
+	// If a target was specified, forward the request to the relevant node.
+	response := ForwardedResponseIfTargetIsRemote(d, r)
+	if response != nil {
+		return response
+	}
+
 	srv.Auth = "trusted"
 
 	uname, err := shared.Uname()
@@ -222,6 +228,12 @@ func api10Get(d *Daemon, r *http.Request) Response {
 }
 
 func api10Put(d *Daemon, r *http.Request) Response {
+	// If a target was specified, forward the request to the relevant node.
+	response := ForwardedResponseIfTargetIsRemote(d, r)
+	if response != nil {
+		return response
+	}
+
 	req := api.ServerPut{}
 	if err := shared.ReadToJSON(r.Body, &req); err != nil {
 		return BadRequest(err)
@@ -264,6 +276,12 @@ func api10Put(d *Daemon, r *http.Request) Response {
 }
 
 func api10Patch(d *Daemon, r *http.Request) Response {
+	// If a target was specified, forward the request to the relevant node.
+	response := ForwardedResponseIfTargetIsRemote(d, r)
+	if response != nil {
+		return response
+	}
+
 	render, err := daemonConfigRender(d.State())
 	if err != nil {
 		return InternalError(err)

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -637,6 +637,7 @@ type container interface {
 
 	// Properties
 	Id() int
+	Location() string
 	Project() string
 	Name() string
 	Description() string

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8745,6 +8745,10 @@ func (c *containerLXC) DaemonState() *state.State {
 	return c.state
 }
 
+func (c *containerLXC) Location() string {
+	return c.node
+}
+
 func (c *containerLXC) Project() string {
 	return c.project
 }

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -661,7 +661,6 @@ func doNetworkUpdate(d *Daemon, name string, oldConfig map[string]string, req ap
 
 func networkLeasesGet(d *Daemon, r *http.Request) Response {
 	name := mux.Vars(r)["name"]
-	leaseFile := shared.VarPath("networks", name, "dnsmasq.leases")
 
 	// Try to get the network
 	n, err := doNetworkGet(d, name)
@@ -674,61 +673,75 @@ func networkLeasesGet(d *Daemon, r *http.Request) Response {
 		return NotFound(errors.New("Leases not found"))
 	}
 
-	if !shared.PathExists(leaseFile) {
-		return BadRequest(fmt.Errorf("No lease file for network"))
+	leases := []api.NetworkLease{}
+
+	// Get all static leases
+	if !isClusterNotification(r) {
+		// Get all the containers
+		containers, err := containerLoadFromAllProjects(d.State())
+		if err != nil {
+			return SmartError(err)
+		}
+
+		for _, c := range containers {
+			// Go through all its devices (including profiles
+			for k, d := range c.ExpandedDevices() {
+				// Skip uninteresting entries
+				if d["type"] != "nic" || d["nictype"] != "bridged" || d["parent"] != name {
+					continue
+				}
+
+				// Fill in the hwaddr from volatile
+				d, err = c.(*containerLXC).fillNetworkDevice(k, d)
+				if err != nil {
+					continue
+				}
+
+				// Add the lease
+				if d["ipv4.address"] != "" {
+					leases = append(leases, api.NetworkLease{
+						Hostname: c.Name(),
+						Address:  d["ipv4.address"],
+						Hwaddr:   d["hwaddr"],
+						Type:     "static",
+						Location: c.Location(),
+					})
+				}
+
+				if d["ipv6.address"] != "" {
+					leases = append(leases, api.NetworkLease{
+						Hostname: c.Name(),
+						Address:  d["ipv6.address"],
+						Hwaddr:   d["hwaddr"],
+						Type:     "static",
+						Location: c.Location(),
+					})
+				}
+			}
+		}
 	}
 
-	// Read all the leases
+	// Local server name
+	var serverName string
+	err = d.cluster.Transaction(func(tx *db.ClusterTx) error {
+		serverName, err = tx.NodeName()
+		return err
+	})
+	if err != nil {
+		return SmartError(err)
+	}
+
+	// Get dynamic leases
+	leaseFile := shared.VarPath("networks", name, "dnsmasq.leases")
+	if !shared.PathExists(leaseFile) {
+		return SyncResponse(true, leases)
+	}
+
 	content, err := ioutil.ReadFile(leaseFile)
 	if err != nil {
 		return SmartError(err)
 	}
 
-	leases := []api.NetworkLease{}
-
-	// Get all the containers
-	containers, err := containerLoadFromAllProjects(d.State())
-	if err != nil {
-		return SmartError(err)
-	}
-
-	// Get static leases
-	for _, c := range containers {
-		// Go through all its devices (including profiles
-		for k, d := range c.ExpandedDevices() {
-			// Skip uninteresting entries
-			if d["type"] != "nic" || d["nictype"] != "bridged" || d["parent"] != name {
-				continue
-			}
-
-			// Fill in the hwaddr from volatile
-			d, err = c.(*containerLXC).fillNetworkDevice(k, d)
-			if err != nil {
-				continue
-			}
-
-			// Add the lease
-			if d["ipv4.address"] != "" {
-				leases = append(leases, api.NetworkLease{
-					Hostname: c.Name(),
-					Address:  d["ipv4.address"],
-					Hwaddr:   d["hwaddr"],
-					Type:     "static",
-				})
-			}
-
-			if d["ipv6.address"] != "" {
-				leases = append(leases, api.NetworkLease{
-					Hostname: c.Name(),
-					Address:  d["ipv6.address"],
-					Hwaddr:   d["hwaddr"],
-					Type:     "static",
-				})
-			}
-		}
-	}
-
-	// Get dynamic leases
 	for _, lease := range strings.Split(string(content), "\n") {
 		fields := strings.Fields(lease)
 		if len(fields) >= 5 {
@@ -759,7 +772,29 @@ func networkLeasesGet(d *Daemon, r *http.Request) Response {
 				Address:  fields[2],
 				Hwaddr:   macStr,
 				Type:     "dynamic",
+				Location: serverName,
 			})
+		}
+	}
+
+	// Collect leases from other servers
+	if !isClusterNotification(r) {
+		notifier, err := cluster.NewNotifier(d.State(), d.endpoints.NetworkCert(), cluster.NotifyAlive)
+		if err != nil {
+			return SmartError(err)
+		}
+
+		err = notifier(func(client lxd.ContainerServer) error {
+			memberLeases, err := client.GetNetworkLeases(name)
+			if err != nil {
+				return err
+			}
+
+			leases = append(leases, memberLeases...)
+			return nil
+		})
+		if err != nil {
+			return SmartError(err)
 		}
 	}
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -830,6 +830,12 @@ func networkShutdown(s *state.State) error {
 }
 
 func networkStateGet(d *Daemon, r *http.Request) Response {
+	// If a target was specified, forward the request to the relevant node.
+	response := ForwardedResponseIfTargetIsRemote(d, r)
+	if response != nil {
+		return response
+	}
+
 	name := mux.Vars(r)["name"]
 
 	// Get some information

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -79,7 +79,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the configuration.\n"
@@ -320,6 +320,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -394,7 +399,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Aliasse:\n"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, fuzzy, c-format
 msgid "Architecture: %s"
 msgstr "Architektur: %s\n"
@@ -480,11 +485,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -496,11 +501,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
@@ -535,8 +540,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -561,7 +566,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -584,10 +589,12 @@ msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -631,7 +638,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the target container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, fuzzy, c-format
@@ -786,7 +793,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create the container with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
@@ -805,12 +812,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -869,9 +876,9 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -886,35 +893,35 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -966,7 +973,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
@@ -996,7 +1003,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1171,7 +1178,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -1228,7 +1235,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1250,7 +1257,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1275,7 +1282,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1287,7 +1294,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1401,7 +1408,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Invalid format %q"
@@ -1448,7 +1455,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1460,7 +1467,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1481,7 +1488,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1494,11 +1501,11 @@ msgstr "Aliasse:\n"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1667,25 +1674,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1693,7 +1700,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1720,7 +1727,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1818,15 +1825,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1863,14 +1870,14 @@ msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1956,18 +1963,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1987,7 +1994,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
@@ -1996,7 +2003,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -2053,7 +2060,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2094,11 +2101,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -2116,7 +2123,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2126,7 +2133,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -2147,7 +2154,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -2202,7 +2209,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, fuzzy, c-format
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
@@ -2314,7 +2321,7 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remote operation canceled by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2365,7 +2372,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2402,7 +2409,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2457,11 +2464,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2509,11 +2516,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr "Alternatives config Verzeichnis."
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2526,7 +2533,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
@@ -2565,11 +2572,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2602,7 +2609,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2614,7 +2621,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2628,7 +2635,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show storage volume configurations"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
@@ -2636,15 +2643,15 @@ msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2670,7 +2677,7 @@ msgstr "Größe: %.2vMB\n"
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2693,12 +2700,12 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2766,11 +2773,11 @@ msgstr "Profil %s erstellt\n"
 msgid "Store the container state"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2786,7 +2793,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2888,7 +2895,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2919,11 +2927,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2935,7 +2943,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2964,11 +2972,11 @@ msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2981,7 +2989,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3030,7 +3038,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3234,7 +3242,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3266,7 +3274,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3311,7 +3319,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -3337,7 +3345,7 @@ msgstr "Fehler: %v\n"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3393,7 +3401,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3415,7 +3423,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3431,7 +3439,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3447,8 +3455,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3472,7 +3480,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3501,13 +3509,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3553,7 +3561,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3713,7 +3721,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3747,7 +3755,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3852,7 +3860,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3900,11 +3908,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3924,7 +3932,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3952,7 +3960,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3960,7 +3968,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3981,7 +3989,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -4003,7 +4011,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4015,11 +4023,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -4043,7 +4051,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -4052,7 +4060,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -4068,11 +4076,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4092,11 +4100,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -50,7 +50,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,6 +195,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -266,7 +271,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -350,11 +355,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -366,11 +371,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
@@ -400,8 +405,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -426,7 +431,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -449,10 +454,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -493,7 +500,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -636,7 +643,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -654,12 +661,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -714,9 +721,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -731,35 +738,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -811,7 +818,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
@@ -840,7 +847,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1006,7 +1013,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1059,7 +1066,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1080,7 +1087,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1104,7 +1111,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1116,7 +1123,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1227,7 +1234,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1273,7 +1280,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1285,7 +1292,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1306,7 +1313,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1318,11 +1325,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1472,25 +1479,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1498,7 +1505,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1523,7 +1530,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1612,15 +1619,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
@@ -1655,14 +1662,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1740,18 +1747,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1771,7 +1778,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1780,7 +1787,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -1834,7 +1841,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1875,11 +1882,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1896,7 +1903,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1906,7 +1913,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1927,7 +1934,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1980,7 +1987,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2087,7 +2094,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2134,7 +2141,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2167,7 +2174,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2218,11 +2225,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2267,11 +2274,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2283,7 +2290,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2319,11 +2326,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2355,7 +2362,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2367,7 +2374,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2379,7 +2386,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2387,15 +2394,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2420,7 +2427,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2442,12 +2449,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2510,11 +2517,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2530,7 +2537,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2625,7 +2632,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2656,11 +2664,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2672,7 +2680,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2700,11 +2708,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2716,7 +2724,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2761,7 +2769,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2834,7 +2842,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2940,7 +2948,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2972,7 +2980,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3012,7 +3020,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3033,7 +3041,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3076,7 +3084,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3098,7 +3106,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3114,7 +3122,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3130,8 +3138,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3155,7 +3163,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3184,13 +3192,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3236,7 +3244,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3387,7 +3395,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3415,7 +3423,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3501,7 +3509,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3535,11 +3543,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3555,7 +3563,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3583,7 +3591,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3591,7 +3599,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3607,7 +3615,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3619,7 +3627,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3627,11 +3635,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3651,7 +3659,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3660,7 +3668,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3676,11 +3684,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3696,11 +3704,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2019-02-26 09:18+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -64,7 +64,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -267,6 +267,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
@@ -339,7 +344,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Aliases:"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr "Arquitectura: %s"
@@ -423,11 +428,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr "Ambas: todas y el nombre del contenedor dado"
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -439,11 +444,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
@@ -472,8 +477,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "No se peude leer desde stdin: %s"
@@ -499,7 +504,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -522,10 +527,12 @@ msgstr "Certificado del cliente almacenado en el servidor:"
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -566,7 +573,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -710,7 +717,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
@@ -728,12 +735,12 @@ msgstr "Creando el contenedor"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
@@ -788,9 +795,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -805,35 +812,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -885,7 +892,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
@@ -913,7 +920,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1081,7 +1088,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
@@ -1134,7 +1141,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1155,7 +1162,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1179,7 +1186,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1191,7 +1198,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1303,7 +1310,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1349,7 +1356,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1361,7 +1368,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1382,7 +1389,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1395,11 +1402,11 @@ msgstr "Aliases:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1549,25 +1556,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1575,7 +1582,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1600,7 +1607,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1689,15 +1696,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1732,14 +1739,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1819,18 +1826,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1850,7 +1857,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1859,7 +1866,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1912,7 +1919,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1953,11 +1960,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1974,7 +1981,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1984,7 +1991,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -2005,7 +2012,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -2058,7 +2065,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2165,7 +2172,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2212,7 +2219,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2245,7 +2252,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2296,11 +2303,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2345,11 +2352,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2361,7 +2368,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2397,11 +2404,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2433,7 +2440,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2445,7 +2452,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2457,7 +2464,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2465,15 +2472,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2498,7 +2505,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2520,12 +2527,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2588,11 +2595,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2608,7 +2615,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2703,7 +2710,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2734,11 +2742,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2750,7 +2758,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2778,11 +2786,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2794,7 +2802,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2839,7 +2847,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2913,7 +2921,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3019,7 +3027,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3051,7 +3059,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3113,7 +3121,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, fuzzy, c-format
 msgid "expires at %s"
 msgstr "Expira: %s"
@@ -3156,7 +3164,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3178,7 +3186,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3194,7 +3202,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3210,8 +3218,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3235,7 +3243,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3264,13 +3272,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3316,7 +3324,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3467,7 +3475,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3495,7 +3503,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3581,7 +3589,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3615,11 +3623,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3635,7 +3643,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3663,7 +3671,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3671,7 +3679,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3687,7 +3695,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -3700,7 +3708,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3708,11 +3716,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3732,7 +3740,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3741,7 +3749,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3757,11 +3765,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3777,11 +3785,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -74,7 +74,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -310,6 +310,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
@@ -385,7 +390,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Alias :"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architecture : %s"
@@ -471,11 +476,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -487,11 +492,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
@@ -522,8 +527,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
@@ -550,7 +555,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, fuzzy, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -574,10 +579,12 @@ msgstr "Certificat client enregistré sur le serveur : "
 msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -626,7 +633,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the target container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -796,7 +803,7 @@ msgstr "Copie de l'image : %s"
 msgid "Create the container with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
@@ -814,12 +821,12 @@ msgstr "Création du conteneur"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -879,9 +886,9 @@ msgstr "Copie de l'image : %s"
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -896,35 +903,35 @@ msgstr "Copie de l'image : %s"
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -976,7 +983,7 @@ msgstr "Désactiver l'allocation pseudo-terminal"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
@@ -1007,7 +1014,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1191,7 +1198,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1245,7 +1252,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1267,7 +1274,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1294,7 +1301,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -1308,7 +1315,7 @@ msgstr "PID"
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1427,7 +1434,7 @@ msgstr "Clé de configuration invalide"
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Invalid format %q"
@@ -1474,7 +1481,7 @@ msgstr "Source invalide %s"
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr "IPs :"
 
@@ -1486,7 +1493,7 @@ msgstr "Garder l'image à jour après la copie initiale"
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1507,7 +1514,7 @@ msgstr "Dernière utilisation : %s"
 msgid "Last used: never"
 msgstr "Dernière utilisation : jamais"
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1520,11 +1527,11 @@ msgstr "Alias :"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1738,25 +1745,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
@@ -1764,7 +1771,7 @@ msgstr "GÉRÉ"
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1789,7 +1796,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1886,15 +1893,15 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
@@ -1933,15 +1940,15 @@ msgid "Missing name"
 msgstr "Résumé manquant."
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -2028,18 +2035,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr "NOM"
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr "NON"
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -2059,7 +2066,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
@@ -2068,7 +2075,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -2130,7 +2137,7 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
@@ -2173,11 +2180,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -2195,7 +2202,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid : %d"
@@ -2205,7 +2212,7 @@ msgstr "Pid : %d"
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
@@ -2226,7 +2233,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -2280,7 +2287,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr "Profils : %s"
@@ -2393,7 +2400,7 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remote operation canceled by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr "Serveur distant : %s"
@@ -2444,7 +2451,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2480,7 +2487,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -2536,11 +2543,11 @@ msgstr "TAILLE"
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr "SOURCE"
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr "ÉTAT"
 
@@ -2589,12 +2596,12 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 #, fuzzy
 msgid "Set container or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2609,7 +2616,7 @@ msgstr "Clé de configuration invalide"
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
@@ -2648,12 +2655,12 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 #, fuzzy
 msgid "Show container or server configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 #, fuzzy
 msgid "Show container or server information"
 msgstr "Afficher des informations supplémentaires"
@@ -2689,7 +2696,7 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
@@ -2704,7 +2711,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2718,7 +2725,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show storage volume configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
@@ -2727,15 +2734,15 @@ msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2761,7 +2768,7 @@ msgstr "Taille : %.2f Mo"
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -2784,12 +2791,12 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr "État : %s"
@@ -2856,11 +2863,11 @@ msgstr "Image copiée avec succès !"
 msgid "Store the container state"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -2878,7 +2885,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr "TYPE"
@@ -2983,7 +2990,8 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3014,11 +3022,11 @@ msgstr "Transfert de l'image : %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr "Type : éphémère"
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr "Type : persistant"
 
@@ -3030,7 +3038,7 @@ msgstr "DATE DE PUBLICATION"
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -3060,12 +3068,12 @@ msgstr "tous les profils de la source n'existent pas sur la cible"
 msgid "Unset container device configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 #, fuzzy
 msgid "Unset container or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3080,7 +3088,7 @@ msgstr "Clé de configuration invalide"
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3131,7 +3139,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr "OUI"
@@ -3208,7 +3216,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3339,7 +3347,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3371,7 +3379,7 @@ msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3419,7 +3427,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -3448,7 +3456,7 @@ msgstr "erreur : %v"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, fuzzy, c-format
 msgid "expires at %s"
 msgstr "Expire : %s"
@@ -3507,7 +3515,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3530,7 +3538,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3546,7 +3554,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3562,8 +3570,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3587,7 +3595,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3616,13 +3624,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3668,7 +3676,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 #, fuzzy
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
@@ -3849,7 +3857,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3883,7 +3891,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -4000,7 +4008,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4054,11 +4062,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4078,7 +4086,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -4106,7 +4114,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -4114,7 +4122,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4138,7 +4146,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -4166,7 +4174,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4178,11 +4186,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr "sans suivi d'état"
 
@@ -4208,7 +4216,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "switch [<remote>:] <project>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr "pris à %s"
@@ -4217,7 +4225,7 @@ msgstr "pris à %s"
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -4233,11 +4241,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4257,11 +4265,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -65,7 +65,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -232,6 +232,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
@@ -304,7 +309,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Alias:"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr "Architettura: %s"
@@ -388,11 +393,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -404,11 +409,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
@@ -438,8 +443,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
@@ -464,7 +469,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -487,10 +492,12 @@ msgstr "Certificato del client salvato dal server: "
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -531,7 +538,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -676,7 +683,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -694,12 +701,12 @@ msgstr "Creazione del container in corso"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -754,9 +761,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -771,35 +778,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -851,7 +858,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
@@ -879,7 +886,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1047,7 +1054,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
@@ -1101,7 +1108,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1122,7 +1129,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1146,7 +1153,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1158,7 +1165,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, fuzzy, c-format
 msgid "Invalid format %q"
@@ -1318,7 +1325,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1330,7 +1337,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1351,7 +1358,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1364,11 +1371,11 @@ msgstr "Alias:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1519,25 +1526,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1545,7 +1552,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1570,7 +1577,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1661,15 +1668,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1704,14 +1711,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1790,18 +1797,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1821,7 +1828,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1830,7 +1837,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1883,7 +1890,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1924,11 +1931,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1946,7 +1953,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1956,7 +1963,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1977,7 +1984,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2030,7 +2037,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2137,7 +2144,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2184,7 +2191,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2217,7 +2224,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2269,11 +2276,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2318,11 +2325,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2334,7 +2341,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2370,11 +2377,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2406,7 +2413,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2418,7 +2425,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2430,7 +2437,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2438,15 +2445,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2471,7 +2478,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2494,12 +2501,12 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2563,11 +2570,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr "Creazione del container in corso"
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2583,7 +2590,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2679,7 +2686,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2710,11 +2718,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2726,7 +2734,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2755,11 +2763,11 @@ msgstr "non tutti i profili dell'origine esistono nella destinazione"
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2771,7 +2779,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2816,7 +2824,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2891,7 +2899,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2997,7 +3005,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3029,7 +3037,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3134,7 +3142,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3156,7 +3164,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3172,7 +3180,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3188,8 +3196,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3213,7 +3221,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3242,13 +3250,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3294,7 +3302,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3445,7 +3453,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3473,7 +3481,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3559,7 +3567,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3593,11 +3601,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3613,7 +3621,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3641,7 +3649,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3649,7 +3657,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3665,7 +3673,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
@@ -3678,7 +3686,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3686,11 +3694,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr "senza stato"
 
@@ -3710,7 +3718,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr "salvato alle %s"
@@ -3719,7 +3727,7 @@ msgstr "salvato alle %s"
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3735,11 +3743,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3755,11 +3763,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2019-02-16 19:26+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -50,7 +50,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -196,6 +196,12 @@ msgstr "--container-only はコピー元がスナップショットの場合は�
 msgid "--refresh can only be used with containers"
 msgstr "--refresh はコンテナの場合のみ使えます"
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+#, fuzzy
+msgid "--target cannot be used with containers"
+msgstr "--refresh はコンテナの場合のみ使えます"
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -267,7 +273,7 @@ msgstr "エイリアスを指定してください"
 msgid "Aliases:"
 msgstr "エイリアス:"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr "アーキテクチャ: %s"
@@ -356,11 +362,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr "--all とコンテナ名を両方同時に指定することはできません"
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -372,11 +378,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
@@ -406,8 +412,8 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
@@ -433,7 +439,7 @@ msgstr "クラスタでない場合はカラムとして L は指定できませ
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
@@ -456,10 +462,12 @@ msgstr "クライアント証明書がサーバに格納されました: "
 msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -504,7 +512,7 @@ msgstr "新しいプロジェクトに適用するキー/値の設定"
 msgid "Config key/value to apply to the target container"
 msgstr "移動先のコンテナに適用するキー/値の設定"
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -655,7 +663,7 @@ msgstr "ストレージプールを作成します"
 msgid "Create the container with no profiles applied"
 msgstr "プロファイルを適用しないコンテナを作成します"
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
@@ -673,12 +681,12 @@ msgstr "コンテナを作成中"
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -733,9 +741,9 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -750,35 +758,35 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr "説明"
 
@@ -830,7 +838,7 @@ msgstr "擬似端末の割り当てを無効にします"
 msgid "Disable stdin (reads from /dev/null)"
 msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
@@ -859,7 +867,7 @@ msgstr "コンテナのファイルテンプレートを編集します"
 msgid "Edit container metadata files"
 msgstr "コンテナのメタデータファイルを編集します"
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr "コンテナもしくはサーバの設定をYAMLファイルで編集します"
 
@@ -1050,7 +1058,7 @@ msgstr "パス %s にアクセスできませんでした: %s"
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
@@ -1103,7 +1111,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
@@ -1124,7 +1132,7 @@ msgstr "ネットワークのランタイム情報を取得します"
 msgid "Get values for container device configuration keys"
 msgstr "コンテナのデバイスの設定値を取得します"
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr "コンテナもしくはサーバの設定値を取得します"
 
@@ -1148,7 +1156,7 @@ msgstr "ストレージプールの設定値を取得します"
 msgid "Get values for storage volume configuration keys"
 msgstr "ストレージボリュームの設定値を取得します"
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1160,7 +1168,7 @@ msgstr "ID"
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1277,7 +1285,7 @@ msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1326,7 +1334,7 @@ msgstr "不正なソース %s"
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr "IPアドレス:"
 
@@ -1338,7 +1346,7 @@ msgstr "最初にコピーした後も常にイメージを最新の状態に保
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1359,7 +1367,7 @@ msgstr "最終使用: %s"
 msgid "Last used: never"
 msgstr "最終使用: 未使用"
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
@@ -1371,11 +1379,11 @@ msgstr "エイリアスを一覧表示します"
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
@@ -1610,25 +1618,25 @@ msgstr "信頼済みクライアントを一覧表示します"
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1636,7 +1644,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1661,7 +1669,7 @@ msgstr "クラスタのメンバを管理します"
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr "コンテナやサーバの設定を管理します"
 
@@ -1767,15 +1775,15 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
@@ -1809,14 +1817,14 @@ msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1899,18 +1907,18 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -1930,7 +1938,7 @@ msgstr "ネットワーク %s を削除しました"
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
@@ -1939,7 +1947,7 @@ msgstr "ネットワーク名 %s を %s に変更しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -1992,7 +2000,7 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
@@ -2033,11 +2041,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -2054,7 +2062,7 @@ msgstr "コンテナを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid: %d"
@@ -2064,7 +2072,7 @@ msgstr "Pid: %d"
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
@@ -2085,7 +2093,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -2138,7 +2146,7 @@ msgstr "移動先のコンテナに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
@@ -2245,7 +2253,7 @@ msgstr "リモートの管理者パスワード"
 msgid "Remote operation canceled by user"
 msgstr "リモート操作がユーザによってキャンセルされました"
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr "リモート名: %s"
@@ -2292,7 +2300,7 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename containers and snapshots"
 msgstr "コンテナまたはコンテナのスナップショットの名前を変更します"
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
@@ -2326,7 +2334,7 @@ msgstr "ストレージボリューム名 \"%s\" を \"%s\" に変更しまし�
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -2383,11 +2391,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2432,11 +2440,11 @@ msgstr "サーバのバージョン: %s\n"
 msgid "Set container device configuration keys"
 msgstr "コンテナデバイスの設定項目を設定します"
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr "コンテナもしくはサーバの設定項目を設定します"
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
@@ -2448,7 +2456,7 @@ msgstr "プロファイルの設定項目を設定します"
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
@@ -2484,11 +2492,11 @@ msgstr "詳細な情報を出力します"
 msgid "Show container metadata files"
 msgstr "コンテナのメタデータファイルを表示します"
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr "コンテナもしくはサーバの設定を表示します"
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr "コンテナもしくはサーバの情報を表示します"
 
@@ -2520,7 +2528,7 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
@@ -2532,7 +2540,7 @@ msgstr "プロファイルの設定を表示します"
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
@@ -2544,7 +2552,7 @@ msgstr "ストレージボリュームの設定を表示します"
 msgid "Show storage volume configurations"
 msgstr "ストレージボリュームの設定を表示する"
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr "コンテナログの最後の 100 行を表示しますか?"
 
@@ -2552,15 +2560,15 @@ msgstr "コンテナログの最後の 100 行を表示しますか?"
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr "拡張した設定を表示する"
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
@@ -2585,7 +2593,7 @@ msgstr "サイズ: %.2fMB"
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -2607,12 +2615,12 @@ msgstr "コンテナを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr "状態: %s"
@@ -2675,11 +2683,11 @@ msgstr "ストレージボリュームの移動が成功しました!"
 msgid "Store the container state"
 msgstr "コンテナの状態を保存します"
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -2695,7 +2703,7 @@ msgstr "デフォルトのリモートを切り替えます"
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2801,7 +2809,8 @@ msgstr ""
 "初めてコンテナを起動するには、\"lxc launch ubuntu:18.04\" と実行してみてくだ"
 "さい"
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -2834,11 +2843,11 @@ msgstr "イメージを転送中: %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr "タイプ: ephemeral"
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr "タイプ: persistent"
 
@@ -2850,7 +2859,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2878,11 +2887,11 @@ msgstr "移動先のコンテナのすべてのプロファイルを削除しま
 msgid "Unset container device configuration keys"
 msgstr "コンテナデバイスの設定を削除します"
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr "コンテナもしくはサーバの設定を削除します"
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
@@ -2894,7 +2903,7 @@ msgstr "プロファイルの設定を削除します"
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
@@ -2944,7 +2953,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -3017,7 +3026,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3126,7 +3135,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr "delete [<remote>:]<project>"
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr "説明"
 
@@ -3160,7 +3169,7 @@ msgstr ""
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr "ドライバ"
 
@@ -3200,7 +3209,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "restore [<remote>:]<container> <snapshot>"
@@ -3222,7 +3231,7 @@ msgstr "エラー: %v"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, fuzzy, c-format
 msgid "expires at %s"
 msgstr "失効日時: %s"
@@ -3267,7 +3276,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr "get [<remote>:]<project> <key>"
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3289,7 +3298,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr "ストレージ情報"
 
@@ -3305,7 +3314,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3321,8 +3330,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3346,7 +3355,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3384,7 +3393,7 @@ msgstr ""
 "c1 path=opt\n"
 "    ホストの /share/c1 をコンテナ内の /opt にマウントします。"
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
@@ -3392,7 +3401,7 @@ msgstr ""
 "lxc config edit <container> < container.yaml\n"
 "    コンテナの設定を config.yaml を使って更新します。"
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3461,7 +3470,7 @@ msgstr ""
 "lxc import backup0.tar.gz\n"
 "    backup0.tar.gz を使って新しいコンテナを作成します。"
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3680,7 +3689,7 @@ msgstr ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr "名前"
 
@@ -3708,7 +3717,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr "pause [<remote>:]<container> [[<remote>:]<container>...]"
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
@@ -3800,7 +3809,7 @@ msgstr "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3836,11 +3845,11 @@ msgstr "restore [<remote>:]<pool> <volume> <snapshot>"
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3856,7 +3865,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr "set [<remote>:]<project> <key> <value>"
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3884,7 +3893,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3892,7 +3901,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3908,7 +3917,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr "restore [<remote>:]<container> <snapshot>"
@@ -3921,7 +3930,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr "使用量"
 
@@ -3929,11 +3938,11 @@ msgstr "使用量"
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr "start [<remote>:]<container> [[<remote>:]<container>...]"
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr "ステートレス"
 
@@ -3953,7 +3962,7 @@ msgstr "switch <remote>"
 msgid "switch [<remote>:] <project>"
 msgstr "switch [<remote>:] <project>"
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr "%s に取得しました"
@@ -3962,7 +3971,7 @@ msgstr "%s に取得しました"
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr "総容量"
 
@@ -3978,11 +3987,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3998,11 +4007,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr "unset [<remote>:]<project> <key>"
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr "ストレージを使用中の"
 

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-03-06 16:45-0500\n"
+        "POT-Creation-Date: 2019-03-11 15:34-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -45,7 +45,7 @@ msgid   "### This is a yaml representation of a storage volume.\n"
         "###   size: \"61203283968\""
 msgstr  ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid   "### This is a yaml representation of the configuration.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -184,6 +184,10 @@ msgstr  ""
 msgid   "--refresh can only be used with containers"
 msgstr  ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624 lxc/info.go:126
+msgid   "--target cannot be used with containers"
+msgstr  ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid   "ALIAS"
 msgstr  ""
@@ -255,7 +259,7 @@ msgstr  ""
 msgid   "Aliases:"
 msgstr  ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid   "Architecture: %s"
 msgstr  ""
@@ -337,11 +341,11 @@ msgstr  ""
 msgid   "Both --all and container name given"
 msgstr  ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -353,11 +357,11 @@ msgstr  ""
 msgid   "COMMON NAME"
 msgstr  ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid   "CPU usage:"
 msgstr  ""
 
@@ -386,7 +390,7 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561 lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561 lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
@@ -411,7 +415,7 @@ msgstr  ""
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
@@ -434,7 +438,7 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106 lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307 lxc/storage_volume.go:467 lxc/storage_volume.go:544 lxc/storage_volume.go:786 lxc/storage_volume.go:983 lxc/storage_volume.go:1152 lxc/storage_volume.go:1182 lxc/storage_volume.go:1285 lxc/storage_volume.go:1368 lxc/storage_volume.go:1461
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571 lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732 lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591 lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307 lxc/storage_volume.go:467 lxc/storage_volume.go:544 lxc/storage_volume.go:786 lxc/storage_volume.go:983 lxc/storage_volume.go:1152 lxc/storage_volume.go:1182 lxc/storage_volume.go:1285 lxc/storage_volume.go:1368 lxc/storage_volume.go:1461
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -469,7 +473,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the target container"
 msgstr  ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144 lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305 lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144 lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305 lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -608,7 +612,7 @@ msgstr  ""
 msgid   "Create the container with no profiles applied"
 msgstr  ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid   "Created: %s"
 msgstr  ""
@@ -626,11 +630,11 @@ msgstr  ""
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861 lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871 lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid   "DRIVER"
 msgstr  ""
 
@@ -682,7 +686,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149 lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30 lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520 lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034 lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147 lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149 lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32 lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567 lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589 lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54 lxc/config_metadata.go:176 lxc/config_template.go:30 lxc/config_template.go:67 lxc/config_template.go:110 lxc/config_template.go:152 lxc/config_template.go:236 lxc/config_template.go:298 lxc/config_trust.go:30 lxc/config_trust.go:59 lxc/config_trust.go:115 lxc/config_trust.go:197 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:39 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:42 lxc/image.go:131 lxc/image.go:265 lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793 lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26 lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149 lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35 lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110 lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378 lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729 lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004 lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185 lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660 lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220 lxc/storage_volume.go:303 lxc/storage_volume.go:464 lxc/storage_volume.go:541 lxc/storage_volume.go:617 lxc/storage_volume.go:699 lxc/storage_volume.go:780 lxc/storage_volume.go:980 lxc/storage_volume.go:1069 lxc/storage_volume.go:1148 lxc/storage_volume.go:1179 lxc/storage_volume.go:1282 lxc/storage_volume.go:1359 lxc/storage_volume.go:1458 lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -734,7 +738,7 @@ msgstr  ""
 msgid   "Disable stdin (reads from /dev/null)"
 msgstr  ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid   "Disk usage:"
 msgstr  ""
 
@@ -762,7 +766,7 @@ msgstr  ""
 msgid   "Edit container metadata files"
 msgstr  ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid   "Edit container or server configurations as YAML"
 msgstr  ""
 
@@ -920,7 +924,7 @@ msgstr  ""
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -968,7 +972,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584 lxc/remote.go:456
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584 lxc/remote.go:456
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -988,7 +992,7 @@ msgstr  ""
 msgid   "Get values for container device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid   "Get values for container or server configuration keys"
 msgstr  ""
 
@@ -1012,7 +1016,7 @@ msgstr  ""
 msgid   "Get values for storage volume configuration keys"
 msgstr  ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -1024,7 +1028,7 @@ msgstr  ""
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid   "IP ADDRESS"
 msgstr  ""
 
@@ -1132,7 +1136,7 @@ msgstr  ""
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662 lxc/remote.go:551
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662 lxc/remote.go:551
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
@@ -1176,7 +1180,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid   "Ips:"
 msgstr  ""
 
@@ -1188,7 +1192,7 @@ msgstr  ""
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1209,7 +1213,7 @@ msgstr  ""
 msgid   "Last used: never"
 msgstr  ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid   "List DHCP leases"
 msgstr  ""
 
@@ -1221,11 +1225,11 @@ msgstr  ""
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid   "List available networks"
 msgstr  ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid   "List available storage pools"
 msgstr  ""
 
@@ -1369,25 +1373,25 @@ msgstr  ""
 msgid   "List, show and delete background operations"
 msgstr  ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid   "Location: %s"
 msgstr  ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid   "MANAGED"
 msgstr  ""
 
@@ -1395,7 +1399,7 @@ msgstr  ""
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -1420,7 +1424,7 @@ msgstr  ""
 msgid   "Manage command aliases"
 msgstr  ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid   "Manage container and server configuration options"
 msgstr  ""
 
@@ -1506,15 +1510,15 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid   "Memory usage:"
 msgstr  ""
 
@@ -1542,11 +1546,11 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402 lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754 lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060 lxc/network.go:1129
+#: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402 lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755 lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080 lxc/network.go:1149
 msgid   "Missing network name"
 msgstr  ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413 lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165 lxc/storage_volume.go:244 lxc/storage_volume.go:489 lxc/storage_volume.go:565 lxc/storage_volume.go:641 lxc/storage_volume.go:723 lxc/storage_volume.go:822 lxc/storage_volume.go:1005 lxc/storage_volume.go:1093 lxc/storage_volume.go:1204 lxc/storage_volume.go:1307 lxc/storage_volume.go:1390 lxc/storage_volume.go:1512 lxc/storage_volume.go:1583
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414 lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165 lxc/storage_volume.go:244 lxc/storage_volume.go:489 lxc/storage_volume.go:565 lxc/storage_volume.go:641 lxc/storage_volume.go:723 lxc/storage_volume.go:822 lxc/storage_volume.go:1005 lxc/storage_volume.go:1093 lxc/storage_volume.go:1204 lxc/storage_volume.go:1307 lxc/storage_volume.go:1390 lxc/storage_volume.go:1512 lxc/storage_volume.go:1583
 msgid   "Missing pool name"
 msgstr  ""
 
@@ -1613,15 +1617,15 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622 lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549 lxc/storage_volume.go:1120
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622 lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559 lxc/storage_volume.go:1120
 msgid   "NAME"
 msgstr  ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426 lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426 lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid   "NO"
 msgstr  ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -1641,7 +1645,7 @@ msgstr  ""
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
@@ -1650,7 +1654,7 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid   "Network usage:"
 msgstr  ""
 
@@ -1703,7 +1707,7 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
@@ -1744,11 +1748,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid   "Packets sent"
 msgstr  ""
 
@@ -1765,7 +1769,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid   "Pid: %d"
 msgstr  ""
@@ -1774,7 +1778,7 @@ msgstr  ""
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145 lxc/config_template.go:205 lxc/image.go:410
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145 lxc/config_template.go:205 lxc/image.go:410
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -1794,7 +1798,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -1847,7 +1851,7 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid   "Profiles: %s"
 msgstr  ""
@@ -1953,7 +1957,7 @@ msgstr  ""
 msgid   "Remote operation canceled by user"
 msgstr  ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid   "Remote: %s"
 msgstr  ""
@@ -1999,7 +2003,7 @@ msgstr  ""
 msgid   "Rename containers and snapshots"
 msgstr  ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid   "Rename networks"
 msgstr  ""
 
@@ -2032,7 +2036,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid   "Resources:"
 msgstr  ""
 
@@ -2081,11 +2085,11 @@ msgstr  ""
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid   "SOURCE"
 msgstr  ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid   "STATE"
 msgstr  ""
 
@@ -2130,11 +2134,11 @@ msgstr  ""
 msgid   "Set container device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid   "Set container or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid   "Set network configuration keys"
 msgstr  ""
 
@@ -2146,7 +2150,7 @@ msgstr  ""
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
@@ -2182,11 +2186,11 @@ msgstr  ""
 msgid   "Show container metadata files"
 msgstr  ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid   "Show container or server configurations"
 msgstr  ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid   "Show container or server information"
 msgstr  ""
 
@@ -2218,7 +2222,7 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid   "Show network configurations"
 msgstr  ""
 
@@ -2230,7 +2234,7 @@ msgstr  ""
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
@@ -2242,7 +2246,7 @@ msgstr  ""
 msgid   "Show storage volume configurations"
 msgstr  ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
@@ -2250,15 +2254,15 @@ msgstr  ""
 msgid   "Show the default remote"
 msgstr  ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid   "Show the expanded configuration"
 msgstr  ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
@@ -2283,7 +2287,7 @@ msgstr  ""
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -2305,12 +2309,12 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid   "State: %s"
 msgstr  ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid   "Status: %s"
 msgstr  ""
@@ -2373,11 +2377,11 @@ msgstr  ""
 msgid   "Store the container state"
 msgstr  ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -2393,7 +2397,7 @@ msgstr  ""
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155 lxc/storage_volume.go:1119
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155 lxc/storage_volume.go:1119
 msgid   "TYPE"
 msgstr  ""
 
@@ -2483,7 +2487,7 @@ msgstr  ""
 msgid   "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr  ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604 lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -2514,11 +2518,11 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid   "Type: ephemeral"
 msgstr  ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid   "Type: persistent"
 msgstr  ""
 
@@ -2530,7 +2534,7 @@ msgstr  ""
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558 lxc/storage_volume.go:1122
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568 lxc/storage_volume.go:1122
 msgid   "USED BY"
 msgstr  ""
 
@@ -2557,11 +2561,11 @@ msgstr  ""
 msgid   "Unset container device configuration keys"
 msgstr  ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid   "Unset container or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid   "Unset network configuration keys"
 msgstr  ""
 
@@ -2573,7 +2577,7 @@ msgstr  ""
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
@@ -2614,7 +2618,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428 lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428 lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid   "YES"
 msgstr  ""
 
@@ -2682,7 +2686,7 @@ msgstr  ""
 msgid   "cluster"
 msgstr  ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid   "config"
 msgstr  ""
 
@@ -2786,7 +2790,7 @@ msgstr  ""
 msgid   "delete [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid   "description"
 msgstr  ""
 
@@ -2818,7 +2822,7 @@ msgstr  ""
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid   "driver"
 msgstr  ""
 
@@ -2858,7 +2862,7 @@ msgstr  ""
 msgid   "edit [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid   "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
@@ -2879,7 +2883,7 @@ msgstr  ""
 msgid   "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr  ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid   "expires at %s"
 msgstr  ""
@@ -2920,7 +2924,7 @@ msgstr  ""
 msgid   "get [<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid   "get [<remote>:][<container>] <key>"
 msgstr  ""
 
@@ -2940,7 +2944,7 @@ msgstr  ""
 msgid   "import [<remote>:] <backup file>"
 msgstr  ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid   "info"
 msgstr  ""
 
@@ -2956,7 +2960,7 @@ msgstr  ""
 msgid   "info [<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid   "info [<remote>:][<container>]"
 msgstr  ""
 
@@ -2972,7 +2976,7 @@ msgstr  ""
 msgid   "list"
 msgstr  ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796 lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806 lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid   "list [<remote>:]"
 msgstr  ""
 
@@ -2996,7 +3000,7 @@ msgstr  ""
 msgid   "list [<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid   "list-leases [<remote>:]<network>"
 msgstr  ""
 
@@ -3020,12 +3024,12 @@ msgid   "lxc config device add [<remote>:]container1 <device-name> disk source=/
         "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr  ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid   "lxc config edit <container> < container.yaml\n"
         "    Update the container configuration from config.yaml."
 msgstr  ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid   "lxc config set [<remote>:]<container> limits.cpu 2\n"
         "    Will set a CPU limit of \"2\" for the container.\n"
         "\n"
@@ -3064,7 +3068,7 @@ msgid   "lxc import backup0.tar.gz\n"
         "    Create a new container using backup0.tar.gz as the source."
 msgstr  ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid   "lxc info [<remote>:]<container> [--show-log]\n"
         "    For container information.\n"
         "\n"
@@ -3193,7 +3197,7 @@ msgstr  ""
 msgid   "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid   "name"
 msgstr  ""
 
@@ -3221,7 +3225,7 @@ msgstr  ""
 msgid   "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr  ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid   "please use `lxc profile`"
 msgstr  ""
 
@@ -3301,7 +3305,7 @@ msgstr  ""
 msgid   "rename [<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid   "rename [<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -3333,11 +3337,11 @@ msgstr  ""
 msgid   "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid   "set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid   "set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
@@ -3353,7 +3357,7 @@ msgstr  ""
 msgid   "set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid   "set [<remote>:][<container>] <key> <value>"
 msgstr  ""
 
@@ -3381,7 +3385,7 @@ msgstr  ""
 msgid   "show [<remote>:]<member>"
 msgstr  ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid   "show [<remote>:]<network>"
 msgstr  ""
 
@@ -3389,7 +3393,7 @@ msgstr  ""
 msgid   "show [<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid   "show [<remote>:]<pool>"
 msgstr  ""
 
@@ -3405,7 +3409,7 @@ msgstr  ""
 msgid   "show [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid   "show [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
@@ -3417,7 +3421,7 @@ msgstr  ""
 msgid   "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid   "space used"
 msgstr  ""
 
@@ -3425,11 +3429,11 @@ msgstr  ""
 msgid   "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr  ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid   "stateful"
 msgstr  ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid   "stateless"
 msgstr  ""
 
@@ -3449,7 +3453,7 @@ msgstr  ""
 msgid   "switch [<remote>:] <project>"
 msgstr  ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid   "taken at %s"
 msgstr  ""
@@ -3458,7 +3462,7 @@ msgstr  ""
 msgid   "template"
 msgstr  ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid   "total space"
 msgstr  ""
 
@@ -3474,11 +3478,11 @@ msgstr  ""
 msgid   "unset [<remote>:]<container|profile> <device> <key>"
 msgstr  ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid   "unset [<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid   "unset [<remote>:]<pool> <key>"
 msgstr  ""
 
@@ -3494,11 +3498,11 @@ msgstr  ""
 msgid   "unset [<remote>:]<project> <key>"
 msgstr  ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid   "unset [<remote>:][<container>] <key>"
 msgstr  ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid   "used by"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2019-02-26 09:18+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -73,7 +73,7 @@ msgstr ""
 "### config:\n"
 "###  size: \"61203283968\""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -241,6 +241,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ALIAS"
@@ -312,7 +317,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -396,11 +401,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -412,11 +417,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -445,8 +450,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -471,7 +476,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -494,10 +499,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -538,7 +545,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -681,7 +688,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -699,12 +706,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -759,9 +766,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -776,35 +783,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -856,7 +863,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -884,7 +891,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1050,7 +1057,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1103,7 +1110,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1124,7 +1131,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1148,7 +1155,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1160,7 +1167,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1317,7 +1324,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1329,7 +1336,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1350,7 +1357,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1362,11 +1369,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1516,25 +1523,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1542,7 +1549,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1567,7 +1574,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1656,15 +1663,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1698,14 +1705,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1783,18 +1790,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1814,7 +1821,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1823,7 +1830,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1876,7 +1883,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1917,11 +1924,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1938,7 +1945,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1948,7 +1955,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1969,7 +1976,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2022,7 +2029,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2129,7 +2136,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2176,7 +2183,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2209,7 +2216,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2309,11 +2316,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2325,7 +2332,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2361,11 +2368,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2397,7 +2404,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2421,7 +2428,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2429,15 +2436,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2462,7 +2469,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2484,12 +2491,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2552,11 +2559,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2572,7 +2579,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2667,7 +2674,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2698,11 +2706,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2714,7 +2722,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2742,11 +2750,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2758,7 +2766,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2803,7 +2811,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2876,7 +2884,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2982,7 +2990,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3014,7 +3022,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3054,7 +3062,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3075,7 +3083,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3118,7 +3126,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3140,7 +3148,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3156,7 +3164,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3172,8 +3180,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3197,7 +3205,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3226,13 +3234,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3278,7 +3286,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3429,7 +3437,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3457,7 +3465,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3543,7 +3551,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3577,11 +3585,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3597,7 +3605,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3625,7 +3633,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3633,7 +3641,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3649,7 +3657,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3661,7 +3669,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3693,7 +3701,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3702,7 +3710,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3718,11 +3726,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3738,11 +3746,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -61,7 +61,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -241,6 +241,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -312,7 +317,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -396,11 +401,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -412,11 +417,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -445,8 +450,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -471,7 +476,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -494,10 +499,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -538,7 +545,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -681,7 +688,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -699,12 +706,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -759,9 +766,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -776,35 +783,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -856,7 +863,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -884,7 +891,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1050,7 +1057,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1103,7 +1110,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1124,7 +1131,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1148,7 +1155,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1160,7 +1167,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1317,7 +1324,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1329,7 +1336,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1350,7 +1357,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1362,11 +1369,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1516,25 +1523,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1542,7 +1549,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1567,7 +1574,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1656,15 +1663,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1698,14 +1705,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1783,18 +1790,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1814,7 +1821,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1823,7 +1830,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1876,7 +1883,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1917,11 +1924,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1938,7 +1945,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1948,7 +1955,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1969,7 +1976,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2022,7 +2029,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2129,7 +2136,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2176,7 +2183,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2209,7 +2216,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2309,11 +2316,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2325,7 +2332,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2361,11 +2368,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2397,7 +2404,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2409,7 +2416,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2421,7 +2428,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2429,15 +2436,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2462,7 +2469,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2484,12 +2491,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2552,11 +2559,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2572,7 +2579,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2667,7 +2674,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2698,11 +2706,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2714,7 +2722,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2742,11 +2750,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2758,7 +2766,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2803,7 +2811,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2876,7 +2884,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2982,7 +2990,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3014,7 +3022,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3054,7 +3062,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3075,7 +3083,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3118,7 +3126,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3140,7 +3148,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3156,7 +3164,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3172,8 +3180,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3197,7 +3205,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3226,13 +3234,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3278,7 +3286,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3429,7 +3437,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3457,7 +3465,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3543,7 +3551,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3577,11 +3585,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3597,7 +3605,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3625,7 +3633,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3633,7 +3641,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3649,7 +3657,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3661,7 +3669,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3693,7 +3701,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3702,7 +3710,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3718,11 +3726,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3738,11 +3746,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2019-02-16 19:26+0000\n"
 "Last-Translator: Renato dos Santos <shazaum@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -75,7 +75,7 @@ msgstr ""
 "### config:\n"
 "###   size: \"61203283968\""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -312,6 +312,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -383,7 +388,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -467,11 +472,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -483,11 +488,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -516,8 +521,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -542,7 +547,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -565,10 +570,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -609,7 +616,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -752,7 +759,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -770,12 +777,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -830,9 +837,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -847,35 +854,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -927,7 +934,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -955,7 +962,7 @@ msgstr "Editar templates de arquivo do container"
 msgid "Edit container metadata files"
 msgstr "Editar arquivos de metadados do container"
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
@@ -1122,7 +1129,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1175,7 +1182,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1196,7 +1203,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1221,7 +1228,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1233,7 +1240,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1344,7 +1351,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1390,7 +1397,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1402,7 +1409,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1423,7 +1430,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1435,11 +1442,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1589,25 +1596,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1615,7 +1622,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1640,7 +1647,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1729,15 +1736,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1771,14 +1778,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1856,18 +1863,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1887,7 +1894,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1896,7 +1903,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1949,7 +1956,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1990,11 +1997,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -2011,7 +2018,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2021,7 +2028,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -2042,7 +2049,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2095,7 +2102,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2202,7 +2209,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2249,7 +2256,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2282,7 +2289,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2333,11 +2340,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2382,11 +2389,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2399,7 +2406,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2435,11 +2442,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2471,7 +2478,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2483,7 +2490,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2495,7 +2502,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2503,15 +2510,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2536,7 +2543,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2558,12 +2565,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2626,11 +2633,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2646,7 +2653,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2741,7 +2748,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2772,11 +2780,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2788,7 +2796,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2816,11 +2824,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2833,7 +2841,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2878,7 +2886,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2951,7 +2959,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3057,7 +3065,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3089,7 +3097,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3129,7 +3137,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3150,7 +3158,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3193,7 +3201,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3215,7 +3223,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3231,7 +3239,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3247,8 +3255,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3272,7 +3280,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3301,13 +3309,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3353,7 +3361,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3504,7 +3512,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3532,7 +3540,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3618,7 +3626,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3652,11 +3660,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3672,7 +3680,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3700,7 +3708,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3708,7 +3716,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3724,7 +3732,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3736,7 +3744,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3744,11 +3752,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3768,7 +3776,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3777,7 +3785,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3793,11 +3801,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3813,11 +3821,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -65,7 +65,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -302,6 +302,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
@@ -375,7 +380,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr "Псевдонимы:"
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr "Архитектура: %s"
@@ -459,11 +464,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -475,11 +480,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
@@ -510,8 +515,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
@@ -536,7 +541,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -559,10 +564,12 @@ msgstr "Сертификат клиента хранится на сервере
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -603,7 +610,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -752,7 +759,7 @@ msgstr "Копирование образа: %s"
 msgid "Create the container with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -770,12 +777,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -833,9 +840,9 @@ msgstr "Копирование образа: %s"
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -850,35 +857,35 @@ msgstr "Копирование образа: %s"
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -930,7 +937,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
@@ -960,7 +967,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1129,7 +1136,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1182,7 +1189,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1203,7 +1210,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1227,7 +1234,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1239,7 +1246,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1353,7 +1360,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1399,7 +1406,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1411,7 +1418,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1432,7 +1439,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1445,11 +1452,11 @@ msgstr "Псевдонимы:"
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1601,25 +1608,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1627,7 +1634,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1652,7 +1659,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1744,15 +1751,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
@@ -1788,14 +1795,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1876,18 +1883,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1907,7 +1914,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1916,7 +1923,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -1971,7 +1978,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -2012,11 +2019,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -2033,7 +2040,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2043,7 +2050,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -2064,7 +2071,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2117,7 +2124,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2225,7 +2232,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2274,7 +2281,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2309,7 +2316,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2361,11 +2368,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2410,11 +2417,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2426,7 +2433,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2463,11 +2470,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2500,7 +2507,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2512,7 +2519,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2524,7 +2531,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2532,15 +2539,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2566,7 +2573,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2588,12 +2595,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2658,11 +2665,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2678,7 +2685,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2773,7 +2780,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2804,11 +2812,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2820,7 +2828,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2848,11 +2856,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2864,7 +2872,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2909,7 +2917,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2983,7 +2991,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -3109,7 +3117,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -3141,7 +3149,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3185,7 +3193,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 #, fuzzy
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -3210,7 +3218,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3265,7 +3273,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3287,7 +3295,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3303,7 +3311,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3319,8 +3327,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3344,7 +3352,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3373,13 +3381,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3425,7 +3433,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3580,7 +3588,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3714,7 +3722,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3760,11 +3768,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3784,7 +3792,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3812,7 +3820,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3820,7 +3828,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3840,7 +3848,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 #, fuzzy
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
@@ -3860,7 +3868,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3872,11 +3880,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3900,7 +3908,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3909,7 +3917,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3925,11 +3933,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3949,11 +3957,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -47,7 +47,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,6 +192,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -263,7 +268,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -347,11 +352,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -363,11 +368,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -396,8 +401,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -422,7 +427,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -445,10 +450,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -489,7 +496,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -632,7 +639,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -650,12 +657,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -710,9 +717,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -727,35 +734,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -807,7 +814,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -835,7 +842,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1001,7 +1008,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1054,7 +1061,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1075,7 +1082,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1099,7 +1106,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1111,7 +1118,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1222,7 +1229,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1268,7 +1275,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1280,7 +1287,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1301,7 +1308,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1313,11 +1320,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1467,25 +1474,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1493,7 +1500,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1518,7 +1525,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1607,15 +1614,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1649,14 +1656,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1734,18 +1741,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1765,7 +1772,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1774,7 +1781,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1827,7 +1834,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1868,11 +1875,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1889,7 +1896,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1899,7 +1906,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1920,7 +1927,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1973,7 +1980,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2080,7 +2087,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2127,7 +2134,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2160,7 +2167,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2211,11 +2218,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2260,11 +2267,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2276,7 +2283,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2312,11 +2319,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2348,7 +2355,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2360,7 +2367,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2372,7 +2379,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2380,15 +2387,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2413,7 +2420,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2435,12 +2442,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2503,11 +2510,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2523,7 +2530,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2618,7 +2625,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2649,11 +2657,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2665,7 +2673,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2693,11 +2701,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2709,7 +2717,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2754,7 +2762,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2827,7 +2835,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2933,7 +2941,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2965,7 +2973,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3005,7 +3013,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3026,7 +3034,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3069,7 +3077,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3091,7 +3099,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3107,7 +3115,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3123,8 +3131,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3148,7 +3156,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3177,13 +3185,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3229,7 +3237,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3380,7 +3388,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3408,7 +3416,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3494,7 +3502,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3528,11 +3536,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3548,7 +3556,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3576,7 +3584,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3584,7 +3592,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,7 +3608,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3612,7 +3620,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3620,11 +3628,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3644,7 +3652,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3653,7 +3661,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3669,11 +3677,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3689,11 +3697,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-03-06 16:45-0500\n"
+"POT-Creation-Date: 2019-03-11 15:34-0400\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -50,7 +50,7 @@ msgid ""
 "###   size: \"61203283968\""
 msgstr ""
 
-#: lxc/config.go:101
+#: lxc/config.go:104
 msgid ""
 "### This is a yaml representation of the configuration.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -195,6 +195,11 @@ msgstr ""
 msgid "--refresh can only be used with containers"
 msgstr ""
 
+#: lxc/config.go:151 lxc/config.go:407 lxc/config.go:497 lxc/config.go:624
+#: lxc/info.go:126
+msgid "--target cannot be used with containers"
+msgstr ""
+
 #: lxc/alias.go:127 lxc/image.go:940 lxc/image_alias.go:228
 msgid "ALIAS"
 msgstr ""
@@ -266,7 +271,7 @@ msgstr ""
 msgid "Aliases:"
 msgstr ""
 
-#: lxc/image.go:843 lxc/info.go:133
+#: lxc/image.go:843 lxc/info.go:149
 #, c-format
 msgid "Architecture: %s"
 msgstr ""
@@ -350,11 +355,11 @@ msgstr ""
 msgid "Both --all and container name given"
 msgstr ""
 
-#: lxc/info.go:226 lxc/network.go:778
+#: lxc/info.go:242 lxc/network.go:788
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:227 lxc/network.go:779
+#: lxc/info.go:243 lxc/network.go:789
 msgid "Bytes sent"
 msgstr ""
 
@@ -366,11 +371,11 @@ msgstr ""
 msgid "COMMON NAME"
 msgstr ""
 
-#: lxc/info.go:190
+#: lxc/info.go:206
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:194
+#: lxc/info.go:210
 msgid "CPU usage:"
 msgstr ""
 
@@ -399,8 +404,8 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/config.go:468 lxc/network.go:1083 lxc/profile.go:838 lxc/project.go:561
-#: lxc/storage.go:622 lxc/storage_volume.go:1333
+#: lxc/config.go:506 lxc/network.go:1103 lxc/profile.go:838 lxc/project.go:561
+#: lxc/storage.go:632 lxc/storage_volume.go:1333
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
@@ -425,7 +430,7 @@ msgstr ""
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
-#: lxc/config.go:481
+#: lxc/config.go:519
 #, c-format
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
@@ -448,10 +453,12 @@ msgstr ""
 msgid "Client version: %s\n"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/init.go:48 lxc/move.go:58 lxc/network.go:259
-#: lxc/network.go:674 lxc/network.go:1037 lxc/network.go:1106
-#: lxc/network.go:1168 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:581
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:307
+#: lxc/config.go:97 lxc/config.go:377 lxc/config.go:467 lxc/config.go:571
+#: lxc/config.go:689 lxc/copy.go:52 lxc/info.go:42 lxc/init.go:48
+#: lxc/move.go:58 lxc/network.go:259 lxc/network.go:674 lxc/network.go:732
+#: lxc/network.go:1057 lxc/network.go:1126 lxc/network.go:1188
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:591
+#: lxc/storage.go:664 lxc/storage.go:747 lxc/storage_volume.go:307
 #: lxc/storage_volume.go:467 lxc/storage_volume.go:544
 #: lxc/storage_volume.go:786 lxc/storage_volume.go:983
 #: lxc/storage_volume.go:1152 lxc/storage_volume.go:1182
@@ -492,7 +499,7 @@ msgstr ""
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
-#: lxc/config.go:263 lxc/config.go:327 lxc/config_metadata.go:144
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
 #: lxc/image.go:409 lxc/network.go:642 lxc/profile.go:501 lxc/project.go:305
 #: lxc/storage.go:303 lxc/storage_volume.go:919 lxc/storage_volume.go:949
 #, c-format
@@ -635,7 +642,7 @@ msgstr ""
 msgid "Create the container with no profiles applied"
 msgstr ""
 
-#: lxc/image.go:849 lxc/info.go:135
+#: lxc/image.go:849 lxc/info.go:151
 #, c-format
 msgid "Created: %s"
 msgstr ""
@@ -653,12 +660,12 @@ msgstr ""
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:861
-#: lxc/operation.go:156 lxc/storage.go:550 lxc/storage_volume.go:1121
+#: lxc/image.go:945 lxc/image_alias.go:230 lxc/list.go:462 lxc/network.go:871
+#: lxc/operation.go:156 lxc/storage.go:560 lxc/storage_volume.go:1121
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:551
+#: lxc/storage.go:561
 msgid "DRIVER"
 msgstr ""
 
@@ -713,9 +720,9 @@ msgstr ""
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
 #: lxc/alias.go:23 lxc/alias.go:55 lxc/alias.go:99 lxc/alias.go:147
 #: lxc/alias.go:198 lxc/cluster.go:29 lxc/cluster.go:66 lxc/cluster.go:149
-#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:30
-#: lxc/config.go:89 lxc/config.go:357 lxc/config.go:423 lxc/config.go:520
-#: lxc/config.go:624 lxc/config_device.go:24 lxc/config_device.go:76
+#: lxc/cluster.go:199 lxc/cluster.go:249 lxc/cluster.go:334 lxc/config.go:32
+#: lxc/config.go:91 lxc/config.go:374 lxc/config.go:455 lxc/config.go:567
+#: lxc/config.go:686 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321
 #: lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:589
 #: lxc/config_device.go:657 lxc/config_metadata.go:29 lxc/config_metadata.go:54
@@ -730,35 +737,35 @@ msgstr ""
 #: lxc/image.go:316 lxc/image.go:439 lxc/image.go:579 lxc/image.go:793
 #: lxc/image.go:907 lxc/image.go:1237 lxc/image.go:1314 lxc/image_alias.go:26
 #: lxc/image_alias.go:59 lxc/image_alias.go:106 lxc/image_alias.go:149
-#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:29 lxc/init.go:35
+#: lxc/image_alias.go:250 lxc/import.go:27 lxc/info.go:30 lxc/init.go:35
 #: lxc/launch.go:22 lxc/list.go:48 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:34 lxc/network.go:110
 #: lxc/network.go:183 lxc/network.go:256 lxc/network.go:328 lxc/network.go:378
 #: lxc/network.go:463 lxc/network.go:548 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:799 lxc/network.go:919 lxc/network.go:984 lxc/network.go:1034
-#: lxc/network.go:1103 lxc/network.go:1165 lxc/operation.go:25
-#: lxc/operation.go:54 lxc/operation.go:101 lxc/operation.go:177
-#: lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167 lxc/profile.go:247
-#: lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407 lxc/profile.go:531
-#: lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754 lxc/profile.go:804
-#: lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30 lxc/project.go:87
-#: lxc/project.go:152 lxc/project.go:215 lxc/project.go:335 lxc/project.go:383
-#: lxc/project.go:472 lxc/project.go:527 lxc/project.go:587 lxc/project.go:616
-#: lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:37
-#: lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452 lxc/remote.go:568
-#: lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718 lxc/rename.go:21
-#: lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89
-#: lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388
-#: lxc/storage.go:496 lxc/storage.go:578 lxc/storage.go:650 lxc/storage.go:734
-#: lxc/storage_volume.go:34 lxc/storage_volume.go:141 lxc/storage_volume.go:220
-#: lxc/storage_volume.go:303 lxc/storage_volume.go:464
-#: lxc/storage_volume.go:541 lxc/storage_volume.go:617
-#: lxc/storage_volume.go:699 lxc/storage_volume.go:780
-#: lxc/storage_volume.go:980 lxc/storage_volume.go:1069
-#: lxc/storage_volume.go:1148 lxc/storage_volume.go:1179
-#: lxc/storage_volume.go:1282 lxc/storage_volume.go:1359
-#: lxc/storage_volume.go:1458 lxc/storage_volume.go:1489
-#: lxc/storage_volume.go:1560 lxc/version.go:22
+#: lxc/network.go:809 lxc/network.go:929 lxc/network.go:1004
+#: lxc/network.go:1054 lxc/network.go:1123 lxc/network.go:1185
+#: lxc/operation.go:25 lxc/operation.go:54 lxc/operation.go:101
+#: lxc/operation.go:177 lxc/profile.go:32 lxc/profile.go:104 lxc/profile.go:167
+#: lxc/profile.go:247 lxc/profile.go:303 lxc/profile.go:357 lxc/profile.go:407
+#: lxc/profile.go:531 lxc/profile.go:580 lxc/profile.go:678 lxc/profile.go:754
+#: lxc/profile.go:804 lxc/profile.go:863 lxc/profile.go:917 lxc/project.go:30
+#: lxc/project.go:87 lxc/project.go:152 lxc/project.go:215 lxc/project.go:335
+#: lxc/project.go:383 lxc/project.go:472 lxc/project.go:527 lxc/project.go:587
+#: lxc/project.go:616 lxc/project.go:669 lxc/publish.go:35 lxc/query.go:30
+#: lxc/remote.go:37 lxc/remote.go:88 lxc/remote.go:416 lxc/remote.go:452
+#: lxc/remote.go:568 lxc/remote.go:630 lxc/remote.go:680 lxc/remote.go:718
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:506 lxc/storage.go:588 lxc/storage.go:660
+#: lxc/storage.go:744 lxc/storage_volume.go:34 lxc/storage_volume.go:141
+#: lxc/storage_volume.go:220 lxc/storage_volume.go:303
+#: lxc/storage_volume.go:464 lxc/storage_volume.go:541
+#: lxc/storage_volume.go:617 lxc/storage_volume.go:699
+#: lxc/storage_volume.go:780 lxc/storage_volume.go:980
+#: lxc/storage_volume.go:1069 lxc/storage_volume.go:1148
+#: lxc/storage_volume.go:1179 lxc/storage_volume.go:1282
+#: lxc/storage_volume.go:1359 lxc/storage_volume.go:1458
+#: lxc/storage_volume.go:1489 lxc/storage_volume.go:1560 lxc/version.go:22
 msgid "Description"
 msgstr ""
 
@@ -810,7 +817,7 @@ msgstr ""
 msgid "Disable stdin (reads from /dev/null)"
 msgstr ""
 
-#: lxc/info.go:183
+#: lxc/info.go:199
 msgid "Disk usage:"
 msgstr ""
 
@@ -838,7 +845,7 @@ msgstr ""
 msgid "Edit container metadata files"
 msgstr ""
 
-#: lxc/config.go:88 lxc/config.go:89
+#: lxc/config.go:90 lxc/config.go:91
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
@@ -1004,7 +1011,7 @@ msgstr ""
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:830 lxc/operation.go:129
+#: lxc/network.go:840 lxc/operation.go:129
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1057,7 +1064,7 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:803 lxc/profile.go:584
+#: lxc/image.go:932 lxc/list.go:118 lxc/network.go:813 lxc/profile.go:584
 #: lxc/remote.go:456
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1078,7 +1085,7 @@ msgstr ""
 msgid "Get values for container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:356 lxc/config.go:357
+#: lxc/config.go:373 lxc/config.go:374
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
@@ -1102,7 +1109,7 @@ msgstr ""
 msgid "Get values for storage volume configuration keys"
 msgstr ""
 
-#: lxc/network.go:962
+#: lxc/network.go:978
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1114,7 +1121,7 @@ msgstr ""
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:964
+#: lxc/network.go:980
 msgid "IP ADDRESS"
 msgstr ""
 
@@ -1225,7 +1232,7 @@ msgstr ""
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:903 lxc/profile.go:662
+#: lxc/image.go:1221 lxc/list.go:371 lxc/network.go:913 lxc/profile.go:662
 #: lxc/remote.go:551
 #, c-format
 msgid "Invalid format %q"
@@ -1271,7 +1278,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:164 lxc/network.go:770
+#: lxc/info.go:180 lxc/network.go:780
 msgid "Ips:"
 msgstr ""
 
@@ -1283,7 +1290,7 @@ msgstr ""
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:487 lxc/storage_volume.go:1125
+#: lxc/list.go:487 lxc/network.go:984 lxc/storage_volume.go:1125
 msgid "LOCATION"
 msgstr ""
 
@@ -1304,7 +1311,7 @@ msgstr ""
 msgid "Last used: never"
 msgstr ""
 
-#: lxc/network.go:918 lxc/network.go:919
+#: lxc/network.go:928 lxc/network.go:929
 msgid "List DHCP leases"
 msgstr ""
 
@@ -1316,11 +1323,11 @@ msgstr ""
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:798 lxc/network.go:799
+#: lxc/network.go:808 lxc/network.go:809
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:495 lxc/storage.go:496
+#: lxc/storage.go:505 lxc/storage.go:506
 msgid "List available storage pools"
 msgstr ""
 
@@ -1470,25 +1477,25 @@ msgstr ""
 msgid "List, show and delete background operations"
 msgstr ""
 
-#: lxc/info.go:127
+#: lxc/info.go:143
 #, c-format
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:283
+#: lxc/info.go:299
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:963
+#: lxc/network.go:979
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:764
+#: lxc/network.go:774
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
 
-#: lxc/network.go:860
+#: lxc/network.go:870
 msgid "MANAGED"
 msgstr ""
 
@@ -1496,7 +1503,7 @@ msgstr ""
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:765
+#: lxc/network.go:775
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1521,7 +1528,7 @@ msgstr ""
 msgid "Manage command aliases"
 msgstr ""
 
-#: lxc/config.go:29 lxc/config.go:30
+#: lxc/config.go:31 lxc/config.go:32
 msgid "Manage container and server configuration options"
 msgstr ""
 
@@ -1610,15 +1617,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:201
+#: lxc/info.go:217
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:205
+#: lxc/info.go:221
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:217
+#: lxc/info.go:233
 msgid "Memory usage:"
 msgstr ""
 
@@ -1652,14 +1659,14 @@ msgid "Missing name"
 msgstr ""
 
 #: lxc/network.go:134 lxc/network.go:207 lxc/network.go:352 lxc/network.go:402
-#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:754
-#: lxc/network.go:943 lxc/network.go:1008 lxc/network.go:1060
-#: lxc/network.go:1129
+#: lxc/network.go:487 lxc/network.go:592 lxc/network.go:697 lxc/network.go:755
+#: lxc/network.go:953 lxc/network.go:1028 lxc/network.go:1080
+#: lxc/network.go:1149
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:413
-#: lxc/storage.go:608 lxc/storage.go:682 lxc/storage_volume.go:165
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:618 lxc/storage.go:692 lxc/storage_volume.go:165
 #: lxc/storage_volume.go:244 lxc/storage_volume.go:489
 #: lxc/storage_volume.go:565 lxc/storage_volume.go:641
 #: lxc/storage_volume.go:723 lxc/storage_volume.go:822
@@ -1737,18 +1744,18 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:858 lxc/profile.go:622
-#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:549
+#: lxc/cluster.go:126 lxc/list.go:464 lxc/network.go:868 lxc/profile.go:622
+#: lxc/project.go:450 lxc/remote.go:509 lxc/storage.go:559
 #: lxc/storage_volume.go:1120
 msgid "NAME"
 msgstr ""
 
-#: lxc/network.go:844 lxc/operation.go:141 lxc/project.go:426
+#: lxc/network.go:854 lxc/operation.go:141 lxc/project.go:426
 #: lxc/project.go:431 lxc/remote.go:473 lxc/remote.go:478
 msgid "NO"
 msgstr ""
 
-#: lxc/info.go:125 lxc/network.go:763
+#: lxc/info.go:141 lxc/network.go:773
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -1768,7 +1775,7 @@ msgstr ""
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:1018
+#: lxc/network.go:1038
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
@@ -1777,7 +1784,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:234 lxc/network.go:777
+#: lxc/info.go:250 lxc/network.go:787
 msgid "Network usage:"
 msgstr ""
 
@@ -1830,7 +1837,7 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:618 lxc/network.go:1074
+#: lxc/network.go:618 lxc/network.go:1094
 msgid "Only managed networks can be modified"
 msgstr ""
 
@@ -1871,11 +1878,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:228 lxc/network.go:780
+#: lxc/info.go:244 lxc/network.go:790
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:229 lxc/network.go:781
+#: lxc/info.go:245 lxc/network.go:791
 msgid "Packets sent"
 msgstr ""
 
@@ -1892,7 +1899,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:146
+#: lxc/info.go:162
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -1902,7 +1909,7 @@ msgstr ""
 msgid "Press enter to open the editor again"
 msgstr ""
 
-#: lxc/config.go:264 lxc/config.go:328 lxc/config_metadata.go:145
+#: lxc/config.go:272 lxc/config.go:345 lxc/config_metadata.go:145
 #: lxc/config_template.go:205 lxc/image.go:410
 msgid "Press enter to start the editor again"
 msgstr ""
@@ -1923,7 +1930,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:170
+#: lxc/info.go:186
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -1976,7 +1983,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:144
+#: lxc/info.go:160
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2083,7 +2090,7 @@ msgstr ""
 msgid "Remote operation canceled by user"
 msgstr ""
 
-#: lxc/info.go:130
+#: lxc/info.go:146
 #, c-format
 msgid "Remote: %s"
 msgstr ""
@@ -2130,7 +2137,7 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:983 lxc/network.go:984
+#: lxc/network.go:1003 lxc/network.go:1004
 msgid "Rename networks"
 msgstr ""
 
@@ -2163,7 +2170,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:167
+#: lxc/info.go:183
 msgid "Resources:"
 msgstr ""
 
@@ -2214,11 +2221,11 @@ msgstr ""
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:556
+#: lxc/storage.go:566
 msgid "SOURCE"
 msgstr ""
 
-#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:865 lxc/storage.go:554
+#: lxc/cluster.go:129 lxc/list.go:469 lxc/network.go:875 lxc/storage.go:564
 msgid "STATE"
 msgstr ""
 
@@ -2263,11 +2270,11 @@ msgstr ""
 msgid "Set container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:422 lxc/config.go:423
+#: lxc/config.go:454 lxc/config.go:455
 msgid "Set container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1033 lxc/network.go:1034
+#: lxc/network.go:1053 lxc/network.go:1054
 msgid "Set network configuration keys"
 msgstr ""
 
@@ -2279,7 +2286,7 @@ msgstr ""
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:577 lxc/storage.go:578
+#: lxc/storage.go:587 lxc/storage.go:588
 msgid "Set storage pool configuration keys"
 msgstr ""
 
@@ -2315,11 +2322,11 @@ msgstr ""
 msgid "Show container metadata files"
 msgstr ""
 
-#: lxc/config.go:519 lxc/config.go:520
+#: lxc/config.go:566 lxc/config.go:567
 msgid "Show container or server configurations"
 msgstr ""
 
-#: lxc/info.go:28 lxc/info.go:29
+#: lxc/info.go:29 lxc/info.go:30
 msgid "Show container or server information"
 msgstr ""
 
@@ -2351,7 +2358,7 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1102 lxc/network.go:1103
+#: lxc/network.go:1122 lxc/network.go:1123
 msgid "Show network configurations"
 msgstr ""
 
@@ -2363,7 +2370,7 @@ msgstr ""
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:659 lxc/storage.go:660
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2375,7 +2382,7 @@ msgstr ""
 msgid "Show storage volume configurations"
 msgstr ""
 
-#: lxc/info.go:39
+#: lxc/info.go:40
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
@@ -2383,15 +2390,15 @@ msgstr ""
 msgid "Show the default remote"
 msgstr ""
 
-#: lxc/config.go:523
+#: lxc/config.go:570
 msgid "Show the expanded configuration"
 msgstr ""
 
-#: lxc/info.go:40
+#: lxc/info.go:41
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:663
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
@@ -2416,7 +2423,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:248
+#: lxc/info.go:264
 msgid "Snapshots:"
 msgstr ""
 
@@ -2438,12 +2445,12 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:766
+#: lxc/network.go:776
 #, c-format
 msgid "State: %s"
 msgstr ""
 
-#: lxc/info.go:138
+#: lxc/info.go:154
 #, c-format
 msgid "Status: %s"
 msgstr ""
@@ -2506,11 +2513,11 @@ msgstr ""
 msgid "Store the container state"
 msgstr ""
 
-#: lxc/info.go:209
+#: lxc/info.go:225
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:213
+#: lxc/info.go:229
 msgid "Swap (peak)"
 msgstr ""
 
@@ -2526,7 +2533,7 @@ msgstr ""
 msgid "TARGET"
 msgstr ""
 
-#: lxc/list.go:470 lxc/network.go:859 lxc/network.go:965 lxc/operation.go:155
+#: lxc/list.go:470 lxc/network.go:869 lxc/network.go:981 lxc/operation.go:155
 #: lxc/storage_volume.go:1119
 msgid "TYPE"
 msgstr ""
@@ -2621,7 +2628,8 @@ msgstr ""
 msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
-#: lxc/copy.go:116
+#: lxc/config.go:294 lxc/config.go:419 lxc/config.go:538 lxc/config.go:604
+#: lxc/copy.go:116 lxc/info.go:86 lxc/network.go:761 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -2652,11 +2660,11 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/info.go:140
+#: lxc/info.go:156
 msgid "Type: ephemeral"
 msgstr ""
 
-#: lxc/info.go:142
+#: lxc/info.go:158
 msgid "Type: persistent"
 msgstr ""
 
@@ -2668,7 +2676,7 @@ msgstr ""
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:862 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:558
+#: lxc/network.go:872 lxc/profile.go:623 lxc/project.go:453 lxc/storage.go:568
 #: lxc/storage_volume.go:1122
 msgid "USED BY"
 msgstr ""
@@ -2696,11 +2704,11 @@ msgstr ""
 msgid "Unset container device configuration keys"
 msgstr ""
 
-#: lxc/config.go:623 lxc/config.go:624
+#: lxc/config.go:685 lxc/config.go:686
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1164 lxc/network.go:1165
+#: lxc/network.go:1184 lxc/network.go:1185
 msgid "Unset network configuration keys"
 msgstr ""
 
@@ -2712,7 +2720,7 @@ msgstr ""
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:743 lxc/storage.go:744
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -2757,7 +2765,7 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:846 lxc/operation.go:143 lxc/project.go:428
+#: lxc/network.go:856 lxc/operation.go:143 lxc/project.go:428
 #: lxc/project.go:433 lxc/remote.go:475 lxc/remote.go:480
 msgid "YES"
 msgstr ""
@@ -2830,7 +2838,7 @@ msgstr ""
 msgid "cluster"
 msgstr ""
 
-#: lxc/config.go:28
+#: lxc/config.go:30
 msgid "config"
 msgstr ""
 
@@ -2936,7 +2944,7 @@ msgstr ""
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:436
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
@@ -2968,7 +2976,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:435
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3008,7 +3016,7 @@ msgstr ""
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:87
+#: lxc/config.go:89
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3029,7 +3037,7 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:259
+#: lxc/info.go:275
 #, c-format
 msgid "expires at %s"
 msgstr ""
@@ -3072,7 +3080,7 @@ msgstr ""
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:355
+#: lxc/config.go:372
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
@@ -3094,7 +3102,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:433
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3110,7 +3118,7 @@ msgstr ""
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/info.go:27
+#: lxc/info.go:28
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
@@ -3126,8 +3134,8 @@ msgstr ""
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:796
-#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:493
+#: lxc/cluster.go:63 lxc/config_trust.go:112 lxc/network.go:806
+#: lxc/operation.go:98 lxc/profile.go:577 lxc/project.go:380 lxc/storage.go:503
 msgid "list [<remote>:]"
 msgstr ""
 
@@ -3151,7 +3159,7 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:917
+#: lxc/network.go:927
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
@@ -3180,13 +3188,13 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/config.go:91
+#: lxc/config.go:93
 msgid ""
 "lxc config edit <container> < container.yaml\n"
 "    Update the container configuration from config.yaml."
 msgstr ""
 
-#: lxc/config.go:425
+#: lxc/config.go:457
 msgid ""
 "lxc config set [<remote>:]<container> limits.cpu 2\n"
 "    Will set a CPU limit of \"2\" for the container.\n"
@@ -3232,7 +3240,7 @@ msgid ""
 "    Create a new container using backup0.tar.gz as the source."
 msgstr ""
 
-#: lxc/info.go:31
+#: lxc/info.go:32
 msgid ""
 "lxc info [<remote>:]<container> [--show-log]\n"
 "    For container information.\n"
@@ -3383,7 +3391,7 @@ msgid ""
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:434
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
@@ -3411,7 +3419,7 @@ msgstr ""
 msgid "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/config.go:53
+#: lxc/config.go:55
 msgid "please use `lxc profile`"
 msgstr ""
 
@@ -3497,7 +3505,7 @@ msgstr ""
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:981
+#: lxc/network.go:1001
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -3531,11 +3539,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1032
+#: lxc/network.go:1052
 msgid "set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:576
+#: lxc/storage.go:586
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -3551,7 +3559,7 @@ msgstr ""
 msgid "set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/config.go:421
+#: lxc/config.go:453
 msgid "set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
@@ -3579,7 +3587,7 @@ msgstr ""
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1101
+#: lxc/network.go:1121
 msgid "show [<remote>:]<network>"
 msgstr ""
 
@@ -3587,7 +3595,7 @@ msgstr ""
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:658
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -3603,7 +3611,7 @@ msgstr ""
 msgid "show [<remote>:]<project>"
 msgstr ""
 
-#: lxc/config.go:518
+#: lxc/config.go:565
 msgid "show [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
@@ -3615,7 +3623,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:438
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -3623,11 +3631,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:263
+#: lxc/info.go:279
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:265
+#: lxc/info.go:281
 msgid "stateless"
 msgstr ""
 
@@ -3647,7 +3655,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:255
+#: lxc/info.go:271
 #, c-format
 msgid "taken at %s"
 msgstr ""
@@ -3656,7 +3664,7 @@ msgstr ""
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:437
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
@@ -3672,11 +3680,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1163
+#: lxc/network.go:1183
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:742
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3692,11 +3700,11 @@ msgstr ""
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
-#: lxc/config.go:622
+#: lxc/config.go:684
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:432
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 

--- a/shared/api/network.go
+++ b/shared/api/network.go
@@ -57,6 +57,9 @@ type NetworkLease struct {
 	Hwaddr   string `json:"hwaddr" yaml:"hwaddr"`
 	Address  string `json:"address" yaml:"address"`
 	Type     string `json:"type" yaml:"type"`
+
+	// API extension: network_leases_location
+	Location string `json:"location" yaml:"location"`
 }
 
 // NetworkState represents the network state

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -139,6 +139,7 @@ var APIExtensions = []string{
 	"snapshot_expiry",
 	"container_backup_override_pool",
 	"snapshot_expiry_creation",
+	"network_leases_location",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This makes sure we consistently have `--target` available in the CLI for any endpoint where server-specific data makes sense:
 - lxc config {get,set,show,edit,unset}
 - lxc info
 - lxc network info
 - lxc storage info

It also makes it so the network leases API returns a consistent view of the cluster with a location field.