### PR TITLE
Add socket number to resources API

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -698,3 +698,6 @@ snapshot's expiry at creation time.
 Introductes a "Location" field in the leases list.
 This is used when querying a cluster to show what node a particular
 lease was found on.
+
+## resources\_cpu\_socket
+Add Socket field to CPU resources in case we get out of order socket information.

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -122,8 +122,8 @@ func (c *cmdInfo) remoteInfo(d lxd.ContainerServer) error {
 			renderCPU(resources.CPU.Sockets[0], "  ")
 		} else if len(resources.CPU.Sockets) > 1 {
 			fmt.Printf(i18n.G("CPUs:") + "\n")
-			for id, cpu := range resources.CPU.Sockets {
-				fmt.Printf("  "+i18n.G("Socket %d:")+"\n", id)
+			for _, cpu := range resources.CPU.Sockets {
+				fmt.Printf("  "+i18n.G("Socket %d:")+"\n", cpu.Socket)
 				renderCPU(cpu, "    ")
 			}
 		}

--- a/lxd/util/resources.go
+++ b/lxd/util/resources.go
@@ -256,6 +256,7 @@ func CPUResource() (*api.ResourcesCPU, error) {
 			cur = &c.Sockets[v.socketID]
 		}
 
+		cur.Socket = v.socketID
 		cur.Threads++
 		cur.Name = v.name
 		cur.Vendor = v.vendor

--- a/shared/api/resource.go
+++ b/shared/api/resource.go
@@ -16,6 +16,9 @@ type ResourcesCPUSocket struct {
 	Name           string `json:"name,omitempty" yaml:"name,omitempty"`
 	Vendor         string `json:"vendor,omitempty" yaml:"vendor,omitempty"`
 	Threads        uint64 `json:"threads" yaml:"threads"`
+
+	// API extension: resources_cpu_socket
+	Socket uint64 `json:"socket" yaml:"socket"`
 }
 
 // ResourcesCPU represents the cpu resources available on the system

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -140,6 +140,7 @@ var APIExtensions = []string{
 	"container_backup_override_pool",
 	"snapshot_expiry_creation",
 	"network_leases_location",
+	"resources_cpu_socket",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
It's a bit unlikely but not impossible to be on a system with multiple CPUs and have CPU0 offline, which would cause our current socket logic to break down.

Now, we'll be explicit and directly list the socket number in each entry so it's guaranteed to be correct.