### PR TITLE
lxd-p2c: Workaround for broken /proc/self/exe

### DIFF
--- a/lxd-p2c/transfer.go
+++ b/lxd-p2c/transfer.go
@@ -65,6 +65,10 @@ func rsyncSendSetup(path string, rsyncArgs string) (*exec.Cmd, net.Conn, io.Read
 		return nil, nil, nil, err
 	}
 
+	if !shared.PathExists(execPath) {
+		execPath = os.Args[0]
+	}
+
 	rsyncCmd := fmt.Sprintf("sh -c \"%s netcat %s\"", execPath, auds)
 
 	args := []string{


### PR DESCRIPTION
Apparently some systems sometimes return garbage in that path even for
what shouldn't be a deleted file.

In such cases, just use os.Args[0] and hope for the best.

Closes #5555

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>