### PR TITLE
simplestreams: Align JSON struct for index.json

### DIFF
--- a/shared/simplestreams/simplestreams.go
+++ b/shared/simplestreams/simplestreams.go
@@ -75,10 +75,10 @@ var ssDefaultOS = map[string]string{
 }
 
 type SimpleStreamsManifest struct {
-	Updated  string                                  `json:"updated"`
+	Updated  string                                  `json:"updated,omitempty"`
 	DataType string                                  `json:"datatype"`
 	Format   string                                  `json:"format"`
-	License  string                                  `json:"license"`
+	License  string                                  `json:"license,omitempty"`
 	Products map[string]SimpleStreamsManifestProduct `json:"products"`
 }
 
@@ -303,13 +303,14 @@ type SimpleStreamsManifestProductVersionItem struct {
 type SimpleStreamsIndex struct {
 	Format  string                              `json:"format"`
 	Index   map[string]SimpleStreamsIndexStream `json:"index"`
-	Updated string                              `json:"updated"`
+	Updated string                              `json:"updated,omitempty"`
 }
 
 type SimpleStreamsIndexStream struct {
-	Updated  string   `json:"updated"`
+	Updated  string   `json:"updated,omitempty"`
 	DataType string   `json:"datatype"`
 	Path     string   `json:"path"`
+	Format   string   `json:"format,omitempty"`
 	Products []string `json:"products"`
 }
 


### PR DESCRIPTION
Hi,
FWIS current [index.json](https://uk.images.linuxcontainers.org/streams/v1/index.json) file doesn't contain updated attributes so I added `omitempty` to these options.

In additional in current SimpleStreamsIndexStream struct is not present an attribute for `format` (related to value `products:1.0`)