### PR TITLE
lxd/backups: Attempt to delete storage on failure

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -617,7 +617,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) Re
 
 		// Dump tarball to storage
 		f.Seek(0, 0)
-		err = containerCreateFromBackup(d.State(), *bInfo, f, pool != "")
+		cPool, err := containerCreateFromBackup(d.State(), *bInfo, f, pool != "")
 		if err != nil {
 			return errors.Wrap(err, "Create container from backup")
 		}
@@ -627,6 +627,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) Re
 			Force: true,
 		})
 		if err != nil {
+			cPool.ContainerDelete(&containerLXC{name: bInfo.Name, project: project})
 			return errors.Wrap(err, "Marshal internal import request")
 		}
 
@@ -639,6 +640,7 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) Re
 		resp := internalImport(d, req)
 
 		if resp.String() != "success" {
+			cPool.ContainerDelete(&containerLXC{name: bInfo.Name, project: project})
 			return fmt.Errorf("Internal import request: %v", resp.String())
 		}
 


### PR DESCRIPTION
This is rather ugly as there's no container struct around to pass to the
normal delete functions, but this will hopefully do the trick for now.

Once we get the new internal storage API, we should be able to change
this to returning a lower level storage driver and can then call its
delete function rather than ContainerDelete.

Closes #5597

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>