### PR TITLE
lxc/action: skip containers with intended state

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -222,6 +222,16 @@ func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		for _, ct := range ctslist {
+			switch cmd.Name() {
+			case "start":
+				if ct.StatusCode == api.Running {
+					continue
+				}
+			case "stop":
+				if ct.StatusCode == api.Stopped {
+					continue
+				}
+			}
 			names = append(names, ct.Name)
 		}
 	} else {


### PR DESCRIPTION
If a container is already stopped or running skip it so we don't report
useless errors.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>