### PR TITLE
Introduce volatile.idmap.current

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -710,3 +710,15 @@ Shows the NUMA node for all CPUs and GPUs.
 
 ## kernel\_features
 Exposes the state of optional kernel features through the server environment.
+
+## id\_map\_current
+This introduces a new internal `volatile.idmap.current` key which is
+used to track the current mapping for the container.
+
+This effectively gives us:
+ - `volatile.last\_state.idmap` => On-disk idmap
+ - `volatile.idmap.current` => Current kernel map
+ - `volatile.idmap.next` => Next on-disk idmap
+
+This is required to implement environments where the on-disk map isn't
+changed but the kernel map is (e.g. shiftfs).

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -92,6 +92,7 @@ volatile.apply\_quota           | string    | -             | Disk quota to be a
 volatile.apply\_template        | string    | -             | The name of a template hook which should be triggered upon next startup
 volatile.base\_image            | string    | -             | The hash of the image the container was created from, if any.
 volatile.idmap.base             | integer   | -             | The first id in the container's primary idmap range
+volatile.idmap.current          | string    | -             | The idmap currently in use by the container
 volatile.idmap.next             | string    | -             | The idmap to use next time the container starts
 volatile.last\_state.idmap      | string    | -             | Serialized container uid/gid map
 volatile.last\_state.power      | string    | -             | Container state as of last host shutdown

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -673,10 +673,12 @@ type container interface {
 	StorageStart() (bool, error)
 	StorageStop() (bool, error)
 	Storage() storage
-	IdmapSet() (*idmap.IdmapSet, error)
-	LastIdmapSet() (*idmap.IdmapSet, error)
 	TemplateApply(trigger string) error
 	DaemonState() *state.State
+
+	CurrentIdmap() (*idmap.IdmapSet, error)
+	DiskIdmap() (*idmap.IdmapSet, error)
+	NextIdmap() (*idmap.IdmapSet, error)
 }
 
 // Loader functions

--- a/lxd/container_console.go
+++ b/lxd/container_console.go
@@ -303,7 +303,7 @@ func containerConsolePost(d *Daemon, r *http.Request) Response {
 	ws := &consoleWs{}
 	ws.fds = map[int]string{}
 
-	idmapset, err := c.IdmapSet()
+	idmapset, err := c.CurrentIdmap()
 	if err != nil {
 		return InternalError(err)
 	}

--- a/lxd/container_exec.go
+++ b/lxd/container_exec.go
@@ -426,7 +426,7 @@ func containerExecPost(d *Daemon, r *http.Request) Response {
 		ws := &execWs{}
 		ws.fds = map[int]string{}
 
-		idmapset, err := c.IdmapSet()
+		idmapset, err := c.CurrentIdmap()
 		if err != nil {
 			return InternalError(err)
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8735,6 +8735,33 @@ func (c *containerLXC) LastIdmapSet() (*idmap.IdmapSet, error) {
 	return c.idmapsetFromConfig("volatile.last_state.idmap")
 }
 
+func (c *containerLXC) CurrentIdmap() (*idmap.IdmapSet, error) {
+	jsonIdmap, ok := c.LocalConfig()["volatile.idmap.current"]
+	if !ok {
+		return c.DiskIdmap()
+	}
+
+	return idmapsetFromString(jsonIdmap)
+}
+
+func (c *containerLXC) DiskIdmap() (*idmap.IdmapSet, error) {
+	jsonIdmap, ok := c.LocalConfig()["volatile.last_state.idmap"]
+	if !ok {
+		return nil, nil
+	}
+
+	return idmapsetFromString(jsonIdmap)
+}
+
+func (c *containerLXC) NextIdmap() (*idmap.IdmapSet, error) {
+	jsonIdmap, ok := c.LocalConfig()["volatile.idmap.next"]
+	if !ok {
+		return c.CurrentIdmap()
+	}
+
+	return idmapsetFromString(jsonIdmap)
+}
+
 func (c *containerLXC) DaemonState() *state.State {
 	// FIXME: This function should go away, since the abstract container
 	//        interface should not be coupled with internal state details.

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -264,9 +264,9 @@ func (suite *containerTestSuite) TestContainer_findIdmap_isolated() {
 	suite.Req.Nil(err)
 	defer c2.Delete()
 
-	map1, err := c1.(*containerLXC).NextIdmapSet()
+	map1, err := c1.(*containerLXC).NextIdmap()
 	suite.Req.Nil(err)
-	map2, err := c2.(*containerLXC).NextIdmapSet()
+	map2, err := c2.(*containerLXC).NextIdmap()
 	suite.Req.Nil(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
@@ -305,9 +305,9 @@ func (suite *containerTestSuite) TestContainer_findIdmap_mixed() {
 	suite.Req.Nil(err)
 	defer c2.Delete()
 
-	map1, err := c1.(*containerLXC).NextIdmapSet()
+	map1, err := c1.(*containerLXC).NextIdmap()
 	suite.Req.Nil(err)
-	map2, err := c2.(*containerLXC).NextIdmapSet()
+	map2, err := c2.(*containerLXC).NextIdmap()
 	suite.Req.Nil(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
@@ -337,7 +337,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_raw() {
 	suite.Req.Nil(err)
 	defer c1.Delete()
 
-	map1, err := c1.(*containerLXC).NextIdmapSet()
+	map1, err := c1.(*containerLXC).NextIdmap()
 	suite.Req.Nil(err)
 
 	host := suite.d.os.IdmapSet.Idmap[0]
@@ -383,7 +383,7 @@ func (suite *containerTestSuite) TestContainer_findIdmap_maxed() {
 
 		defer c.Delete()
 
-		m, err := c.(*containerLXC).NextIdmapSet()
+		m, err := c.(*containerLXC).NextIdmap()
 		suite.Req.Nil(err)
 
 		maps = append(maps, m)

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -231,7 +231,7 @@ func hoistReq(f func(*Daemon, container, http.ResponseWriter, *http.Request) *de
 		// Access control
 		rootUid := int64(0)
 
-		idmapset, err := c.LastIdmapSet()
+		idmapset, err := c.CurrentIdmap()
 		if err == nil && idmapset != nil {
 			uid, _ := idmapset.ShiftIntoNs(0, 0)
 			rootUid = int64(uid)

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -337,7 +337,7 @@ func (s *migrationSourceWs) Do(migrateOp *operation) error {
 
 	idmaps := make([]*migration.IDMapType, 0)
 
-	idmapset, err := s.container.LastIdmapSet()
+	idmapset, err := s.container.DiskIdmap()
 	if err != nil {
 		return err
 	}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -411,7 +411,7 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 		return st, nil
 	}
 
-	// get last idmapset
+	// Get the on-disk idmap for the volume
 	var lastIdmap *idmap.IdmapSet
 	if poolVolumePut.Config["volatile.idmap.last"] != "" {
 		lastIdmap, err = idmapsetFromString(poolVolumePut.Config["volatile.idmap.last"])
@@ -421,8 +421,13 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 		}
 	}
 
-	// get next idmapset
-	nextIdmap, err := c.IdmapSet()
+	// Get the container's idmap
+	var nextIdmap *idmap.IdmapSet
+	if c.IsRunning() {
+		nextIdmap, err = c.CurrentIdmap()
+	} else {
+		nextIdmap, err = c.NextIdmap()
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -460,7 +465,12 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 					continue
 				}
 
-				ctNextIdmap, err := ct.IdmapSet()
+				var ctNextIdmap *idmap.IdmapSet
+				if ct.IsRunning() {
+					ctNextIdmap, err = ct.CurrentIdmap()
+				} else {
+					ctNextIdmap, err = ct.NextIdmap()
+				}
 				if err != nil {
 					return nil, fmt.Errorf("Failed to retrieve idmap of container")
 				}
@@ -745,7 +755,7 @@ func deleteSnapshotMountpoint(snapshotMountpoint string, snapshotsSymlinkTarget 
 }
 
 func resetContainerDiskIdmap(container container, srcIdmap *idmap.IdmapSet) error {
-	dstIdmap, err := container.IdmapSet()
+	dstIdmap, err := container.DiskIdmap()
 	if err != nil {
 		return err
 	}

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -92,9 +92,9 @@ _have lxc && {
       security.syscalls.blacklist_compat security.syscalls.blacklist_default \
       snapshots.schedule snapshots.schedule.stopped snapshots.pattern \
       volatile.apply_quota volatile.apply_template volatile.base_image \
-      volatile.idmap.base volatile.idmap.next volatile.last_state.idmap \
-      volatile.last_state.power user.meta-data user.network-config \
-      user.network_mode user.user-data user.vendor-data"
+      volatile.idmap.base volatile.idmap.current volatile.idmap.next \
+      volatile.last_state.idmap volatile.last_state.power user.meta-data \
+      user.network-config user.network_mode user.user-data user.vendor-data"
 
     networks_keys="bridge.driver bridge.external_interfaces bridge.mode \
       bridge.mtu bridge.hwaddr dns.domain dns.mode fan.overlay_subnet fan.type \

--- a/shared/container.go
+++ b/shared/container.go
@@ -302,8 +302,9 @@ var KnownContainerConfigKeys = map[string]func(value string) error{
 	"volatile.base_image":       IsAny,
 	"volatile.last_state.idmap": IsAny,
 	"volatile.last_state.power": IsAny,
-	"volatile.idmap.next":       IsAny,
 	"volatile.idmap.base":       IsAny,
+	"volatile.idmap.current":    IsAny,
+	"volatile.idmap.next":       IsAny,
 	"volatile.apply_quota":      IsAny,
 }
 

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -144,6 +144,7 @@ var APIExtensions = []string{
 	"resources_gpu",
 	"resources_numa",
 	"kernel_features",
+	"id_map_current",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This should properly split the 3 different cases we have for idmap throughout the LXD codebase.
It also renames all our existing functions to have names better matching their use.

This is infrastructure needed for the upcoming shiftfs work.