### PR TITLE
client: Optimize copies on same nodes

### DIFF
--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -355,7 +355,7 @@ func (r *ProtocolLXD) CopyContainer(source ContainerServer, container api.Contai
 	}
 
 	// Optimization for the local copy case
-	if destInfo.URL == sourceInfo.URL && !r.IsClustered() {
+	if destInfo.URL == sourceInfo.URL && (!r.IsClustered() || container.Location == r.clusterTarget) {
 		// Project handling
 		if destInfo.Project != sourceInfo.Project {
 			if !r.HasExtension("container_copy_project") {


### PR DESCRIPTION
If the user requests that a container be copied on the same node that it
currently resides on, skip using the migration API and just use the
local copy API instead.

Closes #5613

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>