### PR TITLE
 Allow setting the NAT source address (SNAT instead of MASQUERADE)

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -566,6 +566,10 @@ will be done via iptables instead of proxy devices.
 This introduces the `ipv4.nat.order` and `ipv6.nat.order` configuration keys for LXD bridges.
 Those keys control whether to put the LXD rules before or after any pre-existing rules in the chain.
 
+## network\_nat\_address
+This introduces the `ipv4.nat.address` and `ipv6.nat.address` configuration keys for LXD bridges.
+Those keys control the source address used for outbound traffic from the bridge.
+
 ## container\_full
 This introduces a new recursion=2 mode for `GET /1.0/containers` which allows for the retrieval of
 all container structs, including the state, snapshots and backup structs.

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1276,13 +1276,19 @@ func (n *network) Start() error {
 
 		// Configure NAT
 		if shared.IsTrue(n.config["ipv4.nat"]) {
+			//If a SNAT source address is specified, use that, otherwise default to using MASQUERADE mode.
+			args := []string{"-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE"}
+			if n.config["ipv4.nat.address"] != "" {
+				args = []string{"-s", subnet.String(), "!", "-d", subnet.String(), "-j", "SNAT", "--to", n.config["ipv4.nat.address"]}
+			}
+
 			if n.config["ipv4.nat.order"] == "after" {
-				err = networkIptablesAppend("ipv4", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				err = networkIptablesAppend("ipv4", n.name, "nat", "POSTROUTING", args...)
 				if err != nil {
 					return err
 				}
 			} else {
-				err = networkIptablesPrepend("ipv4", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				err = networkIptablesPrepend("ipv4", n.name, "nat", "POSTROUTING", args...)
 				if err != nil {
 					return err
 				}
@@ -1445,13 +1451,18 @@ func (n *network) Start() error {
 
 		// Configure NAT
 		if shared.IsTrue(n.config["ipv6.nat"]) {
+			args := []string{"-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE"}
+			if n.config["ipv6.nat.address"] != "" {
+				args = []string{"-s", subnet.String(), "!", "-d", subnet.String(), "-j", "SNAT", "--to", n.config["ipv6.nat.address"]}
+			}
+
 			if n.config["ipv6.nat.order"] == "after" {
-				err = networkIptablesAppend("ipv6", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				err = networkIptablesAppend("ipv6", n.name, "nat", "POSTROUTING", args...)
 				if err != nil {
 					return err
 				}
 			} else {
-				err = networkIptablesPrepend("ipv6", n.name, "nat", "POSTROUTING", "-s", subnet.String(), "!", "-d", subnet.String(), "-j", "MASQUERADE")
+				err = networkIptablesPrepend("ipv6", n.name, "nat", "POSTROUTING", args...)
 				if err != nil {
 					return err
 				}

--- a/lxd/networks_config.go
+++ b/lxd/networks_config.go
@@ -67,6 +67,7 @@ var networkConfigKeys = map[string]func(value string) error{
 	"ipv4.nat.order": func(value string) error {
 		return shared.IsOneOf(value, []string{"before", "after"})
 	},
+	"ipv4.nat.address":  networkValidAddressV4,
 	"ipv4.dhcp":         shared.IsBool,
 	"ipv4.dhcp.gateway": networkValidAddressV4,
 	"ipv4.dhcp.expiry":  shared.IsAny,
@@ -86,6 +87,7 @@ var networkConfigKeys = map[string]func(value string) error{
 	"ipv6.nat.order": func(value string) error {
 		return shared.IsOneOf(value, []string{"before", "after"})
 	},
+	"ipv6.nat.address":   networkValidAddressV6,
 	"ipv6.dhcp":          shared.IsBool,
 	"ipv6.dhcp.expiry":   shared.IsAny,
 	"ipv6.dhcp.stateful": shared.IsBool,

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -99,9 +99,9 @@ _have lxc && {
     networks_keys="bridge.driver bridge.external_interfaces bridge.mode \
       bridge.mtu bridge.hwaddr dns.domain dns.mode fan.overlay_subnet fan.type \
       fan.underlay_subnet ipv4.address ipv4.dhcp ipv4.dhcp.expiry ipv4.dhcp.gateway \
-      ipv4.dhcp.ranges ipv4.firewall ipv4.nat ipv4.routes ipv4.routing \
+      ipv4.dhcp.ranges ipv4.firewall ipv4.nat ipv4.nat.address ipv4.routes ipv4.routing \
       ipv6.address ipv6.dhcp ipv6.dhcp.expiry ipv6.dhcp.ranges \
-      ipv6.dhcp.stateful ipv6.firewall ipv6.nat ipv6.routes ipv6.routing \
+      ipv6.dhcp.stateful ipv6.firewall ipv6.nat ipv6.nat.address ipv6.routes ipv6.routing \
       raw.dnsmasq"
 
     storage_pool_keys="source size btrfs.mount_options ceph.cluster_name \


### PR DESCRIPTION
Adds the following network config settings to allow specifying an SNAT source address:

```
ipv4.nat.address
ipv6.nat.address
```

Related to https://github.com/lxc/lxd/issues/5648