### PR TITLE
lxd/container: network up hook for network limits

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -634,6 +634,7 @@ type container interface {
 	// Hooks
 	OnStart() error
 	OnStop(target string) error
+	OnNetworkUp(deviceName string, hostVeth string) error
 
 	// Properties
 	Id() int

--- a/lxd/main_callhook.go
+++ b/lxd/main_callhook.go
@@ -17,7 +17,7 @@ type cmdCallhook struct {
 
 func (c *cmdCallhook) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = "callhook <path> <id> <state>"
+	cmd.Use = "callhook <path> <id> <hook>"
 	cmd.Short = "Call container lifecycle hook in LXD"
 	cmd.Long = `Description:
   Call container lifecycle hook in LXD
@@ -72,6 +72,8 @@ func (c *cmdCallhook) Run(cmd *cobra.Command, args []string) error {
 			target = "unknown"
 		}
 		url = fmt.Sprintf("%s?target=%s", url, target)
+	} else if state == "network-up" {
+		url = fmt.Sprintf("%s?device=%s&host_name=%s", url, args[3], os.Getenv("LXC_NET_PEER"))
 	}
 
 	// Setup the request


### PR DESCRIPTION
lxd/container: Moves network limits to be run as a network up hook rather than container start hook

Signed-off-by: tomponline <tomp@tomp.uk>