### PR TITLE
lxc/file: Dynamically shrinks output for long files

### DIFF
--- a/lxc/utils/progress.go
+++ b/lxc/utils/progress.go
@@ -32,10 +32,9 @@ func (p *ProgressRenderer) truncate(msg string) string {
 
 	newSize := len(msg)
 	if width < newSize {
-		newSize = width
+		return ""
 	}
 
-	msg = msg[0:newSize]
 	return msg
 }
 


### PR DESCRIPTION
lxc/file: Dynamically shrinks output for long files when using `lxc file pull`

Fixes #5668

Signed-off-by: tomponline <thomas.parrott@canonical.com>