### PR TITLE
lxd/storage/btrfs: Don't make ro snapshots when unpriv

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -684,7 +684,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			oldSnapshotMntPoint := shared.VarPath("snapshots", cs)
 			newSnapshotMntPoint := getSnapshotMountPoint("default", defaultPoolName, cs)
 			if shared.PathExists(oldSnapshotMntPoint) && !shared.PathExists(newSnapshotMntPoint) {
-				err = btrfsSnapshot(oldSnapshotMntPoint, newSnapshotMntPoint, true)
+				err = btrfsSnapshot(d.State(), oldSnapshotMntPoint, newSnapshotMntPoint, true)
 				if err != nil {
 					err := btrfsSubVolumeCreate(newSnapshotMntPoint)
 					if err != nil {

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -2267,10 +2267,10 @@ func btrfsSubVolumesDelete(subvol string) error {
  * btrfsSnapshot creates a snapshot of "source" to "dest"
  * the result will be readonly if "readonly" is True.
  */
-func btrfsSnapshot(source string, dest string, readonly bool) error {
+func btrfsSnapshot(s *state.State, source string, dest string, readonly bool) error {
 	var output string
 	var err error
-	if readonly {
+	if readonly && !s.OS.RunningInUserNS {
 		output, err = shared.RunCommand(
 			"btrfs",
 			"subvolume",
@@ -2299,7 +2299,7 @@ func btrfsSnapshot(source string, dest string, readonly bool) error {
 }
 
 func (s *storageBtrfs) btrfsPoolVolumeSnapshot(source string, dest string, readonly bool) error {
-	return btrfsSnapshot(source, dest, readonly)
+	return btrfsSnapshot(s.s, source, dest, readonly)
 }
 
 func (s *storageBtrfs) btrfsPoolVolumesSnapshot(source string, dest string, readonly bool, recursive bool) error {


### PR DESCRIPTION
Ran into some problems when using btrfs combined with shiftfs where we could create read-only snapshots but then not clear the read-only flag nor delete it.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>