### PR TITLE
network: physical and macvlan nictype MTU support

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -86,20 +86,21 @@ user.\*                                 | string    | -                 | n/a   
 
 The following volatile keys are currently internally used by LXD:
 
-Key                             | Type      | Default       | Description
-:--                             | :---      | :------       | :----------
-volatile.apply\_quota           | string    | -             | Disk quota to be applied on next container start
-volatile.apply\_template        | string    | -             | The name of a template hook which should be triggered upon next startup
-volatile.base\_image            | string    | -             | The hash of the image the container was created from, if any.
-volatile.idmap.base             | integer   | -             | The first id in the container's primary idmap range
-volatile.idmap.current          | string    | -             | The idmap currently in use by the container
-volatile.idmap.next             | string    | -             | The idmap to use next time the container starts
-volatile.last\_state.idmap      | string    | -             | Serialized container uid/gid map
-volatile.last\_state.power      | string    | -             | Container state as of last host shutdown
-volatile.\<name\>.host\_name    | string    | -             | Network device name on the host (for nictype=bridged or nictype=p2p, or nictype=sriov)
-volatile.\<name\>.hwaddr        | string    | -             | Network device MAC address (when no hwaddr property is set on the device itself)
-volatile.\<name\>.name          | string    | -             | Network device name (when no name propery is set on the device itself)
-
+Key                                     | Type      | Default       | Description
+:--                                     | :---      | :------       | :----------
+volatile.apply\_quota                   | string    | -             | Disk quota to be applied on next container start
+volatile.apply\_template                | string    | -             | The name of a template hook which should be triggered upon next startup
+volatile.base\_image                    | string    | -             | The hash of the image the container was created from, if any.
+volatile.idmap.base                     | integer   | -             | The first id in the container's primary idmap range
+volatile.idmap.current                  | string    | -             | The idmap currently in use by the container
+volatile.idmap.next                     | string    | -             | The idmap to use next time the container starts
+volatile.last\_state.idmap              | string    | -             | Serialized container uid/gid map
+volatile.last\_state.power              | string    | -             | Container state as of last host shutdown
+volatile.\<name\>.host\_name            | string    | -             | Network device name on the host (for nictype=bridged or nictype=p2p, or nictype=sriov)
+volatile.\<name\>.hwaddr                | string    | -             | Network device MAC address (when no hwaddr property is set on the device itself)
+volatile.\<name\>.last\_state.created   | string    | -             | Whether or not the network device physical device was created ("true" or "false")
+volatile.\<name\>.last\_state.mtu       | string    | -             | Network device original MTU used when moving a physical device into a container
+volatile.\<name\>.last\_state.hwaddr    | string    | -             | Network device original MAC used when moving a physical device into a container
 
 Additionally, those user keys have become common with images (support isn't guaranteed):
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -681,6 +681,7 @@ type container interface {
 
 	// Hooks
 	OnStart() error
+	OnStopNS(target string, netns string) error
 	OnStop(target string) error
 	OnNetworkUp(deviceName string, hostVeth string) error
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8435,7 +8435,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 
 	// Return empty list if not running
 	if !c.IsRunning() {
-		return fmt.Errorf("Can't insert device into stopped container")
+		return fmt.Errorf("Can't remove device from stopped container")
 	}
 
 	// Get a temporary device name

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2674,6 +2674,28 @@ func (c *containerLXC) startCommon() (string, error) {
 	return configPath, nil
 }
 
+// snapshotPhysicalNic records properties of a network device into volatile map supplied.
+func (c *containerLXC) snapshotPhysicalNic(deviceName string, hostName string, volatile map[string]string) error {
+	mtuKey := "volatile." + deviceName + ".last_state.mtu"
+	macKey := "volatile." + deviceName + ".last_state.hwaddr"
+
+	// Store current MTU for restoration on detach
+	mtu, err := networkGetDevMTU(hostName)
+	if err != nil {
+		return err
+	}
+	volatile[mtuKey] = fmt.Sprintf("%d", mtu)
+
+	// Store current MAC for restoration on detach
+	mac, err := networkGetDevMAC(hostName)
+	if err != nil {
+		return err
+	}
+	volatile[macKey] = mac
+
+	return nil
+}
+
 func (c *containerLXC) Start(stateful bool) error {
 	var ctxMap log.Ctx
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2777,6 +2777,90 @@ func (c *containerLXC) detachInterfaceRename(netns string, ifName string, hostNa
 	return nil
 }
 
+// restorePhysicalNic uses the data in c.localConfig to restore physical nic properties from the
+// volatile data gathered when the device was attached.
+func (c *containerLXC) restorePhysicalNic(deviceName string, hostName string, netns string) error {
+	createdKey := "volatile." + deviceName + ".last_state.created"
+	mtuKey := "volatile." + deviceName + ".last_state.mtu"
+	macKey := "volatile." + deviceName + ".last_state.hwaddr"
+
+	// If a stop hook netns is supplied and the device isn't present on the host's namespace yet
+	// try detaching it as LXC may have not known about it if it was hot plugged.
+	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", hostName)) {
+		if netns == "" {
+			return nil // Nothing to do if device doesn't exist and we can't retrieve it.
+		}
+
+		ifNameKey := "volatile." + deviceName + ".name"
+		err := c.detachInterfaceRename(netns, c.localConfig[ifNameKey], hostName)
+		if err != nil {
+			return fmt.Errorf("Failed to detach interface: %s to %s: %v", c.localConfig[ifNameKey], hostName, err)
+		}
+	}
+
+	// If we created the "physical" device and then it should be removed.
+	if shared.IsTrue(c.localConfig[createdKey]) {
+		return deviceRemoveInterface(hostName)
+	}
+
+	// Bring the interface down, as this is sometimes needed to change settings on the nic.
+	_, err := shared.RunCommand("ip", "link", "set", "dev", hostName, "down")
+	if err != nil {
+		return fmt.Errorf("Failed to bring down \"%s\": %v", hostName, err)
+	}
+
+	// If MTU value is specified then there is an original MTU that needs restoring.
+	if c.localConfig[mtuKey] != "" {
+		mtuInt, err := strconv.ParseUint(c.localConfig[mtuKey], 10, 32)
+		if err != nil {
+			return fmt.Errorf("Failed to convert mtu for \"%s\" mtu \"%s\": %v", hostName, c.localConfig[mtuKey], err)
+		}
+
+		err = networkSetDevMTU(hostName, mtuInt)
+		if err != nil {
+			return fmt.Errorf("Failed to restore physical dev \"%s\" mtu to \"%d\": %v", hostName, mtuInt, err)
+		}
+	}
+
+	// If MAC value is specified then there is an original MAC that needs restoring.
+	if c.localConfig[macKey] != "" {
+		err := networkSetDevMAC(hostName, c.localConfig[macKey])
+		if err != nil {
+			return fmt.Errorf("Failed to restore physical dev \"%s\" mac to \"%s\": %v", hostName, c.localConfig[macKey], err)
+		}
+	}
+
+	return nil
+}
+
+// restorePhysicalParent restores parent device settings when removed from a container using the
+// volatile data that was stored when the device was first added with setupPhysicalParent().
+func (c *containerLXC) restorePhysicalParent(deviceName string, m types.Device, netns string) {
+	// Clear volatile data when function finishes.
+	defer func() {
+		// Volatile keys used for parent restore.
+		createdKey := "volatile." + deviceName + ".last_state.created"
+		mtuKey := "volatile." + deviceName + ".last_state.mtu"
+		macKey := "volatile." + deviceName + ".last_state.hwaddr"
+
+		err := c.VolatileSet(map[string]string{createdKey: "", mtuKey: "", macKey: ""})
+		if err != nil {
+			logger.Errorf("Failed to remove volatile config for %s: %v", deviceName, err)
+		}
+	}()
+
+	// Nothing to do if we don't know the original device name.
+	hostName := networkGetHostDevice(m["parent"], m["vlan"])
+	if hostName == "" {
+		return
+	}
+
+	err := c.restorePhysicalNic(deviceName, hostName, netns)
+	if err != nil {
+		logger.Errorf("%v", err)
+	}
+}
+
 func (c *containerLXC) Start(stateful bool) error {
 	var ctxMap log.Ctx
 
@@ -3209,6 +3293,9 @@ func (c *containerLXC) OnStopNS(target string, netns string) error {
 		return fmt.Errorf("Invalid stop target: %s", target)
 	}
 
+	// Clean up networking devices
+	c.cleanupNetworkDevices(netns)
+
 	return nil
 }
 
@@ -3362,6 +3449,21 @@ func (c *containerLXC) cleanupHostVethDevices() error {
 	}
 
 	return nil
+}
+
+// cleanupNetworkDevices performs any needed network device cleanup steps when container is stopped.
+func (c *containerLXC) cleanupNetworkDevices(netns string) {
+	for _, k := range c.expandedDevices.DeviceNames() {
+		m := c.expandedDevices[k]
+		if m["type"] != "nic" {
+			continue
+		}
+
+		// Restore physical parent devices
+		if m["nictype"] == "physical" {
+			c.restorePhysicalParent(k, m, netns)
+		}
+	}
 }
 
 // OnNetworkUp is called by the LXD callhook when the LXC network up script is run.
@@ -8465,7 +8567,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	// Get a temporary device name
 	var hostName string
 	if m["nictype"] == "physical" {
-		hostName = m["parent"]
+		hostName = networkGetHostDevice(m["parent"], m["vlan"])
 	} else if m["nictype"] == "sriov" {
 		hostName = m["host_name"]
 	} else {
@@ -8490,13 +8592,18 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	if shared.StringInSlice(m["name"], ifaces) {
 		err = cc.DetachInterfaceRename(m["name"], hostName)
 		if err != nil {
-			return fmt.Errorf("Failed to detach interface: %s: %v", m["name"], err)
+			return fmt.Errorf("Failed to detach interface: %s to %s: %v", m["name"], hostName, err)
 		}
 	}
 
 	// Remove any static veth routes
 	if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
 		c.removeNetworkRoutes(name, m)
+	}
+
+	// If physical dev, restore MTU using value recorded on parent after removal from container.
+	if m["nictype"] == "physical" {
+		c.restorePhysicalParent(name, m, "")
 	}
 
 	// If a veth, destroy it

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2555,17 +2555,11 @@ func (c *containerLXC) startCommon() (string, error) {
 				}
 			}
 
-			// Create VLAN devices
-			if shared.StringInSlice(m["nictype"], []string{"macvlan", "ipvlan", "physical"}) && m["vlan"] != "" {
-				device := networkGetHostDevice(m["parent"], m["vlan"])
-				if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", device)) {
-					_, err := shared.RunCommand("ip", "link", "add", "link", m["parent"], "name", device, "up", "type", "vlan", "id", m["vlan"])
-					if err != nil {
-						return "", err
-					}
-
-					// Attempt to disable IPv6 router advertisement acceptance
-					networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", device), "0")
+			// Create VLAN device on parent
+			if shared.StringInSlice(m["nictype"], []string{"macvlan", "ipvlan", "physical"}) {
+				_, err := c.setupPhysicalParent(k, m)
+				if err != nil {
+					return "", err
 				}
 			}
 		}
@@ -2694,6 +2688,69 @@ func (c *containerLXC) snapshotPhysicalNic(deviceName string, hostName string, v
 	volatile[macKey] = mac
 
 	return nil
+}
+
+// createVlanDeviceIfNeeded detects the device type and whether it has a vlan parent configured.
+// It then attempts to detect if the parent vlan interface exists, and if not creates one.
+// Returns boolean as to whether we created it and any errors.
+func (c *containerLXC) createVlanDeviceIfNeeded(m types.Device, hostName string) (bool, error) {
+	if m["vlan"] != "" {
+		if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", hostName)) {
+			_, err := shared.RunCommand("ip", "link", "add", "link", m["parent"], "name", hostName, "up", "type", "vlan", "id", m["vlan"])
+			if err != nil {
+				return false, err
+			}
+
+			// Attempt to disable IPv6 router advertisement acceptance
+			networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", hostName), "0")
+
+			// We created a new vlan interface, return true
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// setupPhysicalParent creates a VLAN device on parent if needed and tracks original properties of
+// the physical device if not just created so they can be restored when the device is detached.
+// Returns the parent device name detected.
+func (c *containerLXC) setupPhysicalParent(deviceName string, m types.Device) (string, error) {
+	if m["parent"] == "" {
+		return "", errors.New("No parent property on device")
+	}
+
+	hostName := networkGetHostDevice(m["parent"], m["vlan"])
+	createdDev, err := c.createVlanDeviceIfNeeded(m, hostName)
+	if err != nil {
+		return hostName, err
+	}
+
+	// If we are passing the parent device into the container, we need to save properties
+	// of the original device in case they are changed during their time inside the container,
+	// so that we can restore those properties when the device is detached from the container.
+	if m["nictype"] == "physical" {
+		createdKey := "volatile." + deviceName + ".last_state.created"
+		volatile := map[string]string{
+			createdKey: fmt.Sprintf("%t", createdDev),
+		}
+
+		// If we didn't create the device we should track various properties so we can
+		// restore them when the container is stopped or the device is detached.
+		if createdDev == false {
+			err = c.snapshotPhysicalNic(deviceName, hostName, volatile)
+			if err != nil {
+				return hostName, err
+			}
+		}
+
+		err = c.VolatileSet(volatile)
+		if err != nil {
+			return hostName, err
+		}
+	}
+
+	return hostName, nil
 }
 
 func (c *containerLXC) Start(stateful bool) error {
@@ -7877,19 +7934,10 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 
 	// Handle physical and macvlan
 	if shared.StringInSlice(m["nictype"], []string{"macvlan", "physical"}) {
-		// Deal with VLAN
-		device := m["parent"]
-		if m["vlan"] != "" {
-			device = networkGetHostDevice(m["parent"], m["vlan"])
-			if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", device)) {
-				_, err := shared.RunCommand("ip", "link", "add", "link", m["parent"], "name", device, "up", "type", "vlan", "id", m["vlan"])
-				if err != nil {
-					return "", err
-				}
-
-				// Attempt to disable IPv6 router advertisement acceptance
-				networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", device), "0")
-			}
+		// Deal with VLAN on parent
+		device, err := c.setupPhysicalParent(name, m)
+		if err != nil {
+			return "", err
 		}
 
 		// Handle physical

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -585,6 +585,7 @@ func (d *Daemon) init() error {
 		"network_ipvlan",
 		"network_l2proxy",
 		"network_gateway_device_route",
+		"network_phys_macvlan_mtu",
 	}
 	for _, extension := range lxcExtensions {
 		d.os.LXCFeatures[extension] = lxc.HasApiExtension(extension)

--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -81,17 +81,34 @@ void error(char *msg)
 }
 
 int dosetns(int pid, char *nstype) {
-	__do_close_prot_errno int mntns = -EBADF;
+	__do_close_prot_errno int ns_fd = -EBADF;
 	char buf[PATH_MAX];
 
 	sprintf(buf, "/proc/%d/ns/%s", pid, nstype);
-	mntns = open(buf, O_RDONLY);
-	if (mntns < 0) {
-		error("error: open mntns");
+	ns_fd = open(buf, O_RDONLY);
+	if (ns_fd < 0) {
+		error("error: open namespace");
 		return -1;
 	}
 
-	if (setns(mntns, 0) < 0) {
+	if (setns(ns_fd, 0) < 0) {
+		error("error: setns");
+		return -1;
+	}
+
+	return 0;
+}
+
+int dosetns_file(char *file, char *nstype) {
+	__do_close_prot_errno int ns_fd = -EBADF;
+
+	ns_fd = open(file, O_RDONLY);
+	if (ns_fd < 0) {
+		error("error: open namespace");
+		return -1;
+	}
+
+	if (setns(ns_fd, 0) < 0) {
 		error("error: setns");
 		return -1;
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"reflect"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -1576,14 +1575,8 @@ func (n *network) Start() error {
 		}
 
 		// Update the MTU based on overlay device (if available)
-		content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
+		fanMtuInt, err := networkGetDevMTU(devName)
 		if err == nil {
-			// Parse value
-			fanMtuInt, err := strconv.ParseInt(strings.TrimSpace(string(content)), 10, 32)
-			if err != nil {
-				return err
-			}
-
 			// Apply overhead
 			if n.config["fan.type"] == "ipip" {
 				fanMtuInt = fanMtuInt - 20

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1317,3 +1317,19 @@ func networkGetState(netIf net.Interface) api.NetworkState {
 	network.Counters = shared.NetworkGetCounters(netIf.Name)
 	return network
 }
+
+// networkGetDevMTU retrieves the current MTU setting for a named network device.
+func networkGetDevMTU(devName string) (uint64, error) {
+	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
+	if err != nil {
+		return 0, err
+	}
+
+	// Parse value
+	mtu, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 32)
+	if err != nil {
+		return 0, err
+	}
+
+	return mtu, nil
+}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1334,6 +1334,24 @@ func networkGetDevMTU(devName string) (uint64, error) {
 	return mtu, nil
 }
 
+// networkSetDevMTU sets the MTU setting for a named network device if different from current.
+func networkSetDevMTU(devName string, mtu uint64) error {
+	curMTU, err := networkGetDevMTU(devName)
+	if err != nil {
+		return err
+	}
+
+	// Only try and change the MTU if the requested mac is different to current one.
+	if curMTU != mtu {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "mtu", fmt.Sprintf("%d", mtu))
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 // networkGetDevMAC retrieves the current MAC setting for a named network device.
 func networkGetDevMAC(devName string) (string, error) {
 	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1333,3 +1333,13 @@ func networkGetDevMTU(devName string) (uint64, error) {
 
 	return mtu, nil
 }
+
+// networkGetDevMAC retrieves the current MAC setting for a named network device.
+func networkGetDevMAC(devName string) (string, error) {
+	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
+}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1343,3 +1343,21 @@ func networkGetDevMAC(devName string) (string, error) {
 
 	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
 }
+
+// networkSetDevMAC sets the MAC setting for a named network device if different from current.
+func networkSetDevMAC(devName string, mac string) error {
+	curMac, err := networkGetDevMAC(devName)
+	if err != nil {
+		return err
+	}
+
+	// Only try and change the MAC if the requested mac is different to current one.
+	if curMac != mac {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "address", mac)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/shared/container.go
+++ b/shared/container.go
@@ -331,6 +331,14 @@ func ConfigKeyChecker(key string) (func(value string) error, error) {
 		if strings.HasSuffix(key, ".host_name") {
 			return IsAny, nil
 		}
+
+		if strings.HasSuffix(key, ".mtu") {
+			return IsAny, nil
+		}
+
+		if strings.HasSuffix(key, ".created") {
+			return IsAny, nil
+		}
 	}
 
 	if strings.HasPrefix(key, "environment.") {

--- a/test/suites/container_devices_nic_physical.sh
+++ b/test/suites/container_devices_nic_physical.sh
@@ -2,53 +2,186 @@ test_container_devices_nic_physical() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  ct_name="nt$$"
+  ctName="nt$$"
+  dummyMAC="AA:3B:97:97:0F:D5"
+  ctMAC="0A:92:a7:0d:b7:D9"
 
   # Create dummy interface for use as parent.
-  ip link add "${ct_name}" type dummy
-  ip link set "${ct_name}" up
+  ip link add "${ctName}" address "${dummyMAC}" type dummy
 
   # Create test container from default profile.
-  lxc init testimage "${ct_name}"
+  lxc init testimage "${ctName}"
 
   # Add physical device to container/
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=physical \
-    parent="${ct_name}" \
+    parent="${ctName}" \
     name=eth0 \
-    mtu=1400
+    mtu=1400 \
+    hwaddr="${ctMAC}"
 
-  # Lauch container and check it has nic applied correctly.
-  lxc start "${ct_name}"
+  # Launch container and check it has nic applied correctly.
+  lxc start "${ctName}"
 
   # Check custom MTU is applied if feature available in LXD.
   if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
-    if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+    if ! lxc exec "${ctName}" -- grep "1400" /sys/class/net/eth0/mtu ; then
       echo "mtu invalid"
       false
     fi
   fi
 
-  lxc config device remove "${ct_name}" eth0
-
-  # Test hot-plugging physical device based on vlan parent.
-  ip link set "${ct_name}" up
-  lxc config device add "${ct_name}" eth0 nic \
-    nictype=physical \
-    parent="${ct_name}" \
-    name=eth0 \
-    vlan=10 \
-    mtu=1399 #This must be less than or equal to the MTU of the parent device (which is not being reset)
-
-  # Check custom MTU is applied.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1399" ; then
-    echo "mtu invalid"
+  # Check custom MAC is applied in container.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
     false
   fi
 
-  # Destroy the container and check the physical interface is returned to the host for clean up.
-  lxc delete "${ct_name}" -f
+  # Stop container and check MTU is restored.
+  lxc stop "${ctName}"
 
-  # Remove dummy interface if present.
-  ip link delete "${ct_name}" || true
+  # Check original MTU is restored on physical device.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! grep "1500" /sys/class/net/"${ctName}"/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check original MAC is restored on physical device.
+   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Remove boot time physical device and check MTU is restored.
+  lxc start "${ctName}"
+  lxc config device remove "${ctName}" eth0
+
+  # Check original MTU is restored on physical device.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! grep "1500" /sys/class/net/"${ctName}"/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check original MAC is restored on physical device.
+   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Test hot-plugging physical device based on vlan parent.
+  # Make the MTU higher than the original boot time 1400 MTU above to check that the
+  # parent device's MTU is reset on removal to the pre-boot value on host (expect >=1500).
+  ip link set "${ctName}" up #VLAN requires parent nic be up.
+  lxc config device add "${ctName}" eth0 nic \
+    nictype=physical \
+    parent="${ctName}" \
+    name=eth0 \
+    vlan=10 \
+    hwaddr="${ctMAC}" \
+    mtu=1401 #Higher than 1400 boot time value above
+
+  # Check custom MTU is applied if feature available in LXD.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! lxc exec "${ctName}" -- grep "1401" /sys/class/net/eth0/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check custom MAC is applied in container.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Remove hot-plugged physical device and check MTU is restored.
+  lxc config device remove "${ctName}" eth0
+
+  # Check original MTU is restored on physical device.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! grep "1500" /sys/class/net/"${ctName}"/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check original MAC is restored on physical device.
+   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Test hot-plugging physical device based on existing parent.
+  # Make the MTU higher than the original boot time 1400 MTU above to check that the
+  # parent device's MTU is reset on removal to the pre-boot value on host (expect >=1500).
+  lxc config device add "${ctName}" eth0 nic \
+    nictype=physical \
+    parent="${ctName}" \
+    name=eth0 \
+    hwaddr="${ctMAC}" \
+    mtu=1402 #Higher than 1400 boot time value above
+
+  # Check custom MTU is applied if feature available in LXD.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! lxc exec "${ctName}" -- grep "1402" /sys/class/net/eth0/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check custom MAC is applied in container.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Test removing a physical device an check its MTU gets restored to default 1500 mtu
+  lxc config device remove "${ctName}" eth0
+
+  # Check original MTU is restored on physical device.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! grep "1500" /sys/class/net/"${ctName}"/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check original MAC is restored on physical device.
+   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Test hot-plugging physical device based on existing parent with new name that LXC doesn't know about.
+  lxc config device add "${ctName}" eth1 nic \
+    nictype=physical \
+    parent="${ctName}" \
+    hwaddr="${ctMAC}" \
+    mtu=1402 #Higher than 1400 boot time value above
+
+  # Stop the container, LXC doesn't know about the nic, so we will rely on LXD to restore it.
+  lxc stop "${ctName}"
+
+  # Check original MTU is restored on physical device.
+  if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
+    if ! grep "1500" /sys/class/net/"${ctName}"/mtu ; then
+      echo "mtu invalid"
+      false
+    fi
+  fi
+
+  # Check original MAC is restored on physical device.
+   if ! grep -i "${dummyMAC}" /sys/class/net/"${ctName}"/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  lxc delete "${ctName}"
+
+  # Remove dummy interface (should still exist).
+  ip link delete "${ctName}"
 }


### PR DESCRIPTION
This exposes the `network_phys_macvlan_mtu` support in LXC for setting a boot time custom MTU on `physical` and `macvlan` nic device types and updates tests to expect the MTU to be changed if that feature is present.

It also modifies LXD to restore the MTU and MAC of physical devices if changed by the container's settings or from within the container.

Depends on https://github.com/lxc/lxc/pull/2985