### PR TITLE
network: static routes for bridged nic types

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3102,6 +3102,12 @@ func (c *containerLXC) OnStop(target string) error {
 		logger.Error("Failed to set container state", log.Ctx{"container": c.Name(), "err": err})
 	}
 
+	// Clean up networking routes
+	err = c.cleanupNetworkRoutes()
+	if err != nil {
+		logger.Error("Failed to cleanup network routes: ", log.Ctx{"container": c.Name(), "err": err})
+	}
+
 	go func(c *containerLXC, target string, op *lxcContainerOperation) {
 		c.fromHook = false
 		err = nil
@@ -3157,15 +3163,33 @@ func (c *containerLXC) OnStop(target string) error {
 	return nil
 }
 
+// cleanupNetworkRoutes removes any static routes added on the host for nic devices.
+func (c *containerLXC) cleanupNetworkRoutes() error {
+	for _, k := range c.expandedDevices.DeviceNames() {
+		m := c.expandedDevices[k]
+		if m["type"] != "nic" {
+			continue
+		}
+
+		// Remove any static veth routes
+		if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
+			c.removeNetworkRoutes(m)
+		}
+
+	}
+
+	return nil
+}
+
 // OnNetworkUp is called by the LXD callhook when the LXC network up script is run.
 func (c *containerLXC) OnNetworkUp(deviceName string, hostName string) error {
 	device := c.expandedDevices[deviceName]
 	device["host_name"] = hostName
-	return c.setupHostVethDevice(device)
+	return c.setupHostVethDevice(device, types.Device{})
 }
 
 // setupHostVethDevice configures a nic device's host side veth settings.
-func (c *containerLXC) setupHostVethDevice(device types.Device) error {
+func (c *containerLXC) setupHostVethDevice(device types.Device, oldDevice types.Device) error {
 	// If not already, populate network device with host name.
 	if device["host_name"] == "" {
 		device["host_name"] = c.getHostInterface(device["name"])
@@ -3183,7 +3207,7 @@ func (c *containerLXC) setupHostVethDevice(device types.Device) error {
 	}
 
 	// Setup static routes to container
-	err = c.setNetworkRoutes(device)
+	err = c.setNetworkRoutes(device, oldDevice)
 	if err != nil {
 		return err
 	}
@@ -4936,7 +4960,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						return err
 					}
 
-					err = c.setupHostVethDevice(m)
+					err = c.setupHostVethDevice(m, oldExpandedDevices[k])
 					if err != nil {
 						return err
 					}
@@ -5062,13 +5086,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						return err
 					}
 
-					// Populate network device with host name.
-					m["host_name"] = c.getHostInterface(m["name"])
-					if m["host_name"] == "" {
-						return fmt.Errorf("LXC doesn't know about this device and the host_name property isn't set, can't find host side veth name")
-					}
-
-					err = c.setupHostVethDevice(m)
+					err = c.setupHostVethDevice(m, oldExpandedDevices[k])
 					if err != nil {
 						return err
 					}
@@ -8274,6 +8292,11 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 		}
 	}
 
+	// Remove any static veth routes
+	if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
+		c.removeNetworkRoutes(m)
+	}
+
 	// If a veth, destroy it
 	if m["nictype"] != "physical" && m["nictype"] != "sriov" {
 		deviceRemoveInterface(hostName)
@@ -8824,28 +8847,25 @@ func (c *containerLXC) getHostInterface(name string) string {
 }
 
 // setNetworkRoutes applies any static routes configured from the host to the container nic.
-func (c *containerLXC) setNetworkRoutes(m types.Device) error {
+func (c *containerLXC) setNetworkRoutes(m types.Device, oldDevice types.Device) error {
 	if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", m["host_name"])) {
 		return fmt.Errorf("Unknown or missing host side veth: %s", m["host_name"])
 	}
 
-	// Flush all IPv4 routes
-	_, err := shared.RunCommand("ip", "-4", "route", "flush", "dev", m["host_name"], "proto", "static")
-	if err != nil {
-		return err
-	}
+	// Remove any old routes that were setup for this nic device.
+	c.removeNetworkRoutes(oldDevice)
 
-	// Flush all IPv6 routes
-	_, err = shared.RunCommand("ip", "-6", "route", "flush", "dev", m["host_name"], "proto", "static")
-	if err != nil {
-		return err
+	// Decide whether the route should point to the veth parent or the bridge parent
+	routeDev := m["host_name"]
+	if m["nictype"] == "bridged" {
+		routeDev = m["parent"]
 	}
 
 	// Add additional IPv4 routes
 	if m["ipv4.routes"] != "" {
 		for _, route := range strings.Split(m["ipv4.routes"], ",") {
 			route = strings.TrimSpace(route)
-			_, err := shared.RunCommand("ip", "-4", "route", "add", "dev", m["host_name"], route, "proto", "static")
+			_, err := shared.RunCommand("ip", "-4", "route", "add", route, "dev", routeDev, "proto", "static")
 			if err != nil {
 				return err
 			}
@@ -8856,7 +8876,7 @@ func (c *containerLXC) setNetworkRoutes(m types.Device) error {
 	if m["ipv6.routes"] != "" {
 		for _, route := range strings.Split(m["ipv6.routes"], ",") {
 			route = strings.TrimSpace(route)
-			_, err := shared.RunCommand("ip", "-6", "route", "add", "dev", m["host_name"], route, "proto", "static")
+			_, err := shared.RunCommand("ip", "-6", "route", "add", route, "dev", routeDev, "proto", "static")
 			if err != nil {
 				return err
 			}
@@ -8864,6 +8884,49 @@ func (c *containerLXC) setNetworkRoutes(m types.Device) error {
 	}
 
 	return nil
+}
+
+// removeNetworkRoutes removes any routes created for this device on the host that were first added
+// with setNetworkRoutes(). Expects to be passed the device config from the oldExpandedDevices.
+func (c *containerLXC) removeNetworkRoutes(m types.Device) {
+	// Decide whether the route should point to the veth parent or the bridge parent
+	routeDev := m["host_name"]
+	if m["nictype"] == "bridged" {
+		routeDev = m["parent"]
+	}
+
+	if m["ipv4.routes"] != "" || m["ipv6.routes"] != "" {
+		if routeDev == "" {
+			logger.Errorf("Failed to remove static routes as route dev isn't set")
+			return
+		}
+
+		if !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", routeDev)) {
+			return //Routes will already be gone if device doesn't exist.
+		}
+	}
+
+	// Remove IPv4 routes
+	if m["ipv4.routes"] != "" {
+		for _, route := range strings.Split(m["ipv4.routes"], ",") {
+			route = strings.TrimSpace(route)
+			_, err := shared.RunCommand("ip", "-4", "route", "flush", route, "dev", routeDev, "proto", "static")
+			if err != nil {
+				logger.Errorf("Failed to remove static route: %s to %s: %s", route, routeDev, err)
+			}
+		}
+	}
+
+	// Remove IPv6 routes
+	if m["ipv6.routes"] != "" {
+		for _, route := range strings.Split(m["ipv6.routes"], ",") {
+			route = strings.TrimSpace(route)
+			_, err := shared.RunCommand("ip", "-6", "route", "flush", route, "dev", routeDev, "proto", "static")
+			if err != nil {
+				logger.Errorf("Failed to remove static route: %s to %s: %s", route, routeDev, err)
+			}
+		}
+	}
 }
 
 func (c *containerLXC) setNetworkLimits(m types.Device) error {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3185,19 +3185,20 @@ func (c *containerLXC) cleanupNetworkRoutes() error {
 func (c *containerLXC) OnNetworkUp(deviceName string, hostName string) error {
 	device := c.expandedDevices[deviceName]
 	device["host_name"] = hostName
-	return c.setupHostVethDevice(device, types.Device{})
+	return c.setupHostVethDevice(deviceName, device, types.Device{})
 }
 
 // setupHostVethDevice configures a nic device's host side veth settings.
-func (c *containerLXC) setupHostVethDevice(device types.Device, oldDevice types.Device) error {
-	// If not already, populate network device with host name.
+func (c *containerLXC) setupHostVethDevice(deviceName string, device types.Device, oldDevice types.Device) error {
+	// If not populated already, check if volatile data contains the most recently added host_name.
 	if device["host_name"] == "" {
-		device["host_name"] = c.getHostInterface(device["name"])
+		configKey := fmt.Sprintf("volatile.%s.host_name", deviceName)
+		device["host_name"] = c.localConfig[configKey]
 	}
 
 	// Check whether host device resolution succeeded.
 	if device["host_name"] == "" {
-		return fmt.Errorf("LXC doesn't know about this device and the host_name property isn't set, can't find host side veth name")
+		return fmt.Errorf("Failed to find host side veth name for device \"%s\"", deviceName)
 	}
 
 	// Refresh tc limits
@@ -4960,7 +4961,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						return err
 					}
 
-					err = c.setupHostVethDevice(m, oldExpandedDevices[k])
+					err = c.setupHostVethDevice(k, m, oldExpandedDevices[k])
 					if err != nil {
 						return err
 					}
@@ -5086,7 +5087,7 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 						return err
 					}
 
-					err = c.setupHostVethDevice(m, oldExpandedDevices[k])
+					err = c.setupHostVethDevice(k, m, oldExpandedDevices[k])
 					if err != nil {
 						return err
 					}
@@ -7744,6 +7745,10 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 			networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", n1), "0")
 		}
 
+		// Record the new device's host name for use in setupHostVethDevice()
+		configKey := fmt.Sprintf("volatile.%s.host_name", name)
+		c.localConfig[configKey] = n1
+
 		dev = n2
 	}
 
@@ -8114,7 +8119,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m types.Device) (types.Dev
 	}
 
 	// Fill in the host name (but don't generate a static one ourselves)
-	if m["host_name"] == "" && shared.StringInSlice(m["nictype"], []string{"bridged", "p2p", "sriov"}) {
+	if m["host_name"] == "" && shared.StringInSlice(m["nictype"], []string{"sriov"}) {
 		configKey := fmt.Sprintf("volatile.%s.host_name", name)
 		newDevice["host_name"] = c.localConfig[configKey]
 	}

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -2,8 +2,9 @@ test_container_devices_nic_bridged() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  veth_host_name="veth$$"
-  ct_name="nt$$"
+  vethHostName="veth$$"
+  ctName="nt$$"
+  ctMAC="0A:92:a7:0d:b7:D9"
   ipRand=$(shuf -i 0-9 -n 1)
   brName="lxdt$$"
 
@@ -15,46 +16,65 @@ test_container_devices_nic_bridged() {
   lxc network set "${brName}" ipv6.routing false
   lxc network set "${brName}" ipv6.dhcp.stateful true
   lxc network set "${brName}" bridge.hwaddr 00:11:22:33:44:55
+  lxc network set "${brName}" ipv4.address 192.0.2.1/24
+  lxc network set "${brName}" ipv6.address 2001:db8::1/64
   [ "$(cat /sys/class/net/${brName}/address)" = "00:11:22:33:44:55" ]
 
-  # Test pre-launch profile config is applied at launch.
-  lxc profile copy default "${ct_name}"
-  lxc profile device set "${ct_name}" eth0 ipv4.routes "192.0.2.1${ipRand}/32"
-  lxc profile device set "${ct_name}" eth0 ipv6.routes "2001:db8::1${ipRand}/128"
-  lxc profile device set "${ct_name}" eth0 limits.ingress 1Mbit
-  lxc profile device set "${ct_name}" eth0 limits.egress 2Mbit
-  lxc profile device set "${ct_name}" eth0 host_name "${veth_host_name}"
-  lxc profile device set "${ct_name}" eth0 mtu "1400"
-  lxc launch testimage "${ct_name}" -p "${ct_name}"
+  # Test pre-launch profile config is applied at launch
+  lxc profile copy default "${ctName}"
+  lxc profile device set "${ctName}" eth0 ipv4.routes "192.0.2.1${ipRand}/32"
+  lxc profile device set "${ctName}" eth0 ipv6.routes "2001:db8::1${ipRand}/128"
+  lxc profile device set "${ctName}" eth0 limits.ingress 1Mbit
+  lxc profile device set "${ctName}" eth0 limits.egress 2Mbit
+  lxc profile device set "${ctName}" eth0 host_name "${vethHostName}"
+  lxc profile device set "${ctName}" eth0 mtu "1400"
+  lxc profile device set "${ctName}" eth0 hwaddr "${ctMAC}"
+  lxc profile device set "${ctName}" eth0 parent "${brName}"
+  lxc profile device set "${ctName}" eth0 nictype "bridged"
+  lxc launch testimage "${ctName}" -p "${ctName}"
 
   # Check profile routes are applied on boot.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.1${ipRand}" ; then
+  if ! ip -4 r list dev "${brName}" | grep "192.0.2.1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::1${ipRand}" ; then
+  if ! ip -6 r list dev "${brName}" | grep "2001:db8::1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check profile limits are applied on boot.
-  if ! tc class show dev "${veth_host_name}" | grep "1Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "1Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "2Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "2Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
-  # Check profile custom MTU is applied on boot.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+  # Check profile custom MTU is applied in container on boot.
+  if ! lxc exec "${ctName}" -- grep "1400" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check profile custom MAC is applied in container on boot.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Add IP alias to container and check routes actually work.
+  lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
+  lxc exec "${ctName}" -- ip -4 route add default dev eth0
+  ping -c2 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
+  sleep 1 #Wait for link local gateway advert.
+  ping6 -c2 -W1 "2001:db8::1${ipRand}"
+
   # Test hot plugging a container nic with different settings to profile with the same name.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=bridged \
     name=eth0 \
     parent=${brName} \
@@ -62,106 +82,152 @@ test_container_devices_nic_bridged() {
     ipv6.routes="2001:db8::2${ipRand}/128" \
     limits.ingress=3Mbit \
     limits.egress=4Mbit \
-    host_name="${veth_host_name}" \
+    host_name="${vethHostName}" \
+    hwaddr="${ctMAC}" \
     mtu=1401
 
+  # Check profile routes are removed on hot-plug.
+  if ip -4 r list dev "${brName}" | grep "192.0.2.1${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
+  if ip -6 r list dev "${brName}" | grep "2001:db8::1${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
+
   # Check routes are applied on hot-plug.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.2${ipRand}" ; then
+  if ! ip -4 r list dev "${brName}" | grep "192.0.2.2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::2${ipRand}" ; then
+  if ! ip -6 r list dev "${brName}" | grep "2001:db8::2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check limits are applied on hot-plug.
-  if ! tc class show dev "${veth_host_name}" | grep "3Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "3Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "4Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "4Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
   # Check custom MTU is applied on hot-plug.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1401" ; then
+  if ! lxc exec "${ctName}" -- grep "1401" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check custom MAC is applied on hot-plug.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
   # Test removing hot plugged device and check profile nic is restored.
-  lxc config device remove "${ct_name}" eth0
+  lxc config device remove "${ctName}" eth0
+
+  # Check routes are removed on hot-plug.
+  if ip -4 r list dev "${brName}" | grep "192.0.2.2${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
+  if ip -6 r list dev "${brName}" | grep "2001:db8::2${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
 
   # Check profile routes are applied on hot-removal.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.1${ipRand}" ; then
+  if ! ip -4 r list dev "${brName}" | grep "192.0.2.1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::1${ipRand}" ; then
+  if ! ip -6 r list dev "${brName}" | grep "2001:db8::1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check profile limits are applie on hot-removal.
-  if ! tc class show dev "${veth_host_name}" | grep "1Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "1Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "2Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "2Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
   # Check profile custom MTU is applied on hot-removal.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+  if ! lxc exec "${ctName}" -- grep "1400" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
   # Test hot plugging a container nic then updating it.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=bridged \
     name=eth0 \
     parent=${brName} \
-    host_name="${veth_host_name}"
+    host_name="${vethHostName}" \
+    ipv4.routes="192.0.2.1${ipRand}/32" \
+    ipv6.routes="2001:db8::1${ipRand}/128"
 
-  lxc config device set "${ct_name}" eth0 ipv4.routes "192.0.2.2${ipRand}/32"
-  lxc config device set "${ct_name}" eth0 ipv6.routes "2001:db8::2${ipRand}/128"
-  lxc config device set "${ct_name}" eth0 limits.ingress 3Mbit
-  lxc config device set "${ct_name}" eth0 limits.egress 4Mbit
-  lxc config device set "${ct_name}" eth0 mtu 1402
+  lxc config device set "${ctName}" eth0 ipv4.routes "192.0.2.2${ipRand}/32"
+  lxc config device set "${ctName}" eth0 ipv6.routes "2001:db8::2${ipRand}/128"
+  lxc config device set "${ctName}" eth0 limits.ingress 3Mbit
+  lxc config device set "${ctName}" eth0 limits.egress 4Mbit
+  lxc config device set "${ctName}" eth0 mtu 1402
+  lxc config device set "${ctName}" eth0 hwaddr "${ctMAC}"
+
+  # Check original routes are removed on hot-plug.
+  if ip -4 r list dev "${brName}" | grep "192.0.2.1${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
+  if ip -6 r list dev "${brName}" | grep "2001:db8::1${ipRand}" ; then
+    echo "ipv4.routes remain"
+    false
+  fi
 
   # Check routes are applied on update.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.2${ipRand}" ; then
+  if ! ip -4 r list dev "${brName}" | grep "192.0.2.2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::2${ipRand}" ; then
+  if ! ip -6 r list dev "${brName}" | grep "2001:db8::2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check limits are applied on update.
-  if ! tc class show dev "${veth_host_name}" | grep "3Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "3Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "4Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "4Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
   # Check custom MTU is applied update.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1402" ; then
+  if ! lxc exec "${ctName}" -- grep "1402" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check custom MAC is applied update.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
   # Cleanup.
-  lxc config device remove "${ct_name}" eth0
-  lxc delete "${ct_name}" -f
+  lxc config device remove "${ctName}" eth0
+  lxc delete "${ctName}" -f
   lxc network delete "${brName}"
-  lxc profile delete "${ct_name}"
+  lxc profile delete "${ctName}"
 }

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -2,160 +2,194 @@ test_container_devices_nic_p2p() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  veth_host_name="veth$$"
-  ct_name="nt$$"
+  vethHostName="veth$$"
+  ctName="nt$$"
+  ctMAC="0A:92:a7:0d:b7:D9"
   ipRand=$(shuf -i 0-9 -n 1)
 
   # Test pre-launch profile config is applied at launch.
-  lxc profile copy default ${ct_name}
-  lxc profile device set ${ct_name} eth0 ipv4.routes "192.0.2.1${ipRand}/32"
-  lxc profile device set ${ct_name} eth0 ipv6.routes "2001:db8::1${ipRand}/128"
-  lxc profile device set ${ct_name} eth0 limits.ingress 1Mbit
-  lxc profile device set ${ct_name} eth0 limits.egress 2Mbit
-  lxc profile device set ${ct_name} eth0 host_name "${veth_host_name}"
-  lxc profile device set ${ct_name} eth0 mtu "1400"
-  lxc profile device set ${ct_name} eth0 nictype "p2p"
-  lxc launch testimage "${ct_name}" -p ${ct_name}
+  lxc profile copy default ${ctName}
+  lxc profile device set ${ctName} eth0 ipv4.routes "192.0.2.1${ipRand}/32"
+  lxc profile device set ${ctName} eth0 ipv6.routes "2001:db8::1${ipRand}/128"
+  lxc profile device set ${ctName} eth0 limits.ingress 1Mbit
+  lxc profile device set ${ctName} eth0 limits.egress 2Mbit
+  lxc profile device set ${ctName} eth0 host_name "${vethHostName}"
+  lxc profile device set ${ctName} eth0 mtu "1400"
+  lxc profile device set ${ctName} eth0 hwaddr "${ctMAC}"
+  lxc profile device set ${ctName} eth0 nictype "p2p"
+  lxc launch testimage "${ctName}" -p ${ctName}
 
   # Check profile routes are applied on boot.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.1${ipRand}" ; then
+  if ! ip -4 r list dev "${vethHostName}" | grep "192.0.2.1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::1${ipRand}" ; then
+  if ! ip -6 r list dev "${vethHostName}" | grep "2001:db8::1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check profile limits are applied on boot.
-  if ! tc class show dev "${veth_host_name}" | grep "1Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "1Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "2Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "2Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
-  # Check profile custom MTU is applied on boot.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+  # Check profile custom MTU is applied in container on boot.
+  if ! lxc exec "${ctName}" -- grep "1400" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check profile custom MAC is applied in container on boot.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
+  # Add IP alias to container and check routes actually work.
+  ip -4 addr add 192.0.2.1/32 dev "${vethHostName}"
+  lxc exec "${ctName}" -- ip -4 addr add "192.0.2.1${ipRand}/32" dev eth0
+  lxc exec "${ctName}" -- ip -4 route add default dev eth0
+  sleep 1
+  ping -c2 -W1 "192.0.2.1${ipRand}"
+  ip -6 addr add 2001:db8::1/128 dev "${vethHostName}"
+  lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
+  lxc exec "${ctName}" -- ip -6 route add default dev eth0
+  sleep 1
+  ping6 -c2 -W1 "2001:db8::1${ipRand}"
+
   # Test hot plugging a container nic with different settings to profile with the same name.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=p2p \
     name=eth0 \
     ipv4.routes="192.0.2.3${ipRand}/32" \
     ipv6.routes="2001:db8::3${ipRand}/128" \
     limits.ingress=3Mbit \
     limits.egress=4Mbit \
-    host_name="${veth_host_name}p2p" \
+    host_name="${vethHostName}p2p" \
+    hwaddr="${ctMAC}" \
     mtu=1401
 
   # Check routes are applied on hot-plug.
-  if ! ip -4 r list dev "${veth_host_name}p2p" | grep "192.0.2.3${ipRand}" ; then
+  if ! ip -4 r list dev "${vethHostName}p2p" | grep "192.0.2.3${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}p2p" | grep "2001:db8::3${ipRand}" ; then
+  if ! ip -6 r list dev "${vethHostName}p2p" | grep "2001:db8::3${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check limits are applied on hot-plug.
-  if ! tc class show dev "${veth_host_name}p2p" | grep "3Mbit" ; then
+  if ! tc class show dev "${vethHostName}p2p" | grep "3Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}p2p" egress | grep "4Mbit" ; then
+  if ! tc filter show dev "${vethHostName}p2p" egress | grep "4Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
-  # Check custom MTU is applied  on hot-plug.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1401" ; then
+  # Check custom MTU is applied on hot-plug.
+  if ! lxc exec "${ctName}" -- grep "1401" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check custom MAC is applied on hot-plug.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
   # Test removing hot plugged device and check profile nic is restored.
-  lxc config device remove "${ct_name}" eth0
+  lxc config device remove "${ctName}" eth0
 
   # Check profile routes are applied on hot-removal.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.1${ipRand}" ; then
+  if ! ip -4 r list dev "${vethHostName}" | grep "192.0.2.1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::1${ipRand}" ; then
+  if ! ip -6 r list dev "${vethHostName}" | grep "2001:db8::1${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! tc class show dev "${veth_host_name}" | grep "1Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "1Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
 
   # Check profile limits are applied on hot-removal.
-  if ! tc filter show dev "${veth_host_name}" egress | grep "2Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "2Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
   # Check profile custom MTU is applied on hot-removal.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+  if ! lxc exec "${ctName}" -- grep "1400" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
   # Test hot plugging a container nic then updating it.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=p2p \
     name=eth0 \
-    host_name="${veth_host_name}"
+    host_name="${vethHostName}"
 
-  lxc config device set "${ct_name}" eth0 ipv4.routes "192.0.2.2${ipRand}/32"
-  lxc config device set "${ct_name}" eth0 ipv6.routes "2001:db8::2${ipRand}/128"
-  lxc config device set "${ct_name}" eth0 limits.ingress 3Mbit
-  lxc config device set "${ct_name}" eth0 limits.egress 4Mbit
-  lxc config device set "${ct_name}" eth0 mtu 1402
+  lxc config device set "${ctName}" eth0 ipv4.routes "192.0.2.2${ipRand}/32"
+  lxc config device set "${ctName}" eth0 ipv6.routes "2001:db8::2${ipRand}/128"
+  lxc config device set "${ctName}" eth0 limits.ingress 3Mbit
+  lxc config device set "${ctName}" eth0 limits.egress 4Mbit
+  lxc config device set "${ctName}" eth0 mtu 1402
+  lxc config device set "${ctName}" eth0 hwaddr "${ctMAC}"
 
   # Check routes are applied on update.
-  if ! ip -4 r list dev "${veth_host_name}" | grep "192.0.2.2${ipRand}" ; then
+  if ! ip -4 r list dev "${vethHostName}" | grep "192.0.2.2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
-  if ! ip -6 r list dev "${veth_host_name}" | grep "2001:db8::2${ipRand}" ; then
+  if ! ip -6 r list dev "${vethHostName}" | grep "2001:db8::2${ipRand}" ; then
     echo "ipv4.routes invalid"
     false
   fi
 
   # Check limits are applied on update.
-  if ! tc class show dev "${veth_host_name}" | grep "3Mbit" ; then
+  if ! tc class show dev "${vethHostName}" | grep "3Mbit" ; then
     echo "limits.ingress invalid"
     false
   fi
-  if ! tc filter show dev "${veth_host_name}" egress | grep "4Mbit" ; then
+  if ! tc filter show dev "${vethHostName}" egress | grep "4Mbit" ; then
     echo "limits.egress invalid"
     false
   fi
 
   # Check custom MTU is applied update.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1402" ; then
+  if ! lxc exec "${ctName}" -- grep "1402" /sys/class/net/eth0/mtu ; then
     echo "mtu invalid"
     false
   fi
 
+  # Check custom MAC is applied update.
+  if ! lxc exec "${ctName}" -- grep -i "${ctMAC}" /sys/class/net/eth0/address ; then
+    echo "mac invalid"
+    false
+  fi
+
   # Cleanup.
-  lxc config device remove "${ct_name}" eth0
-  lxc delete "${ct_name}" -f
-  lxc profile delete "${ct_name}"
+  lxc config device remove "${ctName}" eth0
+  lxc delete "${ctName}" -f
+  lxc profile delete "${ctName}"
 
   # Test adding a p2p device to a running container without host_name and no limits/routes.
-  lxc launch testimage "${ct_name}"
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc launch testimage "${ctName}"
+  lxc config device add "${ctName}" eth0 nic \
     nictype=p2p
-  lxc config device remove "${ct_name}" eth0
-  lxc delete "${ct_name}" -f
+  lxc config device remove "${ctName}" eth0
+  lxc delete "${ctName}" -f
 }


### PR DESCRIPTION
This re-works the previously added static routes feature to add support for bridged nic types.

It uses the volatile config keys to store the previous config so that static routes are cleaned up.