### PR TITLE
lxc/container: Fixes minute rollover issue in scheduled snapshots

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1635,10 +1635,18 @@ func autoCreateContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 
 			// Check if it's time to snapshot
 			now := time.Now()
+
+			// Truncate the time now back to the start of the minute, before passing to
+			// the cron scheduler, as it will add 1s to the scheduled time and we don't
+			// want the next scheduled time to roll over to the next minute and break
+			// the time comparison below.
+			now = now.Truncate(time.Minute)
+
+			// Calculate the next scheduled time based on the snapshots.schedule
+			// pattern and the time now.
 			next := sched.Next(now)
 
 			// Ignore everything that is more precise than minutes.
-			now = now.Truncate(time.Minute)
 			next = next.Truncate(time.Minute)
 
 			if !now.Equal(next) {


### PR DESCRIPTION
Fixes #5761

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>