### PR TITLE
container: Renames OnStop hook function to OnPostStop

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -34,7 +34,7 @@ var apiInternal = []APIEndpoint{
 	internalShutdownCmd,
 	internalContainerOnStartCmd,
 	internalContainerOnNetworkUpCmd,
-	internalContainerOnStopCmd,
+	internalContainerOnPostStopCmd,
 	internalContainersCmd,
 	internalSQLCmd,
 	internalClusterAcceptCmd,
@@ -63,10 +63,10 @@ var internalContainerOnStartCmd = APIEndpoint{
 	Get: APIEndpointAction{Handler: internalContainerOnStart},
 }
 
-var internalContainerOnStopCmd = APIEndpoint{
-	Name: "containers/{id}/onstop",
+var internalContainerOnPostStopCmd = APIEndpoint{
+	Name: "containers/{id}/onpoststop",
 
-	Get: APIEndpointAction{Handler: internalContainerOnStop},
+	Get: APIEndpointAction{Handler: internalContainerOnPostStop},
 }
 
 var internalContainerOnNetworkUpCmd = APIEndpoint{
@@ -136,7 +136,7 @@ func internalContainerOnStart(d *Daemon, r *http.Request) Response {
 	return EmptySyncResponse
 }
 
-func internalContainerOnStop(d *Daemon, r *http.Request) Response {
+func internalContainerOnPostStop(d *Daemon, r *http.Request) Response {
 	id, err := strconv.Atoi(mux.Vars(r)["id"])
 	if err != nil {
 		return SmartError(err)
@@ -152,9 +152,9 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	err = c.OnStop(target)
+	err = c.OnPostStop(target)
 	if err != nil {
-		logger.Error("The stop hook failed", log.Ctx{"container": c.Name(), "err": err})
+		logger.Error("The poststop hook failed", log.Ctx{"container": c.Name(), "err": err})
 		return SmartError(err)
 	}
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -681,7 +681,7 @@ type container interface {
 
 	// Hooks
 	OnStart() error
-	OnStop(target string) error
+	OnPostStop(target string) error
 	OnNetworkUp(deviceName string, hostVeth string) error
 
 	// Properties

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1223,7 +1223,7 @@ func (c *containerLXC) initLXC(config bool) error {
 		}
 	}
 
-	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %d stop", c.state.OS.ExecPath, shared.VarPath(""), c.id))
+	err = lxcSetConfigItem(cc, "lxc.hook.post-stop", fmt.Sprintf("%s callhook %s %d poststop", c.state.OS.ExecPath, shared.VarPath(""), c.id))
 	if err != nil {
 		return err
 	}
@@ -3050,10 +3050,12 @@ func (c *containerLXC) Shutdown(timeout time.Duration) error {
 	return nil
 }
 
-func (c *containerLXC) OnStop(target string) error {
+// OnPostStop is triggered by LXC's post-stop hook once a container is shutdown and after the
+// container's namespaces have been closed.
+func (c *containerLXC) OnPostStop(target string) error {
 	// Validate target
 	if !shared.StringInSlice(target, []string{"stop", "reboot"}) {
-		logger.Error("Container sent invalid target to OnStop", log.Ctx{"container": c.Name(), "target": target})
+		logger.Error("Container sent invalid target to OnPostStop", log.Ctx{"container": c.Name(), "target": target})
 		return fmt.Errorf("Invalid stop target: %s", target)
 	}
 

--- a/lxd/main_callhook.go
+++ b/lxd/main_callhook.go
@@ -23,7 +23,7 @@ func (c *cmdCallhook) Command() *cobra.Command {
   Call container lifecycle hook in LXD
 
   This internal command notifies LXD about a container lifecycle event
-  (start, stop, restart) and blocks until LXD has processed it.
+  (start, poststop, restart) and blocks until LXD has processed it.
 
 `
 	cmd.RunE = c.Run
@@ -66,7 +66,7 @@ func (c *cmdCallhook) Run(cmd *cobra.Command, args []string) error {
 
 	// Prepare the request URL
 	url := fmt.Sprintf("/internal/containers/%s/on%s", id, state)
-	if state == "stop" {
+	if state == "poststop" {
 		target = os.Getenv("LXC_TARGET")
 		if target == "" {
 			target = "unknown"


### PR DESCRIPTION
This better reflects the actual LXC hook type being used (lxc.hook.post-stop) and allows the OnStop() function to be added back in the future with different functionality to be run by LXC's lxc.hook.stop hook.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>