### PR TITLE
lxd/storage/btrfs: Delete any orphaned *.ro snapshots

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1442,10 +1442,15 @@ func (s *storageBtrfs) ContainerSnapshotCreate(snapshotContainer container, sour
 
 func btrfsSnapshotDeleteInternal(project, poolName string, snapshotName string) error {
 	snapshotSubvolumeName := getSnapshotMountPoint(project, poolName, snapshotName)
-	if shared.PathExists(snapshotSubvolumeName) && isBtrfsSubVolume(snapshotSubvolumeName) {
-		err := btrfsSubVolumesDelete(snapshotSubvolumeName)
-		if err != nil {
-			return err
+	// Also delete any leftover .ro snapshot.
+	roSnapshotSubvolumeName := fmt.Sprintf("%s.ro", snapshotSubvolumeName)
+	names := []string{snapshotSubvolumeName, roSnapshotSubvolumeName}
+	for _, name := range names {
+		if shared.PathExists(name) && isBtrfsSubVolume(name) {
+			err := btrfsSubVolumesDelete(name)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
See #5763
During a publish, a *.ro subvolume snapshot copy is made
whilst the original snapshot is set read-write.
If lxd is killed before publish finishes, the *.ro copy
can be left orphaned, and should be deleted when
the associated snapshot is deleted.

Signed-off-by: Joel Hockey <joelhockey@chromium.org>