### PR TITLE
Pass the -r flag when copying a snapshot backed by a btrfs subvolume

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1060,7 +1060,7 @@ func (s *storageBtrfs) copySnapshot(target container, source container) error {
 		}
 	}
 
-	err = s.btrfsPoolVolumesSnapshot(sourceContainerSubvolumeName, targetContainerSubvolumeName, false, true)
+	err = s.btrfsPoolVolumesSnapshot(sourceContainerSubvolumeName, targetContainerSubvolumeName, true, true)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This fixes #5804.

The problem was that btrfs send wants a snapshot to be readonly (to prevent
interim modification), but we were not passing the "-r" flag when creating btrfs
subvolume for copying the snapshots of a source container.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>