### PR TITLE
Fan reverse DNS requests

### DIFF
--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -1,11 +1,20 @@
+// forkdns provides a specialised DNS server designed for relaying A and PTR queries.
 package main
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
+	"net"
+	"os"
 	"strings"
 
 	"github.com/miekg/dns"
 	"github.com/spf13/cobra"
+
+	"github.com/lxc/lxd/shared/dnsutil"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/logging"
 )
 
 type cmdForkDNS struct {
@@ -13,67 +22,239 @@ type cmdForkDNS struct {
 }
 
 type dnsHandler struct {
-	domain  string
-	servers []string
+	domain    string
+	leaseFile string
+	servers   []string
 }
 
 func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	var err error
 	msg := dns.Msg{}
 	msg.SetReply(r)
 
 	// We only support single questions for now
 	if len(r.Question) != 1 {
 		msg.SetRcode(r, dns.RcodeNameError)
-		w.WriteMsg(&msg)
-		return
+	} else if r.Question[0].Qtype == dns.TypePTR {
+		msg, err = h.handlePTR(r)
+		if err != nil {
+			logger.Errorf("PTR record lookup failed for %s: %v", r.Question[0].Name, err)
+			msg.SetRcode(r, dns.RcodeNameError)
+		}
+	} else if r.Question[0].Qtype == dns.TypeA {
+		msg, err = h.handleA(r)
+		if err != nil {
+			logger.Errorf("A record lookup failed for %s: %v", r.Question[0].Name, err)
+			msg.SetRcode(r, dns.RcodeNameError)
+		}
+	} else {
+		// Fallback to NXDOMAIN
+		msg.SetRcode(r, dns.RcodeNameError)
 	}
 
-	// Rewrite the question to the internal domain
-	origName := r.Question[0].Name
-	newName := origName
-	if strings.HasSuffix(r.Question[0].Name, fmt.Sprintf(".%s.", h.domain)) {
-		newName = fmt.Sprintf("%s.__internal.", strings.SplitN(r.Question[0].Name, fmt.Sprintf(".%s.", h.domain), 2)[0])
+	err = w.WriteMsg(&msg)
+	if err != nil {
+		logger.Errorf("Failed sending response for %s: %v", r.Question[0].Name, err)
 	}
+}
+
+// handlePTR answers requests for reverse DNS records.
+// It is used with cluster networking to provide cluster wide DNS PTR resolution by consulting the
+// local DHCP leases file and if not found, then relaying the question to the other cluster member's
+// forkdns instance. Returns DNS message to be sent as response.
+func (h *dnsHandler) handlePTR(r *dns.Msg) (dns.Msg, error) {
+	msg := dns.Msg{}
+	msg.SetReply(r)
+
+	// If request is marked as non-recursive it means it is from another forkdns and we should
+	// attempt to answer it using the local dnsmasq lease file and not relay it.
+	if !r.RecursionDesired {
+		// Check if the local DHCP leases file contains a lease for the requested reverse DNS name.
+		// If this fails with an error or no record found, then check other cluster hosts.
+		hostname, err := h.getLeaseHostByReverseIPName(r.Question[0].Name)
+		if err != nil {
+			logger.Errorf("PTR record lease lookup failed for %s: %v", r.Question[0].Name, err)
+		}
+
+		// Record found in local DHCP leases file, generate answer response and send.
+		if hostname != "" {
+			msg.Authoritative = true
+			msg.Answer = append(msg.Answer, &dns.PTR{
+				Hdr: dns.RR_Header{
+					Name:   r.Question[0].Name,
+					Rrtype: dns.TypePTR,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				// Suffix the hostname in the lease with the cluster DNS zone name (e.g. ".lxd.")
+				// The final full stop is important as the response needs to be a FQDN.
+				Ptr: fmt.Sprintf("%s.%s.", hostname, h.domain),
+			})
+
+			return msg, nil
+		}
+
+		// Record not found locally, return NXDOMAIN.
+		msg.SetRcode(r, dns.RcodeNameError)
+		return msg, nil
+	}
+
+	// If we get here, then the recursion desired flag was set, meaning we cannot answer the
+	// query locally and need to relay it to the other forkdns instances.
+
+	// This tells the remote node we only want to query their local data (to stop loops).
+	r.RecursionDesired = false
 
 	// Query all the servers
 	for _, server := range h.servers {
-		// Send the request to the backend server
-		r.Question[0].Name = newName
-		resp, err := dns.Exchange(r, fmt.Sprintf("%s:53", server))
-		r.Question[0].Name = origName
+		resp, err := dns.Exchange(r, fmt.Sprintf("%s:1053", server))
 		if err != nil || len(resp.Answer) == 0 {
 			// Error or empty response, try the next one
 			continue
 		}
 
-		// Send back the answer
-		answers := []dns.RR{}
-		for _, answer := range resp.Answer {
-			rr, err := dns.NewRR(strings.Replace(answer.String(), ".__internal.", fmt.Sprintf(".%s.", h.domain), -1))
-			if err != nil {
-				continue
-			}
-
-			answers = append(answers, rr)
-		}
-		msg.Answer = answers
-		w.WriteMsg(&msg)
-		return
+		return *resp, nil
 	}
 
-	// Fallback to NXDOMAIN
+	// Record not found in any of the remove servers.
 	msg.SetRcode(r, dns.RcodeNameError)
-	w.WriteMsg(&msg)
+	return msg, nil
+}
+
+// getLeaseHostByReverseIPName finds the hostname used in the DHCP lease by supplying a reverse
+// DNS hostname of the device's IP.
+func (h *dnsHandler) getLeaseHostByReverseIPName(reverseName string) (string, error) {
+	ip := dnsutil.ExtractAddressFromReverse(reverseName)
+	if ip == "" {
+		return "", errors.New("Failed to convert reverse name to IP")
+	}
+
+	file, err := os.Open(h.leaseFile)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 5 {
+			address := fields[2]
+			if address == ip {
+				return fields[3], nil
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", nil
+}
+
+// handleA answers requests for A DNS records.
+// It is used with cluster networking to provide cluster wide DNS A resolution by consulting the
+// local DHCP leases file and if not found, then relaying the question to the other cluster member's
+// forkdns instance. Returns DNS message to be sent as response.
+func (h *dnsHandler) handleA(r *dns.Msg) (dns.Msg, error) {
+	msg := dns.Msg{}
+	msg.SetReply(r)
+
+	// If request is marked as non-recursive it means it is from another forkdns and we should
+	// attempt to answer it using the local dnsmasq lease file and not relay it.
+	if !r.RecursionDesired {
+		// Check if the local DHCP leases file contains a lease for the requested hostname name.
+		// If this fails with an error or no record found, then check other cluster hosts.
+		ip, err := h.getLeaseHostByDNSName(r.Question[0].Name)
+		if err != nil {
+			logger.Errorf("A record lease lookup failed for %s: %v", r.Question[0].Name, err)
+		}
+
+		// Record found in local DHCP leases file, generate answer response and send.
+		if ip != "" {
+			msg.Authoritative = true
+			msg.Answer = append(msg.Answer, &dns.A{
+				Hdr: dns.RR_Header{
+					Name:   r.Question[0].Name,
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				A: net.ParseIP(ip),
+			})
+
+			return msg, nil
+		}
+
+		// Record not found locally, return NXDOMAIN.
+		msg.SetRcode(r, dns.RcodeNameError)
+		return msg, nil
+	}
+
+	// If we get here, then the recursion desired flag was set, meaning we cannot answer the
+	// query locally and need to relay it to the other forkdns instances.
+
+	// This tells the remote node we only want to query their local data (to stop loops).
+	r.RecursionDesired = false
+
+	// Query all the servers
+	for _, server := range h.servers {
+		resp, err := dns.Exchange(r, fmt.Sprintf("%s:1053", server))
+		if err != nil || len(resp.Answer) == 0 {
+			// Error or empty response, try the next one
+			continue
+		}
+
+		return *resp, nil
+	}
+
+	// Record not found in any of the remove servers.
+	msg.SetRcode(r, dns.RcodeNameError)
+	return msg, nil
+}
+
+// getLeaseHostByDNSName finds the hostname used in the DHCP lease by supplying a DNS A name
+func (h *dnsHandler) getLeaseHostByDNSName(dnsName string) (string, error) {
+	host := strings.TrimSuffix(dnsName, fmt.Sprintf(".%s.", h.domain))
+
+	file, err := os.Open(h.leaseFile)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 5 {
+			hostname := fields[3]
+			if hostname == host {
+				return fields[2], nil
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+
+	return "", nil
 }
 
 func (c *cmdForkDNS) Command() *cobra.Command {
 	// Main subcommand
 	cmd := &cobra.Command{}
-	cmd.Use = "forkdns <listen address> <domain> <servers...>"
+	cmd.Use = "forkdns <listen address> <domain> <leases file> <servers...>"
 	cmd.Short = "Internal DNS proxy for clustering"
 	cmd.Long = `Description:
-  Spawns a tiny DNS server which forwards to all upstream servers until
-  one returns a valid record.
+  Spawns a specialised DNS server designed for relaying A and PTR queries that cannot be answered by
+  the local dnsmasq process to the other cluster member's forkdns process where it will inspect the
+  local dnsmasq lease file looking for an answer to the query.
+  It uses the "recursion desired" flag in incoming DNS requests to modify its behaviour.
+  When "recursion desired" is set to yes, the query is immediately relayed to the other cluster nodes
+  (with the "recursion desired" flag set to no) as it indicates that the local dnsmasq process was
+  unable to answer it from the local lease file.
+  When "recursion desired" flag is set to no, this indicates the request has been sent from another
+  forkdns process, and the local dnsmasq lease file only is parsed to try and answer the query.
 `
 	cmd.RunE = c.Run
 	cmd.Hidden = true
@@ -83,7 +264,7 @@ func (c *cmdForkDNS) Command() *cobra.Command {
 
 func (c *cmdForkDNS) Run(cmd *cobra.Command, args []string) error {
 	// Sanity checks
-	if len(args) < 3 {
+	if len(args) < 4 {
 		cmd.Help()
 
 		if len(args) == 0 {
@@ -93,17 +274,25 @@ func (c *cmdForkDNS) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("Missing required arguments")
 	}
 
+	log, err := logging.GetLogger("lxd-forkdns", "", false, false, eventsHandler{})
+	if err != nil {
+		return err
+	}
+	logger.Log = log
+	logger.Info("Started")
+
 	srv := &dns.Server{
 		Addr: args[0],
 		Net:  "udp",
 	}
 
 	srv.Handler = &dnsHandler{
-		domain:  args[1],
-		servers: args[2:],
+		domain:    args[1],
+		leaseFile: args[2],
+		servers:   args[3:],
 	}
 
-	err := srv.ListenAndServe()
+	err = srv.ListenAndServe()
 	if err != nil {
 		return fmt.Errorf("Failed to set udp listener: %v\n", err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -2064,7 +2064,7 @@ func (n *network) spawnForkDNS(listenAddress string) error {
 	}
 
 	// Grab the network address from the various nodes
-	addresses := []string{listenAddress}
+	addresses := []string{}
 
 	cert := n.state.Endpoints.NetworkCert()
 	for _, node := range nodes {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1792,9 +1792,8 @@ func (n *network) Start() error {
 
 		if n.config["dns.mode"] != "none" {
 			if dnsClustered {
-				dnsmasqCmd = append(dnsmasqCmd, []string{"-s", "__internal", "-S", "/__internal/"}...)
-				dnsmasqCmd = append(dnsmasqCmd, []string{"-S", fmt.Sprintf("/%s/%s#1053", dnsDomain, dnsClusteredAddress)}...)
-				dnsmasqCmd = append(dnsmasqCmd, fmt.Sprintf("--dhcp-option=15,%s", dnsDomain))
+				dnsmasqCmd = append(dnsmasqCmd, "-s", dnsDomain)
+				dnsmasqCmd = append(dnsmasqCmd, "-S", fmt.Sprintf("/%s/%s#1053", dnsDomain, dnsClusteredAddress))
 				dnsmasqCmd = append(dnsmasqCmd, fmt.Sprintf("--rev-server=%s,%s#1053", overlaySubnet, dnsClusteredAddress))
 			} else {
 				dnsmasqCmd = append(dnsmasqCmd, []string{"-s", dnsDomain, "-S", fmt.Sprintf("/%s/", dnsDomain)}...)

--- a/shared/dnsutil/dnsutil.go
+++ b/shared/dnsutil/dnsutil.go
@@ -1,0 +1,83 @@
+// Package dnsutil copied from coredns project
+// https://github.com/coredns/coredns/blob/master/plugin/pkg/dnsutil/reverse.go
+package dnsutil
+
+import (
+	"net"
+	"strings"
+)
+
+// ExtractAddressFromReverse turns a standard PTR reverse record name
+// into an IP address. This works for ipv4 or ipv6.
+//
+// 54.119.58.176.in-addr.arpa. becomes 176.58.119.54. If the conversion
+// fails the empty string is returned.
+func ExtractAddressFromReverse(reverseName string) string {
+	search := ""
+
+	f := reverse
+
+	switch {
+	case strings.HasSuffix(reverseName, IP4arpa):
+		search = strings.TrimSuffix(reverseName, IP4arpa)
+	case strings.HasSuffix(reverseName, IP6arpa):
+		search = strings.TrimSuffix(reverseName, IP6arpa)
+		f = reverse6
+	default:
+		return ""
+	}
+
+	// Reverse the segments and then combine them.
+	return f(strings.Split(search, "."))
+}
+
+// IsReverse returns 0 is name is not in a reverse zone. Anything > 0 indicates
+// name is in a reverse zone. The returned integer will be 1 for in-addr.arpa. (IPv4)
+// and 2 for ip6.arpa. (IPv6).
+func IsReverse(name string) int {
+	if strings.HasSuffix(name, IP4arpa) {
+		return 1
+	}
+	if strings.HasSuffix(name, IP6arpa) {
+		return 2
+	}
+	return 0
+}
+
+func reverse(slice []string) string {
+	for i := 0; i < len(slice)/2; i++ {
+		j := len(slice) - i - 1
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	ip := net.ParseIP(strings.Join(slice, ".")).To4()
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+// reverse6 reverse the segments and combine them according to RFC3596:
+// b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2
+// is reversed to 2001:db8::567:89ab
+func reverse6(slice []string) string {
+	for i := 0; i < len(slice)/2; i++ {
+		j := len(slice) - i - 1
+		slice[i], slice[j] = slice[j], slice[i]
+	}
+	slice6 := []string{}
+	for i := 0; i < len(slice)/4; i++ {
+		slice6 = append(slice6, strings.Join(slice[i*4:i*4+4], ""))
+	}
+	ip := net.ParseIP(strings.Join(slice6, ":")).To16()
+	if ip == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+const (
+	// IP4arpa is the reverse tree suffix for v4 IP addresses.
+	IP4arpa = ".in-addr.arpa."
+	// IP6arpa is the reverse tree suffix for v6 IP addresses.
+	IP6arpa = ".ip6.arpa."
+)


### PR DESCRIPTION
Resolves issue https://github.com/lxc/lxd/issues/5798 that caused DHCP created reverse DNS entries to be returned with the suffix ".__internal" rather than ".lxd".

The original expectation with this PR was that it would be a single line to add forwarding of RDNS zones to the existing forkdns process.

However because the reverse zone name cannot be renamed to something else, unlike the LXD DNS domain, this was not possible.

Instead the following approach was used:

1. Remove the concept of `__internal` zones and make dnsmasq allocate DHCP hostnames to the ".lxd" domain. This makes the behaviour consistent in both clustered and standalone mode.
2. In clustered mode, configure dnsmasq to forward any queries for ".lxd" and FAN RDNS zones that cannot be answered locally to the local forkdns process.
3. The forkdns processes's role has subtly changed, it no longer ever sends requests to the local dnsmasq instance, instead it answers queries from it, and also from other forkdns processes.
4. When a query arrives at the forkdns process from the local dnsmasq process, the "recursion desired" flag in the DNS packet will be sent by dnsmasq. This is used as an indicator that the local dnsmasq instance was not able to answer the query and then relays the request onto the other forkdns nodes in the cluster (but modifies the packet so that the "recursion desired" flag is set to no, indicating that the remote forkdns processes should inspect their local lease file to answer the query and not relay it).
5. When a non-recursive request arrives at a forkdns process, it only inspects its local dnsmasq lease file (by opening it and parsing each line looking for a match). If a match is found, a positive answer is sent back. If a match cannot be found, an NXDOMAIN response is sent back, rather than relay onto other nodes (this avoids loops).

This change will also allow reverse DNS queries to be answered for all cluster nodes, not just the local node as now.