### PR TITLE
lxd/internal: Fix backup.Pool.Name check error message

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -497,7 +497,7 @@ func internalImport(d *Daemon, r *http.Request) Response {
 			return BadRequest(fmt.Errorf(`The storage pool "%s" `+
 				`the container was detected on does not match `+
 				`the storage pool "%s" specified in the `+
-				`backup file`, backup.Pool.Name, containerPoolName))
+				`backup file`, containerPoolName, backup.Pool.Name))
 		}
 
 		if backup.Pool.Driver != pool.Driver {


### PR DESCRIPTION
I just hit this error message and noticed the pool name was inverted here  ;)