### PR TITLE
networks: Maintain DNS clustered mode config during LXD init and node changes

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -926,6 +926,9 @@ func (d *Daemon) startClusterTasks() {
 	// Auto-sync images across the cluster (daily)
 	d.clusterTasks.Add(autoSyncImagesTask(d))
 
+	// Forkdns server list refresh
+	d.clusterTasks.Add(networkUpdateForkdnsServersTask(d))
+
 	// Start all background tasks
 	d.clusterTasks.Start()
 }

--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -27,6 +27,9 @@ type dnsHandler struct {
 	servers   []string
 }
 
+const forkdnsServersListPath = "forkdns.servers"
+const forkdnsServersListFile = "servers.conf"
+
 func (h *dnsHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	var err error
 	msg := dns.Msg{}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1854,6 +1854,21 @@ func (n *network) Start() error {
 
 		// Spawn DNS forwarder if needed (backgrounded to avoid deadlocks during cluster boot)
 		if dnsClustered {
+			// Create forkdns servers directory
+			if !shared.PathExists(shared.VarPath("networks", n.name, forkdnsServersListPath)) {
+				err = os.MkdirAll(shared.VarPath("networks", n.name, forkdnsServersListPath), 0755)
+				if err != nil {
+					return err
+				}
+			}
+
+			// Create forkdns servers.conf file if doesn't exist
+			f, err := os.OpenFile(shared.VarPath("networks", n.name, forkdnsServersListPath+"/"+forkdnsServersListFile), os.O_RDONLY|os.O_CREATE, 0666)
+			if err != nil {
+				return err
+			}
+			f.Close()
+
 			go n.spawnForkDNS(dnsClusteredAddress)
 		}
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1672,9 +1672,17 @@ func (n *network) Start() error {
 		}
 
 		// Setup clustered DNS
-		dnsClustered, err = cluster.Enabled(n.state.Node)
+		clusterAddress, err := node.ClusterAddress(n.state.Node)
 		if err != nil {
 			return err
+		}
+
+		// If clusterAddress is non-empty, this indicates the intention for this node to be
+		// part of a cluster and so we should ensure that dnsmasq and forkdns are started
+		// in cluster mode. Note: During LXD initialisation the cluster may not actually be
+		// setup yet, but we want the DNS processes to be ready for when it is.
+		if clusterAddress != "" {
+			dnsClustered = true
 		}
 
 		dnsClusteredAddress = strings.Split(fanAddress, "/")[0]

--- a/test/main.sh
+++ b/test/main.sh
@@ -46,7 +46,7 @@ import_subdir_files() {
 import_subdir_files includes
 
 echo "==> Checking for dependencies"
-check_dependencies lxd lxc curl dnsmasq jq git xgettext sqlite3 msgmerge msgfmt shuf setfacl uuidgen socat
+check_dependencies lxd lxc curl dnsmasq jq git xgettext sqlite3 msgmerge msgfmt shuf setfacl uuidgen socat dig
 
 if [ "${USER:-'root'}" != "root" ]; then
   echo "The testsuite must be run as root." >&2
@@ -239,6 +239,7 @@ run_test test_clustering_shutdown_nodes "clustering shutdown"
 run_test test_clustering_projects "clustering projects"
 run_test test_clustering_address "clustering address"
 run_test test_clustering_image_replication "clustering image replication"
+run_test test_clustering_dns "clustering DNS"
 #run_test test_clustering_upgrade "clustering upgrade"
 
 # shellcheck disable=SC2034


### PR DESCRIPTION
Ensures that DNS clustered mode is correctly enabled when starting the networks, even if the network is being started as part of LXD init before a cluster has been setup.

This has the effect of starting dnsmasq and forkdns with the correct settings for clustered mode.

It uses the node.ClusterAddress() to indicate an intention for the node to join a cluster at some point in the future.

Fixes #5805

Progress:

- [x] dnsmasq cluster config is not applied after `lxd init` to forward requests to forkdns
- [x] forkdns does not detect nodes being added/removed
- [x] forkdns not started when new cluster is setup via `lxd init`

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>