### PR TITLE
main_forkdns: Ensures forkdns remains running when LXD exits

### DIFF
--- a/lxd/main_nsexec.go
+++ b/lxd/main_nsexec.go
@@ -41,6 +41,7 @@ extern void forkfile();
 extern void forkmknod();
 extern void forkmount();
 extern void forknet();
+extern void forkdns();
 extern void forkproxy();
 extern void forkuevent();
 
@@ -272,6 +273,8 @@ __attribute__((constructor)) void init(void) {
 		forkmount();
 	else if (strcmp(cmdline_cur, "forknet") == 0)
 		forknet();
+	else if (strcmp(cmdline_cur, "forkdns") == 0)
+		forkdns();
 	else if (strcmp(cmdline_cur, "forkproxy") == 0)
 		forkproxy();
 	else if (strcmp(cmdline_cur, "forkuevent") == 0)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1020,6 +1020,14 @@ func (n *network) Rename(name string) error {
 		}
 	}
 
+	forkDNSLogPath := fmt.Sprintf("forkdns.%s.log", n.name)
+	if shared.PathExists(shared.LogPath(forkDNSLogPath)) {
+		err := os.Rename(forkDNSLogPath, shared.LogPath(fmt.Sprintf("forkdns.%s.log", name)))
+		if err != nil {
+			return err
+		}
+	}
+
 	// Rename the database entry
 	err := n.state.Cluster.NetworkRename(n.name, name)
 	if err != nil {
@@ -2085,6 +2093,7 @@ func (n *network) spawnForkDNS(listenAddress string) error {
 	_, err := shared.RunCommand(
 		n.state.OS.ExecPath,
 		"forkdns",
+		shared.LogPath(fmt.Sprintf("forkdns.%s.log", n.name)),
 		shared.VarPath("networks", n.name, "forkdns.pid"),
 		fmt.Sprintf("%s:1053", listenAddress),
 		dnsDomain,

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1309,7 +1309,7 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest1/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns "${lxdDir}"/forkdns1.pid 127.0.1.1"${ipRand}":1053 lxd lxdtest1
+  lxd forkdns "${lxdDir}"/forkdns1.log "${lxdDir}"/forkdns1.pid 127.0.1.1"${ipRand}":1053 lxd lxdtest1
 
   # Create first dummy interface for forkdns
   ip link add "${prefix}2" type dummy
@@ -1320,7 +1320,7 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest2/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns "${lxdDir}"/forkdns2.pid 127.0.1.2"${ipRand}":1053 lxd lxdtest2
+  lxd forkdns "${lxdDir}"/forkdns2.log "${lxdDir}"/forkdns2.pid 127.0.1.2"${ipRand}":1053 lxd lxdtest2
 
   # Let the processes come up
   sleep 1

--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -1309,8 +1309,7 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest1/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns 127.0.1.1"${ipRand}":1053 lxd lxdtest1 &
-  forkdns_pid1=$!
+  lxd forkdns "${lxdDir}"/forkdns1.pid 127.0.1.1"${ipRand}":1053 lxd lxdtest1
 
   # Create first dummy interface for forkdns
   ip link add "${prefix}2" type dummy
@@ -1321,11 +1320,12 @@ test_clustering_dns() {
   mkdir "${lxdDir}"/networks/lxdtest2/forkdns.servers -p
 
   # Launch forkdns (we expect syslog error about missing servers.conf file)
-  lxd forkdns 127.0.1.2"${ipRand}":1053 lxd lxdtest2 &
-  forkdns_pid2=$!
+  lxd forkdns "${lxdDir}"/forkdns2.pid 127.0.1.2"${ipRand}":1053 lxd lxdtest2
 
   # Let the processes come up
   sleep 1
+  forkdns_pid1=$(cat "${lxdDir}/forkdns1.pid")
+  forkdns_pid2=$(cat "${lxdDir}/forkdns2.pid")
 
   # Create servers list file for forkdns1 pointing at forkdns2 (should be live reloaded)
   echo "127.0.1.2${ipRand}" > "${lxdDir}"/networks/lxdtest1/forkdns.servers/servers.conf
@@ -1360,8 +1360,8 @@ test_clustering_dns() {
   fi
 
   # Cleanup
-  kill ${forkdns_pid1}
-  kill ${forkdns_pid2}
+  kill "${forkdns_pid1}"
+  kill "${forkdns_pid2}"
   ip link delete "${prefix}1"
   ip link delete "${prefix}2"
 }


### PR DESCRIPTION
Adds double fork to forkdns.

Also adds PID path as first command argument.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>