### PR TITLE
main_forkdns: Restores usage output text when running with no arguments

### DIFF
--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -25,14 +25,9 @@ import (
 #include <errno.h>
 #include <fcntl.h>
 #include <stdbool.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/epoll.h>
-#include <sys/socket.h>
-#include <sys/stat.h>
-#include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 

--- a/lxd/main_forkdns.go
+++ b/lxd/main_forkdns.go
@@ -66,7 +66,13 @@ void forkdns()
 
 	close(STDIN_FILENO);
 
-	log_path = advance_arg(true);
+	log_path = advance_arg(false);
+	pid_path = advance_arg(false);
+
+	// If arguments are missing, fall through to Go part without double forking to output usage info.
+	if (log_path == NULL || pid_path == NULL)
+		return;
+
 	log_fd = open(log_path, O_WRONLY | O_CREAT | O_CLOEXEC | O_TRUNC, 0600);
 	if (log_fd < 0)
 		_exit(EXIT_FAILURE);
@@ -79,7 +85,6 @@ void forkdns()
 	if (ret < 0)
 		_exit(EXIT_FAILURE);
 
-	pid_path = advance_arg(true);
 	pid_file = fopen(pid_path, "we+");
 	if (!pid_file) {
 		fprintf(stderr,


### PR DESCRIPTION
@stgraber  emphasised the use of the usage text when running the program here https://github.com/lxc/lxd/pull/5817#discussion_r291122104

This change restores access to it when running without any arguments.

This PR also removes some unused includes.