### PR TITLE
forkmknod: attach to mntns when task is chrooted

### DIFF
--- a/lxd/main_forkmknod.go
+++ b/lxd/main_forkmknod.go
@@ -119,15 +119,6 @@ void forkmknod()
 	mode = atoi(advance_arg(true));
 	dev = atoi(advance_arg(true));
 
-	snprintf(cwd, sizeof(cwd), "/proc/%d/cwd", pid);
-	bytes = readlink(cwd, cwd_path, sizeof(cwd_path));
-	if (bytes < 0 || bytes >= sizeof(cwd_path)) {
-		fprintf(stderr, "Failed to retrieve cwd of target process: %s\n",
-			strerror(errno));
-		_exit(EXIT_FAILURE);
-	}
-	cwd_path[bytes] = '\0';
-
 	uid = get_root_uid(pid);
 	if (uid < 0)
 		fprintf(stderr, "No root uid found (%d)\n", uid);
@@ -136,13 +127,14 @@ void forkmknod()
 	if (gid < 0)
 		fprintf(stderr, "No root gid found (%d)\n", gid);
 
-	snprintf(cwd, sizeof(cwd), "/proc/%d/root", pid);
-	if (chroot(cwd)) {
+	snprintf(cwd, sizeof(cwd), "/proc/%d/cwd", pid);
+	if (chdir(cwd)) {
 		fprintf(stderr, "%d", errno);
 		_exit(EXIT_FAILURE);
 	}
 
-	if (chdir(cwd_path)) {
+	snprintf(cwd, sizeof(cwd), "/proc/%d/root", pid);
+	if (chroot(cwd)) {
 		fprintf(stderr, "%d", errno);
 		_exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
Have forkmknod attach to the mntns when the target is chrooted.

When the target is chrooted we can either go on to diff `/proc/<pid>/cwd`
and `/proc/<pid>/root`, strip what is identical from `/proc/<pid>/cwd`, then
`chroot("/proc/<pid>/root")` and take the remainder of `/proc/<pid>/cwd` to
be relative to the new root or we simply attach to the mnts and chdir to
`/proc/<pid>/cwd`. Guess what's simpler.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>