### PR TITLE
Use DHCP Release to remove dnsmasq leases to avoid restarting dnsmasq

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4374,7 +4374,10 @@ func (c *containerLXC) Delete() error {
 				continue
 			}
 
-			networkClearLease(c.state, c.name, m["parent"], m["hwaddr"])
+			err = networkClearLease(c.state, c.name, m["parent"], m["hwaddr"])
+			if err != nil {
+				logger.Error("Failed to delete DHCP lease", log.Ctx{"name": c.Name(), "err": err, "device": k, "hwaddr": m["hwaddr"]})
+			}
 		}
 	}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4363,6 +4363,9 @@ func (c *containerLXC) Delete() error {
 			return err
 		}
 
+		// Remove any static lease file
+		networkUpdateStatic(c.state, "")
+
 		// Update network files
 		for k, m := range c.expandedDevices {
 			if m["type"] != "nic" || m["nictype"] != "bridged" {
@@ -4399,11 +4402,6 @@ func (c *containerLXC) Delete() error {
 		if err != nil {
 			return err
 		}
-	}
-
-	if !c.IsSnapshot() {
-		// Remove any static lease file
-		networkUpdateStatic(c.state, "")
 	}
 
 	logger.Info("Deleted container", ctxMap)

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1289,12 +1289,19 @@ func (n *network) Start() error {
 		"--no-ping", // --no-ping is very important to prevent delays to lease file updates.
 		fmt.Sprintf("--interface=%s", n.name)}
 
+	dnsmasqVersion, err := networkGetDnsmasqVersion()
+
+	// --dhcp-rapid-commit option is only supported on >2.79
+	minVer, _ := version.NewDottedVersion("2.79")
+	if dnsmasqVersion.Compare(minVer) > 0 {
+		dnsmasqCmd = append(dnsmasqCmd, "--dhcp-rapid-commit")
+	}
+
 	if !debug {
 		// --quiet options are only supported on >2.67
 		minVer, _ := version.NewDottedVersion("2.67")
 
-		v, err := networkGetDnsmasqVersion()
-		if err == nil && v.Compare(minVer) > 0 {
+		if err == nil && dnsmasqVersion.Compare(minVer) > 0 {
 			dnsmasqCmd = append(dnsmasqCmd, []string{"--quiet-dhcp", "--quiet-dhcp6", "--quiet-ra"}...)
 		}
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1286,6 +1286,7 @@ func (n *network) Start() error {
 	dnsmasqCmd := []string{"dnsmasq", "--strict-order", "--bind-interfaces",
 		fmt.Sprintf("--pid-file=%s", shared.VarPath("networks", n.name, "dnsmasq.pid")),
 		"--except-interface=lo",
+		"--no-ping", // --no-ping is very important to prevent delays to lease file updates.
 		fmt.Sprintf("--interface=%s", n.name)}
 
 	if !debug {

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1180,65 +1180,98 @@ func networkClearLease(s *state.State, name string, network string, hwaddr strin
 		return nil
 	}
 
-	// Restart the network when we're done here
-	n, err := networkLoadByName(s, network)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		err := n.Start()
-		if err != nil {
-			logger.Errorf("Failed to reload network '%s': %v", network, err)
-		}
-	}()
-
-	// Stop dnsmasq
-	err = networkKillDnsmasq(network, false)
+	// Convert MAC string to bytes to avoid any case comparison issues later.
+	srcMAC, err := net.ParseMAC(hwaddr)
 	if err != nil {
 		return err
 	}
 
-	// Mangle the lease file
-	leases, err := ioutil.ReadFile(leaseFile)
+	iface, err := net.InterfaceByName(network)
 	if err != nil {
 		return err
 	}
 
-	fd, err := os.Create(leaseFile)
+	// Get IPv4 and IPv6 address of interface running dnsmasq on host.
+	addrs, err := iface.Addrs()
 	if err != nil {
 		return err
 	}
 
-	knownMac := networkGetMacSlice(hwaddr)
-	for _, lease := range strings.Split(string(leases), "\n") {
-		if lease == "" {
-			continue
-		}
-
-		fields := strings.Fields(lease)
-		if len(fields) > 2 {
-			if strings.Contains(fields[1], ":") {
-				leaseMac := networkGetMacSlice(fields[1])
-				leaseMacStr := strings.Join(leaseMac, ":")
-
-				knownMacStr := strings.Join(knownMac[len(knownMac)-len(leaseMac):], ":")
-				if knownMacStr == leaseMacStr {
-					continue
-				}
-			} else if len(fields) > 3 && fields[3] == name {
-				// Mostly IPv6 leases which don't contain a MAC address...
-				continue
-			}
-		}
-
-		_, err := fd.WriteString(fmt.Sprintf("%s\n", lease))
+	var dstIPv4, dstIPv6 net.IP
+	for _, addr := range addrs {
+		ip, _, err := net.ParseCIDR(addr.String())
 		if err != nil {
 			return err
 		}
+		if !ip.IsGlobalUnicast() {
+			continue
+		}
+		if ip.To4() == nil {
+			dstIPv6 = ip
+		} else {
+			dstIPv4 = ip
+		}
 	}
 
-	err = fd.Close()
+	// Iterate the dnsmasq leases file looking for matching leases for this container to release.
+	file, err := os.Open(leaseFile)
 	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	var dstDUID string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		fieldsLen := len(fields)
+
+		// Handle lease lines
+		if fieldsLen == 5 {
+			if srcMAC.String() == fields[1] { // Handle IPv4 leases by matching MAC address to lease.
+				srcIP := net.ParseIP(fields[2])
+
+				if dstIPv4 == nil {
+					logger.Errorf("Failed to release DHCPv4 lease for container \"%s\", IP \"%s\", MAC \"%s\", %v", name, srcIP, srcMAC, "No server address found")
+					continue
+				}
+
+				err = networkDHCPv4Release(srcMAC, srcIP, dstIPv4)
+				if err != nil {
+					logger.Errorf("Failed to release DHCPv4 lease for container \"%s\", IP \"%s\", MAC \"%s\", %v", name, srcIP, srcMAC, err)
+				}
+			} else if name == fields[3] { // Handle IPv6 addresses by matching hostname to lease.
+				IAID := fields[1]
+				srcIP := net.ParseIP(fields[2])
+				DUID := fields[4]
+
+				// Skip IPv4 addresses.
+				if srcIP.To4() != nil {
+					continue
+				}
+
+				if dstIPv6 == nil {
+					logger.Errorf("Failed to release DHCPv6 lease for container \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %s", name, srcIP, DUID, IAID, "No server address found")
+					continue // Cant send release packet if no dstIP found.
+				}
+
+				if dstDUID == "" {
+					logger.Errorf("Failed to release DHCPv6 lease for container \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %s", name, srcIP, DUID, IAID, "No server DUID found")
+					continue // Cant send release packet if no dstDUID found.
+				}
+
+				err = networkDHCPv6Release(DUID, IAID, srcIP, dstIPv6, dstDUID)
+				if err != nil {
+					logger.Errorf("Failed to release DHCPv6 lease for container \"%s\", IP \"%s\", DUID \"%s\", IAID \"%s\": %v", name, srcIP, DUID, IAID, err)
+				}
+			}
+		} else if fieldsLen == 2 && fields[0] == "duid" {
+			// Handle server DUID line needed for releasing IPv6 leases.
+			// This should come before the IPv6 leases in the lease file.
+			dstDUID = fields[1]
+		}
+	}
+	if err := scanner.Err(); err != nil {
 		return err
 	}
 

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1598,3 +1598,85 @@ func networkDHCPv4Release(srcMAC net.HardwareAddr, srcIP net.IP, dstIP net.IP) e
 	_, err = conn.Write(buf.Bytes())
 	return err
 }
+
+// networkDHCPv6Release sends a DHCPv6 release packet to a DHCP server.
+func networkDHCPv6Release(srcDUID string, srcIAID string, srcIP net.IP, dstIP net.IP, dstDUID string) error {
+	dstAddr, err := net.ResolveUDPAddr("udp6", fmt.Sprintf("[%s]:547", dstIP.String()))
+	if err != nil {
+		return err
+	}
+	conn, err := net.DialUDP("udp6", nil, dstAddr)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	// Construct a DHCPv6 packet pretending to be from the source IP and MAC supplied.
+	dhcp := layers.DHCPv6{
+		MsgType: layers.DHCPv6MsgTypeRelease,
+	}
+
+	// Convert Server DUID from string to byte array
+	dstDUIDRaw, err := hex.DecodeString(strings.Replace(dstDUID, ":", "", -1))
+	if err != nil {
+		return err
+	}
+
+	// Convert DUID from string to byte array
+	srcDUIDRaw, err := hex.DecodeString(strings.Replace(srcDUID, ":", "", -1))
+	if err != nil {
+		return err
+	}
+
+	// Convert IAID string to int
+	srcIAIDRaw, err := strconv.Atoi(srcIAID)
+	if err != nil {
+		return err
+	}
+
+	// Build the Identity Association details option manually (as not provided by gopacket).
+	iaAddr := networkDHCPv6CreateIAAddress(srcIP)
+	ianaRaw := networkDHCPv6CreateIANA(srcIAIDRaw, iaAddr)
+
+	// Add options to DHCP release packet.
+	dhcp.Options = append(dhcp.Options,
+		layers.NewDHCPv6Option(layers.DHCPv6OptServerID, dstDUIDRaw),
+		layers.NewDHCPv6Option(layers.DHCPv6OptClientID, srcDUIDRaw),
+		layers.NewDHCPv6Option(layers.DHCPv6OptIANA, ianaRaw),
+	)
+
+	buf := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		ComputeChecksums: true,
+		FixLengths:       true,
+	}
+
+	err = gopacket.SerializeLayers(buf, opts, &dhcp)
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Write(buf.Bytes())
+	return err
+}
+
+// networkDHCPv6CreateIANA creates a DHCPv6 Identity Association for Non-temporary Address (rfc3315 IA_NA) option.
+func networkDHCPv6CreateIANA(IAID int, IAAddr []byte) []byte {
+	data := make([]byte, 12)
+	binary.BigEndian.PutUint32(data[0:4], uint32(IAID)) // Identity Association Identifier
+	binary.BigEndian.PutUint32(data[4:8], uint32(0))    // T1
+	binary.BigEndian.PutUint32(data[8:12], uint32(0))   // T2
+	data = append(data, IAAddr...)                      // Append the IA Address details
+	return data
+}
+
+// networkDHCPv6CreateIAAddress creates a DHCPv6 Identity Association Address (rfc3315) option.
+func networkDHCPv6CreateIAAddress(IP net.IP) []byte {
+	data := make([]byte, 28)
+	binary.BigEndian.PutUint16(data[0:2], uint16(layers.DHCPv6OptIAAddr)) // Sub-Option type
+	binary.BigEndian.PutUint16(data[2:4], uint16(24))                     // Length (fixed at 24 bytes)
+	copy(data[4:20], IP)                                                  // IPv6 address to be released
+	binary.BigEndian.PutUint32(data[20:24], uint32(0))                    // Preferred liftetime
+	binary.BigEndian.PutUint32(data[24:28], uint32(0))                    // Valid lifetime
+	return data
+}

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -10,7 +10,7 @@ test_container_devices_nic_bridged() {
 
   # Standard bridge with random subnet and a bunch of options
   lxc network create "${brName}"
-  lxc network set "${brName}" dns.mode dynamic
+  lxc network set "${brName}" dns.mode managed
   lxc network set "${brName}" dns.domain blah
   lxc network set "${brName}" ipv4.nat true
   lxc network set "${brName}" ipv4.routing false
@@ -254,9 +254,35 @@ test_container_devices_nic_bridged() {
     false
   fi
 
-  # Cleanup.
-  lxc config device remove "${ctName}" eth0
+  # Test DHCP lease clearance.
   lxc delete "${ctName}" -f
+  lxc launch testimage "${ctName}" -p "${ctName}"
+
+  # Request DHCPv4 lease with custom name (to check managed name is allocated instead).
+  lxc exec "${ctName}" -- /sbin/udhcpc -i eth0 -F "${ctName}custom"
+
+  # Check DHCPv4 lease is allocated.
+  if ! grep -i "${ctMAC}" "${LXD_DIR}/networks/${brName}/dnsmasq.leases" ; then
+    echo "DHCPv4 lease not allocated"
+    false
+  fi
+
+  # Check DHCPv4 lease has DNS record assigned.
+  if ! dig @192.0.2.1 "${ctName}.blah" | grep "${ctName}.blah.\+0.\+IN.\+A.\+192.0.2." ; then
+    echo "DNS resolution of DHCP name failed"
+    false
+  fi
+
+  # Delete container, check LXD releases lease.
+  lxc delete "${ctName}" -f
+
+  # Check DHCPv4 lease is released.
+  if grep -i "${ctMAC}" "${LXD_DIR}/networks/${brName}/dnsmasq.leases" ; then
+    echo "DHCPv4 lease not released"
+    false
+  fi
+
+  # Cleanup.
   lxc network delete "${brName}"
   lxc profile delete "${ctName}"
 }


### PR DESCRIPTION
This PR addresses https://github.com/lxc/lxd/issues/5833 by sending DHCP release packets to dnsmasq when a container is deleted rather than stopping dnsmasq, manually removing the entry from the leases file and restarting dnsmasq.

Progress:

- [x] IPv4
- [x] IPv6
- [x] Tests