### PR TITLE
seccomp: retry with mount hotplug

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -725,6 +725,7 @@ type container interface {
 	Storage() storage
 	TemplateApply(trigger string) error
 	DaemonState() *state.State
+	InsertSeccompUnixDevice(prefix string, m types.Device, pid int) error
 
 	CurrentIdmap() (*idmap.IdmapSet, error)
 	DiskIdmap() (*idmap.IdmapSet, error)

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7399,6 +7399,37 @@ func (c *containerLXC) insertUnixDevice(prefix string, m types.Device, defaultMo
 	return nil
 }
 
+func (c *containerLXC) InsertSeccompUnixDevice(prefix string, m types.Device, pid int) error {
+	if pid < 0 {
+		return fmt.Errorf("Invalid request PID specified")
+	}
+
+	cwdLink := fmt.Sprintf("/proc/%d/cwd", pid)
+	prefixPath, err := os.Readlink(cwdLink)
+	if err != nil {
+		return err
+	}
+
+	rootLink := fmt.Sprintf("/proc/%d/root", pid)
+	rootPath, err := os.Readlink(rootLink)
+	if err != nil {
+		return err
+	}
+
+	prefixPath = strings.TrimPrefix(prefixPath, rootPath)
+	m["path"] = filepath.Join(rootPath, prefixPath, m["path"])
+	paths, err := c.createUnixDevice(prefix, m, true)
+	if err != nil {
+		return fmt.Errorf("Failed to setup device: %s", err)
+	}
+	devPath := paths[0]
+	tgtPath := paths[1]
+
+	// Bind-mount it into the container
+	defer os.Remove(devPath)
+	return c.insertMountLXD(devPath, tgtPath, "none", unix.MS_BIND, pid)
+}
+
 func (c *containerLXC) insertUnixDeviceNum(name string, m types.Device, major int, minor int, path string, defaultMode bool) error {
 	temp := types.Device{}
 	if err := shared.DeepCopy(&m, &temp); err != nil {
@@ -7761,7 +7792,7 @@ func (c *containerLXC) removeUnixDevices() error {
 	// Go through all the unix devices
 	for _, f := range dents {
 		// Skip non-Unix devices
-		if !strings.HasPrefix(f.Name(), "unix.") && !strings.HasPrefix(f.Name(), "infiniband.unix.") {
+		if !strings.HasPrefix(f.Name(), "forkmknod.unix.") && !strings.HasPrefix(f.Name(), "unix.") && !strings.HasPrefix(f.Name(), "infiniband.unix.") {
 			continue
 		}
 


### PR DESCRIPTION
When device creation via mknod fails, fallback to messing with mounts.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>