### PR TITLE
networks: Fixes bug preventing 3rd party routes from being restored

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1219,12 +1219,6 @@ func (n *network) Start() error {
 		return err
 	}
 
-	// Restore container specific IPv4 routes to interface.
-	err = networkApplyBootRoutesV4(n.name, ctRoutes)
-	if err != nil {
-		return err
-	}
-
 	_, err = shared.RunCommand("ip", "-4", "route", "flush", "dev", n.name, "proto", "static")
 	if err != nil {
 		return err
@@ -1375,6 +1369,12 @@ func (n *network) Start() error {
 				}
 			}
 		}
+
+		// Restore container specific IPv4 routes to interface.
+		err = networkApplyBootRoutesV4(n.name, ctRoutes)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Remove any existing IPv6 iptables rules
@@ -1397,12 +1397,6 @@ func (n *network) Start() error {
 
 	// Flush all IPv6 addresses and routes
 	_, err = shared.RunCommand("ip", "-6", "addr", "flush", "dev", n.name, "scope", "global")
-	if err != nil {
-		return err
-	}
-
-	// Restore container specific IPv6 routes to interface.
-	err = networkApplyBootRoutesV6(n.name, ctRoutes)
 	if err != nil {
 		return err
 	}
@@ -1561,6 +1555,12 @@ func (n *network) Start() error {
 					return err
 				}
 			}
+		}
+
+		// Restore container specific IPv6 routes to interface.
+		err = networkApplyBootRoutesV6(n.name, ctRoutes)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1391,7 +1391,7 @@ func networkListBootRoutesV4(devName string) ([]string, error) {
 	cmd.Start()
 	scanner := bufio.NewScanner(ipOut)
 	for scanner.Scan() {
-		route := scanner.Text()
+		route := strings.Replace(scanner.Text(), "linkdown", "", -1)
 		routes = append(routes, route)
 	}
 	cmd.Wait()
@@ -1409,7 +1409,7 @@ func networkListBootRoutesV6(devName string) ([]string, error) {
 	cmd.Start()
 	scanner := bufio.NewScanner(ipOut)
 	for scanner.Scan() {
-		route := scanner.Text()
+		route := strings.Replace(scanner.Text(), "linkdown", "", -1)
 		routes = append(routes, route)
 	}
 	cmd.Wait()

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -70,7 +70,7 @@ test_container_devices_nic_bridged() {
   lxc exec "${ctName}" -- ip -4 route add default dev eth0
   ping -c2 -W1 "192.0.2.1${ipRand}"
   lxc exec "${ctName}" -- ip -6 addr add "2001:db8::1${ipRand}/128" dev eth0
-  sleep 1 #Wait for link local gateway advert.
+  sleep 2 #Wait for link local gateway advert.
   ping6 -c2 -W1 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.


### PR DESCRIPTION
networks: Fixes bug preventing 3rd party routes from being restored on network start.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>