### PR TITLE
lxc/export: Bump expiry to 24 hours

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -65,7 +65,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 
 	req := api.ContainerBackupsPost{
 		Name:             "",
-		ExpiryDate:       time.Now().Add(30 * time.Minute),
+		ExpiryDate:       time.Now().Add(24 * time.Hour),
 		ContainerOnly:    c.flagContainerOnly,
 		OptimizedStorage: c.flagOptimizedStorage,
 	}

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -242,7 +242,7 @@ test_container_devices_nic_p2p() {
   fi
 
   # Now add a nic to a stopped container with routes.
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
   lxc config device add "${ctName}" eth0 nic \
     nictype=p2p \
     ipv4.routes="192.0.2.2${ipRand}/32" \

--- a/test/suites/container_devices_nic_physical.sh
+++ b/test/suites/container_devices_nic_physical.sh
@@ -38,7 +38,7 @@ test_container_devices_nic_physical() {
   fi
 
   # Stop container and check MTU is restored.
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 
   # Check original MTU is restored on physical device.
   if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
@@ -164,7 +164,7 @@ test_container_devices_nic_physical() {
     mtu=1402 #Higher than 1400 boot time value above
 
   # Stop the container, LXC doesn't know about the nic, so we will rely on LXD to restore it.
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 
   # Check original MTU is restored on physical device.
   if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then

--- a/test/suites/container_devices_nic_sriov.sh
+++ b/test/suites/container_devices_nic_sriov.sh
@@ -69,7 +69,7 @@ test_container_devices_nic_sriov() {
     fi
   fi
 
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 
   # Set custom MAC
   lxc config device set "${ctName}" eth0 hwaddr "${ctMAC1}"
@@ -82,7 +82,7 @@ test_container_devices_nic_sriov() {
     false
   fi
 
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 
   # Disable mac filtering and try fresh boot
   lxc config device set "${ctName}" eth0 security.mac_filtering false
@@ -108,7 +108,7 @@ test_container_devices_nic_sriov() {
     false
   fi
 
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 
   # Test setting MAC offline
   lxc config device set "${ctName}" eth1 hwaddr "${ctMAC2}"
@@ -121,5 +121,5 @@ test_container_devices_nic_sriov() {
     false
   fi
 
-  lxc stop "${ctName}"
+  lxc stop -f "${ctName}"
 }

--- a/test/suites/storage_snapshots.sh
+++ b/test/suites/storage_snapshots.sh
@@ -44,7 +44,7 @@ test_storage_volume_snapshots() {
   # is attached to the container
   ! lxc storage volume restore "${storage_pool}" "${storage_volume}" snap0 || false
 
-  lxc stop c1
+  lxc stop -f c1
   lxc storage volume restore "${storage_pool}" "${storage_volume}" snap0
 
   lxc start c1


### PR DESCRIPTION
Some users after containers that take hours to backup, the one hour expiry would cause them to expire before they've been retrieved. As we immediately call Delete on the backup post-export, the expiry is only needed to handle with crashes/network issues so 24 hours should be fine.