### PR TITLE
main/daemon: Fixes test runner by allowing empty command arg

### DIFF
--- a/lxd/main_daemon.go
+++ b/lxd/main_daemon.go
@@ -40,7 +40,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 }
 
 func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
-	if len(args) > 1 || (len(args) == 1 && args[0] != "daemon") {
+	if len(args) > 1 || (len(args) == 1 && args[0] != "daemon" && args[0] != "") {
 		return fmt.Errorf("unknown command \"%s\" for \"%s\"", args[0], cmd.CommandPath())
 	}
 


### PR DESCRIPTION
This change https://github.com/lxc/lxd/commit/0c51a6574afe002a2ac795f42eff09f78eb9b5ed was upsetting the test runner because of this: 

https://github.com/lxc/lxd/blob/master/test/includes/lxd.sh#L46

Specifically the `"${DEBUG-}"` bit.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>