### PR TITLE
Fixes dnsmasq host file cleanup

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4399,7 +4399,9 @@ func (c *containerLXC) Delete() error {
 	}
 
 	if !c.IsSnapshot() {
-		// Remove any static lease file
+		// Remove any static lease file *after* container config has been removed from cluster.
+		// This ordering is important, as if it is done earlier than c.state.Cluster.ContainerRemove
+		// then the static host config is re-created and left after the container is deleted.
 		networkUpdateStatic(c.state, "")
 	}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4360,9 +4360,6 @@ func (c *containerLXC) Delete() error {
 			return err
 		}
 
-		// Remove any static lease file
-		networkUpdateStatic(c.state, "")
-
 		// Update network files
 		for k, m := range c.expandedDevices {
 			if m["type"] != "nic" || m["nictype"] != "bridged" {
@@ -4399,6 +4396,11 @@ func (c *containerLXC) Delete() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if !c.IsSnapshot() {
+		// Remove any static lease file
+		networkUpdateStatic(c.state, "")
 	}
 
 	logger.Info("Deleted container", ctxMap)

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -282,6 +282,12 @@ test_container_devices_nic_bridged() {
     false
   fi
 
+  # Check dnsmasq host config file is removed.
+  if [ -f "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctName}" ] ; then
+    echo "dnsmasq host config file not removed"
+    false
+  fi
+
   # Cleanup.
   lxc network delete "${brName}"
   lxc profile delete "${ctName}"


### PR DESCRIPTION
One of my earlier attempts to keep the dnsmasq cleanup code together has introduced a bug where the dnsmasq host config file is not removed on container delete.

This PR reverts the original problem commit, adds comments explaining why the ordering is important, and adds a test to ensure it isn't re-introduced in the future.