### PR TITLE
Refreshes dnsmasq config on NIC add/remove

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5790,12 +5790,15 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 		}
 	}
 
-	// Update network leases
+	// Update network leases if a bridged device has changed.
 	needsUpdate := false
-	for _, m := range updateDevices {
-		if m["type"] == "nic" && m["nictype"] == "bridged" {
-			needsUpdate = true
-			break
+	deviceLists := []map[string]types.Device{removeDevices, addDevices, updateDevices}
+	for _, deviceList := range deviceLists {
+		for _, m := range deviceList {
+			if m["type"] == "nic" && m["nictype"] == "bridged" {
+				needsUpdate = true
+				break
+			}
 		}
 	}
 


### PR DESCRIPTION
Previously dnsmasq config was not refreshed when a NIC was added or removed, resulting in static IP config not being applied consistently.