### PR TITLE
IP Filtering with dynamic IPs

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -443,19 +443,11 @@ func containerValidDevices(cluster *db.Cluster, devices types.Devices, profile b
 				if m["nictype"] != "bridged" {
 					return fmt.Errorf("Bad nic type for security.ipv4_filtering: %s", m["nictype"])
 				}
-
-				if m["ipv4.address"] == "" {
-					return fmt.Errorf("ipv4.address required for security.ipv4_filtering")
-				}
 			}
 
 			if shared.IsTrue(m["security.ipv6_filtering"]) {
 				if m["nictype"] != "bridged" {
 					return fmt.Errorf("Bad nic type for security.ipv6_filtering: %s", m["nictype"])
-				}
-
-				if m["ipv6.address"] == "" {
-					return fmt.Errorf("ipv6.address required for security.ipv6_filtering")
 				}
 			}
 		} else if m["type"] == "infiniband" {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8698,7 +8698,7 @@ func (c *containerLXC) generateNetworkFilterEbtablesRules(m types.Device, IPv4 n
 }
 
 // generateNetworkFilterIptablesRules returns a customised set of iptables filter rules based on the device.
-func (c *containerLXC) generateNetworkFilterIptablesRules(m types.Device) (rules [][]string, err error) {
+func (c *containerLXC) generateNetworkFilterIptablesRules(m types.Device, IPv6 net.IP) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(m["hwaddr"])
 	if err != nil {
 		return
@@ -8714,14 +8714,8 @@ func (c *containerLXC) generateNetworkFilterIptablesRules(m types.Device) (rules
 	// not assigned to the container by sending a specially crafted gratuitous NDP packet with
 	// correct source address and MAC at the IP & ethernet layers, but a fraudulent IP or MAC
 	// inside the ICMPv6 NDP packet.
-	if shared.IsTrue(m["security.ipv6_filtering"]) && m["ipv6.address"] != "" {
-		ipv6 := net.ParseIP(m["ipv6.address"])
-		if ipv6 == nil {
-			err = fmt.Errorf("Invalid IPv6 address")
-			return
-		}
-
-		ipv6Hex := hex.EncodeToString(ipv6)
+	if shared.IsTrue(m["security.ipv6_filtering"]) && IPv6 != nil {
+		ipv6Hex := hex.EncodeToString(IPv6)
 
 		rules = append(rules,
 			// Prevent Neighbor Advertisement IP spoofing (prevents the container redirecting traffic for IPs that are not its own).

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2134,6 +2134,14 @@ func (c *containerLXC) startCommon() (string, error) {
 			if m["parent"] != "" && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", m["parent"])) {
 				return "", fmt.Errorf("Missing parent '%s' for nic '%s'", m["parent"], name)
 			}
+
+			if shared.IsTrue(m["security.ipv6_filtering"]) {
+				// Check br_netfilter is loaded and enabled for IPv6.
+				sysctlVal, err := networkSysctlGet("bridge/bridge-nf-call-ip6tables")
+				if err != nil || sysctlVal != "1\n" {
+					return "", errors.Wrapf(err, "security.ipv6_filtering requires br_netfilter and sysctl net.bridge.bridge-nf-call-ip6tables=1")
+				}
+			}
 		case "unix-char", "unix-block":
 			srcPath, exist := m["source"]
 			if !exist {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3760,12 +3760,12 @@ func (c *containerLXC) setupHostVethDevice(deviceName string, device types.Devic
 		return fmt.Errorf("Failed to find host side veth name for device \"%s\"", deviceName)
 	}
 
-	// Remove any old network filters
+	// Remove any old network filters.
 	if oldDevice["nictype"] == "bridged" && shared.IsTrue(oldDevice["security.mac_filtering"]) || shared.IsTrue(oldDevice["security.ipv4_filtering"]) || shared.IsTrue(oldDevice["security.ipv6_filtering"]) {
 		c.removeNetworkFilters(deviceName, oldDevice)
 	}
 
-	// Setup network filters
+	// Setup network filters.
 	if device["nictype"] == "bridged" && shared.IsTrue(device["security.mac_filtering"]) || shared.IsTrue(device["security.ipv4_filtering"]) || shared.IsTrue(device["security.ipv6_filtering"]) {
 		err := c.setNetworkFilters(deviceName, device)
 		if err != nil {
@@ -3773,7 +3773,7 @@ func (c *containerLXC) setupHostVethDevice(deviceName string, device types.Devic
 		}
 	}
 
-	// Refresh tc limits
+	// Refresh tc limits.
 	err := c.setNetworkLimits(device)
 	if err != nil {
 		return err
@@ -3784,7 +3784,7 @@ func (c *containerLXC) setupHostVethDevice(deviceName string, device types.Devic
 		c.removeNetworkRoutes(deviceName, oldDevice)
 	}
 
-	// Setup static routes to container
+	// Setup static routes to container.
 	err = c.setNetworkRoutes(device)
 	if err != nil {
 		return err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8754,6 +8754,9 @@ func (c *containerLXC) setNetworkFilters(deviceName string, m types.Device) (err
 		}
 	}
 
+	// Retrieve existing IPs, or allocate new ones if needed.
+	IPv4, IPv6, err := c.allocateNetworkFilterIPs(deviceName, m)
+
 	// If anything goes wrong, clean up so we don't leave orphaned rules.
 	defer func() {
 		if err != nil {
@@ -8761,7 +8764,7 @@ func (c *containerLXC) setNetworkFilters(deviceName string, m types.Device) (err
 		}
 	}()
 
-	rules := c.generateNetworkFilterEbtablesRules(m)
+	rules := c.generateNetworkFilterEbtablesRules(m, IPv4, IPv6)
 	for _, rule := range rules {
 		_, err = shared.RunCommand(rule[0], rule[1:]...)
 		if err != nil {
@@ -8769,7 +8772,7 @@ func (c *containerLXC) setNetworkFilters(deviceName string, m types.Device) (err
 		}
 	}
 
-	rules, err = c.generateNetworkFilterIptablesRules(m)
+	rules, err = c.generateNetworkFilterIptablesRules(m, IPv6)
 	if err != nil {
 		return err
 	}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1411,23 +1411,7 @@ func networkUpdateStatic(s *state.State, networkName string) error {
 			}
 
 			// Generate the dhcp-host line
-			if ipv4Address != "" {
-				line += fmt.Sprintf(",%s", ipv4Address)
-			}
-
-			if ipv6Address != "" {
-				line += fmt.Sprintf(",[%s]", ipv6Address)
-			}
-
-			if config["dns.mode"] == "" || config["dns.mode"] == "managed" {
-				line += fmt.Sprintf(",%s", cName)
-			}
-
-			if line == hwaddr {
-				continue
-			}
-
-			err := ioutil.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", projectPrefix(project, cName)), []byte(line+"\n"), 0644)
+			err := networkUpdateStaticContainer(network, project, cName, config, hwaddr, ipv4Address, ipv6Address)
 			if err != nil {
 				return err
 			}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -879,6 +879,153 @@ func networkGetDnsmasqVersion() (*version.DottedVersion, error) {
 	return version.NewDottedVersion(lines[2])
 }
 
+// dhcpAllocation represents an IP allocation from dnsmasq.
+type dhcpAllocation struct {
+	IP     net.IP
+	Name   string
+	MAC    net.HardwareAddr
+	Static bool
+}
+
+// networkDHCPStaticContainerIPs retrieves the dnsmasq statically allocated IPs for a container.
+// Returns IPv4 and IPv6 dhcpAllocation structs respectively.
+func networkDHCPStaticContainerIPs(network string, containerName string) (dhcpAllocation, dhcpAllocation, error) {
+	var IPv4, IPv6 dhcpAllocation
+
+	file, err := os.Open(shared.VarPath("networks", network, "dnsmasq.hosts") + "/" + containerName)
+	if err != nil {
+		return IPv4, IPv6, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.SplitN(scanner.Text(), ",", -1)
+		for _, field := range fields {
+			// Check if field is IPv4 or IPv6 address.
+			if strings.Count(field, ".") == 3 {
+				IP := net.ParseIP(field)
+				if IP.To4() == nil {
+					return IPv4, IPv6, fmt.Errorf("Error parsing IP address: %v", field)
+				}
+				IPv4 = dhcpAllocation{Name: containerName, Static: true, IP: IP.To4()}
+
+			} else if strings.HasPrefix(field, "[") && strings.HasSuffix(field, "]") {
+				IP := net.ParseIP(field[1 : len(field)-1])
+				if IP == nil {
+					return IPv4, IPv6, fmt.Errorf("Error parsing IP address: %v", field)
+				}
+				IPv6 = dhcpAllocation{Name: containerName, Static: true, IP: IP}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return IPv4, IPv6, err
+	}
+
+	return IPv4, IPv6, nil
+}
+
+// networkDHCPAllocatedIPs returns a map of IPs currently allocated (statically and dynamically)
+// in dnsmasq for a specific network. The returned map is keyed by a 16 byte array representing
+// the net.IP format. The value of each map item is a dhcpAllocation struct containing at least
+// whether the allocation was static or dynamic and optionally container name or MAC address.
+// MAC addresses are only included for dynamic IPv4 allocations (where name is not reliable).
+// Static allocations are not overridden by dynamic allocations, allowing for container name to be
+// included for static IPv6 allocations. IPv6 addresses that are dynamically assigned cannot be
+// reliably linked to containers using either name or MAC because dnsmasq does not record the MAC
+// address for these records, and the recorded host name can be set by the container if the dns.mode
+// for the network is set to "dynamic" and so cannot be trusted, so in this case we do not return
+// any identifying info.
+func networkDHCPAllocatedIPs(network string) (map[[4]byte]dhcpAllocation, map[[16]byte]dhcpAllocation, error) {
+	IPv4s := make(map[[4]byte]dhcpAllocation)
+	IPv6s := make(map[[16]byte]dhcpAllocation)
+
+	// First read all statically allocated IPs.
+	files, err := ioutil.ReadDir(shared.VarPath("networks", network, "dnsmasq.hosts"))
+	if err != nil {
+		return IPv4s, IPv6s, err
+	}
+
+	for _, entry := range files {
+		IPv4, IPv6, err := networkDHCPStaticContainerIPs(network, entry.Name())
+		if err != nil {
+			return IPv4s, IPv6s, err
+		}
+
+		if IPv4.IP != nil {
+			var IPKey [4]byte
+			copy(IPKey[:], IPv4.IP.To4())
+			IPv4s[IPKey] = IPv4
+		}
+
+		if IPv6.IP != nil {
+			var IPKey [16]byte
+			copy(IPKey[:], IPv6.IP.To16())
+			IPv6s[IPKey] = IPv6
+		}
+	}
+
+	// Next read all dynamic allocated IPs.
+	file, err := os.Open(shared.VarPath("networks", network, "dnsmasq.leases"))
+	if err != nil {
+		return IPv4s, IPv6s, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) == 5 {
+			IP := net.ParseIP(fields[2])
+			if IP == nil {
+				return IPv4s, IPv6s, fmt.Errorf("Error parsing IP address: %v", fields[2])
+			}
+
+			// Handle IPv6 addresses.
+			if IP.To4() == nil {
+				var IPKey [16]byte
+				copy(IPKey[:], IP.To16())
+
+				// Don't replace IPs from static config as more reliable.
+				if IPv6s[IPKey].Name != "" {
+					continue
+				}
+
+				IPv6s[IPKey] = dhcpAllocation{
+					Static: false,
+					IP:     IP.To16(),
+				}
+			} else {
+				// MAC only available in IPv4 leases.
+				MAC, err := net.ParseMAC(fields[1])
+				if err != nil {
+					return IPv4s, IPv6s, err
+				}
+
+				var IPKey [4]byte
+				copy(IPKey[:], IP.To4())
+
+				// Don't replace IPs from static config as more reliable.
+				if IPv4s[IPKey].Name != "" {
+					continue
+				}
+
+				IPv4s[IPKey] = dhcpAllocation{
+					MAC:    MAC,
+					Static: false,
+					IP:     IP.To4(),
+				}
+			}
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return IPv4s, IPv6s, err
+	}
+
+	return IPv4s, IPv6s, nil
+}
+
 func networkUpdateStatic(s *state.State, networkName string) error {
 	// We don't want to race with ourselves here
 	networkStaticLock.Lock()

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1321,6 +1321,21 @@ func networkUpdateStatic(s *state.State, networkName string) error {
 				entries[d["parent"]] = [][]string{}
 			}
 
+			if (shared.IsTrue(d["security.ipv4_filtering"]) && d["ipv4.address"] == "") || (shared.IsTrue(d["security.ipv6_filtering"]) && d["ipv6.address"] == "") {
+				curIPv4, curIPv6, err := networkDHCPStaticContainerIPs(d["parent"], c.Name())
+				if err != nil && !os.IsNotExist(err) {
+					return err
+				}
+
+				if d["ipv4.address"] == "" && curIPv4.IP != nil {
+					d["ipv4.address"] = curIPv4.IP.String()
+				}
+
+				if d["ipv6.address"] == "" && curIPv6.IP != nil {
+					d["ipv6.address"] = curIPv6.IP.String()
+				}
+			}
+
 			entries[d["parent"]] = append(entries[d["parent"]], []string{d["hwaddr"], c.Project(), c.Name(), d["ipv4.address"], d["ipv6.address"]})
 		}
 	}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1247,6 +1247,35 @@ func networkDHCPFindFreeIPv4(usedIPs map[[4]byte]dhcpAllocation, netConfig map[s
 	return nil, fmt.Errorf("No available IP could not be found")
 }
 
+// networkUpdateStaticContainer writes a single dhcp-host line for a container/network combination.
+func networkUpdateStaticContainer(network string, project string, cName string, netConfig map[string]string, hwaddr string, ipv4Address string, ipv6Address string) error {
+	line := hwaddr
+
+	// Generate the dhcp-host line
+	if ipv4Address != "" {
+		line += fmt.Sprintf(",%s", ipv4Address)
+	}
+
+	if ipv6Address != "" {
+		line += fmt.Sprintf(",[%s]", ipv6Address)
+	}
+
+	if netConfig["dns.mode"] == "" || netConfig["dns.mode"] == "managed" {
+		line += fmt.Sprintf(",%s", cName)
+	}
+
+	if line == hwaddr {
+		return nil
+	}
+
+	err := ioutil.WriteFile(shared.VarPath("networks", network, "dnsmasq.hosts", projectPrefix(project, cName)), []byte(line+"\n"), 0644)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func networkUpdateStatic(s *state.State, networkName string) error {
 	// We don't want to race with ourselves here
 	networkStaticLock.Lock()

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -142,6 +142,42 @@ test_container_devices_nic_bridged_filtering() {
       false
   fi
 
+  # Remove static IP and check IP filter works with previous DHCP release.
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  lxc config device unset "${ctPrefix}A" eth0 ipv4.address
+  lxc start "${ctPrefix}A"
+  if ! grep "192.0.2.2" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+    echo "dnsmasq host config doesnt contain previous lease as static IPv4 config"
+    false
+  fi
+
+  lxc stop "${ctPrefix}A"
+  lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering false
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+
+  # Simulate 192.0.2.2 being used by another container, next free IP is 192.0.2.3
+  kill "$(cat "${LXD_DIR}"/networks/"${brName}"/dnsmasq.pid)"
+  echo "$(date --date="1hour" +%s) 00:16:3e:55:4c:fd 192.0.2.2 c1 ff:6f:c3:ab:c5:00:02:00:00:ab:11:f8:5c:3d:73:db:b2:6a:06" > "${LXD_DIR}/networks/${brName}/dnsmasq.leases"
+  shutdown_lxd "${LXD_DIR}"
+  respawn_lxd "${LXD_DIR}" true
+  lxc config device set "${ctPrefix}A" eth0 security.ipv4_filtering true
+  lxc start "${ctPrefix}A"
+
+  if ! grep "192.0.2.3" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+    echo "dnsmasq host config doesnt contain sequentially allocated static IPv4 config"
+    false
+  fi
+
+  # Simulate changing DHCPv4 ranges.
+  lxc stop "${ctPrefix}A"
+  lxc network set "${brName}" ipv4.dhcp.ranges "192.0.2.100-192.0.2.110"
+  lxc start "${ctPrefix}A"
+
+  if ! grep "192.0.2.100" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+    echo "dnsmasq host config doesnt contain sequentially range allocated static IPv4 config"
+    false
+  fi
+
   # Make sure br_netfilter is loaded, needed for IPv6 filtering.
   modprobe br_netfilter || true
   if ! grep 1 /proc/sys/net/bridge/bridge-nf-call-ip6tables ; then
@@ -154,7 +190,6 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Add a fake IPv6 and check connectivity
-  lxc start "${ctPrefix}A"
   lxc exec "${ctPrefix}B" -- ip -6 a add 2001:db8::3/64 dev eth0
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
   lxc exec "${ctPrefix}A" -- ip -6 a add 2001:db8::254 dev eth0
@@ -223,6 +258,34 @@ test_container_devices_nic_bridged_filtering() {
   if ebtables -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
       echo "IPv6 filter still applied as part of ipv6_filtering in ebtables"
       false
+  fi
+
+  # Set static MAC so that SLAAC address is derived predictably and check it is applied to static config.
+  lxc config device unset "${ctPrefix}A" eth0 ipv6.address
+  lxc config device set "${ctPrefix}A" eth0 hwaddr 00:16:3e:92:f3:c1
+  lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering false
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+  lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering true
+  lxc start "${ctPrefix}A"
+  if ! grep "\[2001:db8::216:3eff:fe92:f3c1\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+    echo "dnsmasq host config doesnt contain dynamically allocated static IPv6 config"
+    false
+  fi
+
+  lxc stop "${ctPrefix}A"
+  lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering false
+  rm "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A"
+
+  # Simulate SLAAC 2001:db8::216:3eff:fe92:f3c1 being used by another container, next free IP is 2001:db8::2
+  kill "$(cat "${LXD_DIR}"/networks/"${brName}"/dnsmasq.pid)"
+  echo "$(date --date="1hour" +%s) 1875094469 2001:db8::216:3eff:fe92:f3c1 c1 00:02:00:00:ab:11:f8:5c:3d:73:db:b2:6a:06" > "${LXD_DIR}/networks/${brName}/dnsmasq.leases"
+  shutdown_lxd "${LXD_DIR}"
+  respawn_lxd "${LXD_DIR}" true
+  lxc config device set "${ctPrefix}A" eth0 security.ipv6_filtering true
+  lxc start "${ctPrefix}A"
+  if ! grep "\[2001:db8::2\]" "${LXD_DIR}/networks/${brName}/dnsmasq.hosts/${ctPrefix}A" ; then
+    echo "dnsmasq host config doesnt contain sequentially allocated static IPv6 config"
+    false
   fi
 
   lxc delete -f "${ctPrefix}A"


### PR DESCRIPTION
Adds support for using IP filtering with dynamically allocated IPs.

- [x] DHCPv4 and DHCPv6 support
- [x] SLAAC support
- [x] Updated tests
- [x] Custom DHCP ranges & tests
