### PR TITLE
forknet: Cleans up forknet detach error logging and output

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2743,7 +2743,7 @@ func (c *containerLXC) detachInterfaceRename(netns string, ifName string, hostNa
 
 	// Process forknet detach response
 	if err != nil {
-		logger.Error("Error calling 'lxd forknet detach", log.Ctx{"container": c.name, "output": out, "pid": c.InitPID()})
+		logger.Error("Error calling 'lxd forknet detach", log.Ctx{"container": c.name, "output": out, "netns": netns, "ifName": ifName, "hostName": hostName, "pid": lxdPID})
 	}
 
 	return nil

--- a/lxd/main_forknet.go
+++ b/lxd/main_forknet.go
@@ -134,6 +134,18 @@ func (c *cmdForknet) RunDetach(cmd *cobra.Command, args []string) error {
 	ifName := args[2]
 	hostName := args[3]
 
+	if lxdPID == "" {
+		return fmt.Errorf("LXD PID argument is required")
+	}
+
+	if ifName == "" {
+		return fmt.Errorf("ifname argument is required")
+	}
+
+	if hostName == "" {
+		return fmt.Errorf("hostname argument is required")
+	}
+
 	// Remove all IP addresses from interface before moving to parent netns.
 	// This is to avoid any container address config leaking into host.
 	_, err := shared.RunCommand("ip", "address", "flush", "dev", ifName)
@@ -147,6 +159,5 @@ func (c *cmdForknet) RunDetach(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Println("OK")
 	return nil
 }

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -78,7 +78,7 @@ test_container_devices_nic_bridged_filtering() {
   lxc exec "${ctPrefix}A" -- ping -c2 -W1 192.0.2.3
 
   # Stop CT A and check filters are cleaned up.
-  lxc stop "${ctPrefix}A"
+  lxc stop -f "${ctPrefix}A"
   if ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter still applied in ebtables"
       false
@@ -136,7 +136,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Stop CT A and check filters are cleaned up.
-  lxc stop "${ctPrefix}A"
+  lxc stop -f "${ctPrefix}A"
   if ebtables -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
       echo "IPv4 filter still applied as part of ipv4_filtering in ebtables"
       false
@@ -219,7 +219,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Stop CT A and check filters are cleaned up.
-  lxc stop "${ctPrefix}A"
+  lxc stop -f "${ctPrefix}A"
   if ebtables -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
       echo "IPv6 filter still applied as part of ipv6_filtering in ebtables"
       false


### PR DESCRIPTION
Also removes -f from stop command in physical nic tests as not needed.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>