### PR TITLE
networks/utils: Remove unused state.State from networkClearLease()

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4380,7 +4380,7 @@ func (c *containerLXC) Delete() error {
 				continue
 			}
 
-			err = networkClearLease(c.state, c.name, m["parent"], m["hwaddr"])
+			err = networkClearLease(c.name, m["parent"], m["hwaddr"])
 			if err != nil {
 				logger.Error("Failed to delete DHCP lease", log.Ctx{"name": c.Name(), "err": err, "device": k, "hwaddr": m["hwaddr"]})
 			}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1568,7 +1568,7 @@ func networkGetMacSlice(hwaddr string) []string {
 	return buf
 }
 
-func networkClearLease(s *state.State, name string, network string, hwaddr string) error {
+func networkClearLease(name string, network string, hwaddr string) error {
 	leaseFile := shared.VarPath("networks", network, "dnsmasq.leases")
 
 	// Check that we are in fact running a dnsmasq for the network


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>