### PR TITLE
container/lxc: Fixes showing host_name of veth pair in lxc info

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7173,6 +7173,14 @@ func (c *containerLXC) networkState() map[string]api.ContainerStateNetwork {
 		result = nw
 	}
 
+	// Get host_name from volatile data if not set already.
+	for name, dev := range result {
+		if dev.HostName == "" {
+			dev.HostName = c.localConfig[fmt.Sprintf("volatile.%s.host_name", name)]
+			result[name] = dev
+		}
+	}
+
 	return result
 }
 


### PR DESCRIPTION
This now reads from volatile data if not available from kernel.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>