### PR TITLE
Device Utils

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2763,7 +2763,7 @@ func (c *containerLXC) restorePhysicalNic(deviceName string, hostName string) er
 
 	// If we created the "physical" device and then it should be removed.
 	if shared.IsTrue(c.localConfig[createdKey]) {
-		return deviceRemoveInterface(hostName)
+		return device.NetworkRemoveInterface(hostName)
 	}
 
 	// Bring the interface down, as this is sometimes needed to change settings on the nic.
@@ -8313,7 +8313,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 		if m["nictype"] == "bridged" {
 			err = networkAttachInterface(m["parent"], n1)
 			if err != nil {
-				deviceRemoveInterface(n2)
+				device.NetworkRemoveInterface(n2)
 				return "", fmt.Errorf("Failed to add interface to bridge: %s", err)
 			}
 
@@ -8356,7 +8356,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 	if m["hwaddr"] != "" {
 		_, err := shared.RunCommand("ip", "link", "set", "dev", dev, "address", m["hwaddr"])
 		if err != nil {
-			deviceRemoveInterface(dev)
+			device.NetworkRemoveInterface(dev)
 			return "", fmt.Errorf("Failed to set the MAC address: %s", err)
 		}
 	}
@@ -8365,7 +8365,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 	if m["mtu"] != "" {
 		_, err := shared.RunCommand("ip", "link", "set", "dev", dev, "mtu", m["mtu"])
 		if err != nil {
-			deviceRemoveInterface(dev)
+			device.NetworkRemoveInterface(dev)
 			return "", fmt.Errorf("Failed to set the MTU: %s", err)
 		}
 	}
@@ -8373,7 +8373,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 	// Bring the interface up
 	_, err := shared.RunCommand("ip", "link", "set", "dev", dev, "up")
 	if err != nil {
-		deviceRemoveInterface(dev)
+		device.NetworkRemoveInterface(dev)
 		return "", fmt.Errorf("Failed to bring up the interface: %s", err)
 	}
 
@@ -9177,7 +9177,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	// Remove host side veth settings and remove veth interface
 	if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
 		c.cleanupHostVethDevice(name, m)
-		deviceRemoveInterface(hostName)
+		device.NetworkRemoveInterface(hostName)
 	}
 
 	// If physical dev, restore MTU using value recorded on parent after removal from container.

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8266,7 +8266,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 		if m["host_name"] != "" {
 			n1 = m["host_name"]
 		} else {
-			n1 = deviceNextVeth()
+			n1 = device.NetworkRandomDevName("veth")
 		}
 	}
 
@@ -8276,7 +8276,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 
 	// Handle bridged and p2p
 	if shared.StringInSlice(m["nictype"], []string{"bridged", "p2p"}) {
-		n2 := deviceNextVeth()
+		n2 := device.NetworkRandomDevName("veth")
 
 		_, err := shared.RunCommand("ip", "link", "add", "dev", n1, "type", "veth", "peer", "name", n2)
 		if err != nil {
@@ -9127,7 +9127,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 		// hostName for sriov devices can change on each boot, so get out of volatile.
 		hostName = c.getVolatileHostName(name)
 	} else {
-		hostName = deviceNextVeth()
+		hostName = device.NetworkRandomDevName("veth")
 	}
 
 	// For some reason, having network config confuses detach, so get our own go-lxc struct

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -8289,7 +8289,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 		}
 
 		if m["nictype"] == "bridged" {
-			err = networkAttachInterface(m["parent"], n1)
+			err = device.NetworkAttachInterface(m["parent"], n1)
 			if err != nil {
 				device.NetworkRemoveInterface(n2)
 				return "", fmt.Errorf("Failed to add interface to bridge: %s", err)

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2651,7 +2651,7 @@ func (c *containerLXC) snapshotPhysicalNic(deviceName string, hostName string, v
 	macKey := "volatile." + deviceName + ".last_state.hwaddr"
 
 	// Store current MTU for restoration on detach
-	mtu, err := networkGetDevMTU(hostName)
+	mtu, err := device.NetworkGetDevMTU(hostName)
 	if err != nil {
 		return err
 	}
@@ -2779,7 +2779,7 @@ func (c *containerLXC) restorePhysicalNic(deviceName string, hostName string) er
 			return fmt.Errorf("Failed to convert mtu for \"%s\" mtu \"%s\": %v", hostName, c.localConfig[mtuKey], err)
 		}
 
-		err = networkSetDevMTU(hostName, mtuInt)
+		err = device.NetworkSetDevMTU(hostName, mtuInt)
 		if err != nil {
 			return fmt.Errorf("Failed to restore physical dev \"%s\" mtu to \"%d\": %v", hostName, mtuInt, err)
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2679,7 +2679,7 @@ func (c *containerLXC) createVlanDeviceIfNeeded(m types.Device, hostName string)
 			}
 
 			// Attempt to disable IPv6 router advertisement acceptance
-			networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", hostName), "0")
+			device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", hostName), "0")
 
 			// We created a new vlan interface, return true
 			return true, nil
@@ -8318,7 +8318,7 @@ func (c *containerLXC) createNetworkDevice(name string, m types.Device) (string,
 			}
 
 			// Attempt to disable router advertisement acceptance
-			networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", n1), "0")
+			device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", n1), "0")
 		}
 
 		// Record the new device's host name for use in setupHostVethDevice()

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -31,6 +31,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/device"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/iptables"
 	"github.com/lxc/lxd/lxd/maas"
@@ -1932,7 +1933,7 @@ func (c *containerLXC) initLXCIPVLAN(cc *lxc.Container, networkKeyPrefix string,
 	if m["ipv4.address"] != "" {
 		//Check necessary sysctls are configured for use with l2proxy parent in IPVLAN l3s mode.
 		ipv4FwdPath := fmt.Sprintf("ipv4/conf/%s/forwarding", m["parent"])
-		sysctlVal, err := networkSysctlGet(ipv4FwdPath)
+		sysctlVal, err := device.NetworkSysctlGet(ipv4FwdPath)
 		if err != nil {
 			return errors.Wrapf(err, "Error reading net sysctl %s", ipv4FwdPath)
 		}
@@ -1957,7 +1958,7 @@ func (c *containerLXC) initLXCIPVLAN(cc *lxc.Container, networkKeyPrefix string,
 	if m["ipv6.address"] != "" {
 		//Check necessary sysctls are configured for use with l2proxy parent in IPVLAN l3s mode.
 		ipv6FwdPath := fmt.Sprintf("ipv6/conf/%s/forwarding", m["parent"])
-		sysctlVal, err := networkSysctlGet(ipv6FwdPath)
+		sysctlVal, err := device.NetworkSysctlGet(ipv6FwdPath)
 		if err != nil {
 			return errors.Wrapf(err, "Error reading net sysctl %s", ipv6FwdPath)
 		}
@@ -1966,7 +1967,7 @@ func (c *containerLXC) initLXCIPVLAN(cc *lxc.Container, networkKeyPrefix string,
 		}
 
 		ipv6ProxyNdpPath := fmt.Sprintf("ipv6/conf/%s/proxy_ndp", m["parent"])
-		sysctlVal, err = networkSysctlGet(ipv6ProxyNdpPath)
+		sysctlVal, err = device.NetworkSysctlGet(ipv6ProxyNdpPath)
 		if err != nil {
 			return errors.Wrapf(err, "Error reading net sysctl %s", ipv6ProxyNdpPath)
 		}
@@ -2144,7 +2145,7 @@ func (c *containerLXC) startCommon() (string, error) {
 
 			if shared.IsTrue(m["security.ipv6_filtering"]) {
 				// Check br_netfilter is loaded and enabled for IPv6.
-				sysctlVal, err := networkSysctlGet("bridge/bridge-nf-call-ip6tables")
+				sysctlVal, err := device.NetworkSysctlGet("bridge/bridge-nf-call-ip6tables")
 				if err != nil || sysctlVal != "1\n" {
 					return "", errors.Wrapf(err, "security.ipv6_filtering requires br_netfilter and sysctl net.bridge.bridge-nf-call-ip6tables=1")
 				}
@@ -8788,7 +8789,7 @@ func (c *containerLXC) setNetworkFilters(deviceName string, m types.Device) (err
 
 	if shared.IsTrue(m["security.ipv6_filtering"]) {
 		// Check br_netfilter is loaded and enabled for IPv6.
-		sysctlVal, err := networkSysctlGet("bridge/bridge-nf-call-ip6tables")
+		sysctlVal, err := device.NetworkSysctlGet("bridge/bridge-nf-call-ip6tables")
 		if err != nil || sysctlVal != "1\n" {
 			return errors.Wrapf(err, "security.ipv6_filtering requires br_netfilter and sysctl net.bridge.bridge-nf-call-ip6tables=1")
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1715,7 +1715,7 @@ func (c *containerLXC) initLXC(config bool) error {
 					return err
 				}
 			} else if shared.StringInSlice(m["nictype"], []string{"macvlan", "ipvlan", "physical"}) {
-				err = lxcSetConfigItem(cc, fmt.Sprintf("%s.%d.link", networkKeyPrefix, networkidx), networkGetHostDevice(m["parent"], m["vlan"]))
+				err = lxcSetConfigItem(cc, fmt.Sprintf("%s.%d.link", networkKeyPrefix, networkidx), device.NetworkGetHostDevice(m["parent"], m["vlan"]))
 				if err != nil {
 					return err
 				}
@@ -2697,7 +2697,7 @@ func (c *containerLXC) setupPhysicalParent(deviceName string, m types.Device) (s
 		return "", errors.New("No parent property on device")
 	}
 
-	hostName := networkGetHostDevice(m["parent"], m["vlan"])
+	hostName := device.NetworkGetHostDevice(m["parent"], m["vlan"])
 	createdDev, err := c.createVlanDeviceIfNeeded(m, hostName)
 	if err != nil {
 		return hostName, err
@@ -2813,7 +2813,7 @@ func (c *containerLXC) restorePhysicalParent(deviceName string, m types.Device) 
 	}()
 
 	// Nothing to do if we don't know the original device name.
-	hostName := networkGetHostDevice(m["parent"], m["vlan"])
+	hostName := device.NetworkGetHostDevice(m["parent"], m["vlan"])
 	if hostName == "" {
 		return
 	}
@@ -9144,7 +9144,7 @@ func (c *containerLXC) removeNetworkDevice(name string, m types.Device) error {
 	// Get a temporary device name
 	var hostName string
 	if m["nictype"] == "physical" {
-		hostName = networkGetHostDevice(m["parent"], m["vlan"])
+		hostName = device.NetworkGetHostDevice(m["parent"], m["vlan"])
 	} else if m["nictype"] == "sriov" {
 		// hostName for sriov devices can change on each boot, so get out of volatile.
 		hostName = c.getVolatileHostName(name)

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2658,7 +2658,7 @@ func (c *containerLXC) snapshotPhysicalNic(deviceName string, hostName string, v
 	volatile[mtuKey] = fmt.Sprintf("%d", mtu)
 
 	// Store current MAC for restoration on detach
-	mac, err := networkGetDevMAC(hostName)
+	mac, err := device.NetworkGetDevMAC(hostName)
 	if err != nil {
 		return err
 	}
@@ -2787,7 +2787,7 @@ func (c *containerLXC) restorePhysicalNic(deviceName string, hostName string) er
 
 	// If MAC value is specified then there is an original MAC that needs restoring.
 	if c.localConfig[macKey] != "" {
-		err := networkSetDevMAC(hostName, c.localConfig[macKey])
+		err := device.NetworkSetDevMAC(hostName, c.localConfig[macKey])
 		if err != nil {
 			return fmt.Errorf("Failed to restore physical dev \"%s\" mac to \"%s\": %v", hostName, c.localConfig[macKey], err)
 		}

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -1,0 +1,17 @@
+package device
+
+import (
+	"fmt"
+	"io/ioutil"
+)
+
+// NetworkSysctlGet retrieves the value of a sysctl file in /proc/sys/net.
+func NetworkSysctlGet(path string) (string, error) {
+	// Read the current content
+	content, err := ioutil.ReadFile(fmt.Sprintf("/proc/sys/net/%s", path))
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -15,3 +15,15 @@ func NetworkSysctlGet(path string) (string, error) {
 
 	return string(content), nil
 }
+
+// NetworkSysctlSet writes a value to a sysctl file in /proc/sys/net.
+func NetworkSysctlSet(path string, value string) error {
+	// Get current value
+	current, err := NetworkSysctlGet(path)
+	if err == nil && current == value {
+		// Nothing to update
+		return nil
+	}
+
+	return ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/%s", path), []byte(value), 0)
+}

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -137,3 +137,9 @@ func NetworkGetHostDevice(parent string, vlan string) string {
 	// Return the default pattern
 	return defaultVlan
 }
+
+// NetworkRemoveInterface removes a network interface by name.
+func NetworkRemoveInterface(nic string) error {
+	_, err := shared.RunCommand("ip", "link", "del", "dev", nic)
+	return err
+}

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -235,3 +235,23 @@ func NetworkRandomDevName(prefix string) string {
 
 	return iface
 }
+
+// NetworkAttachInterface attaches an interface to a bridge.
+func NetworkAttachInterface(netName string, devName string) error {
+	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", netName)) {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "master", netName)
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
+		if err != nil {
+			_, err := shared.RunCommand("ovs-vsctl", "add-port", netName, devName)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -2,6 +2,8 @@ package device
 
 import (
 	"bufio"
+	"crypto/rand"
+	"encoding/hex"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -217,4 +219,19 @@ func networkRestorePhysicalNic(hostName string, volatile map[string]string) erro
 	}
 
 	return nil
+}
+
+// NetworkRandomDevName returns a random device name with prefix.
+// If the random string combined with the prefix exceeds 13 characters then empty string is returned.
+// This is to ensure we support buggy dhclient applications: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=858580
+func NetworkRandomDevName(prefix string) string {
+	// Return a new random veth device name
+	randBytes := make([]byte, 4)
+	rand.Read(randBytes)
+	iface := prefix + hex.EncodeToString(randBytes)
+	if len(iface) > 13 {
+		return ""
+	}
+
+	return iface
 }

--- a/lxd/device/device_utils.go
+++ b/lxd/device/device_utils.go
@@ -65,3 +65,31 @@ func NetworkSetDevMTU(devName string, mtu uint64) error {
 
 	return nil
 }
+
+// NetworkGetDevMAC retrieves the current MAC setting for a named network device.
+func NetworkGetDevMAC(devName string) (string, error) {
+	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
+}
+
+// NetworkSetDevMAC sets the MAC setting for a named network device if different from current.
+func NetworkSetDevMAC(devName string, mac string) error {
+	curMac, err := NetworkGetDevMAC(devName)
+	if err != nil {
+		return err
+	}
+
+	// Only try and change the MAC if the requested mac is different to current one.
+	if curMac != mac {
+		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "address", mac)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/csv"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -1172,13 +1171,6 @@ func deviceNextInterfaceHWAddr() (string, error) {
 	}
 
 	return ret.String(), nil
-}
-
-func deviceNextVeth() string {
-	// Return a new random veth device name
-	randBytes := make([]byte, 4)
-	rand.Read(randBytes)
-	return "veth" + hex.EncodeToString(randBytes)
 }
 
 func deviceMountDisk(srcPath string, dstPath string, readonly bool, recursive bool, propagation string) error {

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -1181,11 +1181,6 @@ func deviceNextVeth() string {
 	return "veth" + hex.EncodeToString(randBytes)
 }
 
-func deviceRemoveInterface(nic string) error {
-	_, err := shared.RunCommand("ip", "link", "del", "dev", nic)
-	return err
-}
-
 func deviceMountDisk(srcPath string, dstPath string, readonly bool, recursive bool, propagation string) error {
 	var err error
 

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -20,6 +20,7 @@ import (
 	lxd "github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/device"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/iptables"
 	"github.com/lxc/lxd/lxd/node"
@@ -1083,12 +1084,12 @@ func (n *network) Start() error {
 
 	// IPv6 bridge configuration
 	if !shared.StringInSlice(n.config["ipv6.address"], []string{"", "none"}) {
-		err := networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/autoconf", n.name), "0")
+		err := device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/autoconf", n.name), "0")
 		if err != nil {
 			return err
 		}
 
-		err = networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_dad", n.name), "0")
+		err = device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_dad", n.name), "0")
 		if err != nil {
 			return err
 		}
@@ -1252,7 +1253,7 @@ func (n *network) Start() error {
 
 		// Allow forwarding
 		if n.config["bridge.mode"] == "fan" || n.config["ipv4.routing"] == "" || shared.IsTrue(n.config["ipv4.routing"]) {
-			err = networkSysctlSet("ipv4/ip_forward", "1")
+			err = device.NetworkSysctlSet("ipv4/ip_forward", "1")
 			if err != nil {
 				return err
 			}
@@ -1418,7 +1419,7 @@ func (n *network) Start() error {
 	// Configure IPv6
 	if !shared.StringInSlice(n.config["ipv6.address"], []string{"", "none"}) {
 		// Enable IPv6 for the subnet
-		err := networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/disable_ipv6", n.name), "0")
+		err := device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/disable_ipv6", n.name), "0")
 		if err != nil {
 			return err
 		}
@@ -1490,7 +1491,7 @@ func (n *network) Start() error {
 					continue
 				}
 
-				err = networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", entry.Name()), "2")
+				err = device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/accept_ra", entry.Name()), "2")
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}
@@ -1498,7 +1499,7 @@ func (n *network) Start() error {
 
 			// Then set forwarding for all of them
 			for _, entry := range entries {
-				err = networkSysctlSet(fmt.Sprintf("ipv6/conf/%s/forwarding", entry.Name()), "1")
+				err = device.NetworkSysctlSet(fmt.Sprintf("ipv6/conf/%s/forwarding", entry.Name()), "1")
 				if err != nil && !os.IsNotExist(err) {
 					return err
 				}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1611,7 +1611,7 @@ func (n *network) Start() error {
 		}
 
 		// Update the MTU based on overlay device (if available)
-		fanMtuInt, err := networkGetDevMTU(devName)
+		fanMtuInt, err := device.NetworkGetDevMTU(devName)
 		if err == nil {
 			// Apply overhead
 			if n.config["fan.type"] == "ipip" {

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1131,7 +1131,7 @@ func (n *network) Start() error {
 		if err == nil {
 			_, err = shared.RunCommand("ip", "link", "set", "dev", fmt.Sprintf("%s-mtu", n.name), "up")
 			if err == nil {
-				networkAttachInterface(n.name, fmt.Sprintf("%s-mtu", n.name))
+				device.NetworkAttachInterface(n.name, fmt.Sprintf("%s-mtu", n.name))
 			}
 		}
 	}
@@ -1185,7 +1185,7 @@ func (n *network) Start() error {
 				return fmt.Errorf("Only unconfigured network interfaces can be bridged")
 			}
 
-			err = networkAttachInterface(n.name, entry)
+			err = device.NetworkAttachInterface(n.name, entry)
 			if err != nil {
 				return err
 			}
@@ -1685,7 +1685,7 @@ func (n *network) Start() error {
 				return err
 			}
 
-			err = networkAttachInterface(n.name, tunName)
+			err = device.NetworkAttachInterface(n.name, tunName)
 			if err != nil {
 				return err
 			}
@@ -1799,7 +1799,7 @@ func (n *network) Start() error {
 		}
 
 		// Bridge it and bring up
-		err = networkAttachInterface(n.name, tunName)
+		err = device.NetworkAttachInterface(n.name, tunName)
 		if err != nil {
 			return err
 		}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/device"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
@@ -1272,17 +1271,6 @@ func networksGetForkdnsServersList(networkName string) ([]string, error) {
 	}
 
 	return servers, nil
-}
-
-func networkSysctlSet(path string, value string) error {
-	// Get current value
-	current, err := device.NetworkSysctlGet(path)
-	if err == nil && current == value {
-		// Nothing to update
-		return nil
-	}
-
-	return ioutil.WriteFile(fmt.Sprintf("/proc/sys/net/%s", path), []byte(value), 0)
 }
 
 func networkGetMacSlice(hwaddr string) []string {

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -50,26 +50,7 @@ func networkAutoAttach(cluster *db.Cluster, devName string) error {
 		return nil
 	}
 
-	return networkAttachInterface(dbInfo.Name, devName)
-}
-
-func networkAttachInterface(netName string, devName string) error {
-	if shared.PathExists(fmt.Sprintf("/sys/class/net/%s/bridge", netName)) {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "master", netName)
-		if err != nil {
-			return err
-		}
-	} else {
-		_, err := shared.RunCommand("ovs-vsctl", "port-to-br", devName)
-		if err != nil {
-			_, err := shared.RunCommand("ovs-vsctl", "add-port", netName, devName)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
+	return device.NetworkAttachInterface(dbInfo.Name, devName)
 }
 
 func networkDetachInterface(netName string, devName string) error {

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1482,40 +1482,6 @@ func networkGetState(netIf net.Interface) api.NetworkState {
 	return network
 }
 
-// networkGetDevMTU retrieves the current MTU setting for a named network device.
-func networkGetDevMTU(devName string) (uint64, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/mtu", devName))
-	if err != nil {
-		return 0, err
-	}
-
-	// Parse value
-	mtu, err := strconv.ParseUint(strings.TrimSpace(string(content)), 10, 32)
-	if err != nil {
-		return 0, err
-	}
-
-	return mtu, nil
-}
-
-// networkSetDevMTU sets the MTU setting for a named network device if different from current.
-func networkSetDevMTU(devName string, mtu uint64) error {
-	curMTU, err := networkGetDevMTU(devName)
-	if err != nil {
-		return err
-	}
-
-	// Only try and change the MTU if the requested mac is different to current one.
-	if curMTU != mtu {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "mtu", fmt.Sprintf("%d", mtu))
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // networkGetDevMAC retrieves the current MAC setting for a named network device.
 func networkGetDevMAC(devName string) (string, error) {
 	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/device"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/state"
@@ -1273,19 +1274,9 @@ func networksGetForkdnsServersList(networkName string) ([]string, error) {
 	return servers, nil
 }
 
-func networkSysctlGet(path string) (string, error) {
-	// Read the current content
-	content, err := ioutil.ReadFile(fmt.Sprintf("/proc/sys/net/%s", path))
-	if err != nil {
-		return "", err
-	}
-
-	return string(content), nil
-}
-
 func networkSysctlSet(path string, value string) error {
 	// Get current value
-	current, err := networkSysctlGet(path)
+	current, err := device.NetworkSysctlGet(path)
 	if err == nil && current == value {
 		// Nothing to update
 		return nil

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -1482,34 +1482,6 @@ func networkGetState(netIf net.Interface) api.NetworkState {
 	return network
 }
 
-// networkGetDevMAC retrieves the current MAC setting for a named network device.
-func networkGetDevMAC(devName string) (string, error) {
-	content, err := ioutil.ReadFile(fmt.Sprintf("/sys/class/net/%s/address", devName))
-	if err != nil {
-		return "", err
-	}
-
-	return strings.TrimSpace(fmt.Sprintf("%s", content)), nil
-}
-
-// networkSetDevMAC sets the MAC setting for a named network device if different from current.
-func networkSetDevMAC(devName string, mac string) error {
-	curMac, err := networkGetDevMAC(devName)
-	if err != nil {
-		return err
-	}
-
-	// Only try and change the MAC if the requested mac is different to current one.
-	if curMac != mac {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", devName, "address", mac)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // networkListBootRoutesV4 returns a list of IPv4 boot routes on a named network device.
 func networkListBootRoutesV4(devName string) ([]string, error) {
 	routes := []string{}


### PR DESCRIPTION
This PR creates a new package called `device` and moves some of the network and device related utility functions into it, as well as updating all existing references to the functions.

Its purpose is to allow these functions to be accessed by the device interface project and other non-main packages.