### PR TITLE
device/instance/id: Adds instanceIdentifier interface

### DIFF
--- a/lxd/device/device_instance_id.go
+++ b/lxd/device/device_instance_id.go
@@ -1,0 +1,8 @@
+package device
+
+// instanceIdentifier is an interface that allows us to identify an Instance and its properties.
+type instanceIdentifier interface {
+	Name() string
+	Type() string
+	Project() string
+}


### PR DESCRIPTION
This is used by the device implementations to expose a common subset of functions that are implemented by every instance type.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>