### PR TITLE
task/group: Moves wait group Done() after g.running update 

### DIFF
--- a/lxd/task/group.go
+++ b/lxd/task/group.go
@@ -59,11 +59,13 @@ func (g *Group) Start() {
 
 		go func(i int) {
 			task.loop(ctx)
-			g.wg.Done()
 
+			// Ensure running map is updated before wait group Done() is called.
 			g.mu.Lock()
 			g.running[i] = false
 			g.mu.Unlock()
+
+			g.wg.Done()
 		}(i)
 	}
 }


### PR DESCRIPTION
To avoid race on task end.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>