### PR TITLE
forksyscall: use correct error handling for chdirchroot()

### DIFF
--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -169,10 +169,11 @@ static void forkmknod()
 		_exit(EXIT_FAILURE);
 	}
 
-	if (chdirchroot(pid)) {
+	if (!chdirchroot(pid)) {
 		fprintf(stderr, "%d", ENOANO);
 		_exit(EXIT_FAILURE);
 	}
+
 	if (setns(mnt_fd, CLONE_NEWNS)) {
 		fprintf(stderr, "%d", ENOANO);
 		_exit(EXIT_FAILURE);


### PR DESCRIPTION
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>