### PR TITLE
cluster/heartbeat: Stops using node ID for comparison of nodes

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -179,9 +179,9 @@ func (g *Gateway) HandlerFuncs(nodeRefreshTask func(*APIHeartbeat)) map[string]h
 
 			nodes := make([]db.RaftNode, 0)
 			for _, node := range heartbeatData.Members {
-				if node.Raft {
+				if node.RaftNodeID > 0 {
 					nodes = append(nodes, db.RaftNode{
-						ID:      node.ID,
+						ID:      node.RaftNodeID,
 						Address: node.Address,
 					})
 				}


### PR DESCRIPTION
raft_nodes and nodes tables do not share the same IDs and it is not safe to assume they will always match.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>