### PR TITLE
Cluster heartbeat format change

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1357,7 +1357,7 @@ func (d *Daemon) NodeRefreshTask(heartbeatData *cluster.APIHeartbeat) {
 	}
 
 	// Only refresh forkdns peers if the full state list has been generated.
-	if heartbeatData.FullStateList {
+	if heartbeatData.FullStateList && len(heartbeatData.Members) > 0 {
 		for i, node := range heartbeatData.Members {
 			// Exclude nodes that the leader considers offline.
 			// This is to avoid forkdns delaying results by querying an offline node.


### PR DESCRIPTION
This PR changes how the heartbeat members list is generated, it now uses the `nodes` table as the authoritative source of all nodes (and their associated IDs in the map). However it also uses the `raft_nodes` table to detect members by address and mark them as raft members.

Also includes fix from @stgraber in https://github.com/lxc/lxd/pull/5985