### PR TITLE
Fix setxattr handling

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7608,8 +7608,14 @@ func (c *containerLXC) InsertSeccompUnixDevice(prefix string, m types.Device, pi
 		return err
 	}
 
-	m["uid"] = fmt.Sprintf("%d", GetNSUid(uint(uid), pid))
-	m["gid"] = fmt.Sprintf("%d", GetNSGid(uint(gid), pid))
+	idmapset, err := c.CurrentIdmap()
+	if err != nil {
+		return err
+	}
+
+	nsuid, nsgid := idmapset.ShiftFromNs(uid, gid)
+	m["uid"] = fmt.Sprintf("%d", nsuid)
+	m["gid"] = fmt.Sprintf("%d", nsgid)
 
 	if !path.IsAbs(m["path"]) {
 		cwdLink := fmt.Sprintf("/proc/%d/cwd", pid)

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -309,7 +309,7 @@ static void forksetxattr()
 	}
 
 	if (whiteout == 1) {
-		if (setxattr(path, "trusted.overlay.opaque", "y", 1, flags)) {
+		if (fsetxattr(target_fd, "trusted.overlay.opaque", "y", 1, flags)) {
 			fprintf(stderr, "%d", errno);
 			_exit(EXIT_FAILURE);
 		}

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -284,7 +284,7 @@ static void forksetxattr()
 		_exit(EXIT_FAILURE);
 	}
 
-	target_fd = open(path, O_RDWR | O_CLOEXEC);
+	target_fd = open(path, O_RDONLY | O_CLOEXEC);
 	if (target_fd < 0) {
 		fprintf(stderr, "%d", errno);
 		_exit(EXIT_FAILURE);

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -214,7 +214,7 @@ static bool setnsat(int ns_fd, const char *ns)
 	if (fd < 0)
 		return false;
 
-	return setns(fd, CLONE_NEWUSER) == 0;
+	return setns(fd, 0) == 0;
 }
 
 static bool change_creds(int ns_fd, cap_t caps, uid_t nsuid, gid_t nsgid, uid_t nsfsuid, gid_t nsfsgid)

--- a/lxd/seccomp.go
+++ b/lxd/seccomp.go
@@ -1066,10 +1066,13 @@ func (s *SeccompServer) HandleSetxattrSyscall(c container, siov *SeccompIovec) i
 		return int(-C.EPERM)
 	}
 
-	args.nsuid = GetNSUid(uint(uid), args.pid)
-	args.nsgid = GetNSGid(uint(gid), args.pid)
-	args.nsfsuid = GetNSUid(uint(fsuid), args.pid)
-	args.nsfsgid = GetNSGid(uint(fsgid), args.pid)
+	idmapset, err := c.CurrentIdmap()
+	if err != nil {
+		return int(-C.EINVAL)
+	}
+
+	args.nsuid, args.nsgid = idmapset.ShiftFromNs(uid, gid)
+	args.nsfsuid, args.nsfsgid = idmapset.ShiftFromNs(fsuid, fsgid)
 
 	// const char *path
 	cBuf := [unix.PathMax]C.char{}

--- a/lxd/seccomp.go
+++ b/lxd/seccomp.go
@@ -788,7 +788,7 @@ func NewSeccompServer(d *Daemon, path string) (*SeccompServer, error) {
 	return &s, nil
 }
 
-func taskIds(pid int) (error, int32, int32, int32, int32) {
+func taskIds(pid int) (error, int64, int64, int64, int64) {
 	status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
 	if err != nil {
 		return err, -1, -1, -1, -1
@@ -796,10 +796,10 @@ func taskIds(pid int) (error, int32, int32, int32, int32) {
 
 	reUid := regexp.MustCompile("Uid:\\s*([0-9]*)\\s*([0-9]*)\\s*([0-9]*)\\s*([0-9]*)")
 	reGid := regexp.MustCompile("Gid:\\s*([0-9]*)\\s*([0-9]*)\\s*([0-9]*)\\s*([0-9]*)")
-	var gid int32 = -1
-	var uid int32 = -1
-	var fsgid int32 = -1
-	var fsuid int32 = -1
+	var gid int64 = -1
+	var uid int64 = -1
+	var fsgid int64 = -1
+	var fsuid int64 = -1
 	uidFound := false
 	gidFound := false
 	for _, line := range strings.Split(string(status), "\n") {
@@ -811,23 +811,23 @@ func taskIds(pid int) (error, int32, int32, int32, int32) {
 			m := reUid.FindStringSubmatch(line)
 			if m != nil && len(m) > 2 {
 				// effective uid
-				result, err := strconv.Atoi(m[2])
+				result, err := strconv.ParseInt(m[2], 10, 64)
 				if err != nil {
 					return err, -1, -1, -1, -1
 				}
 
-				uid = int32(result)
+				uid = result
 				uidFound = true
 			}
 
 			if m != nil && len(m) > 4 {
 				// fsuid
-				result, err := strconv.Atoi(m[4])
+				result, err := strconv.ParseInt(m[4], 10, 64)
 				if err != nil {
 					return err, -1, -1, -1, -1
 				}
 
-				fsuid = int32(result)
+				fsuid = result
 			}
 
 			continue
@@ -837,23 +837,23 @@ func taskIds(pid int) (error, int32, int32, int32, int32) {
 			m := reGid.FindStringSubmatch(line)
 			if m != nil && len(m) > 2 {
 				// effective gid
-				result, err := strconv.Atoi(m[2])
+				result, err := strconv.ParseInt(m[2], 10, 64)
 				if err != nil {
 					return err, -1, -1, -1, -1
 				}
 
-				gid = int32(result)
+				gid = result
 				gidFound = true
 			}
 
 			if m != nil && len(m) > 4 {
 				// fsgid
-				result, err := strconv.Atoi(m[4])
+				result, err := strconv.ParseInt(m[4], 10, 64)
 				if err != nil {
 					return err, -1, -1, -1, -1
 				}
 
-				fsgid = int32(result)
+				fsgid = result
 			}
 
 			continue
@@ -1036,10 +1036,10 @@ func (s *SeccompServer) HandleMknodatSyscall(c container, siov *SeccompIovec) in
 }
 
 type SetxattrArgs struct {
-	nsuid   int
-	nsgid   int
-	nsfsuid int
-	nsfsgid int
+	nsuid   int64
+	nsgid   int64
+	nsfsuid int64
+	nsfsgid int64
 	size    int
 	pid     int
 	path    string

--- a/lxd/seccomp.go
+++ b/lxd/seccomp.go
@@ -1106,7 +1106,7 @@ func (s *SeccompServer) HandleSetxattrSyscall(c container, siov *SeccompIovec) i
 	args.value = buf
 
 	whiteout := 0
-	if args.size == 1 && string(args.value) == "y" {
+	if string(args.name) == "trusted.overlay.opaque" && string(args.value) == "y" {
 		whiteout = 1
 	}
 


### PR DESCRIPTION
This fixes a variety of problems I ran into when testing the following:
```
root@tmp:/var/lib/docker# mkdir a
root@tmp:/var/lib/docker# touch b
root@tmp:/var/lib/docker# setfattr -n user.blah -v y a
root@tmp:/var/lib/docker# setfattr -n user.blah -v y b
root@tmp:/var/lib/docker# setfattr -n trusted.blah -v y a
setfattr: a: Operation not permitted
root@tmp:/var/lib/docker# setfattr -n trusted.blah -v y b
setfattr: b: Operation not permitted
root@tmp:/var/lib/docker# setfattr -n trusted.overlay.opaque -v y a
root@tmp:/var/lib/docker# setfattr -n trusted.overlay.opaque -v y b
```

The output above is the expected one and the one that this branch achieves.