### PR TITLE
tests: Avoid event forwarding race condition

### DIFF
--- a/test/suites/clustering.sh
+++ b/test/suites/clustering.sh
@@ -831,6 +831,9 @@ test_clustering_publish() {
   ns2="${prefix}2"
   spawn_lxd_and_join_cluster "${ns2}" "${bridge}" "${cert}" 2 1 "${LXD_TWO_DIR}"
 
+  # Give LXD a couple of seconds to get event API connected properly
+  sleep 2
+
   # Init a container on node2, using a client connected to node1
   LXD_DIR="${LXD_TWO_DIR}" ensure_import_testimage
   LXD_DIR="${LXD_ONE_DIR}" lxc init --target node2 testimage foo


### PR DESCRIPTION
There is a tiny potential race right between a cluster node joins and
the event forwarding being functional. If we immediately get requested
to do cross-node activity (in this case importing an image and creating
a container from it), there is a chance that one or multiple events
won't make it, leading to the client tool hanging (waiting for an event).

This problem should disappear when we rework event distribution to move
away from the current broadcast approach, at which point we can have
individual LXD nodes refuse to serve requests until they are connected
to the event hub.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>