### PR TITLE
test: Ensures SR-IOV tests remove all containers

### DIFF
--- a/test/suites/container_devices_nic_sriov.sh
+++ b/test/suites/container_devices_nic_sriov.sh
@@ -121,5 +121,5 @@ test_container_devices_nic_sriov() {
     false
   fi
 
-  lxc stop -f "${ctName}"
+  lxc delete -f "${ctName}"
 }


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>