### PR TITLE
container/lxc: Restores update of disk limit options

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4393,8 +4393,8 @@ func (c *containerLXC) Update(args db.ContainerArgs, userRequested bool) error {
 			return updateFields
 		}
 
-		// No fields can be live updated for this device.
-		return []string{}
+		// Legacy non-nic updatable fields.
+		return []string{"limits.max", "limits.read", "limits.write"}
 	})
 
 	// Do some validation of the config diff


### PR DESCRIPTION
The recent device interface PR #5900 removed detection of disk limit related fields that meant that updates to these would not take effect until container restart.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>