### PR TITLE
test: Fixes bridge tests detection of busybox udhcpc6 presence

### DIFF
--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -303,8 +303,12 @@ test_container_devices_nic_bridged() {
   fi
 
   # Request DHCPv6 lease (if udhcpc6 is in busybox image).
-  busyboxUdhcpc6=$(lxc exec "${ctName}" -- busybox --list | grep udhcpc6)
-  if [ "${busyboxUdhcpc6}" = "udhcpc6" ]; then
+  busyboxUdhcpc6=1
+  if ! lxc exec "${ctName}" -- busybox --list | grep udhcpc6 ; then
+    busyboxUdhcpc6=0
+  fi
+
+  if [ "$busyboxUdhcpc6" = "1" ]; then
         lxc exec "${ctName}" -- udhcpc6 -i eth0
   fi
 

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -234,8 +234,12 @@ test_container_devices_nic_bridged_filtering() {
   # Check DHCPv6 allocation still works (if udhcpc6 is in busybox image).
   lxc exec "${ctPrefix}A" -- ip link set dev eth0 address "${ctAMAC}" up
 
-  busyboxUdhcpc6=$(lxc exec "${ctPrefix}A" -- busybox --list | grep udhcpc6)
-  if [ "${busyboxUdhcpc6}" = "udhcpc6" ]; then
+  busyboxUdhcpc6=1
+  if ! lxc exec "${ctPrefix}A" -- busybox --list | grep udhcpc6 ; then
+    busyboxUdhcpc6=0
+  fi
+
+  if [ "$busyboxUdhcpc6" = "1" ]; then
       lxc exec "${ctPrefix}A" -- udhcpc6 -i eth0 -n
   fi
 


### PR DESCRIPTION
Now tests can run without udhcpc6 cleanly.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>