### PR TITLE
Device post stop hook

### DIFF
--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -46,7 +46,8 @@ type Device interface {
 
 	// Stop performs any host-side cleanup required when a device is removed from an instance,
 	// either due to unplugging it from a running instance or instance is being shutdown.
-	Stop() error
+	// Returns run-time configuration needed for detaching the device from the instance.
+	Stop() (*RunConfig, error)
 
 	// Remove performs any host-side cleanup when an instance is removed from an instance.
 	Remove() error

--- a/lxd/device/device_runconfig.go
+++ b/lxd/device/device_runconfig.go
@@ -6,8 +6,8 @@ type RunConfigItem struct {
 	Value string
 }
 
-// RunConfig represents LXD defined run-time config used for device setup.
+// RunConfig represents LXD defined run-time config used for device setup/cleanup.
 type RunConfig struct {
-	NetworkInterface []RunConfigItem
-	PostStartHooks   []func() error
+	NetworkInterface []RunConfigItem // Network interface configuration settings.
+	PostHooks        []func() error  // Functions to be run after device attach/detach.
 }

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -229,7 +229,16 @@ func (d *nicBridged) Update(oldConfig config.Device, isRunning bool) error {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicBridged) Stop() error {
+func (d *nicBridged) Stop() (*RunConfig, error) {
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicBridged) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"host_name": "",
 	})

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -208,8 +208,17 @@ func (d *nicIPVLAN) setupParentSysctls(parentName string) error {
 	return nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *nicIPVLAN) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *nicIPVLAN) Stop() (*RunConfig, error) {
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicIPVLAN) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"last_state.created": "",
 	})

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -109,8 +109,21 @@ func (d *nicMACVLAN) Start() (*RunConfig, error) {
 	return &runConf, nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *nicMACVLAN) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *nicMACVLAN) Stop() (*RunConfig, error) {
+	v := d.volatileGet()
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+		NetworkInterface: []RunConfigItem{
+			{Key: "link", Value: v["host_name"]},
+		},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicMACVLAN) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"host_name":          "",
 		"last_state.hwaddr":  "",

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -116,8 +116,17 @@ func (d *nicP2P) Update(oldConfig config.Device, isRunning bool) error {
 	return nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *nicP2P) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *nicP2P) Stop() (*RunConfig, error) {
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicP2P) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"host_name": "",
 	})

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -115,8 +115,21 @@ func (d *nicPhysical) Start() (*RunConfig, error) {
 	return &runConf, nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *nicPhysical) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *nicPhysical) Stop() (*RunConfig, error) {
+	v := d.volatileGet()
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+		NetworkInterface: []RunConfigItem{
+			{Key: "link", Value: v["host_name"]},
+		},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicPhysical) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"host_name":          "",
 		"last_state.hwaddr":  "",

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -141,8 +141,21 @@ func (d *nicSRIOV) Start() (*RunConfig, error) {
 	return &runConf, nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *nicSRIOV) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *nicSRIOV) Stop() (*RunConfig, error) {
+	v := d.volatileGet()
+	runConfig := RunConfig{
+		PostHooks: []func() error{d.postStop},
+		NetworkInterface: []RunConfigItem{
+			{Key: "link", Value: v["host_name"]},
+		},
+	}
+
+	return &runConfig, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicSRIOV) postStop() error {
 	defer d.volatileSet(map[string]string{
 		"host_name":                "",
 		"last_state.hwaddr":        "",

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -140,7 +140,7 @@ func (d *proxy) Start() (*RunConfig, error) {
 
 	// Proxy devices have to be setup once the container is running.
 	runConf := RunConfig{}
-	runConf.PostStartHooks = []func() error{
+	runConf.PostHooks = []func() error{
 		func() error {
 			if shared.IsTrue(d.config["nat"]) {
 				return d.setupNAT()
@@ -226,8 +226,8 @@ func (d *proxy) checkProcStarted(logPath string) (bool, error) {
 	return false, nil
 }
 
-// Stop is run when the device is removed from the container.
-func (d *proxy) Stop() error {
+// Stop is run when the device is removed from the instance.
+func (d *proxy) Stop() (*RunConfig, error) {
 	// Remove possible iptables entries
 	iptables.ContainerClear("ipv4", fmt.Sprintf("%s (%s)", d.instance.Name(), d.name), "nat")
 	iptables.ContainerClear("ipv6", fmt.Sprintf("%s (%s)", d.instance.Name(), d.name), "nat")
@@ -237,15 +237,15 @@ func (d *proxy) Stop() error {
 
 	if !shared.PathExists(devPath) {
 		// There's no proxy process if NAT is enabled
-		return nil
+		return nil, nil
 	}
 
 	err := d.killProxyProc(devPath)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	return nil
+	return nil, nil
 }
 
 func (d *proxy) setupNAT() error {

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -283,6 +283,13 @@ test_container_devices_nic_bridged() {
     false
   fi
 
+  # Check volatile cleanup on stop.
+  lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
+
   # Test DHCP lease clearance.
   lxc delete "${ctName}" -f
   lxc launch testimage "${ctName}" -p "${ctName}"

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -274,6 +274,12 @@ test_container_devices_nic_bridged_filtering() {
       false
   fi
 
+  # Check volatile cleanup on stop.
+  if lxc config show "${ctPrefix}A" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
+
   # Set static MAC so that SLAAC address is derived predictably and check it is applied to static config.
   lxc config device unset "${ctPrefix}A" eth0 ipv6.address
   lxc config device set "${ctPrefix}A" eth0 hwaddr 00:16:3e:92:f3:c1

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -64,7 +64,12 @@ test_container_devices_nic_ipvlan() {
     false
   fi
 
-  lxc stop -f "${ct_name}"
+  # Check volatile cleanup on stop.
+  lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr | grep -v volatile.eth0.name ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
 
   # Check parent device is still up.
   if ! grep "1" "/sys/class/net/${ctName}/carrier" ; then

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -7,59 +7,59 @@ test_container_devices_nic_ipvlan() {
     return
   fi
 
-  ct_name="nt$$"
+  ctName="nt$$"
   ipRand=$(shuf -i 0-9 -n 1)
 
   # Test ipvlan support to offline container (hot plugging not supported).
-  ip link add "${ct_name}" type dummy
+  ip link add "${ctName}" type dummy
 
   # Record how many nics we started with.
   startNicCount=$(find /sys/class/net | wc -l)
 
   # Check that starting IPVLAN container.
-  sysctl net.ipv6.conf."${ct_name}".proxy_ndp=1
-  sysctl net.ipv6.conf."${ct_name}".forwarding=1
-  sysctl net.ipv4.conf."${ct_name}".forwarding=1
-  lxc init testimage "${ct_name}"
-  lxc config device add "${ct_name}" eth0 nic \
+  sysctl net.ipv6.conf."${ctName}".proxy_ndp=1
+  sysctl net.ipv6.conf."${ctName}".forwarding=1
+  sysctl net.ipv4.conf."${ctName}".forwarding=1
+  lxc init testimage "${ctName}"
+  lxc config device add "${ctName}" eth0 nic \
     nictype=ipvlan \
-    parent=${ct_name} \
+    parent=${ctName} \
     ipv4.address="192.0.2.1${ipRand}" \
     ipv6.address="2001:db8::1${ipRand}" \
     mtu=1400
-  lxc start "${ct_name}"
+  lxc start "${ctName}"
 
   # Check custom MTU is applied.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+  if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1400" ; then
     echo "mtu invalid"
     false
   fi
 
   #Spin up another container with multiple IPs.
-  lxc init testimage "${ct_name}2"
-  lxc config device add "${ct_name}2" eth0 nic \
+  lxc init testimage "${ctName}2"
+  lxc config device add "${ctName}2" eth0 nic \
     nictype=ipvlan \
-    parent=${ct_name} \
+    parent=${ctName} \
     ipv4.address="192.0.2.2${ipRand}, 192.0.2.3${ipRand}" \
     ipv6.address="2001:db8::2${ipRand}, 2001:db8::3${ipRand}"
-  lxc start "${ct_name}2"
+  lxc start "${ctName}2"
 
   # Check comms between containers.
-  lxc exec "${ct_name}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ct_name}" -- ping -c2 -W1 "192.0.2.3${ipRand}"
-  lxc exec "${ct_name}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
-  lxc exec "${ct_name}" -- ping6 -c2 -W1 "2001:db8::3${ipRand}"
-  lxc exec "${ct_name}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
-  lxc exec "${ct_name}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
-  lxc stop -f "${ct_name}2"
+  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.3${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  lxc stop -f "${ctName}2"
 
   # Check IPVLAN ontop of VLAN parent.
-  lxc stop -f "${ct_name}"
-  lxc config device set "${ct_name}" eth0 vlan 1234
-  lxc start "${ct_name}"
+  lxc stop -f "${ctName}"
+  lxc config device set "${ctName}" eth0 vlan 1234
+  lxc start "${ctName}"
 
   # Check VLAN interface created
-  if ! grep "1" "/sys/class/net/${ct_name}.1234/carrier" ; then
+  if ! grep "1" "/sys/class/net/${ctName}.1234/carrier" ; then
     echo "vlan interface not created"
     false
   fi
@@ -67,7 +67,7 @@ test_container_devices_nic_ipvlan() {
   lxc stop -f "${ct_name}"
 
   # Check parent device is still up.
-  if ! grep "1" "/sys/class/net/${ct_name}/carrier" ; then
+  if ! grep "1" "/sys/class/net/${ctName}/carrier" ; then
     echo "parent is down"
     false
   fi
@@ -80,7 +80,7 @@ test_container_devices_nic_ipvlan() {
   fi
 
   # Cleanup ipvlan checks
-  lxc delete "${ct_name}" -f
-  lxc delete "${ct_name}2" -f
-  ip link delete "${ct_name}" type dummy
+  lxc delete "${ctName}" -f
+  lxc delete "${ctName}2" -f
+  ip link delete "${ctName}" type dummy
 }

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -55,6 +55,14 @@ test_container_devices_nic_macvlan() {
     false
   fi
 
+  # Check volatile cleanup on stop.
+  lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
+
+  lxc start "${ctName}"
   lxc config device remove "${ctName}" eth0
 
   # Test hot plugging macvlan device based on vlan parent.

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -2,86 +2,86 @@ test_container_devices_nic_macvlan() {
   ensure_import_testimage
   ensure_has_localhost_remote "${LXD_ADDR}"
 
-  ct_name="nt$$"
+  ctName="nt$$"
   ipRand=$(shuf -i 0-9 -n 1)
 
   # Create dummy interface for use as parent.
-  ip link add "${ct_name}" type dummy
-  ip link set "${ct_name}" up
+  ip link add "${ctName}" type dummy
+  ip link set "${ctName}" up
 
   # Record how many nics we started with.
   startNicCount=$(find /sys/class/net | wc -l)
 
   # Test pre-launch profile config is applied at launch.
-  lxc profile copy default "${ct_name}"
+  lxc profile copy default "${ctName}"
 
   # Modifiy profile nictype and parent in atomic operation to ensure validation passes.
-  lxc profile show "${ct_name}" | sed  "s/nictype: p2p/nictype: macvlan\n    parent: ${ct_name}/" | lxc profile edit "${ct_name}"
-  lxc profile device set "${ct_name}" eth0 mtu "1400"
+  lxc profile show "${ctName}" | sed  "s/nictype: p2p/nictype: macvlan\n    parent: ${ctName}/" | lxc profile edit "${ctName}"
+  lxc profile device set "${ctName}" eth0 mtu "1400"
 
-  lxc launch testimage "${ct_name}" -p "${ct_name}"
-  lxc exec "${ct_name}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
-  lxc exec "${ct_name}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
+  lxc launch testimage "${ctName}" -p "${ctName}"
+  lxc exec "${ctName}" -- ip addr add "192.0.2.1${ipRand}/24" dev eth0
+  lxc exec "${ctName}" -- ip addr add "2001:db8::1${ipRand}/64" dev eth0
 
   # Check custom MTU is applied if feature available in LXD.
   if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then
-    if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1400" ; then
+    if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1400" ; then
       echo "mtu invalid"
       false
     fi
   fi
 
   #Spin up another container with multiple IPs.
-  lxc launch testimage "${ct_name}2" -p "${ct_name}"
-  lxc exec "${ct_name}2" -- ip addr add "192.0.2.2${ipRand}/24" dev eth0
-  lxc exec "${ct_name}2" -- ip addr add "2001:db8::2${ipRand}/64" dev eth0
+  lxc launch testimage "${ctName}2" -p "${ctName}"
+  lxc exec "${ctName}2" -- ip addr add "192.0.2.2${ipRand}/24" dev eth0
+  lxc exec "${ctName}2" -- ip addr add "2001:db8::2${ipRand}/64" dev eth0
 
   # Check comms between containers.
-  lxc exec "${ct_name}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
-  lxc exec "${ct_name}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
-  lxc exec "${ct_name}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
-  lxc exec "${ct_name}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W1 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W1 "2001:db8::2${ipRand}"
+  lxc exec "${ctName}2" -- ping -c2 -W1 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W1 "2001:db8::1${ipRand}"
 
   # Test hot plugging a container nic with different settings to profile with the same name.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=macvlan \
     name=eth0 \
-    parent="${ct_name}" \
+    parent="${ctName}" \
     mtu=1401
 
   # Check custom MTU is applied on hot-plug.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1401" ; then
+  if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1401" ; then
     echo "mtu invalid"
     false
   fi
 
-  lxc config device remove "${ct_name}" eth0
+  lxc config device remove "${ctName}" eth0
 
   # Test hot plugging macvlan device based on vlan parent.
-  lxc config device add "${ct_name}" eth0 nic \
+  lxc config device add "${ctName}" eth0 nic \
     nictype=macvlan \
-    parent="${ct_name}" \
+    parent="${ctName}" \
     name=eth0 \
     vlan=10 \
     mtu=1402
 
   # Check custom MTU is applied.
-  if ! lxc exec "${ct_name}" -- ip link show eth0 | grep "mtu 1402" ; then
+  if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1402" ; then
     echo "mtu invalid"
     false
   fi
 
   # Check VLAN interface created
-  if ! grep "1" "/sys/class/net/${ct_name}.10/carrier" ; then
+  if ! grep "1" "/sys/class/net/${ctName}.10/carrier" ; then
     echo "vlan interface not created"
     false
   fi
 
   # Remove device from container, this should also remove created VLAN parent device.
-  lxc config device remove "${ct_name}" eth0
+  lxc config device remove "${ctName}" eth0
 
   # Check parent device is still up.
-  if ! grep "1" "/sys/class/net/${ct_name}/carrier" ; then
+  if ! grep "1" "/sys/class/net/${ctName}/carrier" ; then
     echo "parent is down"
     false
   fi
@@ -94,7 +94,7 @@ test_container_devices_nic_macvlan() {
   fi
 
   # Cleanup.
-  lxc delete "${ct_name}" -f
-  lxc delete "${ct_name}2" -f
-  ip link delete "${ct_name}" type dummy
+  lxc delete "${ctName}" -f
+  lxc delete "${ctName}2" -f
+  ip link delete "${ctName}" type dummy
 }

--- a/test/suites/container_devices_nic_p2p.sh
+++ b/test/suites/container_devices_nic_p2p.sh
@@ -244,8 +244,14 @@ test_container_devices_nic_p2p() {
     false
   fi
 
-  # Now add a nic to a stopped container with routes.
+  # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
+
+  # Now add a nic to a stopped container with routes.
   lxc config device add "${ctName}" eth0 nic \
     nictype=p2p \
     ipv4.routes="192.0.2.2${ipRand}/32" \

--- a/test/suites/container_devices_nic_physical.sh
+++ b/test/suites/container_devices_nic_physical.sh
@@ -40,8 +40,12 @@ test_container_devices_nic_physical() {
     false
   fi
 
-  # Stop container and check MTU is restored.
+  # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
 
   # Check original MTU is restored on physical device.
   if lxc info | grep 'network_phys_macvlan_mtu: "true"' ; then

--- a/test/suites/container_devices_nic_sriov.sh
+++ b/test/suites/container_devices_nic_sriov.sh
@@ -72,7 +72,12 @@ test_container_devices_nic_sriov() {
     fi
   fi
 
+  # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr | grep -v volatile.eth0.name ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
 
   # Set custom MAC
   lxc config device set "${ctName}" eth0 hwaddr "${ctMAC1}"


### PR DESCRIPTION
This modifies the `device` interface to allow the `Stop()` function to return a `RunConfig` struct, similar to the `Start()` function. 

This allows the `Stop()` function to return a partially populated `RunConfig` struct to communicate with LXD which devices it should detach from the container and how to do it (such as what interface name to use when detaching a NIC back onto the host).

It also allows a slice of functions to be returned in the `PostHooks` variable, which LXD will then execute after the device has been detached.

This also changes when the `Stop()` function is called, it is now executed *before* any devices are detached from a running container, however the `PostHooks` are called after the detaching has been completed.

It also has a nice side-effect of mirroring the behaviour of the `Start()` function.

The reason for this change is as follows:

1. Allows NIC devices to indicate to LXD that it does not need to detach an interface (such as bridge and p2p veth devices), as the PostHooks will delete the parent device which will delete the veth peer.
2. Allows NIC devices to specify the detach hostname directly, without having to use volatile, which pushes more detach logic down into the device package.
3. Allows future unix devices to figure out which paths need to be detached inside the device package, without having to put device-type specific logic into LXD. 

This PR also adds some more tests to check for volatile key clean up.

