### PR TITLE
test: Fixes proxy device unix tests on Ubuntu Eoan

### DIFF
--- a/test/suites/container_devices_proxy.sh
+++ b/test/suites/container_devices_proxy.sh
@@ -162,6 +162,9 @@ container_devices_proxy_unix() {
   HOST_SOCK="${TEST_DIR}/lxdtest-$(basename "${LXD_DIR}")-host.sock"
   lxc launch testimage proxyTester
 
+  # Some busybox images don't have /tmp globally accessible.
+  lxc exec proxyTester -- chmod 1777 /tmp
+
   # Initial test
   lxc config device add proxyTester proxyDev proxy "listen=unix:${HOST_SOCK}" uid=1234 gid=1234 security.uid=1234 security.gid=1234 connect=unix:/tmp/"lxdtest-$(basename "${LXD_DIR}").sock" bind=host
   (


### PR DESCRIPTION
The file permission on /tmp in the Busybox image on Ubuntu Eoan did not allow global access for all users.

This caused problems when running forkproxy as a non-root UID/GID with UNIX sockets.

This commit sets /tmp inside the container to 1777 before running the UNIX socket tests.

Suggested-By: Stéphane Graber <stgraber@ubuntu.com>
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>