### PR TITLE
device/proxy: Removes unnecessary CanHotPlug function

### DIFF
--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -39,10 +39,6 @@ type proxyProcInfo struct {
 	proxyProtocol  string
 }
 
-func (d *proxy) CanHotPlug() (bool, []string) {
-	return true, []string{}
-}
-
 // validateConfig checks the supplied config for correctness.
 func (d *proxy) validateConfig() error {
 	if d.instance.Type() != instance.TypeContainer {


### PR DESCRIPTION
The common device implementation provides the same behaviour.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>