### PR TITLE
device/proxy: Implements default listen file mode of 0644

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -585,7 +585,7 @@ connect         | string    | -                 | yes       | The address and po
 bind            | string    | host              | no        | Which side to bind on (host/guest)
 uid             | int       | 0                 | no        | UID of the owner of the listening Unix socket
 gid             | int       | 0                 | no        | GID of the owner of the listening Unix socket
-mode            | int       | 0755              | no        | Mode for the listening Unix socket
+mode            | int       | 0644              | no        | Mode for the listening Unix socket
 nat             | bool      | false             | no        | Whether to optimize proxying via NAT
 proxy\_protocol | bool      | false             | no        | Whether to use the HAProxy PROXY protocol to transmit sender information
 security.uid    | int       | 0                 | no        | What UID to drop privilege to

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -406,6 +406,11 @@ func (d *proxy) setupProxyProcInfo() (*proxyProcInfo, error) {
 		return nil, fmt.Errorf("Invalid binding side given. Must be \"host\" or \"guest\"")
 	}
 
+	listenAddrMode := "0644"
+	if d.config["mode"] != "" {
+		listenAddrMode = d.config["mode"]
+	}
+
 	p := &proxyProcInfo{
 		listenPid:      listenPid,
 		connectPid:     connectPid,
@@ -413,7 +418,7 @@ func (d *proxy) setupProxyProcInfo() (*proxyProcInfo, error) {
 		listenAddr:     listenAddr,
 		listenAddrGID:  d.config["gid"],
 		listenAddrUID:  d.config["uid"],
-		listenAddrMode: d.config["mode"],
+		listenAddrMode: listenAddrMode,
 		securityGID:    d.config["security.gid"],
 		securityUID:    d.config["security.uid"],
 		proxyProtocol:  d.config["proxy_protocol"],


### PR DESCRIPTION
The documentation states that the default listen file mode is 0755 if not supplied.

However the mode argument was currently being passed to forkproxy as empty string if not supplied.

There was also no mention of 755 or umask in forkproxy itself, leading me to think the default as documented was not implemented.

After discussions with stgraber, we agreed a sensible default of 0644.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>