### PR TITLE
device/nic/sriov: Fixes mac_filtering when no hwaddr specified

### DIFF
--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -333,7 +333,7 @@ func (d *nicSRIOV) setupSriovParent(vfDevice string, vfID int, volatile map[stri
 		// If no MAC specified in config, use current VF interface MAC.
 		mac := d.config["hwaddr"]
 		if mac == "" {
-			mac = volatile["last_state.vf.hwaddr"]
+			mac = volatile["last_state.hwaddr"]
 		}
 
 		// Set MAC on VF (this combined with spoof checking prevents any other MAC being used).


### PR DESCRIPTION
When testing on mellanox cards, the mac_filtering feature wasn't working when no hwaddr address was specified.

This was because LXD is supposed to set the VF interface's MAC on the parent's VF setting first before enabling spoof checking. However it was using the wrong volatile key.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>