### PR TITLE
lxc/file: Intercept user cancelation

### DIFF
--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -298,7 +298,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d mehr)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s ist kein Verzeichnis"
@@ -308,7 +308,7 @@ msgstr "%s ist kein Verzeichnis"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -604,7 +604,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -629,7 +629,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -838,7 +838,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -949,7 +949,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Delete containers and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -998,8 +998,8 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1139,6 +1139,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 #, fuzzy
 msgid "Edit container file templates"
@@ -1152,7 +1158,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 #, fuzzy
 msgid "Edit files in containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1314,7 +1320,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1631,7 +1637,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "ungültiges Argument %s"
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
@@ -1641,12 +1647,12 @@ msgstr "Ungültiges Ziel %s"
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr "Ungültige Quelle %s"
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
@@ -1970,7 +1976,7 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 #, fuzzy
 msgid "Manage files in containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2143,7 +2149,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -2173,7 +2179,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
@@ -2556,22 +2562,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Publishing container: %s"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 #, fuzzy
 msgid "Pull files from containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 #, fuzzy
 msgid "Push files into containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2581,7 +2587,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2933,15 +2939,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr "Setzt die gid der Datei beim Übertragen"
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr "Setzt die Dateiberechtigungen beim Übertragen"
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr "Setzt die uid der Datei beim Übertragen"
 
@@ -3378,7 +3384,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3388,7 +3394,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, fuzzy, c-format
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -3451,7 +3457,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3651,7 +3657,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 #, fuzzy
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
@@ -3750,7 +3756,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3828,7 +3834,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -4001,14 +4007,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -4242,7 +4248,7 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 #, fuzzy
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
@@ -4253,7 +4259,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 #, fuzzy
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -173,7 +173,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -183,7 +183,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -464,7 +464,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -489,7 +489,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -785,7 +785,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -832,8 +832,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -967,6 +967,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -979,7 +985,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1132,7 +1138,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1439,7 +1445,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1449,12 +1455,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1746,7 +1752,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1908,7 +1914,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1938,7 +1944,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2308,20 +2314,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2331,7 +2337,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2664,15 +2670,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3101,7 +3107,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3161,7 +3167,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3350,7 +3356,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3428,7 +3434,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3492,7 +3498,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3652,14 +3658,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3877,13 +3883,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2019-06-13 16:56+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -245,7 +245,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d más)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s no es un directorio"
@@ -255,7 +255,7 @@ msgstr "%s no es un directorio"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
@@ -537,7 +537,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
@@ -563,7 +563,7 @@ msgstr "No se puede especificar un remote diferente para renombrar."
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -761,7 +761,7 @@ msgstr "Creando el contenedor"
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -862,7 +862,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -909,8 +909,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1043,6 +1043,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -1055,7 +1061,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1210,7 +1216,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1518,7 +1524,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1528,12 +1534,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1826,7 +1832,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1988,7 +1994,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s no es un directorio"
@@ -2019,7 +2025,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2388,20 +2394,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2411,7 +2417,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2744,15 +2750,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3171,7 +3177,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3181,7 +3187,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3241,7 +3247,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3431,7 +3437,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3509,7 +3515,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3574,7 +3580,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3734,14 +3740,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3959,13 +3965,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -288,7 +288,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d de plus)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s n'est pas un répertoire"
@@ -298,7 +298,7 @@ msgstr "%s n'est pas un répertoire"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompre encore deux fois pour forcer)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
@@ -586,7 +586,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 #, fuzzy
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
@@ -613,7 +613,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 #, fuzzy
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "impossible de spécifier uid/gid/mode en mode récursif"
@@ -824,7 +824,7 @@ msgstr "Création du conteneur"
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr "Créer tous répertoires nécessaires"
 
@@ -950,7 +950,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Delete containers and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -1000,8 +1000,8 @@ msgstr "Copie de l'image : %s"
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1137,6 +1137,12 @@ msgstr "ÉPHÉMÈRE"
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 #, fuzzy
 msgid "Edit container file templates"
@@ -1150,7 +1156,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 #, fuzzy
 msgid "Edit files in containers"
 msgstr "Création du conteneur"
@@ -1320,7 +1326,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1644,7 +1650,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "nombre d'arguments incorrect pour la sous-comande"
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, fuzzy, c-format
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
@@ -1654,12 +1660,12 @@ msgstr "Cible invalide %s"
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr "Source invalide %s"
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
@@ -2018,7 +2024,7 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 #, fuzzy
 msgid "Manage files in containers"
 msgstr "Transfert de l'image : %s"
@@ -2194,7 +2200,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Copie de l'image : %s"
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 #, fuzzy
 msgid "Missing target directory"
 msgstr "%s n'est pas un répertoire"
@@ -2226,7 +2232,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "Plus d'un périphérique correspond, spécifier le nom du périphérique."
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
@@ -2614,22 +2620,22 @@ msgstr "Création du conteneur"
 msgid "Publishing container: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 #, fuzzy
 msgid "Pull files from containers"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 #, fuzzy
 msgid "Push files into containers"
 msgstr "Création du conteneur"
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2639,7 +2645,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 #, fuzzy
 msgid "Recursively transfer files"
 msgstr "Pousser ou récupérer des fichiers récursivement"
@@ -2997,15 +3003,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr "Définir le gid du fichier lors de l'envoi"
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr "Définir les permissions du fichier lors de l'envoi"
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr "Définir l'uid du fichier lors de l'envoi"
 
@@ -3454,7 +3460,7 @@ msgstr "UTILISÉ PAR"
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3464,7 +3470,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3533,7 +3539,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3730,7 +3736,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 #, fuzzy
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
@@ -3832,7 +3838,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3916,7 +3922,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -4093,14 +4099,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -4360,7 +4366,7 @@ msgstr ""
 "lxc publish [<remote>:]<container>[/<snapshot>] [<remote>:] [--"
 "alias=ALIAS...] [prop-key=prop-value...]"
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 #, fuzzy
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
@@ -4374,7 +4380,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 #, fuzzy
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -210,7 +210,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (altri %d)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -220,7 +220,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompi altre due volte per forzare)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, fuzzy, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
@@ -527,7 +527,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -724,7 +724,7 @@ msgstr "Creazione del container in corso"
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -826,7 +826,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -873,8 +873,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1007,6 +1007,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -1019,7 +1025,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1174,7 +1180,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1485,7 +1491,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "numero errato di argomenti del sottocomando"
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1495,12 +1501,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1795,7 +1801,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 #, fuzzy
 msgid "Manage files in containers"
 msgstr "Creazione del container in corso"
@@ -1958,7 +1964,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1988,7 +1994,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2358,20 +2364,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr "Creazione del container in corso"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2381,7 +2387,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2715,15 +2721,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3145,7 +3151,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3155,7 +3161,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3216,7 +3222,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3407,7 +3413,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3485,7 +3491,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3550,7 +3556,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3710,14 +3716,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3935,13 +3941,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2019-05-18 08:49+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -173,7 +173,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (他%d個)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s はディレクトリではありません"
@@ -184,7 +184,7 @@ msgid "%v (interrupt two more times to force)"
 msgstr ""
 "%v (強制的に中断したい場合はあと2回Ctrl-Cを入力/SIGINTを送出してください)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
@@ -472,7 +472,7 @@ msgstr "ローカル上のリネームでは、設定やプロファイルの上
 msgid "Can't provide a name for the target image"
 msgstr "ターゲットイメージの名前を取得できません"
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
@@ -499,7 +499,7 @@ msgstr "リネームの場合は異なるリモートを指定できません"
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません"
 
@@ -705,7 +705,7 @@ msgstr "コンテナを作成中"
 msgid "Create and start containers from images"
 msgstr "イメージからコンテナを作成し、起動します"
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr "必要なディレクトリをすべて作成します"
 
@@ -809,7 +809,7 @@ msgstr "コンテナのファイルテンプレートを削除します"
 msgid "Delete containers and snapshots"
 msgstr "コンテナとスナップショットを削除します"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr "コンテナ内のファイルを削除します"
 
@@ -856,8 +856,8 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -994,6 +994,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr "コンテナのファイルテンプレートを編集します"
@@ -1006,7 +1012,7 @@ msgstr "コンテナのメタデータファイルを編集します"
 msgid "Edit container or server configurations as YAML"
 msgstr "コンテナもしくはサーバの設定をYAMLファイルで編集します"
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr "コンテナ内のファイルを編集します"
 
@@ -1184,7 +1190,7 @@ msgstr "新しいコンテナ名が取得できません"
 msgid "Failed to remove alias %s"
 msgstr "エイリアス %s の削除に失敗しました"
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
@@ -1500,7 +1506,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr "引数の数が不正です"
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
@@ -1510,12 +1516,12 @@ msgstr "不正なパス %s"
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr "不正なソース %s"
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
@@ -1892,7 +1898,7 @@ msgstr "コンテナのファイルテンプレートを管理します"
 msgid "Manage container metadata files"
 msgstr "コンテナのメタデータファイルを管理します"
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr "コンテナ内のファイルを管理します"
 
@@ -2070,7 +2076,7 @@ msgstr "コピー元のプロファイル名を指定する必要があります
 msgid "Missing source volume name"
 msgstr "コピー元のボリューム名を指定する必要があります"
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr "コピー先のディレクトリを指定する必要があります"
 
@@ -2103,7 +2109,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
@@ -2475,20 +2481,20 @@ msgstr "コンテナをイメージとして出力します"
 msgid "Publishing container: %s"
 msgstr "コンテナの更新中: %s"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr "コンテナからファイルを取得します"
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr "ファイル %s を %s から取得します: %%s"
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr "コンテナ内にファイルをコピーします"
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
@@ -2498,7 +2504,7 @@ msgstr "ファイル %s をコンテナ %s 内にコピーします: %%s"
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr "再帰的にファイルを転送します"
 
@@ -2838,15 +2844,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr "プッシュ時にファイルのgidを設定します"
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr "プッシュ時にファイルのパーミションを設定します"
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr "プッシュ時にファイルのuidを設定します"
 
@@ -3278,7 +3284,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
@@ -3288,7 +3294,7 @@ msgstr "テンポラリファイルを作成できません: %v"
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
@@ -3350,7 +3356,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3542,7 +3548,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
@@ -3623,7 +3629,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3690,7 +3696,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3873,7 +3879,7 @@ msgstr ""
 "lxc export u1 backup0.tar.gz\n"
 "    u1 コンテナのバックアップ tarball をダウンロードします。"
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
@@ -3883,7 +3889,7 @@ msgstr ""
 "   コンテナの /etc/hosts ファイルを取得し、カレントディレクトリにコピーしま"
 "す。"
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -4181,7 +4187,7 @@ msgstr ""
 "publish [<remote>:]<container>[/<snapshot>] [<remote>:] [flags] "
 "[key=value...]"
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
@@ -4189,7 +4195,7 @@ msgstr ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-08-09 15:51-0400\n"
+        "POT-Creation-Date: 2019-08-11 21:42-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -162,7 +162,7 @@ msgstr  ""
 msgid   "%s (%d more)"
 msgstr  ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid   "%s is not a directory"
 msgstr  ""
@@ -172,7 +172,7 @@ msgstr  ""
 msgid   "%v (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
@@ -449,7 +449,7 @@ msgstr  ""
 msgid   "Can't provide a name for the target image"
 msgstr  ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
@@ -474,7 +474,7 @@ msgstr  ""
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid   "Can't supply uid/gid/mode in recursive mode"
 msgstr  ""
 
@@ -656,7 +656,7 @@ msgstr  ""
 msgid   "Create and start containers from images"
 msgstr  ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid   "Create any directories necessary"
 msgstr  ""
 
@@ -754,7 +754,7 @@ msgstr  ""
 msgid   "Delete containers and snapshots"
 msgstr  ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid   "Delete files in containers"
 msgstr  ""
 
@@ -786,7 +786,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187 lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:412 lxc/remote.go:448 lxc/remote.go:528 lxc/remote.go:590 lxc/remote.go:640 lxc/remote.go:678 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219 lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:412 lxc/remote.go:448 lxc/remote.go:528 lxc/remote.go:590 lxc/remote.go:640 lxc/remote.go:678 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -885,6 +885,10 @@ msgstr  ""
 msgid   "EXPIRY DATE"
 msgstr  ""
 
+#: lxc/file.go:65
+msgid   "Early server side processing of file tranfer requests cannot be canceled (interrupt two more times to force)"
+msgstr  ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid   "Edit container file templates"
 msgstr  ""
@@ -897,7 +901,7 @@ msgstr  ""
 msgid   "Edit container or server configurations as YAML"
 msgstr  ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid   "Edit files in containers"
 msgstr  ""
 
@@ -1042,7 +1046,7 @@ msgstr  ""
 msgid   "Failed to remove alias %s"
 msgstr  ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
@@ -1336,7 +1340,7 @@ msgstr  ""
 msgid   "Invalid number of arguments"
 msgstr  ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid   "Invalid path %s"
 msgstr  ""
@@ -1346,12 +1350,12 @@ msgstr  ""
 msgid   "Invalid protocol: %s"
 msgstr  ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid   "Invalid source %s"
 msgstr  ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid   "Invalid target %s"
 msgstr  ""
@@ -1636,7 +1640,7 @@ msgstr  ""
 msgid   "Manage container metadata files"
 msgstr  ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid   "Manage files in containers"
 msgstr  ""
 
@@ -1775,7 +1779,7 @@ msgstr  ""
 msgid   "Missing source volume name"
 msgstr  ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid   "Missing target directory"
 msgstr  ""
 
@@ -1803,7 +1807,7 @@ msgstr  ""
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
@@ -2167,20 +2171,20 @@ msgstr  ""
 msgid   "Publishing container: %s"
 msgstr  ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid   "Pull files from containers"
 msgstr  ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid   "Pulling %s from %s: %%s"
 msgstr  ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid   "Push files into containers"
 msgstr  ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid   "Pushing %s to %s: %%s"
 msgstr  ""
@@ -2190,7 +2194,7 @@ msgstr  ""
 msgid   "Read-Only: %v"
 msgstr  ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid   "Recursively transfer files"
 msgstr  ""
 
@@ -2504,15 +2508,15 @@ msgstr  ""
 msgid   "Set the URL for the remote"
 msgstr  ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid   "Set the file's gid on push"
 msgstr  ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid   "Set the file's perms on push"
 msgstr  ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid   "Set the file's uid on push"
 msgstr  ""
 
@@ -2924,7 +2928,7 @@ msgstr  ""
 msgid   "UUID: %v"
 msgstr  ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
@@ -2934,7 +2938,7 @@ msgstr  ""
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid   "Unknown file type '%s'"
 msgstr  ""
@@ -2993,7 +2997,7 @@ msgstr  ""
 msgid   "User aborted delete operation"
 msgstr  ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid   "User signaled us three times, exiting. The remote operation will keep running"
 msgstr  ""
 
@@ -3174,7 +3178,7 @@ msgstr  ""
 msgid   "delete [<remote>:]<container> <template>"
 msgstr  ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid   "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr  ""
 
@@ -3250,7 +3254,7 @@ msgstr  ""
 msgid   "edit [<remote>:]<container> <template>"
 msgstr  ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid   "edit [<remote>:]<container>/<path>"
 msgstr  ""
 
@@ -3312,7 +3316,7 @@ msgstr  ""
 msgid   "export [<remote>:]<image> [<target>]"
 msgstr  ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid   "file"
 msgstr  ""
 
@@ -3461,12 +3465,12 @@ msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 container."
 msgstr  ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid   "lxc file pull foo/etc/hosts .\n"
         "   To pull /etc/hosts from the container and write it to the current directory."
 msgstr  ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid   "lxc file push /etc/hosts foo/etc/hosts\n"
         "   To push /etc/hosts into the container \"foo\"."
 msgstr  ""
@@ -3657,11 +3661,11 @@ msgstr  ""
 msgid   "publish [<remote>:]<container>[/<snapshot>] [<remote>:] [flags] [key=value...]"
 msgstr  ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid   "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] <target path>"
 msgstr  ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid   "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2019-02-26 09:18+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -219,7 +219,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (en nog %d)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -229,7 +229,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -877,8 +877,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1009,6 +1009,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -1021,7 +1027,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1174,7 +1180,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1481,7 +1487,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1491,12 +1497,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1788,7 +1794,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1948,7 +1954,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1978,7 +1984,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2347,20 +2353,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2370,7 +2376,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2703,15 +2709,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3130,7 +3136,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3140,7 +3146,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3200,7 +3206,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3389,7 +3395,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3531,7 +3537,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3691,14 +3697,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3916,13 +3922,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -219,7 +219,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -229,7 +229,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -534,7 +534,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -730,7 +730,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -830,7 +830,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -877,8 +877,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1009,6 +1009,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -1021,7 +1027,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1174,7 +1180,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1481,7 +1487,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1491,12 +1497,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1788,7 +1794,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1948,7 +1954,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1978,7 +1984,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2347,20 +2353,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2370,7 +2376,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2703,15 +2709,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3130,7 +3136,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3140,7 +3146,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3200,7 +3206,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3389,7 +3395,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3467,7 +3473,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3531,7 +3537,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3691,14 +3697,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3916,13 +3922,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2019-08-08 18:08+0000\n"
 "Last-Translator: Tiago A. Reul <tiago@reul.space>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -289,7 +289,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr "%s (%d mais)"
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s não é um diretório"
@@ -299,7 +299,7 @@ msgstr "%s não é um diretório"
 msgid "%v (interrupt two more times to force)"
 msgstr "%v (interrompa mais duas vezes para forçar)"
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
@@ -582,7 +582,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr "Não pode fornecer um nome para a imagem de destino"
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
@@ -607,7 +607,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 
@@ -808,7 +808,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -912,7 +912,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -959,8 +959,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1093,6 +1093,12 @@ msgstr "EFÊMERO"
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr "Editar templates de arquivo do container"
@@ -1105,7 +1111,7 @@ msgstr "Editar arquivos de metadados do container"
 msgid "Edit container or server configurations as YAML"
 msgstr "Editar configurações do container ou do servidor como YAML"
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr "Editar arquivos no container"
 
@@ -1259,7 +1265,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1567,7 +1573,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1577,12 +1583,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1874,7 +1880,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -2034,7 +2040,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -2064,7 +2070,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2433,20 +2439,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr "Editar arquivos no container"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2456,7 +2462,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2790,15 +2796,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3217,7 +3223,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3227,7 +3233,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3288,7 +3294,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3477,7 +3483,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3555,7 +3561,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3619,7 +3625,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3779,14 +3785,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -4004,13 +4010,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -280,7 +280,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -290,7 +290,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -797,7 +797,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -904,7 +904,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete containers and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -952,8 +952,8 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -1087,6 +1087,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 #, fuzzy
 msgid "Edit container file templates"
@@ -1100,7 +1106,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1256,7 +1262,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1566,7 +1572,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1576,12 +1582,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1877,7 +1883,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -2044,7 +2050,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr "Копирование образа: %s"
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -2074,7 +2080,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2446,20 +2452,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2469,7 +2475,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2808,15 +2814,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3240,7 +3246,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3250,7 +3256,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3310,7 +3316,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3500,7 +3506,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 #, fuzzy
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
@@ -3598,7 +3604,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3674,7 +3680,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3846,14 +3852,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -4079,7 +4085,7 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 #, fuzzy
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
@@ -4089,7 +4095,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 #, fuzzy
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -170,7 +170,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr ""
@@ -180,7 +180,7 @@ msgstr ""
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -460,7 +460,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -681,7 +681,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -781,7 +781,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -828,8 +828,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -960,6 +960,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -972,7 +978,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1125,7 +1131,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1432,7 +1438,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1442,12 +1448,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1739,7 +1745,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1899,7 +1905,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1929,7 +1935,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2298,20 +2304,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2321,7 +2327,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2654,15 +2660,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3081,7 +3087,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3091,7 +3097,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3151,7 +3157,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3340,7 +3346,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3418,7 +3424,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3482,7 +3488,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3642,14 +3648,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3867,13 +3873,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-09 15:51-0400\n"
+"POT-Creation-Date: 2019-08-11 21:42-0400\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -173,7 +173,7 @@ msgstr ""
 msgid "%s (%d more)"
 msgstr ""
 
-#: lxc/file.go:814
+#: lxc/file.go:846
 #, c-format
 msgid "%s is not a directory"
 msgstr "%s 不是一个目录"
@@ -183,7 +183,7 @@ msgstr "%s 不是一个目录"
 msgid "%v (interrupt two more times to force)"
 msgstr ""
 
-#: lxc/file.go:708
+#: lxc/file.go:740
 #, c-format
 msgid "'%s' isn't a supported file type"
 msgstr ""
@@ -463,7 +463,7 @@ msgstr ""
 msgid "Can't provide a name for the target image"
 msgstr ""
 
-#: lxc/file.go:271
+#: lxc/file.go:303
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
@@ -488,7 +488,7 @@ msgstr ""
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
-#: lxc/file.go:451
+#: lxc/file.go:483
 msgid "Can't supply uid/gid/mode in recursive mode"
 msgstr ""
 
@@ -684,7 +684,7 @@ msgstr ""
 msgid "Create and start containers from images"
 msgstr ""
 
-#: lxc/file.go:193 lxc/file.go:384
+#: lxc/file.go:225 lxc/file.go:416
 msgid "Create any directories necessary"
 msgstr ""
 
@@ -784,7 +784,7 @@ msgstr ""
 msgid "Delete containers and snapshots"
 msgstr ""
 
-#: lxc/file.go:74 lxc/file.go:75
+#: lxc/file.go:106 lxc/file.go:107
 msgid "Delete files in containers"
 msgstr ""
 
@@ -831,8 +831,8 @@ msgstr ""
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
 #: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
-#: lxc/file.go:42 lxc/file.go:75 lxc/file.go:124 lxc/file.go:187
-#: lxc/file.go:377 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
+#: lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219
+#: lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
@@ -963,6 +963,12 @@ msgstr ""
 msgid "EXPIRY DATE"
 msgstr ""
 
+#: lxc/file.go:65
+msgid ""
+"Early server side processing of file tranfer requests cannot be canceled "
+"(interrupt two more times to force)"
+msgstr ""
+
 #: lxc/config_template.go:149 lxc/config_template.go:150
 msgid "Edit container file templates"
 msgstr ""
@@ -975,7 +981,7 @@ msgstr ""
 msgid "Edit container or server configurations as YAML"
 msgstr ""
 
-#: lxc/file.go:123 lxc/file.go:124
+#: lxc/file.go:155 lxc/file.go:156
 msgid "Edit files in containers"
 msgstr ""
 
@@ -1128,7 +1134,7 @@ msgstr ""
 msgid "Failed to remove alias %s"
 msgstr ""
 
-#: lxc/file.go:703
+#: lxc/file.go:735
 #, c-format
 msgid "Failed to walk path for %s: %s"
 msgstr ""
@@ -1435,7 +1441,7 @@ msgstr ""
 msgid "Invalid number of arguments"
 msgstr ""
 
-#: lxc/file.go:99
+#: lxc/file.go:131
 #, c-format
 msgid "Invalid path %s"
 msgstr ""
@@ -1445,12 +1451,12 @@ msgstr ""
 msgid "Invalid protocol: %s"
 msgstr ""
 
-#: lxc/file.go:245
+#: lxc/file.go:277
 #, c-format
 msgid "Invalid source %s"
 msgstr ""
 
-#: lxc/file.go:405
+#: lxc/file.go:437
 #, c-format
 msgid "Invalid target %s"
 msgstr ""
@@ -1742,7 +1748,7 @@ msgstr ""
 msgid "Manage container metadata files"
 msgstr ""
 
-#: lxc/file.go:41 lxc/file.go:42
+#: lxc/file.go:73 lxc/file.go:74
 msgid "Manage files in containers"
 msgstr ""
 
@@ -1902,7 +1908,7 @@ msgstr ""
 msgid "Missing source volume name"
 msgstr ""
 
-#: lxc/file.go:498
+#: lxc/file.go:530
 msgid "Missing target directory"
 msgstr ""
 
@@ -1932,7 +1938,7 @@ msgstr ""
 msgid "More than one device matches, specify the device name"
 msgstr ""
 
-#: lxc/file.go:226
+#: lxc/file.go:258
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
@@ -2301,20 +2307,20 @@ msgstr ""
 msgid "Publishing container: %s"
 msgstr ""
 
-#: lxc/file.go:186 lxc/file.go:187
+#: lxc/file.go:218 lxc/file.go:219
 msgid "Pull files from containers"
 msgstr ""
 
-#: lxc/file.go:334 lxc/file.go:657
+#: lxc/file.go:366 lxc/file.go:689
 #, c-format
 msgid "Pulling %s from %s: %%s"
 msgstr ""
 
-#: lxc/file.go:376 lxc/file.go:377
+#: lxc/file.go:408 lxc/file.go:409
 msgid "Push files into containers"
 msgstr ""
 
-#: lxc/file.go:593 lxc/file.go:749
+#: lxc/file.go:625 lxc/file.go:781
 #, c-format
 msgid "Pushing %s to %s: %%s"
 msgstr ""
@@ -2324,7 +2330,7 @@ msgstr ""
 msgid "Read-Only: %v"
 msgstr ""
 
-#: lxc/file.go:194 lxc/file.go:383
+#: lxc/file.go:226 lxc/file.go:415
 msgid "Recursively transfer files"
 msgstr ""
 
@@ -2657,15 +2663,15 @@ msgstr ""
 msgid "Set the URL for the remote"
 msgstr ""
 
-#: lxc/file.go:386
+#: lxc/file.go:418
 msgid "Set the file's gid on push"
 msgstr ""
 
-#: lxc/file.go:387
+#: lxc/file.go:419
 msgid "Set the file's perms on push"
 msgstr ""
 
-#: lxc/file.go:385
+#: lxc/file.go:417
 msgid "Set the file's uid on push"
 msgstr ""
 
@@ -3084,7 +3090,7 @@ msgstr ""
 msgid "UUID: %v"
 msgstr ""
 
-#: lxc/file.go:149
+#: lxc/file.go:181
 #, c-format
 msgid "Unable to create a temporary file: %v"
 msgstr ""
@@ -3094,7 +3100,7 @@ msgstr ""
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
 
-#: lxc/file.go:690
+#: lxc/file.go:722
 #, c-format
 msgid "Unknown file type '%s'"
 msgstr ""
@@ -3154,7 +3160,7 @@ msgstr ""
 msgid "User aborted delete operation"
 msgstr ""
 
-#: lxc/utils/cancel.go:63
+#: lxc/file.go:62 lxc/utils/cancel.go:63
 msgid ""
 "User signaled us three times, exiting. The remote operation will keep running"
 msgstr ""
@@ -3343,7 +3349,7 @@ msgstr ""
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:72
+#: lxc/file.go:104
 msgid "delete [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr ""
 
@@ -3421,7 +3427,7 @@ msgstr ""
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/file.go:122
+#: lxc/file.go:154
 msgid "edit [<remote>:]<container>/<path>"
 msgstr ""
 
@@ -3485,7 +3491,7 @@ msgstr ""
 msgid "export [<remote>:]<image> [<target>]"
 msgstr ""
 
-#: lxc/file.go:40
+#: lxc/file.go:72
 msgid "file"
 msgstr ""
 
@@ -3645,14 +3651,14 @@ msgid ""
 "    Download a backup tarball of the u1 container."
 msgstr ""
 
-#: lxc/file.go:189
+#: lxc/file.go:221
 msgid ""
 "lxc file pull foo/etc/hosts .\n"
 "   To pull /etc/hosts from the container and write it to the current "
 "directory."
 msgstr ""
 
-#: lxc/file.go:379
+#: lxc/file.go:411
 msgid ""
 "lxc file push /etc/hosts foo/etc/hosts\n"
 "   To push /etc/hosts into the container \"foo\"."
@@ -3870,13 +3876,13 @@ msgid ""
 "[key=value...]"
 msgstr ""
 
-#: lxc/file.go:185
+#: lxc/file.go:217
 msgid ""
 "pull [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...] "
 "<target path>"
 msgstr ""
 
-#: lxc/file.go:375
+#: lxc/file.go:407
 msgid ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"


### PR DESCRIPTION
So we can indicate that the initial server side handling cannot be canceled.
As soon as the transfer does begin, it is cancelable and ctrl+c will work.

Closes #6062

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>