### PR TITLE
lxd: Use unix.MS_LAZYTIME

### DIFF
--- a/lxd/storage_cgo.go
+++ b/lxd/storage_cgo.go
@@ -260,10 +260,6 @@ import (
 // close.
 const LoFlagsAutoclear int = C.LO_FLAGS_AUTOCLEAR
 
-// MS_LAZYTIME retains inode timestamps in memory and updated them on-disk only
-// under certain conditions.
-const MS_LAZYTIME uintptr = C.MS_LAZYTIME
-
 // prepareLoopDev() detects and sets up a loop device for source. It returns an
 // open file descriptor to the free loop device and the path of the free loop
 // device. It's the callers responsibility to close the open file descriptor.

--- a/lxd/storage_utils.go
+++ b/lxd/storage_utils.go
@@ -35,7 +35,7 @@ var MountOptions = map[string]mountOptions{
 	"diratime":      {false, unix.MS_NODIRATIME},
 	"dirsync":       {true, unix.MS_DIRSYNC},
 	"exec":          {false, unix.MS_NOEXEC},
-	"lazytime":      {true, MS_LAZYTIME},
+	"lazytime":      {true, unix.MS_LAZYTIME},
 	"mand":          {true, unix.MS_MANDLOCK},
 	"noatime":       {true, unix.MS_NOATIME},
 	"nodev":         {true, unix.MS_NODEV},


### PR DESCRIPTION
Use the provided unix.MS_LAZYTIME instead of defining the constant
ourselves.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>