### PR TITLE
Bridged device MTU inheritance

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -350,7 +350,7 @@ Device configuration properties:
 Key                     | Type      | Default           | Required  | API extension                          | Description
 :--                     | :--       | :--               | :--       | :--                                    | :--
 name                    | string    | kernel assigned   | no        | -                                      | The name of the interface inside the container
-mtu                     | integer   | parent MTU        | no        | -                                      | The MTU of the new interface
+mtu                     | integer   | kernel assigned   | no        | -                                      | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | -                                      | The MAC address of the new interface
 host\_name              | string    | randomly assigned | no        | -                                      | The name of the interface inside the host
 limits.ingress          | string    | -                 | no        | -                                      | I/O limit in bit/s for incoming traffic (various suffixes supported, see below)
@@ -369,7 +369,7 @@ Key                     | Type      | Default           | Required  | API extens
 :--                     | :--       | :--               | :--       | :--                                    | :--
 parent                  | string    | -                 | yes       | -                                      | The name of the host device
 name                    | string    | kernel assigned   | no        | -                                      | The name of the interface inside the container
-mtu                     | integer   | parent MTU        | no        | -                                      | The MTU of the new interface
+mtu                     | integer   | kernel assigned   | no        | -                                      | The MTU of the new interface
 hwaddr                  | string    | randomly assigned | no        | -                                      | The MAC address of the new interface
 security.mac\_filtering | boolean   | false             | no        | network\_vlan\_sriov                   | Prevent the container from spoofing another's MAC address
 vlan                    | integer   | -                 | no        | network\_vlan\_sriov                   | The VLAN ID to attach to

--- a/test/suites/container_devices_nic_bridged.sh
+++ b/test/suites/container_devices_nic_bridged.sh
@@ -257,6 +257,14 @@ test_container_devices_nic_bridged() {
     false
   fi
 
+  # Check that MTU is inherited from parent device when not specified on device.
+  lxc network set "${brName}" bridge.mtu "1405"
+  lxc config device unset "${ctName}" eth0 mtu
+  if ! lxc exec "${ctName}" -- grep "1405" /sys/class/net/eth0/mtu ; then
+    echo "mtu not inherited from parent"
+    false
+  fi
+  lxc network unset "${brName}" bridge.mtu
 
   # Add an external 3rd party route to the bridge interface and check that it and the container
   # routes remain when the network is reconfigured.

--- a/test/suites/container_devices_nic_ipvlan.sh
+++ b/test/suites/container_devices_nic_ipvlan.sh
@@ -35,6 +35,17 @@ test_container_devices_nic_ipvlan() {
     false
   fi
 
+  lxc stop "${ctName}"
+
+  # Check that MTU is inherited from parent device when not specified on device.
+  ip link set "${ctName}" mtu 1405
+  lxc config device unset "${ctName}" eth0 mtu
+  lxc start "${ctName}"
+  if ! lxc exec "${ctName}" -- grep "1405" /sys/class/net/eth0/mtu ; then
+    echo "mtu not inherited from parent"
+    false
+  fi
+
   #Spin up another container with multiple IPs.
   lxc init testimage "${ctName}2"
   lxc config device add "${ctName}2" eth0 nic \

--- a/test/suites/container_devices_nic_macvlan.sh
+++ b/test/suites/container_devices_nic_macvlan.sh
@@ -55,6 +55,14 @@ test_container_devices_nic_macvlan() {
     false
   fi
 
+  # Check that MTU is inherited from parent device when not specified on device.
+  ip link set "${ctName}" mtu 1405
+  lxc config device unset "${ctName}" eth0 mtu
+  if ! lxc exec "${ctName}" -- grep "1405" /sys/class/net/eth0/mtu ; then
+    echo "mtu not inherited from parent"
+    false
+  fi
+
   # Check volatile cleanup on stop.
   lxc stop -f "${ctName}"
   if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr ; then


### PR DESCRIPTION
It has come to my attention that there is a feature in LXD bridged NIC devices that will inherit the MTU of the parent device if not overriden using the `mtu` device property.

However it has stopped working in LXD 3.16.

This issue existed in LXD 3.15 (and possibly earlier), but only during hot-plug, as LXD used liblxc's MTU inheritance feature for boot time setup.

However in LXD 3.16 the boot-time and hot-plug device setup code was unified and this bug is now present also during boot-time setup.