### PR TITLE
api/project: Fixes issue handling project names with URI encodable characters

### DIFF
--- a/client/lxd_certificates.go
+++ b/client/lxd_certificates.go
@@ -48,7 +48,7 @@ func (r *ProtocolLXD) GetCertificate(fingerprint string) (*api.Certificate, stri
 	certificate := api.Certificate{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/certificates/%s", url.QueryEscape(fingerprint)), nil, "", &certificate)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/certificates/%s", url.PathEscape(fingerprint)), nil, "", &certificate)
 	if err != nil {
 		return nil, "", err
 	}
@@ -74,7 +74,7 @@ func (r *ProtocolLXD) UpdateCertificate(fingerprint string, certificate api.Cert
 	}
 
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/certificates/%s", url.QueryEscape(fingerprint)), certificate, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/certificates/%s", url.PathEscape(fingerprint)), certificate, ETag)
 	if err != nil {
 		return err
 	}
@@ -85,7 +85,7 @@ func (r *ProtocolLXD) UpdateCertificate(fingerprint string, certificate api.Cert
 // DeleteCertificate removes a certificate from the LXD trust store
 func (r *ProtocolLXD) DeleteCertificate(fingerprint string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/certificates/%s", url.QueryEscape(fingerprint)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/certificates/%s", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -74,7 +74,7 @@ func (r *ProtocolLXD) GetContainer(name string) (*api.Container, string, error) 
 	container := api.Container{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), nil, "", &container)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s", url.PathEscape(name)), nil, "", &container)
 	if err != nil {
 		return nil, "", err
 	}
@@ -187,7 +187,7 @@ func (r *ProtocolLXD) tryCreateContainer(req api.ContainersPost, urls []string) 
 			if operation == "" {
 				req.Source.Server = serverURL
 			} else {
-				req.Source.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.QueryEscape(operation))
+				req.Source.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 			}
 
 			op, err := r.CreateContainer(req)
@@ -587,7 +587,7 @@ func (r *ProtocolLXD) proxyMigration(targetOp *operation, targetSecrets map[stri
 // UpdateContainer updates the container definition
 func (r *ProtocolLXD) UpdateContainer(name string, container api.ContainerPut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), container, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -603,7 +603,7 @@ func (r *ProtocolLXD) RenameContainer(name string, container api.ContainerPost) 
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "")
 	if err != nil {
 		return nil, err
 	}
@@ -627,7 +627,7 @@ func (r *ProtocolLXD) tryMigrateContainer(source ContainerServer, name string, r
 		success := false
 		errors := map[string]error{}
 		for _, serverURL := range urls {
-			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.QueryEscape(operation))
+			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateContainer(name, req)
 			if err != nil {
@@ -675,7 +675,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s", url.PathEscape(name)), container, "")
 	if err != nil {
 		return nil, err
 	}
@@ -686,7 +686,7 @@ func (r *ProtocolLXD) MigrateContainer(name string, container api.ContainerPost)
 // DeleteContainer requests that LXD deletes the container
 func (r *ProtocolLXD) DeleteContainer(name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s", url.QueryEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -709,7 +709,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.QueryEscape(containerName)), exec, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/exec", url.PathEscape(containerName)), exec, "")
 	if err != nil {
 		return nil, err
 	}
@@ -841,7 +841,7 @@ func (r *ProtocolLXD) ExecContainer(containerName string, exec api.ContainerExec
 func (r *ProtocolLXD) GetContainerFile(containerName string, path string) (io.ReadCloser, *ContainerFileResponse, error) {
 	// Prepare the HTTP request
 	requestURL, err := shared.URLEncode(
-		fmt.Sprintf("%s/1.0/containers/%s/files", r.httpHost, url.QueryEscape(containerName)),
+		fmt.Sprintf("%s/1.0/containers/%s/files", r.httpHost, url.PathEscape(containerName)),
 		map[string]string{"path": path})
 	if err != nil {
 		return nil, nil, err
@@ -931,7 +931,7 @@ func (r *ProtocolLXD) CreateContainerFile(containerName string, path string, arg
 	}
 
 	// Prepare the HTTP request
-	requestURL := fmt.Sprintf("%s/1.0/containers/%s/files?path=%s", r.httpHost, url.QueryEscape(containerName), url.QueryEscape(path))
+	requestURL := fmt.Sprintf("%s/1.0/containers/%s/files?path=%s", r.httpHost, url.PathEscape(containerName), url.QueryEscape(path))
 
 	requestURL, err := r.setQueryAttributes(requestURL)
 	if err != nil {
@@ -991,7 +991,7 @@ func (r *ProtocolLXD) DeleteContainerFile(containerName string, path string) err
 	}
 
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/files?path=%s", url.QueryEscape(containerName), url.QueryEscape(path)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/files?path=%s", url.PathEscape(containerName), url.QueryEscape(path)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -1004,7 +1004,7 @@ func (r *ProtocolLXD) GetContainerSnapshotNames(containerName string) ([]string,
 	urls := []string{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots", url.QueryEscape(containerName)), nil, "", &urls)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots", url.PathEscape(containerName)), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1012,7 +1012,7 @@ func (r *ProtocolLXD) GetContainerSnapshotNames(containerName string) ([]string,
 	// Parse it
 	names := []string{}
 	for _, uri := range urls {
-		fields := strings.Split(uri, fmt.Sprintf("/containers/%s/snapshots/", url.QueryEscape(containerName)))
+		fields := strings.Split(uri, fmt.Sprintf("/containers/%s/snapshots/", url.PathEscape(containerName)))
 		names = append(names, fields[len(fields)-1])
 	}
 
@@ -1024,7 +1024,7 @@ func (r *ProtocolLXD) GetContainerSnapshots(containerName string) ([]api.Contain
 	snapshots := []api.ContainerSnapshot{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots?recursion=1", url.QueryEscape(containerName)), nil, "", &snapshots)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots?recursion=1", url.PathEscape(containerName)), nil, "", &snapshots)
 	if err != nil {
 		return nil, err
 	}
@@ -1037,7 +1037,7 @@ func (r *ProtocolLXD) GetContainerSnapshot(containerName string, name string) (*
 	snapshot := api.ContainerSnapshot{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots/%s", url.QueryEscape(containerName), url.QueryEscape(name)), nil, "", &snapshot)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), nil, "", &snapshot)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1053,7 +1053,7 @@ func (r *ProtocolLXD) CreateContainerSnapshot(containerName string, snapshot api
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots", url.QueryEscape(containerName)), snapshot, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots", url.PathEscape(containerName)), snapshot, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1279,7 +1279,7 @@ func (r *ProtocolLXD) RenameContainerSnapshot(containerName string, name string,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.QueryEscape(containerName), url.QueryEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1303,7 +1303,7 @@ func (r *ProtocolLXD) tryMigrateContainerSnapshot(source ContainerServer, contai
 		success := false
 		errors := map[string]error{}
 		for _, serverURL := range urls {
-			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.QueryEscape(operation))
+			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			op, err := source.MigrateContainerSnapshot(containerName, name, req)
 			if err != nil {
@@ -1345,7 +1345,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.QueryEscape(containerName), url.QueryEscape(name)), container, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), container, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1356,7 +1356,7 @@ func (r *ProtocolLXD) MigrateContainerSnapshot(containerName string, name string
 // DeleteContainerSnapshot requests that LXD deletes the container snapshot
 func (r *ProtocolLXD) DeleteContainerSnapshot(containerName string, name string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/snapshots/%s", url.QueryEscape(containerName), url.QueryEscape(name)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/snapshots/%s", url.PathEscape(containerName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1372,7 +1372,7 @@ func (r *ProtocolLXD) UpdateContainerSnapshot(containerName string, name string,
 
 	// Send the request
 	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/snapshots/%s",
-		url.QueryEscape(containerName), url.QueryEscape(name)), container, ETag)
+		url.PathEscape(containerName), url.PathEscape(name)), container, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -1385,7 +1385,7 @@ func (r *ProtocolLXD) GetContainerState(name string) (*api.ContainerState, strin
 	state := api.ContainerState{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/state", url.QueryEscape(name)), nil, "", &state)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/state", url.PathEscape(name)), nil, "", &state)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1396,7 +1396,7 @@ func (r *ProtocolLXD) GetContainerState(name string) (*api.ContainerState, strin
 // UpdateContainerState updates the container to match the requested state
 func (r *ProtocolLXD) UpdateContainerState(name string, state api.ContainerStatePut, ETag string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/state", url.QueryEscape(name)), state, ETag)
+	op, _, err := r.queryOperation("PUT", fmt.Sprintf("/containers/%s/state", url.PathEscape(name)), state, ETag)
 	if err != nil {
 		return nil, err
 	}
@@ -1409,7 +1409,7 @@ func (r *ProtocolLXD) GetContainerLogfiles(name string) ([]string, error) {
 	urls := []string{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/logs", url.QueryEscape(name)), nil, "", &urls)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/logs", url.PathEscape(name)), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1417,7 +1417,7 @@ func (r *ProtocolLXD) GetContainerLogfiles(name string) ([]string, error) {
 	// Parse it
 	logfiles := []string{}
 	for _, uri := range logfiles {
-		fields := strings.Split(uri, fmt.Sprintf("/containers/%s/logs/", url.QueryEscape(name)))
+		fields := strings.Split(uri, fmt.Sprintf("/containers/%s/logs/", url.PathEscape(name)))
 		logfiles = append(logfiles, fields[len(fields)-1])
 	}
 
@@ -1429,7 +1429,7 @@ func (r *ProtocolLXD) GetContainerLogfiles(name string) ([]string, error) {
 // Note that it's the caller's responsibility to close the returned ReadCloser
 func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.ReadCloser, error) {
 	// Prepare the HTTP request
-	url := fmt.Sprintf("%s/1.0/containers/%s/logs/%s", r.httpHost, url.QueryEscape(name), url.QueryEscape(filename))
+	url := fmt.Sprintf("%s/1.0/containers/%s/logs/%s", r.httpHost, url.PathEscape(name), url.PathEscape(filename))
 
 	url, err := r.setQueryAttributes(url)
 	if err != nil {
@@ -1466,7 +1466,7 @@ func (r *ProtocolLXD) GetContainerLogfile(name string, filename string) (io.Read
 // DeleteContainerLogfile deletes the requested logfile
 func (r *ProtocolLXD) DeleteContainerLogfile(name string, filename string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/logs/%s", url.QueryEscape(name), url.QueryEscape(filename)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/logs/%s", url.PathEscape(name), url.PathEscape(filename)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -1482,7 +1482,7 @@ func (r *ProtocolLXD) GetContainerMetadata(name string) (*api.ImageMetadata, str
 
 	metadata := api.ImageMetadata{}
 
-	url := fmt.Sprintf("/containers/%s/metadata", url.QueryEscape(name))
+	url := fmt.Sprintf("/containers/%s/metadata", url.PathEscape(name))
 	etag, err := r.queryStruct("GET", url, nil, "", &metadata)
 	if err != nil {
 		return nil, "", err
@@ -1497,7 +1497,7 @@ func (r *ProtocolLXD) SetContainerMetadata(name string, metadata api.ImageMetada
 		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
 	}
 
-	url := fmt.Sprintf("/containers/%s/metadata", url.QueryEscape(name))
+	url := fmt.Sprintf("/containers/%s/metadata", url.PathEscape(name))
 	_, _, err := r.query("PUT", url, metadata, ETag)
 	if err != nil {
 		return err
@@ -1514,7 +1514,7 @@ func (r *ProtocolLXD) GetContainerTemplateFiles(containerName string) ([]string,
 
 	templates := []string{}
 
-	url := fmt.Sprintf("/containers/%s/metadata/templates", url.QueryEscape(containerName))
+	url := fmt.Sprintf("/containers/%s/metadata/templates", url.PathEscape(containerName))
 	_, err := r.queryStruct("GET", url, nil, "", &templates)
 	if err != nil {
 		return nil, err
@@ -1529,7 +1529,7 @@ func (r *ProtocolLXD) GetContainerTemplateFile(containerName string, templateNam
 		return nil, fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
 	}
 
-	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, url.QueryEscape(containerName), url.QueryEscape(templateName))
+	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, url.PathEscape(containerName), url.QueryEscape(templateName))
 
 	url, err := r.setQueryAttributes(url)
 	if err != nil {
@@ -1578,7 +1578,7 @@ func (r *ProtocolLXD) setContainerTemplateFile(containerName string, templateNam
 		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
 	}
 
-	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, url.QueryEscape(containerName), url.QueryEscape(templateName))
+	url := fmt.Sprintf("%s/1.0/containers/%s/metadata/templates?path=%s", r.httpHost, url.PathEscape(containerName), url.QueryEscape(templateName))
 
 	url, err := r.setQueryAttributes(url)
 	if err != nil {
@@ -1613,7 +1613,7 @@ func (r *ProtocolLXD) DeleteContainerTemplateFile(name string, templateName stri
 	if !r.HasExtension("container_edit_metadata") {
 		return fmt.Errorf("The server is missing the required \"container_edit_metadata\" API extension")
 	}
-	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/metadata/templates?path=%s", url.QueryEscape(name), url.QueryEscape(templateName)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/metadata/templates?path=%s", url.PathEscape(name), url.QueryEscape(templateName)), nil, "")
 	return err
 }
 
@@ -1624,7 +1624,7 @@ func (r *ProtocolLXD) ConsoleContainer(containerName string, console api.Contain
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.QueryEscape(containerName)), console, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), console, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1696,7 +1696,7 @@ func (r *ProtocolLXD) GetContainerConsoleLog(containerName string, args *Contain
 	}
 
 	// Prepare the HTTP request
-	url := fmt.Sprintf("%s/1.0/containers/%s/console", r.httpHost, url.QueryEscape(containerName))
+	url := fmt.Sprintf("%s/1.0/containers/%s/console", r.httpHost, url.PathEscape(containerName))
 
 	url, err := r.setQueryAttributes(url)
 	if err != nil {
@@ -1737,7 +1737,7 @@ func (r *ProtocolLXD) DeleteContainerConsoleLog(containerName string, args *Cont
 	}
 
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/console", url.QueryEscape(containerName)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/containers/%s/console", url.PathEscape(containerName)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -1754,7 +1754,7 @@ func (r *ProtocolLXD) GetContainerBackupNames(containerName string) ([]string, e
 	// Fetch the raw value
 	urls := []string{}
 	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/backups",
-		url.QueryEscape(containerName)), nil, "", &urls)
+		url.PathEscape(containerName)), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -1763,7 +1763,7 @@ func (r *ProtocolLXD) GetContainerBackupNames(containerName string) ([]string, e
 	names := []string{}
 	for _, uri := range urls {
 		fields := strings.Split(uri, fmt.Sprintf("/containers/%s/backups/",
-			url.QueryEscape(containerName)))
+			url.PathEscape(containerName)))
 		names = append(names, fields[len(fields)-1])
 	}
 
@@ -1779,7 +1779,7 @@ func (r *ProtocolLXD) GetContainerBackups(containerName string) ([]api.Container
 	// Fetch the raw value
 	backups := []api.ContainerBackup{}
 
-	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/backups?recursion=1", url.QueryEscape(containerName)), nil, "", &backups)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/backups?recursion=1", url.PathEscape(containerName)), nil, "", &backups)
 	if err != nil {
 		return nil, err
 	}
@@ -1795,7 +1795,7 @@ func (r *ProtocolLXD) GetContainerBackup(containerName string, name string) (*ap
 
 	// Fetch the raw value
 	backup := api.ContainerBackup{}
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/backups/%s", url.QueryEscape(containerName), url.QueryEscape(name)), nil, "", &backup)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/containers/%s/backups/%s", url.PathEscape(containerName), url.PathEscape(name)), nil, "", &backup)
 	if err != nil {
 		return nil, "", err
 	}
@@ -1811,7 +1811,7 @@ func (r *ProtocolLXD) CreateContainerBackup(containerName string, backup api.Con
 
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/backups",
-		url.QueryEscape(containerName)), backup, "")
+		url.PathEscape(containerName)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1827,7 +1827,7 @@ func (r *ProtocolLXD) RenameContainerBackup(containerName string, name string, b
 
 	// Send the request
 	op, _, err := r.queryOperation("POST", fmt.Sprintf("/containers/%s/backups/%s",
-		url.QueryEscape(containerName), url.QueryEscape(name)), backup, "")
+		url.PathEscape(containerName), url.PathEscape(name)), backup, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1843,7 +1843,7 @@ func (r *ProtocolLXD) DeleteContainerBackup(containerName string, name string) (
 
 	// Send the request
 	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/containers/%s/backups/%s",
-		url.QueryEscape(containerName), url.QueryEscape(name)), nil, "")
+		url.PathEscape(containerName), url.PathEscape(name)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -1859,7 +1859,7 @@ func (r *ProtocolLXD) GetContainerBackupFile(containerName string, name string, 
 
 	// Build the URL
 	uri := fmt.Sprintf("%s/1.0/containers/%s/backups/%s/export", r.httpHost,
-		url.QueryEscape(containerName), url.QueryEscape(name))
+		url.PathEscape(containerName), url.PathEscape(name))
 	if r.project != "" {
 		uri += fmt.Sprintf("?project=%s", url.QueryEscape(r.project))
 	}

--- a/client/lxd_images.go
+++ b/client/lxd_images.go
@@ -79,7 +79,7 @@ func (r *ProtocolLXD) GetPrivateImage(fingerprint string, secret string) (*api.I
 	image := api.Image{}
 
 	// Build the API path
-	path := fmt.Sprintf("/images/%s", url.QueryEscape(fingerprint))
+	path := fmt.Sprintf("/images/%s", url.PathEscape(fingerprint))
 	var err error
 	path, err = r.setQueryAttributes(path)
 	if err != nil {
@@ -109,7 +109,7 @@ func (r *ProtocolLXD) GetPrivateImageFile(fingerprint string, secret string, req
 		return nil, fmt.Errorf("No file requested")
 	}
 
-	uri := fmt.Sprintf("/1.0/images/%s/export", url.QueryEscape(fingerprint))
+	uri := fmt.Sprintf("/1.0/images/%s/export", url.PathEscape(fingerprint))
 
 	var err error
 	uri, err = r.setQueryAttributes(uri)
@@ -311,7 +311,7 @@ func (r *ProtocolLXD) GetImageAlias(name string) (*api.ImageAliasesEntry, string
 	alias := api.ImageAliasesEntry{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/images/aliases/%s", url.QueryEscape(name)), nil, "", &alias)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/images/aliases/%s", url.PathEscape(name)), nil, "", &alias)
 	if err != nil {
 		return nil, "", err
 	}
@@ -618,7 +618,7 @@ func (r *ProtocolLXD) CopyImage(source ImageServer, image api.Image, args *Image
 // UpdateImage updates the image definition
 func (r *ProtocolLXD) UpdateImage(fingerprint string, image api.ImagePut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/images/%s", url.QueryEscape(fingerprint)), image, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), image, ETag)
 	if err != nil {
 		return err
 	}
@@ -629,7 +629,7 @@ func (r *ProtocolLXD) UpdateImage(fingerprint string, image api.ImagePut, ETag s
 // DeleteImage requests that LXD removes an image from the store
 func (r *ProtocolLXD) DeleteImage(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.QueryEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("DELETE", fmt.Sprintf("/images/%s", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -644,7 +644,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.QueryEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/refresh", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -655,7 +655,7 @@ func (r *ProtocolLXD) RefreshImage(fingerprint string) (Operation, error) {
 // CreateImageSecret requests that LXD issues a temporary image secret
 func (r *ProtocolLXD) CreateImageSecret(fingerprint string) (Operation, error) {
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.QueryEscape(fingerprint)), nil, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/images/%s/secret", url.PathEscape(fingerprint)), nil, "")
 	if err != nil {
 		return nil, err
 	}
@@ -677,7 +677,7 @@ func (r *ProtocolLXD) CreateImageAlias(alias api.ImageAliasesPost) error {
 // UpdateImageAlias updates the image alias definition
 func (r *ProtocolLXD) UpdateImageAlias(name string, alias api.ImageAliasesEntryPut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/images/aliases/%s", url.QueryEscape(name)), alias, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/images/aliases/%s", url.PathEscape(name)), alias, ETag)
 	if err != nil {
 		return err
 	}
@@ -688,7 +688,7 @@ func (r *ProtocolLXD) UpdateImageAlias(name string, alias api.ImageAliasesEntryP
 // RenameImageAlias renames an existing image alias
 func (r *ProtocolLXD) RenameImageAlias(name string, alias api.ImageAliasesEntryPost) error {
 	// Send the request
-	_, _, err := r.query("POST", fmt.Sprintf("/images/aliases/%s", url.QueryEscape(name)), alias, "")
+	_, _, err := r.query("POST", fmt.Sprintf("/images/aliases/%s", url.PathEscape(name)), alias, "")
 	if err != nil {
 		return err
 	}
@@ -699,7 +699,7 @@ func (r *ProtocolLXD) RenameImageAlias(name string, alias api.ImageAliasesEntryP
 // DeleteImageAlias removes an alias from the LXD image store
 func (r *ProtocolLXD) DeleteImageAlias(name string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/images/aliases/%s", url.QueryEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/images/aliases/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_networks.go
+++ b/client/lxd_networks.go
@@ -58,7 +58,7 @@ func (r *ProtocolLXD) GetNetwork(name string) (*api.Network, string, error) {
 	network := api.Network{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s", url.QueryEscape(name)), nil, "", &network)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "", &network)
 	if err != nil {
 		return nil, "", err
 	}
@@ -75,7 +75,7 @@ func (r *ProtocolLXD) GetNetworkLeases(name string) ([]api.NetworkLease, error) 
 	leases := []api.NetworkLease{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s/leases", url.QueryEscape(name)), nil, "", &leases)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s/leases", url.PathEscape(name)), nil, "", &leases)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +92,7 @@ func (r *ProtocolLXD) GetNetworkState(name string) (*api.NetworkState, error) {
 	state := api.NetworkState{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s/state", url.QueryEscape(name)), nil, "", &state)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/networks/%s/state", url.PathEscape(name)), nil, "", &state)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (r *ProtocolLXD) UpdateNetwork(name string, network api.NetworkPut, ETag st
 	}
 
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/networks/%s", url.QueryEscape(name)), network, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, ETag)
 	if err != nil {
 		return err
 	}
@@ -137,7 +137,7 @@ func (r *ProtocolLXD) RenameNetwork(name string, network api.NetworkPost) error 
 	}
 
 	// Send the request
-	_, _, err := r.query("POST", fmt.Sprintf("/networks/%s", url.QueryEscape(name)), network, "")
+	_, _, err := r.query("POST", fmt.Sprintf("/networks/%s", url.PathEscape(name)), network, "")
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (r *ProtocolLXD) DeleteNetwork(name string) error {
 	}
 
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/networks/%s", url.QueryEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/networks/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_operations.go
+++ b/client/lxd_operations.go
@@ -56,7 +56,7 @@ func (r *ProtocolLXD) GetOperation(uuid string) (*api.Operation, string, error) 
 	op := api.Operation{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/operations/%s", url.QueryEscape(uuid)), nil, "", &op)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/operations/%s", url.PathEscape(uuid)), nil, "", &op)
 	if err != nil {
 		return nil, "", err
 	}
@@ -69,7 +69,7 @@ func (r *ProtocolLXD) GetOperationWait(uuid string, timeout int) (*api.Operation
 	op := api.Operation{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/operations/%s/wait?timeout=%d", url.QueryEscape(uuid), timeout), nil, "", &op)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/operations/%s/wait?timeout=%d", url.PathEscape(uuid), timeout), nil, "", &op)
 	if err != nil {
 		return nil, "", err
 	}
@@ -79,7 +79,7 @@ func (r *ProtocolLXD) GetOperationWait(uuid string, timeout int) (*api.Operation
 
 // GetOperationWebsocket returns a websocket connection for the provided operation
 func (r *ProtocolLXD) GetOperationWebsocket(uuid string, secret string) (*websocket.Conn, error) {
-	path := fmt.Sprintf("/operations/%s/websocket", url.QueryEscape(uuid))
+	path := fmt.Sprintf("/operations/%s/websocket", url.PathEscape(uuid))
 	if secret != "" {
 		path = fmt.Sprintf("%s?secret=%s", path, url.QueryEscape(secret))
 	}
@@ -90,7 +90,7 @@ func (r *ProtocolLXD) GetOperationWebsocket(uuid string, secret string) (*websoc
 // DeleteOperation deletes (cancels) a running operation
 func (r *ProtocolLXD) DeleteOperation(uuid string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/operations/%s", url.QueryEscape(uuid)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/operations/%s", url.PathEscape(uuid)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_profiles.go
+++ b/client/lxd_profiles.go
@@ -48,7 +48,7 @@ func (r *ProtocolLXD) GetProfile(name string) (*api.Profile, string, error) {
 	profile := api.Profile{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/profiles/%s", url.QueryEscape(name)), nil, "", &profile)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), nil, "", &profile)
 	if err != nil {
 		return nil, "", err
 	}
@@ -70,7 +70,7 @@ func (r *ProtocolLXD) CreateProfile(profile api.ProfilesPost) error {
 // UpdateProfile updates the profile to match the provided Profile struct
 func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag string) error {
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/profiles/%s", url.QueryEscape(name)), profile, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), profile, ETag)
 	if err != nil {
 		return err
 	}
@@ -81,7 +81,7 @@ func (r *ProtocolLXD) UpdateProfile(name string, profile api.ProfilePut, ETag st
 // RenameProfile renames an existing profile entry
 func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error {
 	// Send the request
-	_, _, err := r.query("POST", fmt.Sprintf("/profiles/%s", url.QueryEscape(name)), profile, "")
+	_, _, err := r.query("POST", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), profile, "")
 	if err != nil {
 		return err
 	}
@@ -92,7 +92,7 @@ func (r *ProtocolLXD) RenameProfile(name string, profile api.ProfilePost) error 
 // DeleteProfile deletes a profile
 func (r *ProtocolLXD) DeleteProfile(name string) error {
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/profiles/%s", url.QueryEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/profiles/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_projects.go
+++ b/client/lxd_projects.go
@@ -60,7 +60,7 @@ func (r *ProtocolLXD) GetProject(name string) (*api.Project, string, error) {
 	project := api.Project{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/projects/%s", url.QueryEscape(name)), nil, "", &project)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/projects/%s", url.PathEscape(name)), nil, "", &project)
 	if err != nil {
 		return nil, "", err
 	}
@@ -90,7 +90,7 @@ func (r *ProtocolLXD) UpdateProject(name string, project api.ProjectPut, ETag st
 	}
 
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/projects/%s", url.QueryEscape(name)), project, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, ETag)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func (r *ProtocolLXD) RenameProject(name string, project api.ProjectPost) (Opera
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.QueryEscape(name)), project, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/projects/%s", url.PathEscape(name)), project, "")
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (r *ProtocolLXD) DeleteProject(name string) error {
 	}
 
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/projects/%s", url.QueryEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/projects/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}

--- a/client/lxd_storage_pools.go
+++ b/client/lxd_storage_pools.go
@@ -60,7 +60,7 @@ func (r *ProtocolLXD) GetStoragePool(name string) (*api.StoragePool, string, err
 	pool := api.StoragePool{}
 
 	// Fetch the raw value
-	etag, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s", url.QueryEscape(name)), nil, "", &pool)
+	etag, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "", &pool)
 	if err != nil {
 		return nil, "", err
 	}
@@ -94,7 +94,7 @@ func (r *ProtocolLXD) UpdateStoragePool(name string, pool api.StoragePoolPut, ET
 	}
 
 	// Send the request
-	_, _, err := r.query("PUT", fmt.Sprintf("/storage-pools/%s", url.QueryEscape(name)), pool, ETag)
+	_, _, err := r.query("PUT", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), pool, ETag)
 	if err != nil {
 		return err
 	}
@@ -109,7 +109,7 @@ func (r *ProtocolLXD) DeleteStoragePool(name string) error {
 	}
 
 	// Send the request
-	_, _, err := r.query("DELETE", fmt.Sprintf("/storage-pools/%s", url.QueryEscape(name)), nil, "")
+	_, _, err := r.query("DELETE", fmt.Sprintf("/storage-pools/%s", url.PathEscape(name)), nil, "")
 	if err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func (r *ProtocolLXD) GetStoragePoolResources(name string) (*api.ResourcesStorag
 	res := api.ResourcesStoragePool{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/resources", url.QueryEscape(name)), nil, "", &res)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/resources", url.PathEscape(name)), nil, "", &res)
 	if err != nil {
 		return nil, err
 	}

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -19,7 +19,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeNames(pool string) ([]string, error) {
 	urls := []string{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/volumes", url.QueryEscape(pool)), nil, "", &urls)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/volumes", url.PathEscape(pool)), nil, "", &urls)
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumeNames(pool string) ([]string, error) {
 	// Parse it
 	names := []string{}
 	for _, uri := range urls {
-		fields := strings.Split(uri, fmt.Sprintf("/storage-pools/%s/volumes/", url.QueryEscape(pool)))
+		fields := strings.Split(uri, fmt.Sprintf("/storage-pools/%s/volumes/", url.PathEscape(pool)))
 		names = append(names, fields[len(fields)-1])
 	}
 
@@ -43,7 +43,7 @@ func (r *ProtocolLXD) GetStoragePoolVolumes(pool string) ([]api.StorageVolume, e
 	volumes := []api.StorageVolume{}
 
 	// Fetch the raw value
-	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/volumes?recursion=1", url.QueryEscape(pool)), nil, "", &volumes)
+	_, err := r.queryStruct("GET", fmt.Sprintf("/storage-pools/%s/volumes?recursion=1", url.PathEscape(pool)), nil, "", &volumes)
 	if err != nil {
 		return nil, err
 	}
@@ -60,7 +60,7 @@ func (r *ProtocolLXD) GetStoragePoolVolume(pool string, volType string, name str
 	volume := api.StorageVolume{}
 
 	// Fetch the raw value
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.QueryEscape(pool), url.QueryEscape(volType), url.QueryEscape(name))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(pool), url.PathEscape(volType), url.PathEscape(name))
 	etag, err := r.queryStruct("GET", path, nil, "", &volume)
 	if err != nil {
 		return nil, "", err
@@ -76,7 +76,7 @@ func (r *ProtocolLXD) CreateStoragePoolVolume(pool string, volume api.StorageVol
 	}
 
 	// Send the request
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.QueryEscape(pool), url.QueryEscape(volume.Type))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 	_, _, err := r.query("POST", path, volume, "")
 	if err != nil {
 		return err
@@ -93,9 +93,9 @@ func (r *ProtocolLXD) CreateStoragePoolVolumeSnapshot(pool string, volumeType st
 
 	// Send the request
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots",
-		url.QueryEscape(pool),
-		url.QueryEscape(volumeType),
-		url.QueryEscape(volumeName))
+		url.PathEscape(pool),
+		url.PathEscape(volumeType),
+		url.PathEscape(volumeName))
 	op, _, err := r.queryOperation("POST", path, snapshot, "")
 	if err != nil {
 		return nil, err
@@ -115,9 +115,9 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshotNames(pool string, volumeType 
 
 	// Send the request
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots",
-		url.QueryEscape(pool),
-		url.QueryEscape(volumeType),
-		url.QueryEscape(volumeName))
+		url.PathEscape(pool),
+		url.PathEscape(volumeType),
+		url.PathEscape(volumeName))
 	_, err := r.queryStruct("GET", path, nil, "", &urls)
 	if err != nil {
 		return nil, err
@@ -143,9 +143,9 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshots(pool string, volumeType stri
 	snapshots := []api.StorageVolumeSnapshot{}
 
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots?recursion=1",
-		url.QueryEscape(pool),
-		url.QueryEscape(volumeType),
-		url.QueryEscape(volumeName))
+		url.PathEscape(pool),
+		url.PathEscape(volumeType),
+		url.PathEscape(volumeName))
 	_, err := r.queryStruct("GET", path, nil, "", &snapshots)
 	if err != nil {
 		return nil, err
@@ -163,10 +163,10 @@ func (r *ProtocolLXD) GetStoragePoolVolumeSnapshot(pool string, volumeType strin
 	snapshot := api.StorageVolumeSnapshot{}
 
 	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s",
-		url.QueryEscape(pool),
-		url.QueryEscape(volumeType),
-		url.QueryEscape(volumeName),
-		url.QueryEscape(snapshotName))
+		url.PathEscape(pool),
+		url.PathEscape(volumeType),
+		url.PathEscape(volumeName),
+		url.PathEscape(snapshotName))
 	etag, err := r.queryStruct("GET", path, nil, "", &snapshot)
 	if err != nil {
 		return nil, "", err
@@ -181,7 +181,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolumeSnapshot(pool string, volumeType st
 		return nil, fmt.Errorf("The server is missing the required \"storage_api_volume_snapshots\" API extension")
 	}
 
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.QueryEscape(pool), url.QueryEscape(volumeType), url.QueryEscape(volumeName), url.QueryEscape(snapshotName))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 	// Send the request
 	op, _, err := r.queryOperation("POST", path, snapshot, "")
 	if err != nil {
@@ -200,7 +200,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolumeSnapshot(pool string, volumeType st
 	// Send the request
 	path := fmt.Sprintf(
 		"/storage-pools/%s/volumes/%s/%s/snapshots/%s",
-		url.QueryEscape(pool), url.QueryEscape(volumeType), url.QueryEscape(volumeName), url.QueryEscape(snapshotName))
+		url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 
 	op, _, err := r.queryOperation("DELETE", path, nil, "")
 	if err != nil {
@@ -217,7 +217,7 @@ func (r *ProtocolLXD) UpdateStoragePoolVolumeSnapshot(pool string, volumeType st
 	}
 
 	// Send the request
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.QueryEscape(pool), url.QueryEscape(volumeType), url.QueryEscape(volumeName), url.QueryEscape(snapshotName))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s/snapshots/%s", url.PathEscape(pool), url.PathEscape(volumeType), url.PathEscape(volumeName), url.PathEscape(snapshotName))
 	_, _, err := r.queryOperation("PUT", path, volume, ETag)
 	if err != nil {
 		return err
@@ -238,7 +238,7 @@ func (r *ProtocolLXD) MigrateStoragePoolVolume(pool string, volume api.StorageVo
 	}
 
 	// Send the request
-	path := fmt.Sprintf("/storage-pools/%s/volumes/custom/%s", url.QueryEscape(pool), volume.Name)
+	path := fmt.Sprintf("/storage-pools/%s/volumes/custom/%s", url.PathEscape(pool), volume.Name)
 	op, _, err := r.queryOperation("POST", path, volume, "")
 	if err != nil {
 		return nil, err
@@ -263,7 +263,7 @@ func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source ContainerServer, pool s
 		success := false
 		errors := map[string]error{}
 		for _, serverURL := range urls {
-			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.QueryEscape(operation))
+			req.Target.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			// Send the request
 			top, err := source.MigrateStoragePoolVolume(pool, req)
@@ -317,10 +317,10 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 		success := false
 		errors := map[string]error{}
 		for _, serverURL := range urls {
-			req.Source.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.QueryEscape(operation))
+			req.Source.Operation = fmt.Sprintf("%s/1.0/operations/%s", serverURL, url.PathEscape(operation))
 
 			// Send the request
-			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.QueryEscape(pool), url.QueryEscape(req.Type))
+			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(req.Type))
 			top, _, err := r.queryOperation("POST", path, req, "")
 			if err != nil {
 				continue
@@ -380,7 +380,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source ContainerServer,
 
 	if r == source {
 		// Send the request
-		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.QueryEscape(pool), url.QueryEscape(volume.Type)), req, "")
+		op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type)), req, "")
 		if err != nil {
 			return nil, err
 		}
@@ -423,7 +423,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source ContainerServer,
 		req.Source.Mode = "push"
 
 		// Send the request
-		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.QueryEscape(pool), url.QueryEscape(volume.Type))
+		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
 		op, _, err := r.queryOperation("POST", path, req, "")
@@ -473,7 +473,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source ContainerServer,
 		req.Source.Mode = "push"
 
 		// Send the request
-		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.QueryEscape(pool), url.QueryEscape(volume.Type))
+		path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(volume.Type))
 
 		// Send the request
 		targetOp, _, err := r.queryOperation("POST", path, req, "")
@@ -535,7 +535,7 @@ func (r *ProtocolLXD) MoveStoragePoolVolume(pool string, source ContainerServer,
 	}
 
 	// Send the request
-	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.QueryEscape(sourcePool), url.QueryEscape(volume.Type), volume.Name), req, "")
+	op, _, err := r.queryOperation("POST", fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(sourcePool), url.PathEscape(volume.Type), volume.Name), req, "")
 	if err != nil {
 		return nil, err
 	}
@@ -565,7 +565,7 @@ func (r *ProtocolLXD) UpdateStoragePoolVolume(pool string, volType string, name 
 	}
 
 	// Send the request
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.QueryEscape(pool), url.QueryEscape(volType), url.QueryEscape(name))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(pool), url.PathEscape(volType), url.PathEscape(name))
 	_, _, err := r.query("PUT", path, volume, ETag)
 	if err != nil {
 		return err
@@ -581,7 +581,7 @@ func (r *ProtocolLXD) DeleteStoragePoolVolume(pool string, volType string, name 
 	}
 
 	// Send the request
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.QueryEscape(pool), url.QueryEscape(volType), url.QueryEscape(name))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(pool), url.PathEscape(volType), url.PathEscape(name))
 	_, _, err := r.query("DELETE", path, nil, "")
 	if err != nil {
 		return err
@@ -595,7 +595,7 @@ func (r *ProtocolLXD) RenameStoragePoolVolume(pool string, volType string, name 
 	if !r.HasExtension("storage_api_volume_rename") {
 		return fmt.Errorf("The server is missing the required \"storage_api_volume_rename\" API extension")
 	}
-	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.QueryEscape(pool), url.QueryEscape(volType), url.QueryEscape(name))
+	path := fmt.Sprintf("/storage-pools/%s/volumes/%s/%s", url.PathEscape(pool), url.PathEscape(volType), url.PathEscape(name))
 
 	// Send the request
 	_, _, err := r.query("POST", path, volume, "")

--- a/client/simplestreams_images.go
+++ b/client/simplestreams_images.go
@@ -57,7 +57,7 @@ func (r *ProtocolSimpleStreams) GetImageFile(fingerprint string, req ImageFileRe
 
 	// Attempt to download from host
 	if shared.PathExists("/dev/lxd/sock") && os.Geteuid() == 0 {
-		unixURI := fmt.Sprintf("http://unix.socket/1.0/images/%s/export", url.QueryEscape(fingerprint))
+		unixURI := fmt.Sprintf("http://unix.socket/1.0/images/%s/export", url.PathEscape(fingerprint))
 
 		// Setup the HTTP client
 		devlxdHTTP, err := unixHTTPClient(nil, "/dev/lxd/sock")


### PR DESCRIPTION
It was possible to do:

`lxc project create "test project"`

But one could not then do:

`lxc project delete "test project"`

As the project name was encoded on the URL as "test+project", but was not decoded when being passed to the database query.

Also see https://discuss.linuxcontainers.org/t/cant-rename-image-alias/5638

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>