### PR TITLE
Fix API inconsistency with backups

### DIFF
--- a/lxc/export.go
+++ b/lxc/export.go
@@ -65,7 +65,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 
 	req := api.ContainerBackupsPost{
 		Name:             "",
-		ExpiryDate:       time.Now().Add(24 * time.Hour),
+		ExpiresAt:        time.Now().Add(24 * time.Hour),
 		ContainerOnly:    c.flagContainerOnly,
 		OptimizedStorage: c.flagOptimizedStorage,
 	}

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -149,8 +149,8 @@ func (b *backup) Delete() error {
 func (b *backup) Render() *api.ContainerBackup {
 	return &api.ContainerBackup{
 		Name:             strings.SplitN(b.name, "/", 2)[1],
-		CreationDate:     b.creationDate,
-		ExpiryDate:       b.expiryDate,
+		CreatedAt:        b.creationDate,
+		ExpiresAt:        b.expiryDate,
 		ContainerOnly:    b.containerOnly,
 		OptimizedStorage: b.optimizedStorage,
 	}

--- a/lxd/container_backup.go
+++ b/lxd/container_backup.go
@@ -149,7 +149,7 @@ func containerBackupsPost(d *Daemon, r *http.Request) Response {
 			Name:             fullName,
 			ContainerID:      c.Id(),
 			CreationDate:     time.Now(),
-			ExpiryDate:       req.ExpiryDate,
+			ExpiryDate:       req.ExpiresAt,
 			ContainerOnly:    req.ContainerOnly,
 			OptimizedStorage: req.OptimizedStorage,
 		}

--- a/shared/api/container_backup.go
+++ b/shared/api/container_backup.go
@@ -6,7 +6,7 @@ import "time"
 // API extension: container_backup
 type ContainerBackupsPost struct {
 	Name             string    `json:"name" yaml:"name"`
-	ExpiryDate       time.Time `json:"expiry" yaml:"expiry"`
+	ExpiresAt        time.Time `json:"expires_at" yaml:"expires_at"`
 	ContainerOnly    bool      `json:"container_only" yaml:"container_only"`
 	OptimizedStorage bool      `json:"optimized_storage" yaml:"optimized_storage"`
 }
@@ -15,8 +15,8 @@ type ContainerBackupsPost struct {
 // API extension: container_backup
 type ContainerBackup struct {
 	Name             string    `json:"name" yaml:"name"`
-	CreationDate     time.Time `json:"creation_date" yaml:"creation_date"`
-	ExpiryDate       time.Time `json:"expiry_date" yaml:"expiry_date"`
+	CreatedAt        time.Time `json:"created_at" yaml:"created_at"`
+	ExpiresAt        time.Time `json:"expires_at" yaml:"expires_at"`
 	ContainerOnly    bool      `json:"container_only" yaml:"container_only"`
 	OptimizedStorage bool      `json:"optimized_storage" yaml:"optimized_storage"`
 }


### PR DESCRIPTION
As even our CLI doesn't make much use of that yet, I don't think the field rename is likely to break anyone and should make things a lot less surprising to API users.