### PR TITLE
lxd/backup: Call tar with --numeric-ids

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -385,7 +385,7 @@ func backupCreateTarball(s *state.State, path string, backup backup) error {
 		os.RemoveAll(backupPath)
 	}()
 
-	args := []string{"-cf", backupPath, "--xattrs", "-C", path, "--transform", "s,^./,backup/,", "."}
+	args := []string{"-cf", backupPath, "--numeric-owner", "--xattrs", "-C", path, "--transform", "s,^./,backup/,", "."}
 	_, err = shared.RunCommand("tar", args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
Otherwise the encoded user/group names may differ on target system
leading to a rewrite of uid/gid...

Closes #6097

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>