### PR TITLE
Device Infiniband resources package

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7162,7 +7162,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m config.Device) (config.D
 	}
 
 	// Fill in the MAC address
-	if !shared.StringInSlice(m["nictype"], []string{"physical", "ipvlan", "infiniband", "sriov"}) && m["hwaddr"] == "" {
+	if !shared.StringInSlice(m["nictype"], []string{"physical", "ipvlan", "sriov"}) && m["hwaddr"] == "" {
 		configKey := fmt.Sprintf("volatile.%s.hwaddr", name)
 		volatileHwaddr := c.localConfig[configKey]
 		if volatileHwaddr == "" {

--- a/lxd/device/device_utils_infiniband.go
+++ b/lxd/device/device_utils_infiniband.go
@@ -1,280 +1,83 @@
 package device
 
 import (
-	"bytes"
 	"fmt"
-	"io/ioutil"
-	"os"
-	"strconv"
-	"strings"
 
 	"github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
-	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
 )
-
-// SCIB Infiniband sys class path.
-const SCIB = "/sys/class/infiniband"
-
-// SCNET Net sys class path.
-const SCNET = "/sys/class/net"
 
 // IBDevPrefix Infiniband devices prefix.
 const IBDevPrefix = "infiniband.unix"
 
-// IBF structure representing Infiniband function config.
-type IBF struct {
-	// port the function belongs to.
-	Port int64
+// infinibandDevices extracts the infiniband parent device from the supplied nic list and any free
+// associated virtual functions (VFs) that are on the same card and port as the specified parent.
+// This function expects that the supplied nic list does not include VFs that are already attached
+// to running instances.
+func infinibandDevices(nics *api.ResourcesNetwork, parent string) map[string]*api.ResourcesNetworkCardPort {
+	ibDevs := make(map[string]*api.ResourcesNetworkCardPort)
+	for _, card := range nics.Cards {
+		for _, port := range card.Ports {
+			// Skip non-infiniband ports.
+			if port.Protocol != "infiniband" {
+				continue
+			}
 
-	// name of the {physical,virtual} function.
-	Fun string
+			// Skip port if not parent.
+			if port.ID != parent {
+				continue
+			}
 
-	// whether this is a physical (true) or virtual (false) function.
-	PF bool
-
-	// device of the function.
-	Device string
-
-	// uverb device of the function.
-	PerPortDevices []string
-	PerFunDevices  []string
-}
-
-func sysfsExists(path string) bool {
-	_, err := os.Lstat(path)
-	if err == nil {
-		return true
-	}
-
-	return false
-}
-
-// infinibandLoadDevices inspects the system and returns information about all infiniband devices.
-func infinibandLoadDevices() (map[string]IBF, error) {
-	// check if there are any infiniband devices.
-	fscib, err := os.Open(SCIB)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, os.ErrNotExist
+			// Store infiniband port info.
+			ibDevs[port.ID] = &port
 		}
-		return nil, err
-	}
-	defer fscib.Close()
 
-	// eg.g. mlx_i for i = 0, 1, ..., n
-	IBDevNames, err := fscib.Readdirnames(-1)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(IBDevNames) == 0 {
-		return nil, os.ErrNotExist
-	}
-
-	// Retrieve all network device names.
-	fscnet, err := os.Open(SCNET)
-	if err != nil {
-		if os.IsNotExist(err) {
-			return nil, os.ErrNotExist
-		}
-		return nil, err
-	}
-	defer fscnet.Close()
-
-	// Retrieve all network devices.
-	NetDevNames, err := fscnet.Readdirnames(-1)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(NetDevNames) == 0 {
-		return nil, os.ErrNotExist
-	}
-
-	UseableDevices := make(map[string]IBF)
-	for _, IBDevName := range IBDevNames {
-		IBDevResourceFile := fmt.Sprintf("/sys/class/infiniband/%s/device/resource", IBDevName)
-		if !sysfsExists(IBDevResourceFile) {
+		// Skip virtual function (VF) extraction if SRIOV isn't supported on port.
+		if card.SRIOV == nil {
 			continue
 		}
 
-		IBDevResourceBuf, err := ioutil.ReadFile(IBDevResourceFile)
-		if err != nil {
-			return nil, err
-		}
+		// Record if parent has been found as a physical function (PF).
+		parentDev, parentIsPF := ibDevs[parent]
 
-		for _, NetDevName := range NetDevNames {
-			NetDevResourceFile := fmt.Sprintf("/sys/class/net/%s/device/resource", NetDevName)
-			if !sysfsExists(NetDevResourceFile) {
-				continue
-			}
-
-			NetDevResourceBuf, err := ioutil.ReadFile(NetDevResourceFile)
-			if err != nil {
-				return nil, err
-			}
-
-			// If the device and the VF have the same address space
-			// they belong together.
-			if bytes.Compare(IBDevResourceBuf, NetDevResourceBuf) != 0 {
-				continue
-			}
-
-			// Now let's find the ports.
-			IBDevID := fmt.Sprintf("/sys/class/net/%s/dev_id", NetDevName)
-			IBDevPort := fmt.Sprintf("/sys/class/net/%s/dev_port", NetDevName)
-			DevIDBuf, err := ioutil.ReadFile(IBDevID)
-			if err != nil {
-				if os.IsNotExist(err) {
+		for _, VF := range card.SRIOV.VFs {
+			for _, port := range VF.Ports {
+				// Skip non-infiniband VFs.
+				if port.Protocol != "infiniband" {
 					continue
 				}
-				return nil, err
+
+				// Skip VF if parent is a PF and VF is not on same port as parent.
+				if parentIsPF && parentDev.Port != port.Port {
+					continue
+				}
+
+				// Skip VF if parent isn't a PF and VF doesn't match parent name.
+				if !parentIsPF && port.ID != parent {
+					continue
+				}
+
+				// Store infiniband VF port info.
+				ibDevs[port.ID] = &port
 			}
-
-			DevIDString := strings.TrimSpace(string(DevIDBuf))
-			DevIDPort, err := strconv.ParseInt(DevIDString, 0, 64)
-			if err != nil {
-				return nil, err
-			}
-
-			DevPort := int64(0)
-			DevPortBuf, err := ioutil.ReadFile(IBDevPort)
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return nil, err
-				}
-			} else {
-				DevPortString := strings.TrimSpace(string(DevPortBuf))
-				DevPort, err = strconv.ParseInt(DevPortString, 0, 64)
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			Port := DevIDPort
-			if DevPort > DevIDPort {
-				Port = DevPort
-			}
-			Port++
-
-			NewIBF := IBF{
-				Port:   Port,
-				Fun:    IBDevName,
-				Device: NetDevName,
-			}
-
-			// Identify the /dev/infiniband/uverb<idx> device.
-			tmp := []string{}
-			IBUverb := fmt.Sprintf("/sys/class/net/%s/device/infiniband_verbs", NetDevName)
-			fuverb, err := os.Open(IBUverb)
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return nil, err
-				}
-			} else {
-				defer fuverb.Close()
-
-				// Optional: retrieve all network devices.
-				tmp, err = fuverb.Readdirnames(-1)
-				if err != nil {
-					return nil, err
-				}
-
-				if len(tmp) == 0 {
-					return nil, os.ErrNotExist
-				}
-			}
-			for _, v := range tmp {
-				if strings.Index(v, "-") != -1 {
-					return nil, fmt.Errorf("Infiniband character device \"%s\" contains \"-\". Cannot guarantee unique encoding", v)
-				}
-				NewIBF.PerPortDevices = append(NewIBF.PerPortDevices, v)
-			}
-
-			// Identify the /dev/infiniband/ucm<idx> device.
-			tmp = []string{}
-			IBcm := fmt.Sprintf("/sys/class/net/%s/device/infiniband_ucm", NetDevName)
-			fcm, err := os.Open(IBcm)
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return nil, err
-				}
-			} else {
-				defer fcm.Close()
-
-				// Optional: retrieve all network devices.
-				tmp, err = fcm.Readdirnames(-1)
-				if err != nil {
-					return nil, err
-				}
-
-				if len(tmp) == 0 {
-					return nil, os.ErrNotExist
-				}
-			}
-			for _, v := range tmp {
-				if strings.Index(v, "-") != -1 {
-					return nil, fmt.Errorf("Infiniband character device \"%s\" contains \"-\". Cannot guarantee unique encoding", v)
-				}
-				devPath := fmt.Sprintf("/dev/infiniband/%s", v)
-				NewIBF.PerPortDevices = append(NewIBF.PerPortDevices, devPath)
-			}
-
-			// Identify the /dev/infiniband/{issm,umad}<idx> devices.
-			IBmad := fmt.Sprintf("/sys/class/net/%s/device/infiniband_mad", NetDevName)
-			ents, err := ioutil.ReadDir(IBmad)
-			if err != nil {
-				if !os.IsNotExist(err) {
-					return nil, err
-				}
-			} else {
-				for _, ent := range ents {
-					IBmadPort := fmt.Sprintf("%s/%s/port", IBmad, ent.Name())
-					portBuf, err := ioutil.ReadFile(IBmadPort)
-					if err != nil {
-						if !os.IsNotExist(err) {
-							return nil, err
-						}
-						continue
-					}
-
-					portStr := strings.TrimSpace(string(portBuf))
-					PortMad, err := strconv.ParseInt(portStr, 0, 64)
-					if err != nil {
-						return nil, err
-					}
-
-					if PortMad != NewIBF.Port {
-						continue
-					}
-
-					if strings.Index(ent.Name(), "-") != -1 {
-						return nil, fmt.Errorf("Infiniband character device \"%s\" contains \"-\". Cannot guarantee unique encoding", ent.Name())
-					}
-
-					NewIBF.PerFunDevices = append(NewIBF.PerFunDevices, ent.Name())
-				}
-			}
-
-			// Figure out whether this is a physical function.
-			IBPF := fmt.Sprintf("/sys/class/net/%s/device/physfn", NetDevName)
-			NewIBF.PF = !shared.PathExists(IBPF)
-
-			UseableDevices[NetDevName] = NewIBF
 		}
 	}
 
-	return UseableDevices, nil
+	return ibDevs
 }
 
 // infinibandAddDevices creates the UNIX devices for the provided IBF device and then configures the
 // supplied runConfig with the Cgroup rules and mount instructions to pass the device into instance.
-func infinibandAddDevices(s *state.State, devicesPath string, deviceName string, ifDev *IBF, runConf *RunConfig) error {
-	for _, unixCharDev := range ifDev.PerPortDevices {
-		destPath := fmt.Sprintf("/dev/infiniband/%s", unixCharDev)
+func infinibandAddDevices(s *state.State, devicesPath string, deviceName string, ibDev *api.ResourcesNetworkCardPort, runConf *RunConfig) error {
+	if ibDev.Infiniband == nil {
+		return fmt.Errorf("No infiniband devices supplied")
+	}
+
+	// Add IsSM device if defined.
+	if ibDev.Infiniband.IsSMName != "" {
 		dummyDevice := config.Device{
-			"source": destPath,
+			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.IsSMName),
 		}
 
 		err := unixDeviceSetup(s, devicesPath, IBDevPrefix, deviceName, dummyDevice, false, runConf)
@@ -283,10 +86,22 @@ func infinibandAddDevices(s *state.State, devicesPath string, deviceName string,
 		}
 	}
 
-	for _, unixCharDev := range ifDev.PerFunDevices {
-		destPath := fmt.Sprintf("/dev/infiniband/%s", unixCharDev)
+	// Add MAD device if defined.
+	if ibDev.Infiniband.MADName != "" {
 		dummyDevice := config.Device{
-			"source": destPath,
+			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.MADName),
+		}
+
+		err := unixDeviceSetup(s, devicesPath, IBDevPrefix, deviceName, dummyDevice, false, runConf)
+		if err != nil {
+			return err
+		}
+	}
+
+	// Add Verb device if defined.
+	if ibDev.Infiniband.VerbName != "" {
+		dummyDevice := config.Device{
+			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.VerbName),
 		}
 
 		err := unixDeviceSetup(s, devicesPath, IBDevPrefix, deviceName, dummyDevice, false, runConf)

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -2,7 +2,6 @@ package device
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -653,45 +652,6 @@ func NetworkValidNetworkV6List(value string) error {
 	}
 
 	return nil
-}
-
-// NetworkSRIOVGetFreeVFInterface checks the contents of the VF directory to find a free VF
-// interface name that belongs to the same device and port as the parent.
-// Returns VF interface name or empty string if no free interface found.
-func NetworkSRIOVGetFreeVFInterface(reservedDevices map[string]struct{}, vfListPath string, pfDevID []byte, pfDevPort []byte) (string, error) {
-	ents, err := ioutil.ReadDir(vfListPath)
-	if err != nil {
-		return "", err
-	}
-
-	for _, ent := range ents {
-		// We can't use this VF interface as it is reserved by another device.
-		_, exists := reservedDevices[ent.Name()]
-		if exists {
-			continue
-		}
-
-		// Get VF dev_port and dev_id values.
-		vfDevPort, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/dev_port", vfListPath, ent.Name()))
-		if err != nil {
-			return "", err
-		}
-
-		vfDevID, err := ioutil.ReadFile(fmt.Sprintf("%s/%s/dev_id", vfListPath, ent.Name()))
-		if err != nil {
-			return "", err
-		}
-
-		// Skip VFs if they do not relate to the same device and port as the parent PF.
-		// Some card vendors change the device ID for each port.
-		if bytes.Compare(pfDevPort, vfDevPort) != 0 || bytes.Compare(pfDevID, vfDevID) != 0 {
-			continue
-		}
-
-		return ent.Name(), nil
-	}
-
-	return "", nil
 }
 
 // networkParsePortRange validates a port range in the form n-n.

--- a/test/suites/container_devices_infiniband_physical.sh
+++ b/test/suites/container_devices_infiniband_physical.sh
@@ -19,8 +19,6 @@ test_container_devices_ib_physical() {
   fi
 
   ctName="nt$$"
-  macRand=$(shuf -i 0-9 -n 1)
-  ctMAC1="a0:00:0a:c0:fe:80:00:00:00:00:00:00:a2:44:3c:1f:b0:15:e2:f${macRand}"
 
   # Record how many nics we started with.
   startNicCount=$(find /sys/class/net | wc -l)
@@ -30,8 +28,7 @@ test_container_devices_ib_physical() {
   lxc config device add "${ctName}" eth0 infiniband \
     nictype=physical \
     parent="${parent}" \
-    mtu=1500 \
-    hwaddr="${ctMAC1}"
+    mtu=1500
   lxc start "${ctName}"
 
   # Check host devices are created.
@@ -103,8 +100,7 @@ test_container_devices_ib_physical() {
   lxc config device add "${ctName}" eth0 infiniband \
     nictype=physical \
     parent="${parent}" \
-    mtu=1500 \
-    hwaddr="${ctMAC1}"
+    mtu=1500
 
   # Check host devices are created.
   ibDevCount=$(find "${LXD_DIR}"/devices/"${ctName}" -type c | wc -l)

--- a/test/suites/container_devices_infiniband_sriov.sh
+++ b/test/suites/container_devices_infiniband_sriov.sh
@@ -19,9 +19,6 @@ test_container_devices_ib_sriov() {
   fi
 
   ctName="nt$$"
-  macRand=$(shuf -i 0-9 -n 1)
-  ctMAC1="a0:00:0a:a0:fe:80:00:00:00:00:00:00:96:29:52:03:73:4b:81:e${macRand}"
-  ctMAC2="a0:00:0a:c0:fe:80:00:00:00:00:00:00:a2:44:3c:1f:b0:15:e2:f${macRand}"
 
   # Set a known start point config
   ip link set "${parent}" up
@@ -34,13 +31,11 @@ test_container_devices_ib_sriov() {
   lxc config device add "${ctName}" eth0 infiniband \
     nictype=sriov \
     parent="${parent}" \
-    mtu=1500 \
-    hwaddr="${ctMAC1}"
+    mtu=1500
   lxc config device add "${ctName}" eth1 infiniband \
     nictype=sriov \
     parent="${parent}" \
-    mtu=1500 \
-    hwaddr="${ctMAC2}"
+    mtu=1500
   lxc start "${ctName}"
 
   # Check host devices are created.
@@ -113,8 +108,7 @@ test_container_devices_ib_sriov() {
   lxc config device add "${ctName}" eth0 infiniband \
     nictype=sriov \
     parent="${parent}" \
-    mtu=1500 \
-    hwaddr="${ctMAC1}"
+    mtu=1500
 
   # Check host devices are created.
   ibDevCount=$(find "${LXD_DIR}"/devices/"${ctName}" -type c | wc -l)


### PR DESCRIPTION
- Updates infiniband device to use resources package for host device discovery
- Moves some SR-IOV code that was shared between nic/sriov and infiniband/sriov devices into nic/sriov device, as no longer needed by infiniband/sriov
- Removes MAC based tests for infiniband devices as they do not work reliably
- Removes ineffective use of "infiniband" as nictype property in fillNetworkDevice

Includes https://github.com/lxc/lxd/pull/6104