### PR TITLE
dnsmasq version check fix with different locales

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5968,6 +5968,7 @@ func (c *containerLXC) FileExists(path string) error {
 
 	// Check if the file exists in the container
 	_, stderr, err := shared.RunCommandSplit(
+		nil,
 		c.state.OS.ExecPath,
 		"forkfile",
 		"exists",
@@ -6015,6 +6016,7 @@ func (c *containerLXC) FilePull(srcpath string, dstpath string) (int64, int64, o
 
 	// Get the file from the container
 	_, stderr, err := shared.RunCommandSplit(
+		nil,
 		c.state.OS.ExecPath,
 		"forkfile",
 		"pull",
@@ -6159,6 +6161,7 @@ func (c *containerLXC) FilePush(type_ string, srcpath string, dstpath string, ui
 
 	// Push the file to the container
 	_, stderr, err := shared.RunCommandSplit(
+		nil,
 		c.state.OS.ExecPath,
 		"forkfile",
 		"push",
@@ -6228,6 +6231,7 @@ func (c *containerLXC) FileRemove(path string) error {
 
 	// Remove the file from the container
 	_, stderr, err := shared.RunCommandSplit(
+		nil,
 		c.state.OS.ExecPath,
 		"forkfile",
 		"remove",

--- a/lxd/dnsmasq/dnsmasq.go
+++ b/lxd/dnsmasq/dnsmasq.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -155,8 +154,7 @@ func Kill(name string, reload bool) error {
 
 // GetVersion returns the version of dnsmasq.
 func GetVersion() (*version.DottedVersion, error) {
-	// Discard stderr on purpose (occasional linker errors)
-	output, err := exec.Command("dnsmasq", "--version").Output()
+	output, err := shared.RunCommandCLocale("dnsmasq", "--version")
 	if err != nil {
 		return nil, fmt.Errorf("Failed to check dnsmasq version: %v", err)
 	}

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1292,6 +1292,9 @@ func (n *network) Start() error {
 		fmt.Sprintf("--interface=%s", n.name)}
 
 	dnsmasqVersion, err := dnsmasq.GetVersion()
+	if err != nil {
+		return err
+	}
 
 	// --dhcp-rapid-commit option is only supported on >2.79
 	minVer, _ := version.NewDottedVersion("2.79")

--- a/lxd/seccomp.go
+++ b/lxd/seccomp.go
@@ -826,7 +826,7 @@ func CallForkmknod(c container, dev config.Device, requestPID int) int {
 		dev["hostpath"] = filepath.Join(c.RootfsPath(), rootPath, dev["path"])
 	}
 
-	_, stderr, err := shared.RunCommandSplit(util.GetExecPath(),
+	_, stderr, err := shared.RunCommandSplit(nil, util.GetExecPath(),
 		"forksyscall", "mknod", dev["pid"], dev["path"],
 		dev["mode_t"], dev["dev_t"], dev["hostpath"],
 		fmt.Sprintf("%d", uid), fmt.Sprintf("%d", gid),
@@ -1030,7 +1030,7 @@ func (s *SeccompServer) HandleSetxattrSyscall(c container, siov *SeccompIovec) i
 		whiteout = 1
 	}
 
-	_, stderr, err := shared.RunCommandSplit(util.GetExecPath(),
+	_, stderr, err := shared.RunCommandSplit(nil, util.GetExecPath(),
 		"forksyscall",
 		"setxattr",
 		fmt.Sprintf("%d", args.pid),

--- a/shared/util.go
+++ b/shared/util.go
@@ -793,8 +793,16 @@ func (e RunError) Error() string {
 	return e.msg
 }
 
-func RunCommandSplit(name string, arg ...string) (string, string, error) {
+// RunCommandSplit runs a command with a supplied environment and optional arguments and returns the
+// resulting stdout and stderr output as separate variables. If the supplied environment is nil then
+// the default environment is used. If the command fails to start or returns a non-zero exit code
+// then an error is returned containing the output of stderr too.
+func RunCommandSplit(env []string, name string, arg ...string) (string, string, error) {
 	cmd := exec.Command(name, arg...)
+
+	if env != nil {
+		cmd.Env = env
+	}
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -815,8 +823,18 @@ func RunCommandSplit(name string, arg ...string) (string, string, error) {
 	return string(stdout.Bytes()), string(stderr.Bytes()), nil
 }
 
+// RunCommand runs a command with optional arguments and returns stdout. If the command fails to
+// start or returns a non-zero exit code then an error is returned containing the output of stderr.
 func RunCommand(name string, arg ...string) (string, error) {
-	stdout, _, err := RunCommandSplit(name, arg...)
+	stdout, _, err := RunCommandSplit(nil, name, arg...)
+	return stdout, err
+}
+
+// RunCommandCLocale runs a command with a LANG=C.UTF-8 environment set with optional arguments and
+// returns stdout. If the command fails to start or returns a non-zero exit code then an error is
+// returned containing the output of stderr.
+func RunCommandCLocale(name string, arg ...string) (string, error) {
+	stdout, _, err := RunCommandSplit(append(os.Environ(), "LANG=C.UTF-8"), name, arg...)
 	return stdout, err
 }
 


### PR DESCRIPTION
Fixes #6109

- Checks error response from `dnsmasq.GetVersion()`.
- Updates `dnsmasq.GetVersion()` to use the new `shared.RunCommandCLocale()` which runs the `dnsmasq --version` command with a `LANG=C.UTF-8` environment variable to avoid issues when the user is using a different locale that affects version string comparison.
- Updates `shared.RunCommandSplit()` to accept and optional environment variable slice to replace the current environment.