### PR TITLE
Fixes some issues with unix inotify

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2696,7 +2696,7 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 				}
 				srcPath = shared.HostPath(srcPath)
 
-				err = deviceInotifyAddClosestLivingAncestor(c.state, srcPath)
+				err = deviceInotifyAddClosestLivingAncestor(c.state, filepath.Dir(srcPath))
 				if err != nil {
 					logger.Errorf("Failed to add \"%s\" to inotify targets", srcPath)
 					return "", postStartHooks, err

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -1087,11 +1087,11 @@ func deviceInotifyDirRescan(s *state.State) {
 			}
 
 			// and add its nearest existing ancestor.
-			err = deviceInotifyAddClosestLivingAncestor(s, cleanDevPath)
+			err = deviceInotifyAddClosestLivingAncestor(s, filepath.Dir(cleanDevPath))
 			if err != nil {
-				logger.Errorf("Failed to add \"%s\" to inotify targets: %s", cleanDevPath, err)
+				logger.Errorf("Failed to add \"%s\" to inotify targets: %s", filepath.Dir(cleanDevPath), err)
 			} else {
-				logger.Debugf("Added \"%s\" to inotify targets", cleanDevPath)
+				logger.Debugf("Added \"%s\" to inotify targets", filepath.Dir(cleanDevPath))
 			}
 		}
 	}


### PR DESCRIPTION
Starting LXD with a container running that has a non-required dev already existing on host, fails to add inotify for that device with `Failed to add "/tmp/testdev" to inotify targets: not a directory` which means it also doesnt get removed if the file is removed.

@stgraber I thought this might be useful to cherry pick into stable releases before I port it over to the `device` package.