### PR TITLE
Allow bridged device removal when DHCP disabled on parent network

### DIFF
--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -1913,6 +1913,15 @@ func (n *network) Start() error {
 				return err
 			}
 		}
+	} else {
+		// Clean up old dnsmasq config if exists and we are not starting dnsmasq.
+		leasesPath := shared.VarPath("networks", n.name, "dnsmasq.leases")
+		if shared.PathExists(leasesPath) {
+			err := os.Remove(leasesPath)
+			if err != nil {
+				return errors.Wrapf(err, "Failed to remove old dnsmasq leases file '%s'", leasesPath)
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Fixes issue where if DHCP is disabled on the parent network after a bridged device has acquired a lease you can no longer remove the device (as it cannot do DHCP release).

Fixes #6102