### PR TITLE
forkproxy: Fixes bug where proxy wouldn't start in snap environment

### DIFF
--- a/lxd/main_forkproxy.go
+++ b/lxd/main_forkproxy.go
@@ -311,9 +311,11 @@ func (c *cmdForkproxy) Run(cmd *cobra.Command, args []string) error {
 	lAddr := proxyParseAddr(listenAddr)
 
 	if C.whoami == C.FORKPROXY_CHILD {
-		err := os.Remove(lAddr.addr)
-		if err != nil && !os.IsNotExist(err) {
-			return err
+		if lAddr.connType == "unix" {
+			err := os.Remove(lAddr.addr)
+			if err != nil && !os.IsNotExist(err) {
+				return err
+			}
 		}
 
 		file, err := getListenerFile(listenAddr)


### PR DESCRIPTION
Fixes #6112

Signed-off-by: Thomas Parrott <tomp@tomp.uk>