### PR TITLE
Adapt to new go dqlite api

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/canonical/go-dqlite"
+	dqlitedriver "github.com/canonical/go-dqlite/driver"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 
@@ -20,7 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
-	driver "github.com/lxc/lxd/lxd/storage"
+	storagedriver "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
@@ -495,7 +495,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) Response {
 			if err != nil {
 				return errors.Wrap(err, "failed to init ceph pool for joining node")
 			}
-			volumeMntPoint := driver.GetStoragePoolVolumeMountPoint(
+			volumeMntPoint := storagedriver.GetStoragePoolVolumeMountPoint(
 				name, storage.(*storageCeph).volume.Name)
 			err = os.MkdirAll(volumeMntPoint, 0711)
 			if err != nil {
@@ -657,8 +657,8 @@ func clusterPutDisable(d *Daemon) Response {
 		"db.bin", store, address, "/unused/db/dir",
 		d.config.DqliteSetupTimeout,
 		nil,
-		dqlite.WithDialFunc(d.gateway.DialFunc()),
-		dqlite.WithContext(d.gateway.Context()),
+		dqlitedriver.WithDialFunc(d.gateway.DialFunc()),
+		dqlitedriver.WithContext(d.gateway.Context()),
 	)
 	if err != nil {
 		return SmartError(err)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -652,7 +652,7 @@ func clusterPutDisable(d *Daemon) Response {
 	if err != nil {
 		return SmartError(err)
 	}
-	store := d.gateway.ServerStore()
+	store := d.gateway.NodeStore()
 	d.cluster, err = db.OpenCluster(
 		"db.bin", store, address, "/unused/db/dir",
 		d.config.DqliteSetupTimeout,

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	dqlite "github.com/canonical/go-dqlite"
+	dqliteclient "github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -405,7 +406,13 @@ func (g *Gateway) Sync() {
 		return
 	}
 
-	files, err := g.server.Dump(context.Background(), "db.bin")
+	client, err := g.getClient()
+	if err != nil {
+		logger.Warnf("Failed to get client: %v", err)
+		return
+	}
+
+	files, err := client.Dump(context.Background(), "db.bin")
 	if err != nil {
 		// Just log a warning, since this is not fatal.
 		logger.Warnf("Failed get database dump: %v", err)
@@ -421,6 +428,10 @@ func (g *Gateway) Sync() {
 
 		}
 	}
+}
+
+func (g *Gateway) getClient() (*dqliteclient.Client, error) {
+	return dqliteclient.New(context.Background(), g.bindAddress)
 }
 
 // Reset the gateway, shutting it down and starting against from scratch using

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -411,6 +411,7 @@ func (g *Gateway) Sync() {
 		logger.Warnf("Failed to get client: %v", err)
 		return
 	}
+	defer client.Close()
 
 	files, err := client.Dump(context.Background(), "db.bin")
 	if err != nil {
@@ -689,7 +690,13 @@ func (g *Gateway) currentRaftNodes() ([]db.RaftNode, error) {
 	if !isLeader {
 		return nil, errNotLeader
 	}
-	servers, err := g.server.Cluster(context.Background())
+	client, err := g.getClient()
+	if err != nil {
+		return nil, err
+	}
+	defer client.Close()
+
+	servers, err := client.Cluster(context.Background())
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -57,7 +57,7 @@ func TestGateway_Single(t *testing.T) {
 	assert.EqualError(t, err, "Node is not clustered")
 
 	driver, err := driver.New(
-		gateway.ServerStore(),
+		gateway.NodeStore(),
 		driver.WithDialFunc(gateway.DialFunc()),
 	)
 	require.NoError(t, err)
@@ -90,7 +90,7 @@ func TestGateway_SingleWithNetworkAddress(t *testing.T) {
 	}
 
 	driver, err := driver.New(
-		gateway.ServerStore(),
+		gateway.NodeStore(),
 		driver.WithDialFunc(gateway.DialFunc()),
 	)
 	require.NoError(t, err)

--- a/lxd/cluster/gateway_test.go
+++ b/lxd/cluster/gateway_test.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/shared"
@@ -56,9 +56,9 @@ func TestGateway_Single(t *testing.T) {
 	assert.Equal(t, "", leader)
 	assert.EqualError(t, err, "Node is not clustered")
 
-	driver, err := dqlite.NewDriver(
+	driver, err := driver.New(
 		gateway.ServerStore(),
-		dqlite.WithDialFunc(gateway.DialFunc()),
+		driver.WithDialFunc(gateway.DialFunc()),
 	)
 	require.NoError(t, err)
 
@@ -89,9 +89,9 @@ func TestGateway_SingleWithNetworkAddress(t *testing.T) {
 		mux.HandleFunc(path, handler)
 	}
 
-	driver, err := dqlite.NewDriver(
+	driver, err := driver.New(
 		gateway.ServerStore(),
-		dqlite.WithDialFunc(gateway.DialFunc()),
+		driver.WithDialFunc(gateway.DialFunc()),
 	)
 	require.NoError(t, err)
 

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
@@ -263,7 +263,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 	dial := gateway.DialFunc()
 	state.Cluster, err = db.OpenCluster(
 		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,
-		dqlite.WithDialFunc(dial))
+		driver.WithDialFunc(dial))
 	require.NoError(f.t, err)
 
 	f.gateways[len(f.gateways)] = gateway

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -259,7 +259,7 @@ func (f *heartbeatFixture) node() (*state.State, *cluster.Gateway, string) {
 
 	var err error
 	require.NoError(f.t, state.Cluster.Close())
-	store := gateway.ServerStore()
+	store := gateway.NodeStore()
 	dial := gateway.DialFunc()
 	state.Cluster, err = db.OpenCluster(
 		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -8,7 +8,6 @@ import (
 	"strconv"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
 	"github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
@@ -714,10 +713,21 @@ func Leave(state *state.State, gateway *Gateway, name string, force bool) (strin
 		log15.Ctx{"id": id, "address": address, "target": target})
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = dqlite.Leave(ctx, uint64(id), gateway.NodeStore(), gateway.raftDial())
+
+	client, err := client.FindLeader(
+		ctx, gateway.NodeStore(),
+		client.WithDialFunc(gateway.raftDial()),
+		client.WithLogFunc(DqliteLog),
+	)
 	if err != nil {
-		return "", err
+		return "", errors.Wrap(err, "Failed to connect to cluster leader")
 	}
+	defer client.Close()
+	err = client.Remove(ctx, id)
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to leave the cluster")
+	}
+
 	return address, nil
 }
 

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/node"
@@ -329,9 +330,18 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 			log15.Ctx{"id": id, "address": address, "target": target.Address})
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err := gateway.server.Join(ctx, gateway.NodeStore(), gateway.raftDial())
+		client, err := client.FindLeader(
+			ctx, gateway.NodeStore(),
+			client.WithDialFunc(gateway.raftDial()),
+			client.WithLogFunc(DqliteLog),
+		)
 		if err != nil {
-			return err
+			return errors.Wrap(err, "Failed to connect to cluster leader")
+		}
+		defer client.Close()
+		err = client.Add(ctx, gateway.raft.info)
+		if err != nil {
+			return errors.Wrap(err, "Failed to join cluster")
 		}
 	} else {
 		logger.Info("Joining cluster as non-database node")
@@ -610,9 +620,15 @@ func Promote(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = gateway.server.Join(ctx, gateway.NodeStore(), gateway.raftDial())
+
+	client, err := client.FindLeader(ctx, gateway.NodeStore(), client.WithDialFunc(gateway.raftDial()))
 	if err != nil {
-		return err
+		return errors.Wrap(err, "Failed to connect to cluster leader")
+	}
+	defer client.Close()
+	err = client.Add(ctx, gateway.raft.info)
+	if err != nil {
+		return errors.Wrap(err, "Failed to join cluster")
 	}
 
 	// Unlock regular access to our cluster database, and make sure our

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -329,7 +329,7 @@ func Join(state *state.State, gateway *Gateway, cert *shared.CertInfo, name stri
 			log15.Ctx{"id": id, "address": address, "target": target.Address})
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		err := gateway.server.Join(ctx, gateway.ServerStore(), gateway.raftDial())
+		err := gateway.server.Join(ctx, gateway.NodeStore(), gateway.raftDial())
 		if err != nil {
 			return err
 		}
@@ -610,7 +610,7 @@ func Promote(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = gateway.server.Join(ctx, gateway.ServerStore(), gateway.raftDial())
+	err = gateway.server.Join(ctx, gateway.NodeStore(), gateway.raftDial())
 	if err != nil {
 		return err
 	}
@@ -698,7 +698,7 @@ func Leave(state *state.State, gateway *Gateway, name string, force bool) (strin
 		log15.Ctx{"id": id, "address": address, "target": target})
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	err = dqlite.Leave(ctx, uint64(id), gateway.ServerStore(), gateway.raftDial())
+	err = dqlite.Leave(ctx, uint64(id), gateway.NodeStore(), gateway.raftDial())
 	if err != nil {
 		return "", err
 	}

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -254,7 +254,7 @@ func TestJoin(t *testing.T) {
 
 	require.NoError(t, targetState.Cluster.Close())
 
-	targetStore := targetGateway.ServerStore()
+	targetStore := targetGateway.NodeStore()
 	targetDialFunc := targetGateway.DialFunc()
 
 	var err error
@@ -293,7 +293,7 @@ func TestJoin(t *testing.T) {
 
 	require.NoError(t, state.Cluster.Close())
 
-	store := gateway.ServerStore()
+	store := gateway.NodeStore()
 	dialFunc := gateway.DialFunc()
 
 	state.Cluster, err = db.OpenCluster(
@@ -378,7 +378,7 @@ func FLAKY_TestPromote(t *testing.T) {
 	targetAddress := targetServer.Listener.Addr().String()
 	var err error
 	require.NoError(t, targetState.Cluster.Close())
-	store := targetGateway.ServerStore()
+	store := targetGateway.NodeStore()
 	dialFunc := targetGateway.DialFunc()
 	targetState.Cluster, err = db.OpenCluster(
 		"db.bin", store, targetAddress, "/unused/db/dir", 5*time.Second, nil,

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
@@ -261,7 +261,7 @@ func TestJoin(t *testing.T) {
 	targetState.Cluster, err = db.OpenCluster(
 		"db.bin", targetStore, targetAddress, "/unused/db/dir",
 		10*time.Second, nil,
-		dqlite.WithDialFunc(targetDialFunc))
+		driver.WithDialFunc(targetDialFunc))
 	require.NoError(t, err)
 
 	targetF := &membershipFixtures{t: t, state: targetState}
@@ -298,7 +298,7 @@ func TestJoin(t *testing.T) {
 
 	state.Cluster, err = db.OpenCluster(
 		"db.bin", store, address, "/unused/db/dir", 5*time.Second, nil,
-		dqlite.WithDialFunc(dialFunc))
+		driver.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 
 	f := &membershipFixtures{t: t, state: state}
@@ -382,7 +382,7 @@ func FLAKY_TestPromote(t *testing.T) {
 	dialFunc := targetGateway.DialFunc()
 	targetState.Cluster, err = db.OpenCluster(
 		"db.bin", store, targetAddress, "/unused/db/dir", 5*time.Second, nil,
-		dqlite.WithDialFunc(dialFunc))
+		driver.WithDialFunc(dialFunc))
 	require.NoError(t, err)
 	targetF := &membershipFixtures{t: t, state: targetState}
 	targetF.ClusterAddress(targetAddress)

--- a/lxd/cluster/migrate_test.go
+++ b/lxd/cluster/migrate_test.go
@@ -25,18 +25,18 @@ func TestMigrateToDqlite10(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.NoError(t, err)
-	info := driver.ServerInfo{ID: uint64(1), Address: "1"}
-	server, err := dqlite.NewServer(info, dir)
+	info := driver.NodeInfo{ID: uint64(1), Address: "1"}
+	server, err := dqlite.New(info, dir)
 	require.NoError(t, err)
 	defer server.Close()
 
 	err = server.Start()
 	require.NoError(t, err)
 
-	store, err := driver.DefaultServerStore(":memory:")
+	store, err := driver.DefaultNodeStore(":memory:")
 	require.NoError(t, err)
 
-	require.NoError(t, store.Set(context.Background(), []driver.ServerInfo{info}))
+	require.NoError(t, store.Set(context.Background(), []driver.NodeInfo{info}))
 
 	dial := func(ctx context.Context, address string) (net.Conn, error) {
 		return net.Dial("unix", "@dqlite-1")

--- a/lxd/cluster/migrate_test.go
+++ b/lxd/cluster/migrate_test.go
@@ -2,13 +2,14 @@ package cluster_test
 
 import (
 	"context"
-	"database/sql/driver"
+	sqldriver "database/sql/driver"
 	"io/ioutil"
 	"net"
 	"os"
 	"testing"
 
 	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/shared"
 	"github.com/stretchr/testify/assert"
@@ -24,7 +25,7 @@ func TestMigrateToDqlite10(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.NoError(t, err)
-	info := dqlite.ServerInfo{ID: uint64(1), Address: "1"}
+	info := driver.ServerInfo{ID: uint64(1), Address: "1"}
 	server, err := dqlite.NewServer(info, dir)
 	require.NoError(t, err)
 	defer server.Close()
@@ -32,27 +33,27 @@ func TestMigrateToDqlite10(t *testing.T) {
 	err = server.Start()
 	require.NoError(t, err)
 
-	store, err := dqlite.DefaultServerStore(":memory:")
+	store, err := driver.DefaultServerStore(":memory:")
 	require.NoError(t, err)
 
-	require.NoError(t, store.Set(context.Background(), []dqlite.ServerInfo{info}))
+	require.NoError(t, store.Set(context.Background(), []driver.ServerInfo{info}))
 
 	dial := func(ctx context.Context, address string) (net.Conn, error) {
 		return net.Dial("unix", "@dqlite-1")
 	}
 
-	drv, err := dqlite.NewDriver(store, dqlite.WithDialFunc(dial))
+	drv, err := driver.New(store, driver.WithDialFunc(dial))
 	require.NoError(t, err)
 
 	conn, err := drv.Open("db.bin")
 	require.NoError(t, err)
 	defer conn.Close()
 
-	queryer := conn.(driver.Queryer)
+	queryer := conn.(sqldriver.Queryer)
 	rows, err := queryer.Query("SELECT name FROM containers", nil)
 	require.NoError(t, err)
 
-	values := make([]driver.Value, 1)
+	values := make([]sqldriver.Value, 1)
 	require.NoError(t, rows.Next(values))
 
 	assert.Equal(t, values[0], "c1")

--- a/lxd/cluster/raft.go
+++ b/lxd/cluster/raft.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"path/filepath"
 
-	dqlite "github.com/canonical/go-dqlite"
+	client "github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/node"
 	"github.com/lxc/lxd/shared"
@@ -65,7 +65,7 @@ func newRaft(database *db.Node, cert *shared.CertInfo, latency float64) (*raftIn
 // A LXD-specific wrapper around raft.Raft, which also holds a reference to its
 // network transport and dqlite FSM.
 type raftInstance struct {
-	info dqlite.ServerInfo
+	info client.ServerInfo
 }
 
 // Create a new raftFactory, instantiating all needed raft dependencies.

--- a/lxd/cluster/raft.go
+++ b/lxd/cluster/raft.go
@@ -65,7 +65,7 @@ func newRaft(database *db.Node, cert *shared.CertInfo, latency float64) (*raftIn
 // A LXD-specific wrapper around raft.Raft, which also holds a reference to its
 // network transport and dqlite FSM.
 type raftInstance struct {
-	info client.ServerInfo
+	info client.NodeInfo
 }
 
 // Create a new raftFactory, instantiating all needed raft dependencies.

--- a/lxd/cluster/raft_test.go
+++ b/lxd/cluster/raft_test.go
@@ -5,7 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/client"
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/util"
@@ -26,7 +26,7 @@ func newRaft(t *testing.T, db *db.Node, cert *shared.CertInfo) *cluster.RaftInst
 // address into the raft_nodes table.
 //
 // This effectively makes the node act as a database raft node.
-func setRaftRole(t *testing.T, database *db.Node, address string) *dqlite.DatabaseServerStore {
+func setRaftRole(t *testing.T, database *db.Node, address string) client.ServerStore {
 	require.NoError(t, database.Transaction(func(tx *db.NodeTx) error {
 		err := tx.UpdateConfig(map[string]string{"cluster.https_address": address})
 		if err != nil {
@@ -36,7 +36,7 @@ func setRaftRole(t *testing.T, database *db.Node, address string) *dqlite.Databa
 		return err
 	}))
 
-	store := dqlite.NewServerStore(database.DB(), "main", "raft_nodes", "address")
+	store := client.NewServerStore(database.DB(), "main", "raft_nodes", "address")
 	return store
 }
 

--- a/lxd/cluster/raft_test.go
+++ b/lxd/cluster/raft_test.go
@@ -26,7 +26,7 @@ func newRaft(t *testing.T, db *db.Node, cert *shared.CertInfo) *cluster.RaftInst
 // address into the raft_nodes table.
 //
 // This effectively makes the node act as a database raft node.
-func setRaftRole(t *testing.T, database *db.Node, address string) client.ServerStore {
+func setRaftRole(t *testing.T, database *db.Node, address string) client.NodeStore {
 	require.NoError(t, database.Transaction(func(tx *db.NodeTx) error {
 		err := tx.UpdateConfig(map[string]string{"cluster.https_address": address})
 		if err != nil {
@@ -36,7 +36,7 @@ func setRaftRole(t *testing.T, database *db.Node, address string) client.ServerS
 		return err
 	}))
 
-	store := client.NewServerStore(database.DB(), "main", "raft_nodes", "address")
+	store := client.NewNodeStore(database.DB(), "main", "raft_nodes", "address")
 	return store
 }
 

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"crypto/x509"
 	"database/sql"
-	"database/sql/driver"
+	sqldriver "database/sql/driver"
 	"fmt"
 	"io"
 	"net/http"
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/CanonicalLtd/candidclient"
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -689,11 +689,11 @@ func (d *Daemon) init() error {
 		d.cluster, err = db.OpenCluster(
 			"db.bin", store, clusterAddress, dir,
 			d.config.DqliteSetupTimeout, dump,
-			dqlite.WithDialFunc(d.gateway.DialFunc()),
-			dqlite.WithContext(d.gateway.Context()),
-			dqlite.WithConnectionTimeout(10*time.Second),
-			dqlite.WithContextTimeout(contextTimeout),
-			dqlite.WithLogFunc(cluster.DqliteLog),
+			driver.WithDialFunc(d.gateway.DialFunc()),
+			driver.WithContext(d.gateway.Context()),
+			driver.WithConnectionTimeout(10*time.Second),
+			driver.WithContextTimeout(contextTimeout),
+			driver.WithLogFunc(cluster.DqliteLog),
 		)
 		if err == nil {
 			break
@@ -1041,7 +1041,7 @@ func (d *Daemon) Stop() error {
 		// If we got io.EOF the network connection was interrupted and
 		// it's likely that the other node shutdown. Let's just log the
 		// event and return cleanly.
-		if errors.Cause(err) == driver.ErrBadConn {
+		if errors.Cause(err) == sqldriver.ErrBadConn {
 			logger.Debugf("Could not close remote database cleanly: %v", err)
 		} else {
 			trackError(err)

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -676,7 +676,7 @@ func (d *Daemon) init() error {
 		logger.Info("Initializing global database")
 		dir := filepath.Join(d.os.VarDir, "database")
 
-		store := d.gateway.ServerStore()
+		store := d.gateway.NodeStore()
 
 		contextTimeout := 5 * time.Second
 		if !clustered {

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -23,7 +23,7 @@ import (
 //
 // The dialer argument is a function that returns a gRPC dialer that can be
 // used to connect to a database node using the gRPC SQL package.
-func Open(name string, store driver.ServerStore, options ...driver.Option) (*sql.DB, error) {
+func Open(name string, store driver.NodeStore, options ...driver.Option) (*sql.DB, error) {
 	driver, err := driver.New(store, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create dqlite driver")

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"sync/atomic"
 
-	dqlite "github.com/canonical/go-dqlite"
+	driver "github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/db/schema"
 	"github.com/lxc/lxd/lxd/util"
@@ -23,8 +23,8 @@ import (
 //
 // The dialer argument is a function that returns a gRPC dialer that can be
 // used to connect to a database node using the gRPC SQL package.
-func Open(name string, store dqlite.ServerStore, options ...dqlite.DriverOption) (*sql.DB, error) {
-	driver, err := dqlite.NewDriver(store, options...)
+func Open(name string, store driver.ServerStore, options ...driver.Option) (*sql.DB, error) {
+	driver, err := driver.New(store, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to create dqlite driver")
 	}

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -163,7 +163,7 @@ type Cluster struct {
 // database matches our version, and possibly trigger a schema update. If the
 // schema update can't be performed right now, because some nodes are still
 // behind, an Upgrading error is returned.
-func OpenCluster(name string, store driver.ServerStore, address, dir string, timeout time.Duration, dump *Dump, options ...driver.Option) (*Cluster, error) {
+func OpenCluster(name string, store driver.NodeStore, address, dir string, timeout time.Duration, dump *Dump, options ...driver.Option) (*Cluster, error) {
 	db, err := cluster.Open(name, store, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open database")

--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -8,7 +8,7 @@ import (
 	"sync"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/pkg/errors"
 
 	"github.com/lxc/lxd/lxd/db/cluster"
@@ -163,7 +163,7 @@ type Cluster struct {
 // database matches our version, and possibly trigger a schema update. If the
 // schema update can't be performed right now, because some nodes are still
 // behind, an Upgrading error is returned.
-func OpenCluster(name string, store dqlite.ServerStore, address, dir string, timeout time.Duration, dump *Dump, options ...dqlite.DriverOption) (*Cluster, error) {
+func OpenCluster(name string, store driver.ServerStore, address, dir string, timeout time.Duration, dump *Dump, options ...driver.Option) (*Cluster, error) {
 	db, err := cluster.Open(name, store, options...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open database")
@@ -194,7 +194,7 @@ func OpenCluster(name string, store dqlite.ServerStore, address, dir string, tim
 		}
 
 		cause := errors.Cause(err)
-		if cause != dqlite.ErrNoAvailableLeader {
+		if cause != driver.ErrNoAvailableLeader {
 			return nil, err
 		}
 
@@ -315,7 +315,7 @@ func ForLocalInspectionWithPreparedStmts(db *sql.DB) (*Cluster, error) {
 
 // SetDefaultTimeout sets the default go-dqlite driver timeout.
 func (c *Cluster) SetDefaultTimeout(timeout time.Duration) {
-	driver := c.db.Driver().(*dqlite.Driver)
+	driver := c.db.Driver().(*driver.Driver)
 	driver.SetContextTimeout(timeout)
 }
 

--- a/lxd/db/migration_test.go
+++ b/lxd/db/migration_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +53,7 @@ func TestImportPreClusteringData(t *testing.T) {
 
 	cluster, err := db.OpenCluster(
 		"test.db", store, "1", dir, 5*time.Second, dump,
-		dqlite.WithDialFunc(dial))
+		driver.WithDialFunc(dial))
 	require.NoError(t, err)
 	defer cluster.Close()
 

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	dqlite "github.com/canonical/go-dqlite"
+	"github.com/canonical/go-dqlite/driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -65,7 +66,7 @@ func NewTestCluster(t *testing.T) (*Cluster, func()) {
 
 	cluster, err := OpenCluster(
 		"test.db", store, "1", dir, 5*time.Second, nil,
-		dqlite.WithLogFunc(log), dqlite.WithDialFunc(dial))
+		driver.WithLogFunc(log), driver.WithDialFunc(dial))
 	require.NoError(t, err)
 
 	cleanup := func() {
@@ -100,7 +101,7 @@ func NewTestClusterTx(t *testing.T) (*ClusterTx, func()) {
 //
 // Return the directory backing the test server and a newly created server
 // store that can be used to connect to it.
-func NewTestDqliteServer(t *testing.T) (string, *dqlite.DatabaseServerStore, func()) {
+func NewTestDqliteServer(t *testing.T) (string, driver.ServerStore, func()) {
 	t.Helper()
 
 	listener, err := net.Listen("unix", "")
@@ -113,7 +114,7 @@ func NewTestDqliteServer(t *testing.T) (string, *dqlite.DatabaseServerStore, fun
 	err = os.Mkdir(filepath.Join(dir, "global"), 0755)
 	require.NoError(t, err)
 
-	info := dqlite.ServerInfo{ID: uint64(1), Address: address}
+	info := driver.ServerInfo{ID: uint64(1), Address: address}
 	server, err := dqlite.NewServer(
 		info, filepath.Join(dir, "global"), dqlite.WithServerBindAddress(address))
 	require.NoError(t, err)
@@ -126,10 +127,10 @@ func NewTestDqliteServer(t *testing.T) (string, *dqlite.DatabaseServerStore, fun
 		dirCleanup()
 	}
 
-	store, err := dqlite.DefaultServerStore(":memory:")
+	store, err := driver.DefaultServerStore(":memory:")
 	require.NoError(t, err)
 	ctx := context.Background()
-	require.NoError(t, store.Set(ctx, []dqlite.ServerInfo{{Address: address}}))
+	require.NoError(t, store.Set(ctx, []driver.ServerInfo{{Address: address}}))
 
 	return dir, store, cleanup
 }

--- a/lxd/response.go
+++ b/lxd/response.go
@@ -11,8 +11,8 @@ import (
 	"os"
 	"time"
 
-	dqlite "github.com/canonical/go-dqlite"
-	"github.com/mattn/go-sqlite3"
+	"github.com/canonical/go-dqlite/driver"
+	sqlite3 "github.com/mattn/go-sqlite3"
 	"github.com/pkg/errors"
 
 	lxd "github.com/lxc/lxd/client"
@@ -541,7 +541,7 @@ func SmartError(err error) Response {
 		}
 
 		return Conflict(nil)
-	case dqlite.ErrNoAvailableLeader:
+	case driver.ErrNoAvailableLeader:
 		return Unavailable(err)
 	default:
 		return InternalError(err)


### PR DESCRIPTION
This completes the move to the final (go-)dqlite 1.0 API.

The biggest change was to split the code into sub-packages in order to be able to build the pure-Go dqlite client without needing CGO. We don't need this ourselves, but that's more future-proof.