### PR TITLE
lxd/apparmor: Prevent writes to /proc/acpi/**

### DIFF
--- a/lxd/apparmor.go
+++ b/lxd/apparmor.go
@@ -76,6 +76,7 @@ const AA_PROFILE_BASE = `
   deny /proc/bus/** wklx,
   deny /proc/kcore rwklx,
   deny /proc/sysrq-trigger rwklx,
+  deny /proc/acpi/** rwklx,
   deny /proc/sys/fs/** wklx,
 
   # Handle securityfs (access handled separately)


### PR DESCRIPTION
Matches https://github.com/lxc/lxc/pull/3117

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>