### PR TITLE
Adapt to changed dqlite.New() signature, not requiring NodeInfo anymore

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -614,7 +614,8 @@ func (g *Gateway) init() error {
 		}
 
 		server, err := dqlite.New(
-			raft.info,
+			raft.info.ID,
+			raft.info.Address,
 			dir,
 			options...,
 		)

--- a/lxd/db/testing.go
+++ b/lxd/db/testing.go
@@ -115,9 +115,8 @@ func NewTestDqliteServer(t *testing.T) (string, driver.NodeStore, func()) {
 	err = os.Mkdir(filepath.Join(dir, "global"), 0755)
 	require.NoError(t, err)
 
-	info := driver.NodeInfo{ID: uint64(1), Address: address}
 	server, err := dqlite.New(
-		info, filepath.Join(dir, "global"), dqlite.WithBindAddress(address))
+		uint64(1), address, filepath.Join(dir, "global"), dqlite.WithBindAddress(address))
 	require.NoError(t, err)
 
 	err = server.Start()


### PR DESCRIPTION
This is a small tweak in the go-dqlite API, which helps decoupling a few things internally.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>