### PR TITLE
Device Disk

### DIFF
--- a/doc/containers.md
+++ b/doc/containers.md
@@ -485,7 +485,7 @@ limits.write    | string    | -                 | no        | I/O limit in byte/
 limits.max      | string    | -                 | no        | Same as modifying both limits.read and limits.write
 path            | string    | -                 | yes       | Path inside the container where the disk will be mounted
 source          | string    | -                 | yes       | Path on the host, either to a file/directory or to a block device
-optional        | boolean   | false             | no        | Controls whether to fail if the source doesn't exist
+required        | boolean   | true              | no        | Controls whether to fail if the source doesn't exist
 readonly        | boolean   | false             | no        | Controls whether to make the mount read-only
 size            | string    | -                 | no        | Disk size in bytes (various suffixes supported, see below). This is only supported for the rootfs (/).
 recursive       | boolean   | false             | no        | Whether or not to recursively mount the source path
@@ -543,7 +543,7 @@ productid   | string    | -                 | no        | The product id of the 
 uid         | int       | 0                 | no        | UID of the device owner in the container
 gid         | int       | 0                 | no        | GID of the device owner in the container
 mode        | int       | 0660              | no        | Mode of the device in the container
-required    | boolean   | false             | no        | Whether or not this device is required to start the container. (The default is no, and all devices are hot-pluggable.)
+required    | boolean   | false             | no        | Whether or not this device is required to start the container. (The default is false, and all devices are hot-pluggable)
 
 ### Type: gpu
 GPU device entries simply make the requested gpu device appear in the

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2287,6 +2287,22 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 	c.removeUnixDevices()
 	c.removeDiskDevices()
 
+	// Create any missing directories.
+	err = os.MkdirAll(c.LogPath(), 0700)
+	if err != nil {
+		return "", postStartHooks, err
+	}
+
+	err = os.MkdirAll(c.DevicesPath(), 0711)
+	if err != nil {
+		return "", postStartHooks, err
+	}
+
+	err = os.MkdirAll(c.ShmountsPath(), 0711)
+	if err != nil {
+		return "", postStartHooks, err
+	}
+
 	// Create the devices
 	nicID := -1
 
@@ -2424,22 +2440,6 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 		}
 	}
 
-	// Create any missing directory
-	err = os.MkdirAll(c.LogPath(), 0700)
-	if err != nil {
-		return "", postStartHooks, err
-	}
-
-	err = os.MkdirAll(c.DevicesPath(), 0711)
-	if err != nil {
-		return "", postStartHooks, err
-	}
-
-	err = os.MkdirAll(c.ShmountsPath(), 0711)
-	if err != nil {
-		return "", postStartHooks, err
-	}
-
 	// Rotate the log file
 	logfile := c.LogFilePath()
 	if shared.PathExists(logfile) {
@@ -2450,7 +2450,7 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 		}
 	}
 
-	// Storage is guaranteed to be mountable now.
+	// Storage is guaranteed to be mountable now (must be called after devices setup).
 	ourStart, err = c.StorageStart()
 	if err != nil {
 		return "", postStartHooks, err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1741,13 +1741,13 @@ func (c *containerLXC) deviceAttachNIC(configCopy map[string]string, netIF []dev
 }
 
 // deviceUpdate loads a new device and calls its Update() function.
-func (c *containerLXC) deviceUpdate(deviceName string, rawConfig config.Device, oldConfig config.Device, isRunning bool) error {
+func (c *containerLXC) deviceUpdate(deviceName string, rawConfig config.Device, oldDevices config.Devices, isRunning bool) error {
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return err
 	}
 
-	err = d.Update(oldConfig, isRunning)
+	err = d.Update(oldDevices, isRunning)
 	if err != nil {
 		return err
 	}
@@ -4899,7 +4899,7 @@ func (c *containerLXC) updateDevices(removeDevices config.Devices, addDevices co
 	}
 
 	for _, dev := range updateDevices.Sorted() {
-		err := c.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices[dev.Name], isRunning)
+		err := c.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices, isRunning)
 		if err != nil && err != device.ErrUnsupportedDevType {
 			return errors.Wrapf(err, "Failed to update device '%s'", dev.Name)
 		}

--- a/lxd/device/config/devices.go
+++ b/lxd/device/config/devices.go
@@ -126,15 +126,15 @@ func (list Devices) Update(newlist Devices, updateFields func(Device, Device) []
 	return rmlist, addlist, updatelist, updateDiff
 }
 
-// DeviceNames returns the name of all devices in the set, sorted properly
-func (list Devices) DeviceNames() []string {
-	sortable := sortableDevices{}
-	for k, d := range list {
-		sortable = append(sortable, namedDevice{k, d})
+// Clone returns a copy of the Devices set.
+func (list Devices) Clone() Devices {
+	copy := Devices{}
+
+	for deviceName, device := range list {
+		copy[deviceName] = device.Clone()
 	}
 
-	sort.Sort(sortable)
-	return sortable.Names()
+	return copy
 }
 
 // CloneNative returns a copy of the Devices set as a native map[string]map[string]string type.
@@ -146,4 +146,26 @@ func (list Devices) CloneNative() map[string]map[string]string {
 	}
 
 	return copy
+}
+
+// Sorted returns the name of all devices in the set, sorted properly.
+func (list Devices) Sorted() DevicesSortable {
+	sortable := DevicesSortable{}
+	for k, d := range list {
+		sortable = append(sortable, DeviceNamed{k, d})
+	}
+
+	sort.Sort(sortable)
+	return sortable
+}
+
+// Reversed returns the name of all devices in the set, sorted reversed.
+func (list Devices) Reversed() DevicesSortable {
+	sortable := DevicesSortable{}
+	for k, d := range list {
+		sortable = append(sortable, DeviceNamed{k, d})
+	}
+
+	sort.Sort(sort.Reverse(sortable))
+	return sortable
 }

--- a/lxd/device/config/devices_sort.go
+++ b/lxd/device/config/devices_sort.go
@@ -1,47 +1,38 @@
 package config
 
-type namedDevice struct {
-	name   string
-	device Device
+// DeviceNamed contains the name of a device and its config.
+type DeviceNamed struct {
+	Name   string
+	Config Device
 }
 
-type sortableDevices []namedDevice
+// DevicesSortable is a sortable slice of device names and config.
+type DevicesSortable []DeviceNamed
 
-func (devices sortableDevices) Len() int {
+func (devices DevicesSortable) Len() int {
 	return len(devices)
 }
 
-func (devices sortableDevices) Less(i, j int) bool {
+func (devices DevicesSortable) Less(i, j int) bool {
 	a := devices[i]
 	b := devices[j]
 
-	// First sort by types
-	if a.device["type"] != b.device["type"] {
-		return a.device["type"] < b.device["type"]
+	// First sort by types.
+	if a.Config["type"] != b.Config["type"] {
+		return a.Config["type"] < b.Config["type"]
 	}
 
-	// Special case disk paths
-	if a.device["type"] == "disk" && b.device["type"] == "disk" {
-		if a.device["path"] != b.device["path"] {
-			return a.device["path"] < b.device["path"]
+	// Special case disk paths.
+	if a.Config["type"] == "disk" && b.Config["type"] == "disk" {
+		if a.Config["path"] != b.Config["path"] {
+			return a.Config["path"] < b.Config["path"]
 		}
 	}
 
-	// Fallback to sorting by names
-	return a.name < b.name
+	// Fallback to sorting by names.
+	return a.Name < b.Name
 }
 
-func (devices sortableDevices) Swap(i, j int) {
-	tmp := devices[i]
-	devices[i] = devices[j]
-	devices[j] = tmp
-}
-
-func (devices sortableDevices) Names() []string {
-	result := []string{}
-	for _, d := range devices {
-		result = append(result, d.name)
-	}
-
-	return result
+func (devices DevicesSortable) Swap(i, j int) {
+	devices[i], devices[j] = devices[j], devices[i]
 }

--- a/lxd/device/config/devices_test.go
+++ b/lxd/device/config/devices_test.go
@@ -7,16 +7,33 @@ import (
 
 func TestSortableDevices(t *testing.T) {
 	devices := Devices{
-		"1": Device{"type": "nic"},
-		"3": Device{"type": "disk", "path": "/foo/bar"},
-		"4": Device{"type": "disk", "path": "/foo"},
-		"2": Device{"type": "nic"},
+		"dev1": Device{"type": "nic"},
+		"dev3": Device{"type": "disk", "path": "/foo/bar"},
+		"dev4": Device{"type": "disk", "path": "/foo"},
+		"dev2": Device{"type": "nic"},
 	}
 
-	expected := []string{"4", "3", "1", "2"}
+	expectedSorted := DevicesSortable{
+		DeviceNamed{Name: "dev4", Config: Device{"type": "disk", "path": "/foo"}},
+		DeviceNamed{Name: "dev3", Config: Device{"type": "disk", "path": "/foo/bar"}},
+		DeviceNamed{Name: "dev1", Config: Device{"type": "nic"}},
+		DeviceNamed{Name: "dev2", Config: Device{"type": "nic"}},
+	}
 
-	result := devices.DeviceNames()
-	if !reflect.DeepEqual(result, expected) {
+	result := devices.Sorted()
+	if !reflect.DeepEqual(result, expectedSorted) {
 		t.Error("devices sorted incorrectly")
+	}
+
+	expectedReversed := DevicesSortable{
+		DeviceNamed{Name: "dev2", Config: Device{"type": "nic"}},
+		DeviceNamed{Name: "dev1", Config: Device{"type": "nic"}},
+		DeviceNamed{Name: "dev3", Config: Device{"type": "disk", "path": "/foo/bar"}},
+		DeviceNamed{Name: "dev4", Config: Device{"type": "disk", "path": "/foo"}},
+	}
+
+	result = devices.Reversed()
+	if !reflect.DeepEqual(result, expectedReversed) {
+		t.Error("devices reverse sorted incorrectly")
 	}
 }

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -50,10 +50,10 @@ type Device interface {
 	Register() error
 
 	// Update performs host-side modifications for a device based on the difference between the
-	// current config and previous config supplied as an argument. This called if the only
-	// config fields that have changed are supplied in the list returned from CanHotPlug().
+	// current config and previous devices config supplied as an argument. This called if the
+	// only config fields that have changed are supplied in the list returned from CanHotPlug().
 	// The function also accepts a boolean indicating whether the instance is running or not.
-	Update(oldConfig config.Device, running bool) error
+	Update(oldDevices config.Devices, running bool) error
 
 	// Stop performs any host-side cleanup required when a device is removed from an instance,
 	// either due to unplugging it from a running instance or instance is being shutdown.
@@ -119,7 +119,7 @@ func (d *deviceCommon) CanHotPlug() (bool, []string) {
 }
 
 // Update returns an error as most devices do not support live updates without being restarted.
-func (d *deviceCommon) Update(oldConfig config.Device, isRunning bool) error {
+func (d *deviceCommon) Update(oldDevices config.Devices, isRunning bool) error {
 	return fmt.Errorf("Device does not support updates whilst started")
 }
 

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -16,6 +16,7 @@ var devTypes = map[string]func(config.Device) device{
 	"usb":        func(c config.Device) device { return &usb{} },
 	"unix-char":  func(c config.Device) device { return &unixCommon{} },
 	"unix-block": func(c config.Device) device { return &unixCommon{} },
+	"disk":       func(c config.Device) device { return &disk{} },
 }
 
 // VolatileSetter is a function that accepts one or more key/value strings to save into the LXD

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -17,6 +17,7 @@ var devTypes = map[string]func(config.Device) device{
 	"unix-char":  func(c config.Device) device { return &unixCommon{} },
 	"unix-block": func(c config.Device) device { return &unixCommon{} },
 	"disk":       func(c config.Device) device { return &disk{} },
+	"none":       func(c config.Device) device { return &none{} },
 }
 
 // VolatileSetter is a function that accepts one or more key/value strings to save into the LXD

--- a/lxd/device/device_instance_id.go
+++ b/lxd/device/device_instance_id.go
@@ -12,6 +12,7 @@ type InstanceIdentifier interface {
 	Type() string
 	Project() string
 	DevicesPath() string
+	RootfsPath() string
 	LogPath() string
 	ExpandedConfig() map[string]string
 	ExpandedDevices() config.Devices

--- a/lxd/device/device_instance_id.go
+++ b/lxd/device/device_instance_id.go
@@ -15,6 +15,7 @@ type InstanceIdentifier interface {
 	RootfsPath() string
 	LogPath() string
 	ExpandedConfig() map[string]string
+	LocalDevices() config.Devices
 	ExpandedDevices() config.Devices
 	DeviceEventHandler(*RunConfig) error
 }

--- a/lxd/device/device_runconfig.go
+++ b/lxd/device/device_runconfig.go
@@ -1,5 +1,14 @@
 package device
 
+// MountOwnerShiftNone do not use owner shifting.
+const MountOwnerShiftNone = ""
+
+// MountOwnerShiftDynamic use shiftfs for dynamic owner shifting.
+const MountOwnerShiftDynamic = "dynamic"
+
+// MountOwnerShiftStatic statically modify ownership.
+const MountOwnerShiftStatic = "static"
+
 // RunConfigItem represents a single config item.
 type RunConfigItem struct {
 	Key   string
@@ -14,7 +23,7 @@ type MountEntryItem struct {
 	Opts       []string // Describes the mount options associated with the filesystem.
 	Freq       int      // Used by dump(8) to determine which filesystems need to be dumped. Defaults to zero (don't dump) if not present.
 	PassNo     int      // Used by fsck(8) to determine the order in which filesystem checks are done at boot time. Defaults to zero (don't fsck) if not present.
-	Shift      bool     // Whether or not to use shiftfs with this mount.
+	OwnerShift string   // Ownership shifting mode, use constants MountOwnerShiftNone, MountOwnerShiftStatic or MountOwnerShiftDynamic.
 }
 
 // RootFSEntryItem represents the root filesystem options for an Instance.

--- a/lxd/device/device_runconfig.go
+++ b/lxd/device/device_runconfig.go
@@ -17,8 +17,15 @@ type MountEntryItem struct {
 	Shift      bool     // Whether or not to use shiftfs with this mount.
 }
 
+// RootFSEntryItem represents the root filesystem options for an Instance.
+type RootFSEntryItem struct {
+	Path string   // Describes the root file system source.
+	Opts []string // Describes the mount options associated with the filesystem.
+}
+
 // RunConfig represents LXD defined run-time config used for device setup/cleanup.
 type RunConfig struct {
+	RootFS           RootFSEntryItem  // RootFS to setup.
 	NetworkInterface []RunConfigItem  // Network interface configuration settings.
 	CGroups          []RunConfigItem  // Cgroup rules to setup.
 	Mounts           []MountEntryItem // Mounts to setup/remove.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -16,6 +16,9 @@ var StorageVolumeMount func(s *state.State, poolName string, volumeName string, 
 // StorageVolumeUmount unmounts a storage volume.
 var StorageVolumeUmount func(s *state.State, poolName string, volumeName string, volumeType int) error
 
+// StorageRootFSApplyQuota applies a new quota.
+var StorageRootFSApplyQuota func(instance InstanceIdentifier, newSize int64) (bool, error)
+
 // BlockFsDetect detects the type of block device.
 func BlockFsDetect(dev string) (string, error) {
 	out, err := shared.RunCommand("blkid", "-s", "TYPE", "-o", "value", dev)

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -6,8 +6,15 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 )
+
+// StorageVolumeMount checks if storage volume is mounted and if not tries to mount it.
+var StorageVolumeMount func(s *state.State, poolName string, volumeName string, volumeTypeName string, instance InstanceIdentifier) error
+
+// StorageVolumeUmount unmounts a storage volume.
+var StorageVolumeUmount func(s *state.State, poolName string, volumeName string, volumeType int) error
 
 // BlockFsDetect detects the type of block device.
 func BlockFsDetect(dev string) (string, error) {

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -58,7 +58,7 @@ func unixDeviceInstanceAttributes(devicesPath string, prefix string, config conf
 
 	// If any config options missing then retrieve all the needed set of attributes from device.
 	if dType == "" || config["major"] == "" || config["minor"] == "" {
-		dType, dMajor, dMinor, err = UnixDeviceAttributes(devPath)
+		dType, dMajor, dMinor, err = unixDeviceAttributes(devPath)
 		if err != nil {
 			return dType, dMajor, dMinor, err
 		}
@@ -67,8 +67,8 @@ func unixDeviceInstanceAttributes(devicesPath string, prefix string, config conf
 	return dType, dMajor, dMinor, err
 }
 
-// UnixDeviceAttributes returns the decice type, major and minor numbers for a device.
-func UnixDeviceAttributes(path string) (string, uint32, uint32, error) {
+// unixDeviceAttributes returns the decice type, major and minor numbers for a device.
+func unixDeviceAttributes(path string) (string, uint32, uint32, error) {
 	// Get a stat struct from the provided path
 	stat := unix.Stat_t{}
 	err := unix.Stat(path, &stat)
@@ -163,7 +163,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 	// Get the major/minor of the device we want to create.
 	if m["major"] == "" && m["minor"] == "" {
 		// If no major and minor are set, use those from the device on the host.
-		_, d.Major, d.Minor, err = UnixDeviceAttributes(srcPath)
+		_, d.Major, d.Minor, err = unixDeviceAttributes(srcPath)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to get device attributes for %s: %s", srcPath, err)
 		}
@@ -493,7 +493,7 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 		})
 
 		absDevPath := filepath.Join(devicesPath, ourDev)
-		dType, dMajor, dMinor, err := UnixDeviceAttributes(absDevPath)
+		dType, dMajor, dMinor, err := unixDeviceAttributes(absDevPath)
 		if err != nil {
 			return fmt.Errorf("Failed to get UNIX device attributes for '%s': %v", absDevPath, err)
 		}

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -339,7 +339,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 		return nil
 	}
 
-	// Instruct liblxc to perform the mount.
+	// Instruct LXD to perform the mount.
 	runConf.Mounts = append(runConf.Mounts, MountEntryItem{
 		DevPath:    d.HostPath,
 		TargetPath: d.RelativePath,
@@ -348,7 +348,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 		OwnerShift: MountOwnerShiftStatic,
 	})
 
-	// Instruct liblxc to setup the cgroup rule.
+	// Instruct LXD to setup the cgroup rule.
 	runConf.CGroups = append(runConf.CGroups, RunConfigItem{
 		Key:   "devices.allow",
 		Value: fmt.Sprintf("%s %d:%d rwm", d.Type, d.Major, d.Minor),

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -345,6 +345,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 		TargetPath: d.RelativePath,
 		FSType:     "none",
 		Opts:       []string{"bind", "create=file"},
+		OwnerShift: MountOwnerShiftStatic,
 	})
 
 	// Instruct liblxc to setup the cgroup rule.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -1,0 +1,981 @@
+package device
+
+import (
+	"bufio"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/units"
+)
+
+type diskBlockLimit struct {
+	readBps   int64
+	readIops  int64
+	writeBps  int64
+	writeIops int64
+}
+
+type disk struct {
+	deviceCommon
+}
+
+// isRequired indicates whether the device config requires this device to start OK.
+func (d *disk) isRequired() bool {
+	// Defaults to required.
+	if (d.config["required"] == "" || shared.IsTrue(d.config["required"])) && !shared.IsTrue(d.config["optional"]) {
+		return true
+	}
+
+	return false
+}
+
+// validateConfig checks the supplied config for correctness.
+func (d *disk) validateConfig() error {
+	if d.instance.Type() != instance.TypeContainer {
+		return ErrUnsupportedDevType
+	}
+
+	// Supported propagation types.
+	// If an empty value is supplied the default behavior is to assume "private" mode.
+	// These come from https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt
+	propagationTypes := []string{"", "private", "shared", "slave", "unbindable", "rshared", "rslave", "runbindable", "rprivate"}
+	validatePropagation := func(input string) error {
+		if !shared.StringInSlice(d.config["bind"], propagationTypes) {
+			return fmt.Errorf("Invalid propagation value. Must be one of: %s", strings.Join(propagationTypes, ", "))
+		}
+
+		return nil
+	}
+
+	rules := map[string]func(string) error{
+		"path":         shared.IsNotEmpty,
+		"required":     shared.IsBool,
+		"optional":     shared.IsBool, // "optional" is deprecated, replaced by "required".
+		"readonly":     shared.IsBool,
+		"recursive":    shared.IsBool,
+		"shift":        shared.IsBool,
+		"source":       shared.IsAny,
+		"limits.read":  shared.IsAny,
+		"limits.write": shared.IsAny,
+		"limits.max":   shared.IsAny,
+		"size":         shared.IsAny,
+		"pool":         shared.IsAny,
+		"propagation":  validatePropagation,
+	}
+
+	err := d.config.Validate(rules)
+	if err != nil {
+		return err
+	}
+
+	if d.config["required"] != "" && d.config["optional"] != "" {
+		return fmt.Errorf("Cannot use both \"required\" and deprecated \"optional\" properties at the same time")
+	}
+
+	if d.config["source"] == "" && d.config["path"] != "/" {
+		return fmt.Errorf("Disk entry is missing the required \"source\" property")
+	}
+
+	if d.config["path"] == "/" && d.config["source"] != "" {
+		return fmt.Errorf("Root disk entry may not have a \"source\" property set")
+	}
+
+	if d.config["size"] != "" && d.config["path"] != "/" {
+		return fmt.Errorf("Only the root disk may have a size quota")
+	}
+
+	if d.config["recursive"] != "" && (d.config["path"] == "/" || !shared.IsDir(shared.HostPath(d.config["source"]))) {
+		return fmt.Errorf("The recursive option is only supported for additional bind-mounted paths")
+	}
+
+	// Check no other devices also have the same path as us. Use LocalDevices for this check so
+	// that we can check before the config is expanded or when a profile is being checked.
+	// Don't take into account the device names, only count active devices that point to the
+	// same path, so that if merged profiles share the same the path and then one is removed
+	// this can still be cleanly removed.
+	pathCount := 0
+	for _, devConfig := range d.instance.LocalDevices() {
+		if devConfig["type"] == "disk" && devConfig["path"] == d.config["path"] {
+			pathCount++
+			if pathCount > 1 {
+				return fmt.Errorf("More than one disk device uses the same path: %s", d.config["path"])
+
+			}
+		}
+	}
+
+	// When we want to attach a storage volume created via the storage api the "source" only
+	// contains the name of the storage volume, not the path where it is mounted. So only check
+	// for the existence of "source" when "pool" is empty.
+	if d.config["pool"] == "" && d.config["source"] != "" && d.isRequired() && !shared.PathExists(shared.HostPath(d.config["source"])) {
+		return fmt.Errorf("Missing source '%s' for disk '%s'", d.config["source"], d.name)
+	}
+
+	if d.config["pool"] != "" {
+		if d.config["shift"] != "" {
+			return fmt.Errorf("The \"shift\" property cannot be used with custom storage volumes")
+		}
+
+		if filepath.IsAbs(d.config["source"]) {
+			return fmt.Errorf("Storage volumes cannot be specified as absolute paths")
+		}
+
+		_, err := d.state.Cluster.StoragePoolGetID(d.config["pool"])
+		if err != nil {
+			return fmt.Errorf("The \"%s\" storage pool doesn't exist", d.config["pool"])
+		}
+
+		// Only check storate volume is available if we are validating an instance device
+		// and not a profile device (check for non-empty instance name), and we have least
+		// one expanded device (this is so we only do this expensive check after devices
+		// have been expanded).
+		if d.instance.Name() != "" && len(d.instance.ExpandedDevices()) > 0 && d.config["source"] != "" && d.config["path"] != "/" {
+			isAvailable, err := d.state.Cluster.StorageVolumeIsAvailable(d.config["pool"], d.config["source"])
+			if err != nil {
+				return fmt.Errorf("Check if volume is available: %v", err)
+			}
+			if !isAvailable {
+				return fmt.Errorf("Storage volume %q is already attached to a container on a different node", d.config["source"])
+			}
+		}
+	}
+
+	return nil
+}
+
+// getDevicePath returns the absolute path on the host for this device.
+func (d *disk) getDevicePath() string {
+	relativeDestPath := strings.TrimPrefix(d.config["path"], "/")
+	devName := fmt.Sprintf("disk.%s.%s", strings.Replace(d.name, "/", "-", -1), strings.Replace(relativeDestPath, "/", "-", -1))
+	return filepath.Join(d.instance.DevicesPath(), devName)
+}
+
+// validateEnvironment checks the runtime environment for correctness.
+func (d *disk) validateEnvironment() error {
+	if shared.IsTrue(d.config["shift"]) && !d.state.OS.Shiftfs {
+		return fmt.Errorf("shiftfs is required by disk entry but isn't supported on system")
+	}
+
+	return nil
+}
+
+// CanHotPlug returns whether the device can be managed whilst the instance is running, it also
+// returns a list of fields that can be updated without triggering a device remove & add.
+func (d *disk) CanHotPlug() (bool, []string) {
+	return true, []string{"limits.max", "limits.read", "limits.write", "size"}
+}
+
+// Start is run when the device is added to the container.
+func (d *disk) Start() (*RunConfig, error) {
+	err := d.validateEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	runConf := RunConfig{}
+
+	err = d.generateLimits(&runConf)
+	if err != nil {
+		return nil, err
+	}
+
+	isReadOnly := shared.IsTrue(d.config["readonly"])
+
+	// Deal with a rootfs.
+	if shared.IsRootDiskDevice(d.config) {
+		// Set the rootfs path.
+		rootfs := RootFSEntryItem{
+			Path: d.instance.RootfsPath(),
+		}
+
+		// Read-only rootfs (unlikely to work very well).
+		if isReadOnly {
+			rootfs.Opts = append(rootfs.Opts, "ro")
+		}
+
+		v := d.volatileGet()
+
+		// Handle previous requests for setting new quotas.
+		if v["volatile.apply_quota"] != "" {
+			applied, err := d.applyQuota(v["volatile.apply_quota"])
+			if err != nil || !applied {
+				return nil, err
+			}
+
+			// Remove volatile apply_quota key if successful.
+			err = d.volatileSet(map[string]string{"volatile.apply_quota": ""})
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		runConf.RootFS = rootfs
+	} else {
+		// Source path.
+		srcPath := shared.HostPath(d.config["source"])
+
+		// Destination path.
+		destPath := d.config["path"]
+		relativeDestPath := strings.TrimPrefix(destPath, "/")
+
+		// Option checks.
+		isRecursive := shared.IsTrue(d.config["recursive"])
+
+		// If we want to mount a storage volume from a storage pool we created via our
+		// storage api, we are always mounting a directory.
+		isFile := false
+		if d.config["pool"] == "" {
+			isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
+		}
+
+		ownerShift := MountOwnerShiftNone
+		if shared.IsTrue(d.config["shift"]) {
+			ownerShift = MountOwnerShiftDynamic
+		}
+
+		// If ownerShift is none and pool is specified then check whether the pool itself
+		// has owner shifting enabled, and if so enable shifting on this device too.
+		if ownerShift == MountOwnerShiftNone && d.config["pool"] != "" {
+			poolID, _, err := d.state.Cluster.StoragePoolGet(d.config["pool"])
+			if err != nil {
+				return nil, err
+			}
+
+			_, volume, err := d.state.Cluster.StoragePoolNodeVolumeGetTypeByProject(d.instance.Project(), d.config["source"], db.StoragePoolVolumeTypeCustom, poolID)
+			if err != nil {
+				return nil, err
+			}
+
+			if shared.IsTrue(volume.Config["security.shifted"]) {
+				ownerShift = "dynamic"
+			}
+		}
+
+		options := []string{}
+		if isReadOnly {
+			options = append(options, "ro")
+		}
+
+		if isRecursive {
+			options = append(options, "rbind")
+		} else {
+			options = append(options, "bind")
+		}
+
+		if d.config["propagation"] != "" {
+			options = append(options, d.config["propagation"])
+		}
+
+		if isFile {
+			options = append(options, "create=file")
+		} else {
+			options = append(options, "create=dir")
+		}
+
+		sourceDevPath, err := d.createDevice()
+		if err != nil {
+			return nil, err
+		}
+
+		if sourceDevPath != "" {
+			// Instruct LXD to perform the mount.
+			runConf.Mounts = append(runConf.Mounts, MountEntryItem{
+				DevPath:    sourceDevPath,
+				TargetPath: relativeDestPath,
+				FSType:     "none",
+				Opts:       options,
+				OwnerShift: ownerShift,
+			})
+
+			// Unmount host-side mount once instance is started.
+			runConf.PostHooks = append(runConf.PostHooks, d.postStart)
+		}
+	}
+
+	return &runConf, nil
+}
+
+// postStart is run after the instance is started.
+func (d *disk) postStart() error {
+	devPath := d.getDevicePath()
+
+	// Unmount the host side.
+	err := unix.Unmount(devPath, unix.MNT_DETACH)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Update applies configuration changes to a started device.
+func (d *disk) Update(oldDevices config.Devices, isRunning bool) error {
+	if shared.IsRootDiskDevice(d.config) {
+		// Make sure we have a valid root disk device (and only one).
+		expandedDevices := d.instance.ExpandedDevices()
+		newRootDiskDeviceKey, _, err := shared.GetRootDiskDevice(expandedDevices.CloneNative())
+		if err != nil {
+			return errors.Wrap(err, "Detect root disk device")
+		}
+
+		// Retrieve the first old root disk device key, even if there are duplicates.
+		oldRootDiskDeviceKey := ""
+		for k, v := range oldDevices {
+			if shared.IsRootDiskDevice(v) {
+				oldRootDiskDeviceKey = k
+				break
+			}
+		}
+
+		// Check for pool change.
+		oldRootDiskDevicePool := oldDevices[oldRootDiskDeviceKey]["pool"]
+		newRootDiskDevicePool := expandedDevices[newRootDiskDeviceKey]["pool"]
+		if oldRootDiskDevicePool != newRootDiskDevicePool {
+			return fmt.Errorf("The storage pool of the root disk can only be changed through move")
+		}
+
+		// Deal with quota changes.
+		oldRootDiskDeviceSize := oldDevices[oldRootDiskDeviceKey]["size"]
+		newRootDiskDeviceSize := expandedDevices[newRootDiskDeviceKey]["size"]
+
+		// Apply disk quota changes.
+		if newRootDiskDeviceSize != oldRootDiskDeviceSize {
+			applied, err := d.applyQuota(newRootDiskDeviceSize)
+			if err != nil {
+				return err
+			}
+
+			if !applied {
+				// Save volatile apply_quota key for next boot if cannot apply now.
+				err = d.volatileSet(map[string]string{"volatile.apply_quota": newRootDiskDeviceSize})
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	runConf := RunConfig{}
+
+	err := d.generateLimits(&runConf)
+	if err != nil {
+		return err
+	}
+
+	err = d.instance.DeviceEventHandler(&runConf)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *disk) applyQuota(newSize string) (bool, error) {
+	newSizeBytes, err := units.ParseByteSizeString(newSize)
+	if err != nil {
+		return false, err
+	}
+
+	applied, err := StorageRootFSApplyQuota(d.instance, newSizeBytes)
+	if err != nil {
+		return applied, err
+	}
+
+	return applied, nil
+}
+
+// generateLimits adds a set of cgroup rules to apply specified limits to the supplied RunConfig.
+func (d *disk) generateLimits(runConf *RunConfig) error {
+	// Disk priority limits.
+	diskPriority := d.instance.ExpandedConfig()["limits.disk.priority"]
+	if diskPriority != "" {
+		if d.state.OS.CGroupBlkioWeightController {
+			if diskPriority != "" {
+				priorityInt, err := strconv.Atoi(diskPriority)
+				if err != nil {
+					return err
+				}
+
+				priority := priorityInt * 100
+
+				// Minimum valid value is 10
+				if priority == 0 {
+					priority = 10
+				}
+
+				runConf.CGroups = append(runConf.CGroups, RunConfigItem{
+					Key:   "blkio.weight",
+					Value: fmt.Sprintf("%d", priority),
+				})
+			}
+		} else {
+			return fmt.Errorf("Cannot apply limits.disk.priority as blkio.weight cgroup controller is missing")
+		}
+	}
+
+	// Disk throttle limits.
+	hasDiskLimits := false
+	for _, dev := range d.instance.ExpandedDevices() {
+		if dev["type"] != "disk" {
+			continue
+		}
+
+		if dev["limits.read"] != "" || dev["limits.write"] != "" || dev["limits.max"] != "" {
+			hasDiskLimits = true
+		}
+	}
+
+	if hasDiskLimits {
+		if !d.state.OS.CGroupBlkioController {
+			return fmt.Errorf("Cannot apply disk limits as blkio cgroup controller is missing")
+		}
+
+		diskLimits, err := d.getDiskLimits()
+		if err != nil {
+			return err
+		}
+
+		for block, limit := range diskLimits {
+			if limit.readBps > 0 {
+				runConf.CGroups = append(runConf.CGroups, RunConfigItem{
+					Key:   "blkio.throttle.read_bps_device",
+					Value: fmt.Sprintf("%s %d", block, limit.readBps),
+				})
+			}
+
+			if limit.readIops > 0 {
+				runConf.CGroups = append(runConf.CGroups, RunConfigItem{
+					Key:   "blkio.throttle.read_iops_device",
+					Value: fmt.Sprintf("%s %d", block, limit.readIops),
+				})
+			}
+
+			if limit.writeBps > 0 {
+				runConf.CGroups = append(runConf.CGroups, RunConfigItem{
+					Key:   "blkio.throttle.write_bps_device",
+					Value: fmt.Sprintf("%s %d", block, limit.writeBps),
+				})
+			}
+
+			if limit.writeIops > 0 {
+				runConf.CGroups = append(runConf.CGroups, RunConfigItem{
+					Key:   "blkio.throttle.write_iops_device",
+					Value: fmt.Sprintf("%s %d", block, limit.writeIops),
+				})
+			}
+		}
+	}
+
+	return nil
+}
+
+// createDevice creates a disk device mount on host.
+func (d *disk) createDevice() (string, error) {
+	// Paths.
+	devPath := d.getDevicePath()
+	srcPath := shared.HostPath(d.config["source"])
+
+	// Check if read-only.
+	isRequired := d.isRequired()
+	isReadOnly := shared.IsTrue(d.config["readonly"])
+	isRecursive := shared.IsTrue(d.config["recursive"])
+
+	isFile := false
+	if d.config["pool"] == "" {
+		isFile = !shared.IsDir(srcPath) && !IsBlockdev(srcPath)
+	} else {
+		// Deal with mounting storage volumes created via the storage api. Extract the name
+		// of the storage volume that we are supposed to attach. We assume that the only
+		// syntactically valid ways of specifying a storage volume are:
+		// - <volume_name>
+		// - <type>/<volume_name>
+		// Currently, <type> must either be empty or "custom".
+		// We do not yet support container mounts.
+
+		if filepath.IsAbs(d.config["source"]) {
+			return "", fmt.Errorf("When the \"pool\" property is set \"source\" must specify the name of a volume, not a path")
+		}
+
+		volumeTypeName := ""
+		volumeName := filepath.Clean(d.config["source"])
+		slash := strings.Index(volumeName, "/")
+		if (slash > 0) && (len(volumeName) > slash) {
+			// Extract volume name.
+			volumeName = d.config["source"][(slash + 1):]
+			// Extract volume type.
+			volumeTypeName = d.config["source"][:slash]
+		}
+
+		switch volumeTypeName {
+		case db.StoragePoolVolumeTypeNameContainer:
+			return "", fmt.Errorf("Using container storage volumes is not supported")
+		case "":
+			// We simply received the name of a storage volume.
+			volumeTypeName = db.StoragePoolVolumeTypeNameCustom
+			fallthrough
+		case db.StoragePoolVolumeTypeNameCustom:
+			srcPath = shared.VarPath("storage-pools", d.config["pool"], volumeTypeName, volumeName)
+		case db.StoragePoolVolumeTypeNameImage:
+			return "", fmt.Errorf("Using image storage volumes is not supported")
+		default:
+			return "", fmt.Errorf("Unknown storage type prefix \"%s\" found", volumeTypeName)
+		}
+
+		err := StorageVolumeMount(d.state, d.config["pool"], volumeName, volumeTypeName, d.instance)
+		if err != nil {
+			msg := fmt.Sprintf("Could not mount storage volume \"%s\" of type \"%s\" on storage pool \"%s\": %s.", volumeName, volumeTypeName, d.config["pool"], err)
+			if !isRequired {
+				// Will fail the PathExists test below.
+				logger.Warn(msg)
+			} else {
+				return "", fmt.Errorf(msg)
+			}
+		}
+	}
+
+	// Check if the source exists.
+	if !shared.PathExists(srcPath) {
+		if !isRequired {
+			return "", nil
+		}
+		return "", fmt.Errorf("Source path %s doesn't exist for device %s", srcPath, d.name)
+	}
+
+	// Create the devices directory if missing.
+	if !shared.PathExists(d.instance.DevicesPath()) {
+		err := os.Mkdir(d.instance.DevicesPath(), 0711)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Clean any existing entry.
+	if shared.PathExists(devPath) {
+		err := os.Remove(devPath)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Create the mount point.
+	if isFile {
+		f, err := os.Create(devPath)
+		if err != nil {
+			return "", err
+		}
+
+		f.Close()
+	} else {
+		err := os.Mkdir(devPath, 0700)
+		if err != nil {
+			return "", err
+		}
+	}
+
+	// Mount the fs.
+	err := DiskMount(srcPath, devPath, isReadOnly, isRecursive, d.config["propagation"])
+	if err != nil {
+		return "", err
+	}
+
+	return devPath, nil
+}
+
+// Stop is run when the device is removed from the instance.
+func (d *disk) Stop() (*RunConfig, error) {
+	runConf := RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	// Figure out the paths
+	relativeDestPath := strings.TrimPrefix(d.config["path"], "/")
+	devPath := d.getDevicePath()
+
+	// The disk device doesn't exist do nothing.
+	if !shared.PathExists(devPath) {
+		return nil, nil
+	}
+
+	// Request an unmount of the device inside the instance.
+	runConf.Mounts = append(runConf.Mounts, MountEntryItem{
+		TargetPath: relativeDestPath,
+	})
+
+	return &runConf, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *disk) postStop() error {
+	// Check if pool-specific action should be taken.
+	if d.config["pool"] != "" {
+		err := StorageVolumeUmount(d.state, d.config["pool"], d.config["source"], db.StoragePoolVolumeTypeCustom)
+		if err != nil {
+			return err
+		}
+
+	}
+
+	devPath := d.getDevicePath()
+
+	// Clean any existing entry.
+	if shared.PathExists(devPath) {
+		// Unmount the host side if not already.
+		// Don't check for errors here as this is just to catch any existing mounts that
+		// we not unmounted on the host after device was started.
+		unix.Unmount(devPath, unix.MNT_DETACH)
+
+		// Remove the host side.
+		err := os.Remove(devPath)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// getDiskLimits calculates Block I/O limits.
+func (d *disk) getDiskLimits() (map[string]diskBlockLimit, error) {
+	result := map[string]diskBlockLimit{}
+
+	// Build a list of all valid block devices
+	validBlocks := []string{}
+
+	dents, err := ioutil.ReadDir("/sys/class/block/")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, f := range dents {
+		fPath := filepath.Join("/sys/class/block/", f.Name())
+		if shared.PathExists(fmt.Sprintf("%s/partition", fPath)) {
+			continue
+		}
+
+		if !shared.PathExists(fmt.Sprintf("%s/dev", fPath)) {
+			continue
+		}
+
+		block, err := ioutil.ReadFile(fmt.Sprintf("%s/dev", fPath))
+		if err != nil {
+			return nil, err
+		}
+
+		validBlocks = append(validBlocks, strings.TrimSuffix(string(block), "\n"))
+	}
+
+	// Process all the limits
+	blockLimits := map[string][]diskBlockLimit{}
+	for _, dev := range d.instance.ExpandedDevices() {
+		if dev["type"] != "disk" {
+			continue
+		}
+
+		// Apply max limit
+		if dev["limits.max"] != "" {
+			dev["limits.read"] = dev["limits.max"]
+			dev["limits.write"] = dev["limits.max"]
+		}
+
+		// Parse the user input
+		readBps, readIops, writeBps, writeIops, err := d.parseDiskLimit(dev["limits.read"], dev["limits.write"])
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the source path
+		source := shared.HostPath(dev["source"])
+		if source == "" {
+			source = d.instance.RootfsPath()
+		}
+
+		// Don't try to resolve the block device behind a non-existing path
+		if !shared.PathExists(source) {
+			continue
+		}
+
+		// Get the backing block devices (major:minor)
+		blocks, err := d.getParentBlocks(source)
+		if err != nil {
+			if readBps == 0 && readIops == 0 && writeBps == 0 && writeIops == 0 {
+				// If the device doesn't exist, there is no limit to clear so ignore the failure
+				continue
+			} else {
+				return nil, err
+			}
+		}
+
+		device := diskBlockLimit{readBps: readBps, readIops: readIops, writeBps: writeBps, writeIops: writeIops}
+		for _, block := range blocks {
+			blockStr := ""
+
+			if shared.StringInSlice(block, validBlocks) {
+				// Straightforward entry (full block device)
+				blockStr = block
+			} else {
+				// Attempt to deal with a partition (guess its parent)
+				fields := strings.SplitN(block, ":", 2)
+				fields[1] = "0"
+				if shared.StringInSlice(fmt.Sprintf("%s:%s", fields[0], fields[1]), validBlocks) {
+					blockStr = fmt.Sprintf("%s:%s", fields[0], fields[1])
+				}
+			}
+
+			if blockStr == "" {
+				return nil, fmt.Errorf("Block device doesn't support quotas: %s", block)
+			}
+
+			if blockLimits[blockStr] == nil {
+				blockLimits[blockStr] = []diskBlockLimit{}
+			}
+			blockLimits[blockStr] = append(blockLimits[blockStr], device)
+		}
+	}
+
+	// Average duplicate limits
+	for block, limits := range blockLimits {
+		var readBpsCount, readBpsTotal, readIopsCount, readIopsTotal, writeBpsCount, writeBpsTotal, writeIopsCount, writeIopsTotal int64
+
+		for _, limit := range limits {
+			if limit.readBps > 0 {
+				readBpsCount++
+				readBpsTotal += limit.readBps
+			}
+
+			if limit.readIops > 0 {
+				readIopsCount++
+				readIopsTotal += limit.readIops
+			}
+
+			if limit.writeBps > 0 {
+				writeBpsCount++
+				writeBpsTotal += limit.writeBps
+			}
+
+			if limit.writeIops > 0 {
+				writeIopsCount++
+				writeIopsTotal += limit.writeIops
+			}
+		}
+
+		device := diskBlockLimit{}
+
+		if readBpsCount > 0 {
+			device.readBps = readBpsTotal / readBpsCount
+		}
+
+		if readIopsCount > 0 {
+			device.readIops = readIopsTotal / readIopsCount
+		}
+
+		if writeBpsCount > 0 {
+			device.writeBps = writeBpsTotal / writeBpsCount
+		}
+
+		if writeIopsCount > 0 {
+			device.writeIops = writeIopsTotal / writeIopsCount
+		}
+
+		result[block] = device
+	}
+
+	return result, nil
+}
+
+func (d *disk) parseDiskLimit(readSpeed string, writeSpeed string) (int64, int64, int64, int64, error) {
+	parseValue := func(value string) (int64, int64, error) {
+		var err error
+
+		bps := int64(0)
+		iops := int64(0)
+
+		if value == "" {
+			return bps, iops, nil
+		}
+
+		if strings.HasSuffix(value, "iops") {
+			iops, err = strconv.ParseInt(strings.TrimSuffix(value, "iops"), 10, 64)
+			if err != nil {
+				return -1, -1, err
+			}
+		} else {
+			bps, err = units.ParseByteSizeString(value)
+			if err != nil {
+				return -1, -1, err
+			}
+		}
+
+		return bps, iops, nil
+	}
+
+	readBps, readIops, err := parseValue(readSpeed)
+	if err != nil {
+		return -1, -1, -1, -1, err
+	}
+
+	writeBps, writeIops, err := parseValue(writeSpeed)
+	if err != nil {
+		return -1, -1, -1, -1, err
+	}
+
+	return readBps, readIops, writeBps, writeIops, nil
+}
+
+func (d *disk) getParentBlocks(path string) ([]string, error) {
+	var devices []string
+	var dev []string
+
+	// Expand the mount path
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, err
+	}
+
+	expPath, err := filepath.EvalSymlinks(absPath)
+	if err != nil {
+		expPath = absPath
+	}
+
+	// Find the source mount of the path
+	file, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	match := ""
+	for scanner.Scan() {
+		line := scanner.Text()
+		rows := strings.Fields(line)
+
+		if len(rows[4]) <= len(match) {
+			continue
+		}
+
+		if expPath != rows[4] && !strings.HasPrefix(expPath, rows[4]) {
+			continue
+		}
+
+		match = rows[4]
+
+		// Go backward to avoid problems with optional fields
+		dev = []string{rows[2], rows[len(rows)-2]}
+	}
+
+	if dev == nil {
+		return nil, fmt.Errorf("Couldn't find a match /proc/self/mountinfo entry")
+	}
+
+	// Handle the most simple case
+	if !strings.HasPrefix(dev[0], "0:") {
+		return []string{dev[0]}, nil
+	}
+
+	// Deal with per-filesystem oddities. We don't care about failures here
+	// because any non-special filesystem => directory backend.
+	fs, _ := util.FilesystemDetect(expPath)
+
+	if fs == "zfs" && shared.PathExists("/dev/zfs") {
+		// Accessible zfs filesystems
+		poolName := strings.Split(dev[1], "/")[0]
+
+		output, err := shared.RunCommand("zpool", "status", "-P", "-L", poolName)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to query zfs filesystem information for %s: %s", dev[1], output)
+		}
+
+		header := true
+		for _, line := range strings.Split(output, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) < 5 {
+				continue
+			}
+
+			if fields[1] != "ONLINE" {
+				continue
+			}
+
+			if header {
+				header = false
+				continue
+			}
+
+			var path string
+			if shared.PathExists(fields[0]) {
+				if shared.IsBlockdevPath(fields[0]) {
+					path = fields[0]
+				} else {
+					subDevices, err := d.getParentBlocks(fields[0])
+					if err != nil {
+						return nil, err
+					}
+
+					for _, dev := range subDevices {
+						devices = append(devices, dev)
+					}
+				}
+			} else {
+				continue
+			}
+
+			if path != "" {
+				_, major, minor, err := unixDeviceAttributes(path)
+				if err != nil {
+					continue
+				}
+
+				devices = append(devices, fmt.Sprintf("%d:%d", major, minor))
+			}
+		}
+
+		if len(devices) == 0 {
+			return nil, fmt.Errorf("Unable to find backing block for zfs pool: %s", poolName)
+		}
+	} else if fs == "btrfs" && shared.PathExists(dev[1]) {
+		// Accessible btrfs filesystems
+		output, err := shared.RunCommand("btrfs", "filesystem", "show", dev[1])
+		if err != nil {
+			return nil, fmt.Errorf("Failed to query btrfs filesystem information for %s: %s", dev[1], output)
+		}
+
+		for _, line := range strings.Split(output, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 0 || fields[0] != "devid" {
+				continue
+			}
+
+			_, major, minor, err := unixDeviceAttributes(fields[len(fields)-1])
+			if err != nil {
+				return nil, err
+			}
+
+			devices = append(devices, fmt.Sprintf("%d:%d", major, minor))
+		}
+	} else if shared.PathExists(dev[1]) {
+		// Anything else with a valid path
+		_, major, minor, err := unixDeviceAttributes(dev[1])
+		if err != nil {
+			return nil, err
+		}
+
+		devices = append(devices, fmt.Sprintf("%d:%d", major, minor))
+	} else {
+		return nil, fmt.Errorf("Invalid block device: %s", dev[1])
+	}
+
+	return devices, nil
+}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -172,7 +172,9 @@ func (d *nicBridged) Start() (*RunConfig, error) {
 }
 
 // Update applies configuration changes to a started device.
-func (d *nicBridged) Update(oldConfig config.Device, isRunning bool) error {
+func (d *nicBridged) Update(oldDevices config.Devices, isRunning bool) error {
+	oldConfig := oldDevices[d.name]
+
 	// If an IPv6 address has changed, flush all existing IPv6 leases for instance so instance
 	// isn't allocated old IP. This is important with IPv6 because DHCPv6 supports multiple IP
 	// address allocation and would result in instance having leases for both old and new IPs.

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -95,7 +95,9 @@ func (d *nicP2P) Start() (*RunConfig, error) {
 }
 
 // Update applies configuration changes to a started device.
-func (d *nicP2P) Update(oldConfig config.Device, isRunning bool) error {
+func (d *nicP2P) Update(oldDevices config.Devices, isRunning bool) error {
+	oldConfig := oldDevices[d.name]
+
 	if !isRunning {
 		return nil
 	}

--- a/lxd/device/none.go
+++ b/lxd/device/none.go
@@ -1,0 +1,26 @@
+package device
+
+type none struct {
+	deviceCommon
+}
+
+// validateConfig checks the supplied config for correctness.
+func (d *none) validateConfig() error {
+	rules := map[string]func(string) error{} // No fields allowed.
+	err := d.config.Validate(rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Start is run when the device is added to the container.
+func (d *none) Start() (*RunConfig, error) {
+	return nil, nil
+}
+
+// Stop is run when the device is removed from the instance.
+func (d *none) Stop() (*RunConfig, error) {
+	return nil, nil
+}

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -264,12 +264,7 @@ func (d *proxy) setupNAT() error {
 	var IPv4Addr string
 	var IPv6Addr string
 
-	instanceConfig, err := InstanceLoadByProjectAndName(d.state, d.instance.Project(), d.instance.Name())
-	if err != nil {
-		return err
-	}
-
-	for _, devConfig := range instanceConfig.ExpandedDevices() {
+	for _, devConfig := range d.instance.ExpandedDevices() {
 		if devConfig["type"] != "nic" || (devConfig["type"] == "nic" && devConfig["nictype"] != "bridged") {
 			continue
 		}

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -102,7 +102,7 @@ func (d *unixCommon) Register() error {
 			}
 
 			// Get the file type and sanity check it matches what the user was expecting.
-			dType, _, _, err := UnixDeviceAttributes(e.Path)
+			dType, _, _, err := unixDeviceAttributes(e.Path)
 			if err != nil {
 				return nil, err
 			}
@@ -157,7 +157,7 @@ func (d *unixCommon) Start() (*RunConfig, error) {
 	srcPath := unixDeviceSourcePath(d.config)
 
 	// If device file already exists on system, proceed to add it whether its required or not.
-	dType, _, _, err := UnixDeviceAttributes(srcPath)
+	dType, _, _, err := unixDeviceAttributes(srcPath)
 	if err == nil {
 		// Sanity check device type matches what the device config is expecting.
 		if !unixIsOurDeviceType(d.config, dType) {

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -27,6 +27,16 @@ type unixCommon struct {
 	deviceCommon
 }
 
+// isRequired indicates whether the device config requires this device to start OK.
+func (d *unixCommon) isRequired() bool {
+	// Defaults to required.
+	if d.config["required"] == "" || shared.IsTrue(d.config["required"]) {
+		return true
+	}
+
+	return false
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *unixCommon) validateConfig() error {
 	if d.instance.Type() != instance.TypeContainer {
@@ -59,7 +69,7 @@ func (d *unixCommon) validateConfig() error {
 // Register is run after the device is started or when LXD starts.
 func (d *unixCommon) Register() error {
 	// Don't register for hot plug events if the device is required.
-	if d.config["required"] == "" || shared.IsTrue(d.config["required"]) {
+	if d.isRequired() {
 		return nil
 	}
 
@@ -166,7 +176,7 @@ func (d *unixCommon) Start() (*RunConfig, error) {
 			if err != nil {
 				return nil, err
 			}
-		} else if d.config["required"] == "" || shared.IsTrue(d.config["required"]) {
+		} else if d.isRequired() {
 			// If the file is missing and the device is required then we cannot proceed.
 			return nil, fmt.Errorf("The required device path doesn't exist and the major and minor settings are not specified")
 		}

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -31,6 +31,16 @@ type usb struct {
 	deviceCommon
 }
 
+// isRequired indicates whether the device config requires this device to start OK.
+func (d *usb) isRequired() bool {
+	// Defaults to not required.
+	if shared.IsTrue(d.config["required"]) {
+		return true
+	}
+
+	return false
+}
+
 // validateConfig checks the supplied config for correctness.
 func (d *usb) validateConfig() error {
 	if d.instance.Type() != instance.TypeContainer {
@@ -125,7 +135,7 @@ func (d *usb) Start() (*RunConfig, error) {
 		}
 	}
 
-	if shared.IsTrue(d.config["required"]) && len(runConf.Mounts) <= 0 {
+	if d.isRequired() && len(runConf.Mounts) <= 0 {
 		return nil, fmt.Errorf("Required USB device not found")
 	}
 

--- a/lxd/devices.go
+++ b/lxd/devices.go
@@ -523,22 +523,21 @@ func devicesRegister(s *state.State) {
 		}
 
 		devices := c.ExpandedDevices()
-		for _, name := range devices.DeviceNames() {
-			m := devices[name]
-			d, _, err := c.deviceLoad(name, m)
+		for _, dev := range devices.Sorted() {
+			d, _, err := c.deviceLoad(dev.Name, dev.Config)
 			if err == device.ErrUnsupportedDevType {
 				continue
 			}
 
 			if err != nil {
-				logger.Error("Failed to load device to register", log.Ctx{"err": err, "container": c.Name(), "device": name})
+				logger.Error("Failed to load device to register", log.Ctx{"err": err, "container": c.Name(), "device": dev.Name})
 				continue
 			}
 
 			// Check whether device wants to register for any events.
 			err = d.Register()
 			if err != nil {
-				logger.Error("Failed to register device", log.Ctx{"err": err, "container": c.Name(), "device": name})
+				logger.Error("Failed to register device", log.Ctx{"err": err, "container": c.Name(), "device": dev.Name})
 				continue
 			}
 		}

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -2785,18 +2785,16 @@ func patchDevicesNewNamingScheme(name string, d *Daemon) error {
 
 		// go through all devices for each container
 		expandedDevices := c.ExpandedDevices()
-		for _, name := range expandedDevices.DeviceNames() {
-			d := expandedDevices[name]
-
+		for _, dev := range expandedDevices.Sorted() {
 			// We only care about unix-{char,block} and disk devices
 			// since other devices don't create on-disk files.
-			if !shared.StringInSlice(d["type"], []string{"disk", "unix-char", "unix-block"}) {
+			if !shared.StringInSlice(dev.Config["type"], []string{"disk", "unix-char", "unix-block"}) {
 				continue
 			}
 
 			// Handle disks
-			if d["type"] == "disk" {
-				relativeDestPath := strings.TrimPrefix(d["path"], "/")
+			if dev.Config["type"] == "disk" {
+				relativeDestPath := strings.TrimPrefix(dev.Config["path"], "/")
 				hyphenatedDevName := strings.Replace(relativeDestPath, "/", "-", -1)
 				devNameLegacy := fmt.Sprintf("disk.%s", hyphenatedDevName)
 				devPathLegacy := filepath.Join(devicesPath, devNameLegacy)
@@ -2825,9 +2823,9 @@ func patchDevicesNewNamingScheme(name string, d *Daemon) error {
 			}
 
 			// Handle unix devices
-			srcPath := d["source"]
+			srcPath := dev.Config["source"]
 			if srcPath == "" {
-				srcPath = d["path"]
+				srcPath = dev.Config["path"]
 			}
 
 			relativeSrcPathLegacy := strings.TrimPrefix(srcPath, "/")
@@ -2842,9 +2840,9 @@ func patchDevicesNewNamingScheme(name string, d *Daemon) error {
 
 			hasDeviceEntry[devPathLegacy] = true
 
-			srcPath = d["path"]
+			srcPath = dev.Config["path"]
 			if srcPath == "" {
-				srcPath = d["source"]
+				srcPath = dev.Config["source"]
 			}
 
 			relativeSrcPathNew := strings.TrimPrefix(srcPath, "/")

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -106,7 +106,8 @@ func profilesPost(d *Daemon, r *http.Request) Response {
 		return BadRequest(err)
 	}
 
-	err = containerValidDevices(d.State(), d.cluster, deviceConfig.NewDevices(req.Devices), true, false)
+	// Validate container devices with an empty instanceName to indicate profile validation.
+	err = containerValidDevices(d.State(), d.cluster, "", deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return BadRequest(err)
 	}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -19,7 +19,8 @@ func doProfileUpdate(d *Daemon, project, name string, id int64, profile *api.Pro
 		return err
 	}
 
-	err = containerValidDevices(d.State(), d.cluster, deviceConfig.NewDevices(req.Devices), true, false)
+	// Validate container devices with an empty instanceName to indicate profile validation.
+	err = containerValidDevices(d.State(), d.cluster, "", deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/sys/cgroup.go
+++ b/lxd/sys/cgroup.go
@@ -11,6 +11,7 @@ import (
 func (s *OS) initCGroup() {
 	flags := []*bool{
 		&s.CGroupBlkioController,
+		&s.CGroupBlkioWeightController,
 		&s.CGroupCPUController,
 		&s.CGroupCPUacctController,
 		&s.CGroupCPUsetController,
@@ -42,6 +43,7 @@ var cGroups = []struct {
 	warn string
 }{
 	{"blkio", cGroupMissing("blkio", "I/O limits will be ignored")},
+	{"blkio/blkio.weight", cGroupMissing("blkio.weight", "I/O weight limits will be ignored")},
 	{"cpu", cGroupMissing("CPU controller", "CPU time limits will be ignored")},
 	{"cpuacct", cGroupMissing("CPUacct controller", "CPU accounting will not be available")},
 	{"cpuset", cGroupMissing("CPUset controller", "CPU pinning will be ignored")},

--- a/lxd/sys/os.go
+++ b/lxd/sys/os.go
@@ -54,16 +54,17 @@ type OS struct {
 	AppArmorStacking  bool
 
 	// Cgroup features
-	CGroupBlkioController   bool
-	CGroupCPUacctController bool
-	CGroupCPUController     bool
-	CGroupCPUsetController  bool
-	CGroupDevicesController bool
-	CGroupFreezerController bool
-	CGroupMemoryController  bool
-	CGroupNetPrioController bool
-	CGroupPidsController    bool
-	CGroupSwapAccounting    bool
+	CGroupBlkioController       bool
+	CGroupBlkioWeightController bool
+	CGroupCPUacctController     bool
+	CGroupCPUController         bool
+	CGroupCPUsetController      bool
+	CGroupDevicesController     bool
+	CGroupFreezerController     bool
+	CGroupMemoryController      bool
+	CGroupNetPrioController     bool
+	CGroupPidsController        bool
+	CGroupSwapAccounting        bool
 
 	// Kernel features
 	NetnsGetifaddrs bool

--- a/shared/container.go
+++ b/shared/container.go
@@ -133,11 +133,10 @@ func IsDeviceID(value string) error {
 	return nil
 }
 
-// IsRootDiskDevice returns true if the given device representation is
-// configured as root disk for a container. It typically get passed a specific
-// entry of api.Container.Devices.
+// IsRootDiskDevice returns true if the given device representation is configured as root disk for
+// a container. It typically get passed a specific entry of api.Container.Devices.
 func IsRootDiskDevice(device map[string]string) bool {
-	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" {
+	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" && device["pool"] != "" {
 		return true
 	}
 

--- a/test/suites/storage_profiles.sh
+++ b/test/suites/storage_profiles.sh
@@ -108,7 +108,7 @@ test_storage_profiles() {
     lxc launch testimage cOnDefault
     ! lxc profile assign cOnDefault default,dummyDup,dummyNoDup || false
 
-    # Verify that we can create a container with two profiles that speficy the
+    # Verify that we can create a container with two profiles that specify the
     # same root disk device.
     lxc launch testimage cNonConflictingProfiles -p dummy -p dummyDup
 


### PR DESCRIPTION
Migration of disk device into the new device interface.

Adds following behaviour changes:

- Host-side mounts for custom volumes are now unmounted after device start (like rootfs is).
- The `optional` property has been deprecated and replaced with `required` property (defaulting to true) to be consistent with other device types. The `optional` property still works but it has been removed from docs.
- Adds new `CGroupBlkioWeightController` check for `limits.disk.priority`.
- If disk limits cannot be applied due to lack of host cgroup controllers then container wont start.

Part of #5819

- [x] RootFS
- [x] Custom Volumes
- [x] I/O limits
- [x] Live update of limits
- [x] Size quota limits