### PR TITLE
lxc/init: Add parse of options from stdin

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -40,7 +40,7 @@ func (c *cmdInit) Command() *cobra.Command {
 	cmd.Example = cli.FormatSection("", i18n.G(`lxc init ubuntu:16.04 u1
 
 lxc init ubuntu:16.04 u1 < config.yaml
-Create the container with configuration from config.yaml`))
+    Create the container with configuration from config.yaml`))
 	cmd.Hidden = true
 
 	cmd.RunE = c.Run

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
 
 	"github.com/lxc/lxd/client"
 	"github.com/lxc/lxd/lxc/config"
@@ -13,6 +15,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	cli "github.com/lxc/lxd/shared/cmd"
 	"github.com/lxc/lxd/shared/i18n"
+	"github.com/lxc/lxd/shared/termios"
 )
 
 type cmdInit struct {
@@ -31,10 +34,13 @@ type cmdInit struct {
 
 func (c *cmdInit) Command() *cobra.Command {
 	cmd := &cobra.Command{}
-	cmd.Use = i18n.G("init [[<remote>:]<image>] [<remote>:][<name>]")
+	cmd.Use = i18n.G("init [[<remote>:]<image>] [<remote>:][<name>] [< config")
 	cmd.Short = i18n.G("Create containers from images")
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(`Create containers from images`))
-	cmd.Example = cli.FormatSection("", i18n.G(`lxc init ubuntu:16.04 u1`))
+	cmd.Example = cli.FormatSection("", i18n.G(`lxc init ubuntu:16.04 u1
+
+lxc init ubuntu:16.04 u1 < config.yaml
+Create the container with configuration from config.yaml`))
 	cmd.Hidden = true
 
 	cmd.RunE = c.Run
@@ -68,6 +74,22 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 	var remote string
 	var iremote string
 	var err error
+	var stdinData api.ContainerPut
+	var devicesMap map[string]map[string]string
+	var configMap map[string]string
+
+	// If stdin isn't a terminal, read text from it
+	if !termios.IsTerminal(getStdinFd()) {
+		contents, err := ioutil.ReadAll(os.Stdin)
+		if err != nil {
+			return nil, "", err
+		}
+
+		err = yaml.Unmarshal(contents, &stdinData)
+		if err != nil {
+			return nil, "", err
+		}
+	}
 
 	if len(args) > 0 {
 		iremote, image, err = conf.ParseRemote(args[0])
@@ -129,7 +151,12 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 		}
 	}
 
-	devicesMap := map[string]map[string]string{}
+	if len(stdinData.Devices) > 0 {
+		devicesMap = stdinData.Devices
+	} else {
+		devicesMap = map[string]map[string]string{}
+	}
+
 	if c.flagNetwork != "" {
 		network, _, err := d.GetNetwork(c.flagNetwork)
 		if err != nil {
@@ -143,7 +170,11 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 		}
 	}
 
-	configMap := map[string]string{}
+	if len(stdinData.Config) > 0 {
+		configMap = stdinData.Config
+	} else {
+		configMap = map[string]string{}
+	}
 	for _, entry := range c.flagConfig {
 		if !strings.Contains(entry, "=") {
 			return nil, "", fmt.Errorf(i18n.G("Bad key=value pair: %s"), entry)
@@ -174,8 +205,13 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 	}
 	req.Config = configMap
 	req.Devices = devicesMap
+
 	if !c.flagNoProfiles && len(profiles) == 0 {
-		req.Profiles = nil
+		if len(stdinData.Profiles) > 0 {
+			req.Profiles = stdinData.Profiles
+		} else {
+			req.Profiles = nil
+		}
 	} else {
 		req.Profiles = profiles
 	}

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -26,7 +26,7 @@ func (c *cmdLaunch) Command() *cobra.Command {
 		`lxc launch ubuntu:16.04 u1
 
 lxc launch ubuntu:16.04 u1 < config.yaml
-Create and start the container with configuration from config.yaml`))
+    Create and start the container with configuration from config.yaml`))
 	cmd.Hidden = false
 
 	cmd.RunE = c.Run

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -23,7 +23,10 @@ func (c *cmdLaunch) Command() *cobra.Command {
 	cmd.Long = cli.FormatSection(i18n.G("Description"), i18n.G(
 		`Create and start containers from images`))
 	cmd.Example = cli.FormatSection("", i18n.G(
-		`lxc launch ubuntu:16.04 u1`))
+		`lxc launch ubuntu:16.04 u1
+
+lxc launch ubuntu:16.04 u1 < config.yaml
+Create and start the container with configuration from config.yaml`))
 	cmd.Hidden = false
 
 	cmd.RunE = c.Run

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -336,7 +336,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -683,7 +683,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -716,7 +716,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 #, fuzzy
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -746,7 +746,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -841,7 +841,7 @@ msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -867,7 +867,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 #, fuzzy
 msgid "Create containers from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -901,7 +901,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -911,12 +911,12 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 #, fuzzy
 msgid "Creating the container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1015,7 +1015,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -1092,7 +1092,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 #, fuzzy
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
@@ -1227,7 +1227,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Flüchtiger Container"
 
@@ -1599,7 +1599,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2292,7 +2292,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2515,7 +2515,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 #, fuzzy
 msgid "Profile to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2783,7 +2783,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -3109,7 +3109,7 @@ msgstr ""
 msgid "Start containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -3157,7 +3157,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3244,7 +3244,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3259,12 +3259,12 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "The device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3319,11 +3319,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3372,7 +3372,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3937,9 +3937,9 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
+#: lxc/init.go:37
 #, fuzzy
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 "Ändert den Laufzustand eines Containers in %s.\n"
 "\n"
@@ -4068,12 +4068,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -211,7 +211,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -386,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -539,7 +539,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -572,7 +572,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -599,7 +599,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -689,7 +689,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -713,7 +713,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -741,7 +741,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -750,12 +750,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -849,7 +849,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -922,7 +922,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1053,7 +1053,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1409,7 +1409,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2052,7 +2052,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2271,7 +2271,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2520,7 +2520,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2834,7 +2834,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2881,7 +2881,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2964,7 +2964,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2977,12 +2977,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3032,11 +3032,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3085,7 +3085,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3592,8 +3592,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3719,12 +3719,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2019-06-13 16:56+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -283,7 +283,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -459,7 +459,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -613,7 +613,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -646,7 +646,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -673,7 +673,7 @@ msgstr "Log de la consola:"
 msgid "Container name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -764,7 +764,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Creando el contenedor"
@@ -790,7 +790,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -818,7 +818,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -827,12 +827,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr "Creando el contenedor"
 
@@ -926,7 +926,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -999,7 +999,7 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Device: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1129,7 +1129,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1488,7 +1488,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2133,7 +2133,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2351,7 +2351,7 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
@@ -2600,7 +2600,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2914,7 +2914,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2961,7 +2961,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3044,7 +3044,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3057,12 +3057,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3112,11 +3112,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3165,7 +3165,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3674,8 +3674,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3801,12 +3801,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -326,7 +326,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -507,7 +507,7 @@ msgstr "Image copiée avec succès !"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -665,7 +665,7 @@ msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -704,7 +704,7 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
@@ -733,7 +733,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -827,7 +827,7 @@ msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Création du conteneur"
@@ -869,7 +869,7 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 #, fuzzy
 msgid "Create containers from images"
 msgstr "Création du conteneur"
@@ -903,7 +903,7 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -913,12 +913,12 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr "Création du conteneur"
 
@@ -1017,7 +1017,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -1090,7 +1090,7 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 #, fuzzy
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
@@ -1226,7 +1226,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Conteneur éphémère"
 
@@ -1613,7 +1613,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2344,7 +2344,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr "Nom du réseau"
 
@@ -2575,7 +2575,7 @@ msgstr "Profil %s supprimé de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "Profil à appliquer au nouveau conteneur"
 
@@ -2843,7 +2843,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -3181,7 +3181,7 @@ msgstr "Source :"
 msgid "Start containers"
 msgstr "Création du conteneur"
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr "Démarrage de %s"
@@ -3229,7 +3229,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -3322,7 +3322,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
@@ -3337,12 +3337,12 @@ msgstr "Le périphérique n'existe pas"
 msgid "The device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, fuzzy, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -3393,11 +3393,11 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -3448,7 +3448,7 @@ msgstr "Transfert de l'image : %s"
 msgid "Transferring image: %s"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
@@ -4029,9 +4029,9 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
+#: lxc/init.go:37
 #, fuzzy
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 "Change l'état d'un ou plusieurs conteneurs à %s.\n"
 "\n"
@@ -4170,12 +4170,20 @@ msgstr ""
 "lxc info [<serveur distant>:]\n"
 "    Pour l'information du serveur LXD."
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -248,7 +248,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -424,7 +424,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -577,7 +577,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -610,7 +610,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -637,7 +637,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr "Il nome del container è: %s"
@@ -727,7 +727,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Creazione del container in corso"
@@ -753,7 +753,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 #, fuzzy
 msgid "Create containers from images"
 msgstr "Creazione del container in corso"
@@ -782,7 +782,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -791,12 +791,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr "Creazione del container in corso"
 
@@ -890,7 +890,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -963,7 +963,7 @@ msgstr "La periferica esiste già: %s"
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1093,7 +1093,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1454,7 +1454,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2102,7 +2102,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2321,7 +2321,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2571,7 +2571,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2886,7 +2886,7 @@ msgstr ""
 msgid "Start containers"
 msgstr "Creazione del container in corso"
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2933,7 +2933,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3017,7 +3017,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3030,12 +3030,12 @@ msgstr "La periferica esiste già"
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3086,11 +3086,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3139,7 +3139,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3650,8 +3650,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3777,12 +3777,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2019-05-18 08:49+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -212,7 +212,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh はコンテナの場合のみ使えます"
@@ -393,7 +393,7 @@ msgstr "バックアップのエクスポートが成功しました!"
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -549,7 +549,7 @@ msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -586,7 +586,7 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
@@ -613,7 +613,7 @@ msgstr "コンソールログ:"
 msgid "Container name is mandatory"
 msgstr "コンテナ名を指定する必要があります"
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr "コンテナ名: %s"
@@ -708,7 +708,7 @@ msgstr "サーバ証明書格納用のディレクトリを作成できません
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "コンテナを作成中"
@@ -737,7 +737,7 @@ msgstr ""
 "--stateful を指定すると、LXD はコンテナの実行状態（プロセスのメモリ状態、TCP"
 "コネクション、など…を含む）を保存しようとします。"
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr "イメージからコンテナを作成します"
 
@@ -765,7 +765,7 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr "プロファイルを適用しないコンテナを作成します"
 
@@ -774,12 +774,12 @@ msgstr "プロファイルを適用しないコンテナを作成します"
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr "コンテナを作成中"
 
@@ -873,7 +873,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -946,7 +946,7 @@ msgstr "デバイスは既に存在します: %s"
 msgid "Device: %s"
 msgstr "リモート名: %s"
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 #, fuzzy
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
@@ -1091,7 +1091,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Ephemeral コンテナ"
 
@@ -1466,7 +1466,7 @@ msgstr ""
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
@@ -2219,7 +2219,7 @@ msgstr "ネットワーク %s はメンバ %s 上でペンディング状態で�
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr "ネットワーク名:"
 
@@ -2438,7 +2438,7 @@ msgstr "プロファイル %s が %s から削除されました"
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "新しいコンテナに適用するプロファイル"
 
@@ -2694,7 +2694,7 @@ msgstr "スナップショットからストレージボリュームをリスト
 msgid "Retrieve the container's console log"
 msgstr "コンテナのコンソールログを取得します"
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -3008,7 +3008,7 @@ msgstr "取得元:"
 msgid "Start containers"
 msgstr "コンテナを起動します"
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr "%s を起動中"
@@ -3055,7 +3055,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -3140,7 +3140,7 @@ msgstr ""
 "コンテナは現在実行中です。停止して、再起動するために --force を使用してくださ"
 "い"
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたコンテナに接続されているネットワークがありません。"
 
@@ -3153,14 +3153,14 @@ msgstr "デバイスはすでに存在します"
 msgid "The device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3213,12 +3213,12 @@ msgstr "コンテナを強制停止するまでの時間"
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 "コンテナにネットワークを接続するには、lxc network attach を使用してください"
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -3272,7 +3272,7 @@ msgstr "コンテナを転送中: %s"
 msgid "Transferring image: %s"
 msgstr "イメージを転送中: %s"
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
@@ -3790,9 +3790,9 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
+#: lxc/init.go:37
 #, fuzzy
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "delete [<remote>:]<image> [[<remote>:]<image>...]"
 
 #: lxc/launch.go:21
@@ -3958,13 +3958,27 @@ msgstr ""
 "lxc info [<remote>:] [--resources]\n"
 "    LXD サーバの情報を表示します。"
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
-msgstr "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+#, fuzzy
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
+msgstr ""
+"lxc config edit <container> < container.yaml\n"
+"    コンテナの設定を config.yaml を使って更新します。"
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
-msgstr "lxc launch ubuntu:16.04 u1"
+#, fuzzy
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
+msgstr ""
+"lxc config edit <container> < container.yaml\n"
+"    コンテナの設定を config.yaml を使って更新します。"
 
 #: lxc/list.go:103
 msgid ""
@@ -4511,6 +4525,12 @@ msgstr ""
 #: lxc/image.go:995
 msgid "yes"
 msgstr ""
+
+#~ msgid "lxc init ubuntu:16.04 u1"
+#~ msgstr "lxc init ubuntu:16.04 u1"
+
+#~ msgid "lxc launch ubuntu:16.04 u1"
+#~ msgstr "lxc launch ubuntu:16.04 u1"
 
 #~ msgid ""
 #~ "You must use the same source and destination remote when using --target"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-08-27 23:26-0600\n"
+        "POT-Creation-Date: 2019-09-03 09:02-0400\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -200,7 +200,7 @@ msgstr  ""
 msgid   "--container-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -370,7 +370,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176 lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176 lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -520,7 +520,7 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47 lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729 lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145 lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1282 lxc/storage_volume.go:1361 lxc/storage_volume.go:1454
+#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53 lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729 lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145 lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1282 lxc/storage_volume.go:1361 lxc/storage_volume.go:1454
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -543,7 +543,7 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
@@ -568,7 +568,7 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid   "Container name is: %s"
 msgstr  ""
@@ -657,7 +657,7 @@ msgstr  ""
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid   "Create an empty container"
 msgstr  ""
 
@@ -680,7 +680,7 @@ msgid   "Create container snapshots\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid   "Create containers from images"
 msgstr  ""
 
@@ -708,7 +708,7 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid   "Create the container with no profiles applied"
 msgstr  ""
 
@@ -717,12 +717,12 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid   "Creating the container"
 msgstr  ""
 
@@ -795,7 +795,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219 lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:74 lxc/file.go:107 lxc/file.go:156 lxc/file.go:219 lxc/file.go:409 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -840,7 +840,7 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid   "Didn't get any affected image, container or snapshot from server"
 msgstr  ""
 
@@ -962,7 +962,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid   "Ephemeral container"
 msgstr  ""
 
@@ -1302,7 +1302,7 @@ msgstr  ""
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid   "Instance type"
 msgstr  ""
 
@@ -1909,7 +1909,7 @@ msgstr  ""
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid   "Network name"
 msgstr  ""
 
@@ -2125,7 +2125,7 @@ msgstr  ""
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
@@ -2370,7 +2370,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -2669,7 +2669,7 @@ msgstr  ""
 msgid   "Start containers"
 msgstr  ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid   "Starting %s"
 msgstr  ""
@@ -2716,7 +2716,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -2796,7 +2796,7 @@ msgstr  ""
 msgid   "The container is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid   "The container you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -2808,12 +2808,12 @@ msgstr  ""
 msgid   "The device doesn't exist"
 msgstr  ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr  ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
@@ -2858,11 +2858,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid   "To attach a network to a container, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -2910,7 +2910,7 @@ msgstr  ""
 msgid   "Transferring image: %s"
 msgstr  ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
@@ -3401,8 +3401,8 @@ msgstr  ""
 msgid   "info [<remote>:][<container>]"
 msgstr  ""
 
-#: lxc/init.go:34
-msgid   "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid   "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr  ""
 
 #: lxc/launch.go:21
@@ -3513,12 +3513,18 @@ msgid   "lxc info [<remote>:]<container> [--show-log]\n"
         "    For LXD server information."
 msgstr  ""
 
-#: lxc/init.go:37
-msgid   "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid   "lxc init ubuntu:16.04 u1\n"
+        "\n"
+        "lxc init ubuntu:16.04 u1 < config.yaml\n"
+        "    Create the container with configuration from config.yaml"
 msgstr  ""
 
 #: lxc/launch.go:25
-msgid   "lxc launch ubuntu:16.04 u1"
+msgid   "lxc launch ubuntu:16.04 u1\n"
+        "\n"
+        "lxc launch ubuntu:16.04 u1 < config.yaml\n"
+        "    Create and start the container with configuration from config.yaml"
 msgstr  ""
 
 #: lxc/list.go:103

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2019-02-26 09:18+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -584,7 +584,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -617,7 +617,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -795,12 +795,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2310,7 +2310,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2559,7 +2559,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3003,7 +3003,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3016,12 +3016,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3071,11 +3071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3124,7 +3124,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3631,8 +3631,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3758,12 +3758,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -257,7 +257,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -432,7 +432,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -584,7 +584,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -617,7 +617,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -644,7 +644,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -734,7 +734,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -758,7 +758,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -786,7 +786,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -795,12 +795,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -894,7 +894,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -967,7 +967,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1095,7 +1095,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1451,7 +1451,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2092,7 +2092,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2310,7 +2310,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2559,7 +2559,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2873,7 +2873,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2920,7 +2920,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3003,7 +3003,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3016,12 +3016,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3071,11 +3071,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3124,7 +3124,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3631,8 +3631,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3758,12 +3758,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2019-08-08 18:08+0000\n"
 "Last-Translator: Tiago A. Reul <tiago@reul.space>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -327,7 +327,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -504,7 +504,7 @@ msgstr "Backup exportado com sucesso!"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -657,7 +657,7 @@ msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -695,7 +695,7 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
@@ -722,7 +722,7 @@ msgstr "Log de Console:"
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -812,7 +812,7 @@ msgstr "Impossível criar diretório para certificado do servidor"
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -840,7 +840,7 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -868,7 +868,7 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -877,12 +877,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -976,7 +976,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -1049,7 +1049,7 @@ msgstr "O dispositivo já existe: %s"
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1180,7 +1180,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1537,7 +1537,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2178,7 +2178,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2645,7 +2645,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2960,7 +2960,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -3007,7 +3007,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3090,7 +3090,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3103,12 +3103,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3158,11 +3158,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3211,7 +3211,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3719,8 +3719,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3846,12 +3846,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -318,7 +318,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -649,7 +649,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -682,7 +682,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr "Имя контейнера: %s"
@@ -800,7 +800,7 @@ msgstr "Не удалось создать каталог сертификата
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -826,7 +826,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -857,7 +857,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -867,12 +867,12 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -969,7 +969,7 @@ msgstr "Копирование образа: %s"
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -1042,7 +1042,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1174,7 +1174,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1536,7 +1536,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2189,7 +2189,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2409,7 +2409,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2664,7 +2664,7 @@ msgstr "Копирование образа: %s"
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2981,7 +2981,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -3029,7 +3029,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -3113,7 +3113,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3126,12 +3126,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3181,11 +3181,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3234,7 +3234,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3782,9 +3782,9 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
+#: lxc/init.go:37
 #, fuzzy
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 "Изменение состояния одного или нескольких контейнеров %s.\n"
 "\n"
@@ -3913,12 +3913,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -535,7 +535,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -568,7 +568,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -595,7 +595,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -685,7 +685,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -709,7 +709,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -737,7 +737,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -746,12 +746,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -845,7 +845,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -918,7 +918,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1046,7 +1046,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1402,7 +1402,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2043,7 +2043,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2261,7 +2261,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2510,7 +2510,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,7 +2824,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2871,7 +2871,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2954,7 +2954,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2967,12 +2967,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3022,11 +3022,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3075,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3582,8 +3582,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3709,12 +3709,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-08-27 23:26-0600\n"
+"POT-Creation-Date: 2019-09-03 09:02-0400\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -211,7 +211,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:93
+#: lxc/init.go:115
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -386,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:149 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:123 lxc/init.go:180 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -538,7 +538,7 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:47
+#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
 #: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
@@ -571,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:41
+#: lxc/copy.go:44 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -598,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:278
+#: lxc/copy.go:420 lxc/init.go:314
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -688,7 +688,7 @@ msgstr ""
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:49
+#: lxc/init.go:55
 msgid "Create an empty container"
 msgstr ""
 
@@ -712,7 +712,7 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:35 lxc/init.go:36
+#: lxc/init.go:38 lxc/init.go:39
 msgid "Create containers from images"
 msgstr ""
 
@@ -740,7 +740,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:48
+#: lxc/copy.go:54 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -749,12 +749,12 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:128
+#: lxc/init.go:150
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:126
+#: lxc/init.go:148
 msgid "Creating the container"
 msgstr ""
 
@@ -848,7 +848,7 @@ msgstr ""
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
 #: lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
-#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:36
+#: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
 #: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
@@ -921,7 +921,7 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:272
+#: lxc/init.go:308
 msgid "Didn't get any affected image, container or snapshot from server"
 msgstr ""
 
@@ -1049,7 +1049,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:43
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1405,7 +1405,7 @@ msgstr ""
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:46
+#: lxc/init.go:52
 msgid "Instance type"
 msgstr ""
 
@@ -2046,7 +2046,7 @@ msgstr ""
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:44
+#: lxc/init.go:50
 msgid "Network name"
 msgstr ""
 
@@ -2264,7 +2264,7 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:42
+#: lxc/copy.go:46 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
@@ -2513,7 +2513,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:235
+#: lxc/init.go:271
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2827,7 +2827,7 @@ msgstr ""
 msgid "Start containers"
 msgstr ""
 
-#: lxc/launch.go:65
+#: lxc/launch.go:68
 #, c-format
 msgid "Starting %s"
 msgstr ""
@@ -2874,7 +2874,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:45 lxc/move.go:57
+#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
 msgid "Storage pool name"
 msgstr ""
 
@@ -2957,7 +2957,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:329
+#: lxc/init.go:365
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -2970,12 +2970,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:313
+#: lxc/init.go:349
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:309
+#: lxc/init.go:345
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3025,11 +3025,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:331
+#: lxc/init.go:367
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:330
+#: lxc/init.go:366
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3078,7 +3078,7 @@ msgstr ""
 msgid "Transferring image: %s"
 msgstr ""
 
-#: lxc/action.go:196 lxc/launch.go:96
+#: lxc/action.go:196 lxc/launch.go:99
 #, c-format
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
@@ -3585,8 +3585,8 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:34
-msgid "init [[<remote>:]<image>] [<remote>:][<name>]"
+#: lxc/init.go:37
+msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
 #: lxc/launch.go:21
@@ -3712,12 +3712,20 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:37
-msgid "lxc init ubuntu:16.04 u1"
+#: lxc/init.go:40
+msgid ""
+"lxc init ubuntu:16.04 u1\n"
+"\n"
+"lxc init ubuntu:16.04 u1 < config.yaml\n"
+"    Create the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/launch.go:25
-msgid "lxc launch ubuntu:16.04 u1"
+msgid ""
+"lxc launch ubuntu:16.04 u1\n"
+"\n"
+"lxc launch ubuntu:16.04 u1 < config.yaml\n"
+"    Create and start the container with configuration from config.yaml"
 msgstr ""
 
 #: lxc/list.go:103


### PR DESCRIPTION
It's now possible to parse configuration options from stdin in both `lxc init` and `lxc launch` commands.

Example:
```
$# $ cat /tmp/config.yml 
config:
  raw.lxc: |
    lxc.net.0.ipv4.address = 10.10.10.1/24
ephemeral: True
profiles:
- sdpool
- net-lxdbr0

$# lxc launch 64362190ee7c c1 < /tmp/config.yml
```