### PR TITLE
lxc/init: Fix usage with no args

### DIFF
--- a/lxc/init.go
+++ b/lxc/init.go
@@ -58,6 +58,11 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if len(args) == 0 && !c.flagEmpty {
+		cmd.Usage()
+		return nil
+	}
+
 	_, _, err = c.create(c.global.conf, args)
 	return err
 }


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>