### PR TITLE
test: Adds storage quota tests

### DIFF
--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -778,7 +778,7 @@ test_storage() {
     rootMaxKB2="23000"
   fi
 
-  if [ "$lxd_backend" != "dir" ] && [ "$lxd_backend" != "ceph" ]; then
+  if [ "$lxd_backend" != "dir" ]; then
     lxc launch testimage quota1
     rootOrigSizeKB=$(lxc exec quota1 -- df -P / | tail -n1 | awk '{print $2}')
     rootOrigMinSizeKB=$((rootOrigSizeKB-1000))


### PR DESCRIPTION
- Adds basic quota checks for zfs, lvm and ceph (dir and btrfs not supported)
- ZFS checks for live setting and resetting
- LVM doesn't support unsetting quota
- BTRFS doesn't support checking quota using df (AFAIK)

Part of https://github.com/lxc/lxd/issues/5819

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>