### PR TITLE
Reverts root disk device non-empty pool check

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -93,6 +93,10 @@ func (d *disk) validateConfig() error {
 		return fmt.Errorf("Root disk entry may not have a \"source\" property set")
 	}
 
+	if d.config["path"] == "/" && d.config["pool"] == "" {
+		return fmt.Errorf("Root disk entry must have a \"pool\" property set")
+	}
+
 	if d.config["size"] != "" && d.config["path"] != "/" {
 		return fmt.Errorf("Only the root disk may have a size quota")
 	}

--- a/shared/container.go
+++ b/shared/container.go
@@ -133,10 +133,13 @@ func IsDeviceID(value string) error {
 	return nil
 }
 
-// IsRootDiskDevice returns true if the given device representation is
-// configured as root disk for a container. It typically get passed a specific
-// entry of api.Container.Devices.
+// IsRootDiskDevice returns true if the given device representation is configured as root disk for
+// a container. It typically get passed a specific entry of api.Container.Devices.
 func IsRootDiskDevice(device map[string]string) bool {
+	// Root disk devices also need a non-empty "pool" property, but we can't check that here
+	// because this function is used with clients talking to older servers where there was no
+	// concept of a storage pool, and also it is used for migrating from old to new servers.
+	// The validation of the non-empty "pool" property is done inside the disk device itself.
 	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" {
 		return true
 	}

--- a/shared/container.go
+++ b/shared/container.go
@@ -133,10 +133,11 @@ func IsDeviceID(value string) error {
 	return nil
 }
 
-// IsRootDiskDevice returns true if the given device representation is configured as root disk for
-// a container. It typically get passed a specific entry of api.Container.Devices.
+// IsRootDiskDevice returns true if the given device representation is
+// configured as root disk for a container. It typically get passed a specific
+// entry of api.Container.Devices.
 func IsRootDiskDevice(device map[string]string) bool {
-	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" && device["pool"] != "" {
+	if device["type"] == "disk" && device["path"] == "/" && device["source"] == "" {
 		return true
 	}
 


### PR DESCRIPTION
The recent modification to `IsRootDiskDevice` to correctly verify for a non-empty `pool` property has caused issues with the migration process from older server versions that don't have storage pool support, and will also cause problems when using the client against older version versions.

As such this change has been reverted and the non-empty `pool` property check moved into the disk device validation itself.

A comment has been added to avoid confusion in the future.

Part of #5819