### PR TITLE
test: Tunes ZFS quota tests after intermittent failures

### DIFF
--- a/test/suites/storage.sh
+++ b/test/suites/storage.sh
@@ -781,8 +781,8 @@ test_storage() {
   if [ "$lxd_backend" != "dir" ]; then
     lxc launch testimage quota1
     rootOrigSizeKB=$(lxc exec quota1 -- df -P / | tail -n1 | awk '{print $2}')
-    rootOrigMinSizeKB=$((rootOrigSizeKB-1000))
-    rootOrigMaxSizeKB=$((rootOrigSizeKB+1000))
+    rootOrigMinSizeKB=$((rootOrigSizeKB-2000))
+    rootOrigMaxSizeKB=$((rootOrigSizeKB+2000))
 
     lxc profile device set default root size "${QUOTA1}"
     lxc stop -f quota1


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>