### PR TITLE
API Instances

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -823,3 +823,6 @@ Export infiniband character device information (issm, umad, uverb) as part of th
 This introduces two new configuration keys `storage.images\_volume` and
 `storage.backups\_volume` to allow for a storage volume on an existing
 pool be used for storing the daemon-wide images and backups artifacts.
+
+## instances
+This introduces the concept of instances, of which currently the only type is "container".

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1152,12 +1152,12 @@ func containerLoadNodeAll(s *state.State) ([]container, error) {
 }
 
 // Load all containers of this nodes under the given project.
-func containerLoadNodeProjectAll(s *state.State, project string) ([]container, error) {
+func containerLoadNodeProjectAll(s *state.State, project string, instanceType instance.Type) ([]container, error) {
 	// Get all the container arguments
 	var cts []db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		var err error
-		cts, err = tx.ContainerNodeProjectList(project)
+		cts, err = tx.ContainerNodeProjectList(project, instanceType)
 		if err != nil {
 			return err
 		}

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -313,7 +313,7 @@ func TestContainersListByNodeAddress(t *testing.T) {
 	addContainer(t, tx, nodeID3, "c3")
 	addContainer(t, tx, nodeID2, "c4")
 
-	result, err := tx.ContainersListByNodeAddress("default")
+	result, err := tx.ContainersListByNodeAddress("default", instance.TypeContainer)
 	require.NoError(t, err)
 	assert.Equal(
 		t,
@@ -337,7 +337,7 @@ func TestContainersByNodeName(t *testing.T) {
 	addContainer(t, tx, nodeID2, "c1")
 	addContainer(t, tx, nodeID1, "c2")
 
-	result, err := tx.ContainersByNodeName("default")
+	result, err := tx.ContainersByNodeName("default", instance.TypeContainer)
 	require.NoError(t, err)
 	assert.Equal(
 		t,

--- a/lxd/db/instances.mapper.go
+++ b/lxd/db/instances.mapper.go
@@ -5,10 +5,13 @@ package db
 import (
 	"database/sql"
 	"fmt"
+
+	"github.com/pkg/errors"
+
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/pkg/errors"
 )
 
 var _ = api.ServerEnvironment{}
@@ -163,7 +166,7 @@ func (c *ClusterTx) InstanceList(filter InstanceFilter) ([]Instance, error) {
 	if filter.Node != "" {
 		criteria["Node"] = filter.Node
 	}
-	if filter.Type != -1 {
+	if filter.Type != instance.TypeAny {
 		criteria["Type"] = filter.Type
 	}
 

--- a/lxd/instance/instance.go
+++ b/lxd/instance/instance.go
@@ -1,5 +1,9 @@
 package instance
 
+import (
+	"fmt"
+)
+
 // Type indicates the type of instance.
 type Type int
 
@@ -9,3 +13,25 @@ const (
 	// TypeContainer represents a container instance type.
 	TypeContainer = Type(0)
 )
+
+// New validates the supplied string against the allowed types of instance and returns the internal
+// representation of that type. If empty string is supplied then the type returned is TypeContainer.
+// If an invalid name is supplied an error will be returned.
+func New(name string) (Type, error) {
+	// If "container" or "" is supplied, return type as TypeContainer.
+	if name == "container" || name == "" {
+		return TypeContainer, nil
+	}
+
+	return -1, fmt.Errorf("Invalid instance type")
+}
+
+// String converts the internal representation of instance type to a string used in API requests.
+// Returns empty string if value is not a valid instance type.
+func (instanceType Type) String() string {
+	if instanceType == TypeContainer {
+		return "container"
+	}
+
+	return ""
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -164,6 +164,7 @@ var APIExtensions = []string{
 	"storage_shifted",
 	"resources_infiniband",
 	"daemon_storage",
+	"instances",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
- Adds `/1.0/instances` endpoints with support for a `type` field that indicates instance type.
- Adds `instances` API extension.

Includes https://github.com/lxc/lxd/pull/6176