### PR TITLE
client: Rename ContainerServer to InstanceServer

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -58,7 +58,7 @@ type ConnectionArgs struct {
 // If connecting to a LXD daemon running in PKI mode, the PKI CA (TLSCA) must also be provided.
 //
 // Unless the remote server is trusted by the system CA, the remote certificate must be provided (TLSServerCert).
-func ConnectLXD(url string, args *ConnectionArgs) (ContainerServer, error) {
+func ConnectLXD(url string, args *ConnectionArgs) (InstanceServer, error) {
 	logger.Debugf("Connecting to a remote LXD over HTTPs")
 
 	// Cleanup URL
@@ -72,7 +72,7 @@ func ConnectLXD(url string, args *ConnectionArgs) (ContainerServer, error) {
 // If the path argument is empty, then $LXD_SOCKET will be used, if
 // unset $LXD_DIR/unix.socket will be used and if that one isn't set
 // either, then the path will default to /var/lib/lxd/unix.socket.
-func ConnectLXDUnix(path string, args *ConnectionArgs) (ContainerServer, error) {
+func ConnectLXDUnix(path string, args *ConnectionArgs) (InstanceServer, error) {
 	logger.Debugf("Connecting to a local LXD over a Unix socket")
 
 	// Use empty args if not specified
@@ -170,7 +170,7 @@ func ConnectSimpleStreams(url string, args *ConnectionArgs) (ImageServer, error)
 }
 
 // Internal function called by ConnectLXD and ConnectPublicLXD
-func httpsLXD(url string, args *ConnectionArgs) (ContainerServer, error) {
+func httpsLXD(url string, args *ConnectionArgs) (InstanceServer, error) {
 	// Use empty args if not specified
 	if args == nil {
 		args = &ConnectionArgs{}

--- a/client/interfaces_legacy.go
+++ b/client/interfaces_legacy.go
@@ -1,0 +1,126 @@
+package lxd
+
+import (
+	"io"
+
+	"github.com/gorilla/websocket"
+)
+
+// The ContainerServer type is the legacy name for InstanceServer
+type ContainerServer InstanceServer
+
+// The ContainerBackupArgs struct is used when creating a container from a backup
+type ContainerBackupArgs struct {
+	// The backup file
+	BackupFile io.Reader
+
+	// Storage pool to use
+	PoolName string
+}
+
+// The ContainerCopyArgs struct is used to pass additional options during container copy
+type ContainerCopyArgs struct {
+	// If set, the container will be renamed on copy
+	Name string
+
+	// If set, the container running state will be transferred (live migration)
+	Live bool
+
+	// If set, only the container will copied, its snapshots won't
+	ContainerOnly bool
+
+	// The transfer mode, can be "pull" (default), "push" or "relay"
+	Mode string
+
+	// API extension: container_incremental_copy
+	// Perform an incremental copy
+	Refresh bool
+}
+
+// The ContainerSnapshotCopyArgs struct is used to pass additional options during container copy
+type ContainerSnapshotCopyArgs struct {
+	// If set, the container will be renamed on copy
+	Name string
+
+	// The transfer mode, can be "pull" (default), "push" or "relay"
+	Mode string
+
+	// API extension: container_snapshot_stateful_migration
+	// If set, the container running state will be transferred (live migration)
+	Live bool
+}
+
+// The ContainerConsoleArgs struct is used to pass additional options during a
+// container console session
+type ContainerConsoleArgs struct {
+	// Bidirectional fd to pass to the container
+	Terminal io.ReadWriteCloser
+
+	// Control message handler (window resize)
+	Control func(conn *websocket.Conn)
+
+	// Closing this Channel causes a disconnect from the container's console
+	ConsoleDisconnect chan bool
+}
+
+// The ContainerConsoleLogArgs struct is used to pass additional options during a
+// container console log request
+type ContainerConsoleLogArgs struct {
+}
+
+// The ContainerExecArgs struct is used to pass additional options during container exec
+type ContainerExecArgs struct {
+	// Standard input
+	Stdin io.ReadCloser
+
+	// Standard output
+	Stdout io.WriteCloser
+
+	// Standard error
+	Stderr io.WriteCloser
+
+	// Control message handler (window resize, signals, ...)
+	Control func(conn *websocket.Conn)
+
+	// Channel that will be closed when all data operations are done
+	DataDone chan bool
+}
+
+// The ContainerFileArgs struct is used to pass the various options for a container file upload
+type ContainerFileArgs struct {
+	// File content
+	Content io.ReadSeeker
+
+	// User id that owns the file
+	UID int64
+
+	// Group id that owns the file
+	GID int64
+
+	// File permissions
+	Mode int
+
+	// File type (file or directory)
+	Type string
+
+	// File write mode (overwrite or append)
+	WriteMode string
+}
+
+// The ContainerFileResponse struct is used as part of the response for a container file download
+type ContainerFileResponse struct {
+	// User id that owns the file
+	UID int64
+
+	// Group id that owns the file
+	GID int64
+
+	// File permissions
+	Mode int
+
+	// File type (file or directory)
+	Type string
+
+	// If a directory, the list of files inside it
+	Entries []string
+}

--- a/client/lxd_containers.go
+++ b/client/lxd_containers.go
@@ -286,7 +286,7 @@ func (r *ProtocolLXD) CreateContainerFromImage(source ImageServer, image api.Ima
 }
 
 // CopyContainer copies a container from a remote server. Additional options can be passed using ContainerCopyArgs
-func (r *ProtocolLXD) CopyContainer(source ContainerServer, container api.Container, args *ContainerCopyArgs) (RemoteOperation, error) {
+func (r *ProtocolLXD) CopyContainer(source InstanceServer, container api.Container, args *ContainerCopyArgs) (RemoteOperation, error) {
 	// Base request
 	req := api.ContainersPost{
 		Name:         container.Name,
@@ -499,7 +499,7 @@ func (r *ProtocolLXD) CopyContainer(source ContainerServer, container api.Contai
 	return r.tryCreateContainer(req, info.Addresses)
 }
 
-func (r *ProtocolLXD) proxyMigration(targetOp *operation, targetSecrets map[string]string, source ContainerServer, sourceOp *operation, sourceSecrets map[string]string) error {
+func (r *ProtocolLXD) proxyMigration(targetOp *operation, targetSecrets map[string]string, source InstanceServer, sourceOp *operation, sourceSecrets map[string]string) error {
 	// Sanity checks
 	for n := range targetSecrets {
 		_, ok := sourceSecrets[n]
@@ -611,7 +611,7 @@ func (r *ProtocolLXD) RenameContainer(name string, container api.ContainerPost) 
 	return op, nil
 }
 
-func (r *ProtocolLXD) tryMigrateContainer(source ContainerServer, name string, req api.ContainerPost, urls []string) (RemoteOperation, error) {
+func (r *ProtocolLXD) tryMigrateContainer(source InstanceServer, name string, req api.ContainerPost, urls []string) (RemoteOperation, error) {
 	if len(urls) == 0 {
 		return nil, fmt.Errorf("The target server isn't listening on the network")
 	}
@@ -1062,7 +1062,7 @@ func (r *ProtocolLXD) CreateContainerSnapshot(containerName string, snapshot api
 }
 
 // CopyContainerSnapshot copies a snapshot from a remote server into a new container. Additional options can be passed using ContainerCopyArgs
-func (r *ProtocolLXD) CopyContainerSnapshot(source ContainerServer, containerName string, snapshot api.ContainerSnapshot, args *ContainerSnapshotCopyArgs) (RemoteOperation, error) {
+func (r *ProtocolLXD) CopyContainerSnapshot(source InstanceServer, containerName string, snapshot api.ContainerSnapshot, args *ContainerSnapshotCopyArgs) (RemoteOperation, error) {
 	// Backward compatibility (with broken Name field)
 	fields := strings.Split(snapshot.Name, shared.SnapshotDelimiter)
 	cName := containerName
@@ -1287,7 +1287,7 @@ func (r *ProtocolLXD) RenameContainerSnapshot(containerName string, name string,
 	return op, nil
 }
 
-func (r *ProtocolLXD) tryMigrateContainerSnapshot(source ContainerServer, containerName string, name string, req api.ContainerSnapshotPost, urls []string) (RemoteOperation, error) {
+func (r *ProtocolLXD) tryMigrateContainerSnapshot(source InstanceServer, containerName string, name string, req api.ContainerSnapshotPost, urls []string) (RemoteOperation, error) {
 	if len(urls) == 0 {
 		return nil, fmt.Errorf("The target server isn't listening on the network")
 	}

--- a/client/lxd_server.go
+++ b/client/lxd_server.go
@@ -90,7 +90,7 @@ func (r *ProtocolLXD) GetServerResources() (*api.Resources, error) {
 }
 
 // UseProject returns a client that will use a specific project.
-func (r *ProtocolLXD) UseProject(name string) ContainerServer {
+func (r *ProtocolLXD) UseProject(name string) InstanceServer {
 	return &ProtocolLXD{
 		server:               r.server,
 		http:                 r.http,
@@ -109,7 +109,7 @@ func (r *ProtocolLXD) UseProject(name string) ContainerServer {
 // UseTarget returns a client that will target a specific cluster member.
 // Use this member-specific operations such as specific container
 // placement, preparing a new storage pool or network, ...
-func (r *ProtocolLXD) UseTarget(name string) ContainerServer {
+func (r *ProtocolLXD) UseTarget(name string) InstanceServer {
 	return &ProtocolLXD{
 		server:               r.server,
 		http:                 r.http,

--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -247,7 +247,7 @@ func (r *ProtocolLXD) MigrateStoragePoolVolume(pool string, volume api.StorageVo
 	return op, nil
 }
 
-func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source ContainerServer, pool string, req api.StorageVolumePost, urls []string) (RemoteOperation, error) {
+func (r *ProtocolLXD) tryMigrateStoragePoolVolume(source InstanceServer, pool string, req api.StorageVolumePost, urls []string) (RemoteOperation, error) {
 	if len(urls) == 0 {
 		return nil, fmt.Errorf("The source server isn't listening on the network")
 	}
@@ -356,7 +356,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 }
 
 // CopyStoragePoolVolume copies an existing storage volume
-func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source ContainerServer, sourcePool string, volume api.StorageVolume, args *StoragePoolVolumeCopyArgs) (RemoteOperation, error) {
+func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source InstanceServer, sourcePool string, volume api.StorageVolume, args *StoragePoolVolumeCopyArgs) (RemoteOperation, error) {
 	if !r.HasExtension("storage_api_local_volume_handling") {
 		return nil, fmt.Errorf("The server is missing the required \"storage_api_local_volume_handling\" API extension")
 	}
@@ -520,7 +520,7 @@ func (r *ProtocolLXD) CopyStoragePoolVolume(pool string, source ContainerServer,
 }
 
 // MoveStoragePoolVolume renames or moves an existing storage volume
-func (r *ProtocolLXD) MoveStoragePoolVolume(pool string, source ContainerServer, sourcePool string, volume api.StorageVolume, args *StoragePoolVolumeMoveArgs) (RemoteOperation, error) {
+func (r *ProtocolLXD) MoveStoragePoolVolume(pool string, source InstanceServer, sourcePool string, volume api.StorageVolume, args *StoragePoolVolumeMoveArgs) (RemoteOperation, error) {
 	if !r.HasExtension("storage_api_local_volume_handling") {
 		return nil, fmt.Errorf("The server is missing the required \"storage_api_local_volume_handling\" API extension")
 	}


### PR DESCRIPTION
And same to associated structs, alias old names.

Moving forward we will be using the new names in our own code and the
new Instance related functions will be using new versions of the various
argument structs.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>