### PR TITLE
lxc: Switches to use Instance functions of client package

### DIFF
--- a/lxc/action.go
+++ b/lxc/action.go
@@ -142,7 +142,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 
-		d, err := conf.GetContainerServer(conf.DefaultRemote)
+		d, err := conf.GetInstanceServer(conf.DefaultRemote)
 		if err != nil {
 			return err
 		}

--- a/lxc/action.go
+++ b/lxc/action.go
@@ -152,7 +152,7 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 	}
 
 	if action == "start" {
-		current, _, err := d.GetContainer(name)
+		current, _, err := d.GetInstance(name)
 		if err != nil {
 			return err
 		}
@@ -168,14 +168,14 @@ func (c *cmdAction) doAction(action string, conf *config.Config, nameArg string)
 		}
 	}
 
-	req := api.ContainerStatePut{
+	req := api.InstanceStatePut{
 		Action:   action,
 		Timeout:  c.flagTimeout,
 		Force:    c.flagForce,
 		Stateful: state,
 	}
 
-	op, err := d.UpdateContainerState(name, req, "")
+	op, err := d.UpdateInstanceState(name, req, "")
 	if err != nil {
 		return err
 	}
@@ -216,7 +216,7 @@ func (c *cmdAction) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		ctslist, err := d.GetContainers()
+		ctslist, err := d.GetInstances(api.InstanceTypeAny)
 		if err != nil {
 			return err
 		}

--- a/lxc/config/remote.go
+++ b/lxc/config/remote.go
@@ -50,8 +50,8 @@ func (c *Config) ParseRemote(raw string) (string, string, error) {
 	return result[0], result[1], nil
 }
 
-// GetContainerServer returns a ContainerServer struct for the remote
-func (c *Config) GetContainerServer(name string) (lxd.ContainerServer, error) {
+// GetInstanceServer returns a InstanceServer struct for the remote
+func (c *Config) GetInstanceServer(name string) (lxd.InstanceServer, error) {
 	// Handle "local" on non-Linux
 	if name == "local" && runtime.GOOS != "linux" {
 		return nil, ErrNotLinux

--- a/lxc/config_device.go
+++ b/lxc/config_device.go
@@ -137,7 +137,7 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		container, etag, err := resource.server.GetContainer(resource.name)
+		container, etag, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -149,7 +149,7 @@ func (c *cmdConfigDeviceAdd) Run(cmd *cobra.Command, args []string) error {
 
 		container.Devices[devname] = device
 
-		op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+		op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -223,7 +223,7 @@ func (c *cmdConfigDeviceGet) Run(cmd *cobra.Command, args []string) error {
 
 		fmt.Println(dev[key])
 	} else {
-		container, _, err := resource.server.GetContainer(resource.name)
+		container, _, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -291,7 +291,7 @@ func (c *cmdConfigDeviceList) Run(cmd *cobra.Command, args []string) error {
 			devices = append(devices, k)
 		}
 	} else {
-		container, _, err := resource.server.GetContainer(resource.name)
+		container, _, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -346,7 +346,7 @@ func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Override the device
-	container, etag, err := resource.server.GetContainer(resource.name)
+	container, etag, err := resource.server.GetInstance(resource.name)
 	if err != nil {
 		return err
 	}
@@ -377,7 +377,7 @@ func (c *cmdConfigDeviceOverride) Run(cmd *cobra.Command, args []string) error {
 
 	container.Devices[devname] = device
 
-	op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 	if err != nil {
 		return err
 	}
@@ -454,7 +454,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		container, etag, err := resource.server.GetContainer(resource.name)
+		container, etag, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -467,7 +467,7 @@ func (c *cmdConfigDeviceRemove) Run(cmd *cobra.Command, args []string) error {
 			delete(container.Devices, devname)
 		}
 
-		op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+		op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -556,7 +556,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		container, etag, err := resource.server.GetContainer(resource.name)
+		container, etag, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -570,7 +570,7 @@ func (c *cmdConfigDeviceSet) Run(cmd *cobra.Command, args []string) error {
 		}
 		container.Devices[devname] = dev
 
-		op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+		op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 		if err != nil {
 			return err
 		}
@@ -633,7 +633,7 @@ func (c *cmdConfigDeviceShow) Run(cmd *cobra.Command, args []string) error {
 
 		devices = profile.Devices
 	} else {
-		container, _, err := resource.server.GetContainer(resource.name)
+		container, _, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}

--- a/lxc/config_metadata.go
+++ b/lxc/config_metadata.go
@@ -113,10 +113,10 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		return resource.server.SetContainerMetadata(resource.name, metadata, "")
+		return resource.server.SetInstanceMetadata(resource.name, metadata, "")
 	}
 
-	metadata, etag, err := resource.server.GetContainerMetadata(resource.name)
+	metadata, etag, err := resource.server.GetInstanceMetadata(resource.name)
 	if err != nil {
 		return err
 	}
@@ -135,7 +135,7 @@ func (c *cmdConfigMetadataEdit) Run(cmd *cobra.Command, args []string) error {
 		metadata := api.ImageMetadata{}
 		err = yaml.Unmarshal(content, &metadata)
 		if err == nil {
-			err = resource.server.SetContainerMetadata(resource.name, metadata, etag)
+			err = resource.server.SetInstanceMetadata(resource.name, metadata, etag)
 		}
 
 		// Respawn the editor
@@ -200,7 +200,7 @@ func (c *cmdConfigMetadataShow) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show the container metadata
-	metadata, _, err := resource.server.GetContainerMetadata(resource.name)
+	metadata, _, err := resource.server.GetInstanceMetadata(resource.name)
 	if err != nil {
 		return err
 	}

--- a/lxc/config_template.go
+++ b/lxc/config_template.go
@@ -90,7 +90,7 @@ func (c *cmdConfigTemplateCreate) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Create container file template
-	return resource.server.CreateContainerTemplateFile(resource.name, args[1], nil)
+	return resource.server.CreateInstanceTemplateFile(resource.name, args[1], nil)
 }
 
 // Delete
@@ -133,7 +133,7 @@ func (c *cmdConfigTemplateDelete) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Delete container file template
-	return resource.server.DeleteContainerTemplateFile(resource.name, args[1])
+	return resource.server.DeleteInstanceTemplateFile(resource.name, args[1])
 }
 
 // Edit
@@ -176,10 +176,10 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 
 	// Edit container file template
 	if !termios.IsTerminal(getStdinFd()) {
-		return resource.server.UpdateContainerTemplateFile(resource.name, args[1], os.Stdin)
+		return resource.server.UpdateInstanceTemplateFile(resource.name, args[1], os.Stdin)
 	}
 
-	reader, err := resource.server.GetContainerTemplateFile(resource.name, args[1])
+	reader, err := resource.server.GetInstanceTemplateFile(resource.name, args[1])
 	if err != nil {
 		return err
 	}
@@ -196,7 +196,7 @@ func (c *cmdConfigTemplateEdit) Run(cmd *cobra.Command, args []string) error {
 
 	for {
 		reader := bytes.NewReader(content)
-		err := resource.server.UpdateContainerTemplateFile(resource.name, args[1], reader)
+		err := resource.server.UpdateInstanceTemplateFile(resource.name, args[1], reader)
 		// Respawn the editor
 		if err != nil {
 			fmt.Fprintf(os.Stderr, i18n.G("Error updating template file: %s")+"\n", err)
@@ -262,7 +262,7 @@ func (c *cmdConfigTemplateList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// List the templates
-	templates, err := resource.server.GetContainerTemplateFiles(resource.name)
+	templates, err := resource.server.GetInstanceTemplateFiles(resource.name)
 	if err != nil {
 		return err
 	}
@@ -320,7 +320,7 @@ func (c *cmdConfigTemplateShow) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Show the template
-	template, err := resource.server.GetContainerTemplateFile(resource.name, args[1])
+	template, err := resource.server.GetInstanceTemplateFile(resource.name, args[1])
 	if err != nil {
 		return err
 	}

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -120,7 +120,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/console.go
+++ b/lxc/console.go
@@ -54,7 +54,7 @@ func (c *cmdConsole) sendTermSize(control *websocket.Conn) error {
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.InstanceExecControl{}
 	msg.Command = "window-resize"
 	msg.Args = make(map[string]string)
 	msg.Args["width"] = strconv.Itoa(width)
@@ -127,8 +127,8 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 
 	// Show the current log if requested
 	if c.flagShowLog {
-		console := &lxd.ContainerConsoleLogArgs{}
-		log, err := d.GetContainerConsoleLog(name, console)
+		console := &lxd.InstanceConsoleLogArgs{}
+		log, err := d.GetInstanceConsoleLog(name, console)
 		if err != nil {
 			return err
 		}
@@ -161,7 +161,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Prepare the remote console
-	req := api.ContainerConsolePost{
+	req := api.InstanceConsolePost{
 		Width:  width,
 		Height: height,
 	}
@@ -170,7 +170,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 	sendDisconnect := make(chan bool)
 	defer close(sendDisconnect)
 
-	consoleArgs := lxd.ContainerConsoleArgs{
+	consoleArgs := lxd.InstanceConsoleArgs{
 		Terminal: &readWriteCloser{stdinMirror{os.Stdin,
 			sendDisconnect, new(bool)}, os.Stdout},
 		Control:           handler,
@@ -185,7 +185,7 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 	fmt.Printf(i18n.G("To detach from the console, press: <ctrl>+a q") + "\n\r")
 
 	// Attach to the container console
-	op, err := d.ConsoleContainer(name, req, &consoleArgs)
+	op, err := d.ConsoleInstance(name, req, &consoleArgs)
 	if err != nil {
 		return err
 	}

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -88,19 +88,19 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 	}
 
 	// Connect to the source host
-	source, err := conf.GetContainerServer(sourceRemote)
+	source, err := conf.GetInstanceServer(sourceRemote)
 	if err != nil {
 		return err
 	}
 
 	// Connect to the destination host
-	var dest lxd.ContainerServer
+	var dest lxd.InstanceServer
 	if sourceRemote == destRemote {
 		// Source and destination are the same
 		dest = source
 	} else {
 		// Destination is different, connect to it
-		dest, err = conf.GetContainerServer(destRemote)
+		dest, err = conf.GetInstanceServer(destRemote)
 		if err != nil {
 			return err
 		}

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -23,6 +23,7 @@ type cmdCopy struct {
 	flagConfig        []string
 	flagDevice        []string
 	flagEphemeral     bool
+	flagInstanceOnly  bool
 	flagContainerOnly bool
 	flagMode          string
 	flagStateless     bool
@@ -46,7 +47,8 @@ func (c *cmdCopy) Command() *cobra.Command {
 	cmd.Flags().StringArrayVarP(&c.flagProfile, "profile", "p", nil, i18n.G("Profile to apply to the new container")+"``")
 	cmd.Flags().BoolVarP(&c.flagEphemeral, "ephemeral", "e", false, i18n.G("Ephemeral container"))
 	cmd.Flags().StringVar(&c.flagMode, "mode", "pull", i18n.G("Transfer mode. One of pull (default), push or relay")+"``")
-	cmd.Flags().BoolVar(&c.flagContainerOnly, "container-only", false, i18n.G("Copy the container without its snapshots"))
+	cmd.Flags().BoolVar(&c.flagInstanceOnly, "instance-only", false, i18n.G("Copy the instance without its snapshots"))
+	cmd.Flags().BoolVar(&c.flagContainerOnly, "container-only", false, i18n.G("Copy the container without its snapshots (deprecated, use instance-only)"))
 	cmd.Flags().BoolVar(&c.flagStateless, "stateless", false, i18n.G("Copy a stateful container stateless"))
 	cmd.Flags().StringVarP(&c.flagStorage, "storage", "s", "", i18n.G("Storage pool name")+"``")
 	cmd.Flags().StringVar(&c.flagTarget, "target", "", i18n.G("Cluster member name")+"``")
@@ -145,7 +147,7 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 	}
 
 	var op lxd.RemoteOperation
-	var writable api.ContainerPut
+	var writable api.InstancePut
 	var start bool
 
 	if shared.IsSnapshot(sourceName) {
@@ -153,8 +155,8 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 			return fmt.Errorf(i18n.G("--container-only can't be passed when the source is a snapshot"))
 		}
 
-		// Prepare the container creation request
-		args := lxd.ContainerSnapshotCopyArgs{
+		// Prepare the instance creation request
+		args := lxd.InstanceSnapshotCopyArgs{
 			Name: destName,
 			Mode: mode,
 			Live: stateful,
@@ -166,7 +168,7 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 
 		// Copy of a snapshot into a new container
 		srcFields := strings.SplitN(sourceName, shared.SnapshotDelimiter, 2)
-		entry, _, err := source.GetContainerSnapshot(srcFields[0], srcFields[1])
+		entry, _, err := source.GetInstanceSnapshot(srcFields[0], srcFields[1])
 		if err != nil {
 			return err
 		}
@@ -244,22 +246,22 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 			dest = dest.UseTarget(c.flagTarget)
 		}
 
-		op, err = dest.CopyContainerSnapshot(source, srcFields[0], *entry, &args)
+		op, err = dest.CopyInstanceSnapshot(source, srcFields[0], *entry, &args)
 		if err != nil {
 			return err
 		}
 	} else {
 		// Prepare the container creation request
-		args := lxd.ContainerCopyArgs{
-			Name:          destName,
-			Live:          stateful,
-			ContainerOnly: containerOnly,
-			Mode:          mode,
-			Refresh:       c.flagRefresh,
+		args := lxd.InstanceCopyArgs{
+			Name:         destName,
+			Live:         stateful,
+			InstanceOnly: containerOnly,
+			Mode:         mode,
+			Refresh:      c.flagRefresh,
 		}
 
 		// Copy of a container into a new container
-		entry, _, err := source.GetContainer(sourceName)
+		entry, _, err := source.GetInstance(sourceName)
 		if err != nil {
 			return err
 		}
@@ -341,7 +343,7 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 			dest = dest.UseTarget(c.flagTarget)
 		}
 
-		op, err = dest.CopyContainer(source, *entry, &args)
+		op, err = dest.CopyInstance(source, *entry, &args)
 		if err != nil {
 			return err
 		}
@@ -370,12 +372,12 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 	progress.Done("")
 
 	if c.flagRefresh {
-		_, etag, err := dest.GetContainer(destName)
+		_, etag, err := dest.GetInstance(destName)
 		if err != nil {
 			return fmt.Errorf("Failed to refresh target container '%s': %v", destName, err)
 		}
 
-		op, err := dest.UpdateContainer(destName, writable, etag)
+		op, err := dest.UpdateInstance(destName, writable, etag)
 		if err != nil {
 			return err
 		}
@@ -422,11 +424,11 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 
 	// Start the container if needed
 	if start {
-		req := api.ContainerStatePut{
+		req := api.InstanceStatePut{
 			Action: string(shared.Start),
 		}
 
-		op, err := dest.UpdateContainerState(destName, req, "")
+		op, err := dest.UpdateInstanceState(destName, req, "")
 		if err != nil {
 			return err
 		}
@@ -464,13 +466,15 @@ func (c *cmdCopy) Run(cmd *cobra.Command, args []string) error {
 	stateful := !c.flagStateless && !c.flagRefresh
 	keepVolatile := c.flagRefresh
 
+	instanceOnly := c.flagContainerOnly || c.flagInstanceOnly
+
 	// If not target name is specified, one will be chosed by the server
 	if len(args) < 2 {
 		return c.copyContainer(conf, args[0], "", keepVolatile, ephem,
-			stateful, c.flagContainerOnly, mode, c.flagStorage, false)
+			stateful, instanceOnly, mode, c.flagStorage, false)
 	}
 
 	// Normal copy with a pre-determined name
 	return c.copyContainer(conf, args[0], args[1], keepVolatile, ephem,
-		stateful, c.flagContainerOnly, mode, c.flagStorage, false)
+		stateful, instanceOnly, mode, c.flagStorage, false)
 }

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -57,10 +57,10 @@ func (c *cmdDelete) doDelete(d lxd.InstanceServer, name string) error {
 	if shared.IsSnapshot(name) {
 		// Snapshot delete
 		fields := strings.SplitN(name, shared.SnapshotDelimiter, 2)
-		op, err = d.DeleteContainerSnapshot(fields[0], fields[1])
+		op, err = d.DeleteInstanceSnapshot(fields[0], fields[1])
 	} else {
-		// Container delete
-		op, err = d.DeleteContainer(name)
+		// Instance delete
+		op, err = d.DeleteInstance(name)
 	}
 	if err != nil {
 		return err
@@ -94,7 +94,7 @@ func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
 			return c.doDelete(resource.server, resource.name)
 		}
 
-		ct, _, err := resource.server.GetContainer(resource.name)
+		ct, _, err := resource.server.GetInstance(resource.name)
 		if err != nil {
 			return err
 		}
@@ -104,13 +104,13 @@ func (c *cmdDelete) Run(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf(i18n.G("The container is currently running, stop it first or pass --force"))
 			}
 
-			req := api.ContainerStatePut{
+			req := api.InstanceStatePut{
 				Action:  "stop",
 				Timeout: -1,
 				Force:   true,
 			}
 
-			op, err := resource.server.UpdateContainerState(resource.name, req, "")
+			op, err := resource.server.UpdateInstanceState(resource.name, req, "")
 			if err != nil {
 				return err
 			}

--- a/lxc/delete.go
+++ b/lxc/delete.go
@@ -50,7 +50,7 @@ func (c *cmdDelete) promptDelete(name string) error {
 	return nil
 }
 
-func (c *cmdDelete) doDelete(d lxd.ContainerServer, name string) error {
+func (c *cmdDelete) doDelete(d lxd.InstanceServer, name string) error {
 	var op lxd.Operation
 	var err error
 

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -76,7 +76,7 @@ func (c *cmdExec) sendTermSize(control *websocket.Conn) error {
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.InstanceExecControl{}
 	msg.Command = "window-resize"
 	msg.Args = make(map[string]string)
 	msg.Args["width"] = strconv.Itoa(width)
@@ -190,7 +190,7 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 	stdout := getStdout()
 
 	// Prepare the command
-	req := api.ContainerExecPost{
+	req := api.InstanceExecPost{
 		Command:     args[1:],
 		WaitForWS:   true,
 		Interactive: interactive,
@@ -202,7 +202,7 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 		Cwd:         c.flagCwd,
 	}
 
-	execArgs := lxd.ContainerExecArgs{
+	execArgs := lxd.InstanceExecArgs{
 		Stdin:    stdin,
 		Stdout:   stdout,
 		Stderr:   os.Stderr,
@@ -211,7 +211,7 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Run the command in the container
-	op, err := d.ExecContainer(name, req, &execArgs)
+	op, err := d.ExecInstance(name, req, &execArgs)
 	if err != nil {
 		return err
 	}

--- a/lxc/exec.go
+++ b/lxc/exec.go
@@ -115,7 +115,7 @@ func (c *cmdExec) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/exec_unix.go
+++ b/lxc/exec_unix.go
@@ -146,7 +146,7 @@ func (c *cmdExec) forwardSignal(control *websocket.Conn, sig unix.Signal) error 
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.InstanceExecControl{}
 	msg.Command = "signal"
 	msg.Signal = int(sig)
 

--- a/lxc/exec_windows.go
+++ b/lxc/exec_windows.go
@@ -61,7 +61,7 @@ func (c *cmdExec) forwardSignal(control *websocket.Conn, sig windows.Signal) err
 		return err
 	}
 
-	msg := api.ContainerExecControl{}
+	msg := api.InstanceExecControl{}
 	msg.Command = "signal"
 	msg.Signal = int(sig)
 

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -58,7 +58,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -21,6 +21,7 @@ type cmdExport struct {
 	global *cmdGlobal
 
 	flagContainerOnly    bool
+	flagInstanceOnly     bool
 	flagOptimizedStorage bool
 }
 
@@ -36,7 +37,9 @@ func (c *cmdExport) Command() *cobra.Command {
 
 	cmd.RunE = c.Run
 	cmd.Flags().BoolVar(&c.flagContainerOnly, "container-only", false,
-		i18n.G("Whether or not to only backup the container (without snapshots)"))
+		i18n.G("Whether or not to only backup the container (without snapshots), (deprecated, use instance-only)"))
+	cmd.Flags().BoolVar(&c.flagInstanceOnly, "instance-only", false,
+		i18n.G("Whether or not to only backup the instance (without snapshots)"))
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
 
@@ -63,14 +66,17 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	req := api.ContainerBackupsPost{
+	instanceOnly := c.flagContainerOnly || c.flagInstanceOnly
+
+	req := api.InstanceBackupsPost{
 		Name:             "",
 		ExpiresAt:        time.Now().Add(24 * time.Hour),
-		ContainerOnly:    c.flagContainerOnly,
+		ContainerOnly:    instanceOnly,
+		InstanceOnly:     instanceOnly,
 		OptimizedStorage: c.flagOptimizedStorage,
 	}
 
-	op, err := d.CreateContainerBackup(name, req)
+	op, err := d.CreateInstanceBackup(name, req)
 	if err != nil {
 		return errors.Wrap(err, "Create container backup")
 	}
@@ -87,7 +93,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 
 	defer func() {
 		// Delete backup after we're done
-		op, err = d.DeleteContainerBackup(name, backupName)
+		op, err = d.DeleteInstanceBackup(name, backupName)
 		if err == nil {
 			op.Wait()
 		}
@@ -117,7 +123,7 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Export tarball
-	_, err = d.GetContainerBackupFile(name, backupName, &backupFileRequest)
+	_, err = d.GetInstanceBackupFile(name, backupName, &backupFileRequest)
 	if err != nil {
 		os.Remove(targetName)
 		progress.Done("")

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -36,7 +36,7 @@ type cmdFile struct {
 	flagRecursive bool
 }
 
-func fileGetWrapper(server lxd.InstanceServer, container string, path string) (buf io.ReadCloser, resp *lxd.ContainerFileResponse, err error) {
+func fileGetWrapper(server lxd.InstanceServer, container string, path string) (buf io.ReadCloser, resp *lxd.InstanceFileResponse, err error) {
 	// Signal handling
 	chSignal := make(chan os.Signal)
 	signal.Notify(chSignal, os.Interrupt)
@@ -44,7 +44,7 @@ func fileGetWrapper(server lxd.InstanceServer, container string, path string) (b
 	// Operation handling
 	chDone := make(chan bool)
 	go func() {
-		buf, resp, err = server.GetContainerFile(container, path)
+		buf, resp, err = server.GetInstanceFile(container, path)
 		close(chDone)
 	}()
 
@@ -130,7 +130,7 @@ func (c *cmdFileDelete) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Delete the file
-		err = resource.server.DeleteContainerFile(pathSpec[0], pathSpec[1])
+		err = resource.server.DeleteInstanceFile(pathSpec[0], pathSpec[1])
 		if err != nil {
 			return err
 		}
@@ -325,7 +325,7 @@ func (c *cmdFilePull) Run(cmd *cobra.Command, args []string) error {
 						newPath = filepath.Clean(filepath.Join(filepath.Dir(pathSpec[1]), newPath))
 					}
 
-					buf, resp, err = resource.server.GetContainerFile(pathSpec[0], newPath)
+					buf, resp, err = resource.server.GetInstanceFile(pathSpec[0], newPath)
 					if err != nil {
 						return err
 					}
@@ -577,7 +577,7 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 		}
 
 		// Transfer the files
-		args := lxd.ContainerFileArgs{
+		args := lxd.InstanceFileArgs{
 			UID:  -1,
 			GID:  -1,
 			Mode: -1,
@@ -637,7 +637,7 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 		}, f)
 
 		logger.Infof("Pushing %s to %s (%s)", f.Name(), fpath, args.Type)
-		err = resource.server.CreateContainerFile(resource.name, fpath, args)
+		err = resource.server.CreateInstanceFile(resource.name, fpath, args)
 		if err != nil {
 			progress.Done("")
 			return err
@@ -649,7 +649,7 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 }
 
 func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, container string, p string, targetDir string) error {
-	buf, resp, err := d.GetContainerFile(container, p)
+	buf, resp, err := d.GetInstanceFile(container, p)
 	if err != nil {
 		return err
 	}
@@ -741,7 +741,7 @@ func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, container string, sour
 		// Prepare for file transfer
 		targetPath := path.Join(target, filepath.ToSlash(p[sourceLen:]))
 		mode, uid, gid := shared.GetOwnerMode(fInfo)
-		args := lxd.ContainerFileArgs{
+		args := lxd.InstanceFileArgs{
 			UID:  int64(uid),
 			GID:  int64(gid),
 			Mode: int(mode.Perm()),
@@ -805,7 +805,7 @@ func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, container string, sour
 		}
 
 		logger.Infof("Pushing %s to %s (%s)", p, targetPath, args.Type)
-		err = d.CreateContainerFile(container, targetPath, args)
+		err = d.CreateInstanceFile(container, targetPath, args)
 		if err != nil {
 			if args.Type != "directory" {
 				progress.Done("")
@@ -835,7 +835,7 @@ func (c *cmdFile) recursiveMkdir(d lxd.InstanceServer, container string, p strin
 
 	for ; i >= 1; i-- {
 		cur := filepath.Join(parts[:i]...)
-		_, resp, err := d.GetContainerFile(container, cur)
+		_, resp, err := d.GetInstanceFile(container, cur)
 		if err != nil {
 			continue
 		}
@@ -860,7 +860,7 @@ func (c *cmdFile) recursiveMkdir(d lxd.InstanceServer, container string, p strin
 		if mode != nil {
 			modeArg = int(mode.Perm())
 		}
-		args := lxd.ContainerFileArgs{
+		args := lxd.InstanceFileArgs{
 			UID:  uid,
 			GID:  gid,
 			Mode: modeArg,
@@ -868,7 +868,7 @@ func (c *cmdFile) recursiveMkdir(d lxd.InstanceServer, container string, p strin
 		}
 
 		logger.Infof("Creating %s (%s)", cur, args.Type)
-		err := d.CreateContainerFile(container, cur, args)
+		err := d.CreateInstanceFile(container, cur, args)
 		if err != nil {
 			return err
 		}

--- a/lxc/file.go
+++ b/lxc/file.go
@@ -36,7 +36,7 @@ type cmdFile struct {
 	flagRecursive bool
 }
 
-func fileGetWrapper(server lxd.ContainerServer, container string, path string) (buf io.ReadCloser, resp *lxd.ContainerFileResponse, err error) {
+func fileGetWrapper(server lxd.InstanceServer, container string, path string) (buf io.ReadCloser, resp *lxd.ContainerFileResponse, err error) {
 	// Signal handling
 	chSignal := make(chan os.Signal)
 	signal.Notify(chSignal, os.Interrupt)
@@ -648,7 +648,7 @@ func (c *cmdFilePush) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func (c *cmdFile) recursivePullFile(d lxd.ContainerServer, container string, p string, targetDir string) error {
+func (c *cmdFile) recursivePullFile(d lxd.InstanceServer, container string, p string, targetDir string) error {
 	buf, resp, err := d.GetContainerFile(container, p)
 	if err != nil {
 		return err
@@ -723,7 +723,7 @@ func (c *cmdFile) recursivePullFile(d lxd.ContainerServer, container string, p s
 	return nil
 }
 
-func (c *cmdFile) recursivePushFile(d lxd.ContainerServer, container string, source string, target string) error {
+func (c *cmdFile) recursivePushFile(d lxd.InstanceServer, container string, source string, target string) error {
 	source = filepath.Clean(source)
 	sourceDir, _ := filepath.Split(source)
 	sourceLen := len(sourceDir)
@@ -821,7 +821,7 @@ func (c *cmdFile) recursivePushFile(d lxd.ContainerServer, container string, sou
 	return filepath.Walk(source, sendFile)
 }
 
-func (c *cmdFile) recursiveMkdir(d lxd.ContainerServer, container string, p string, mode *os.FileMode, uid int64, gid int64) error {
+func (c *cmdFile) recursiveMkdir(d lxd.InstanceServer, container string, p string, mode *os.FileMode, uid int64, gid int64) error {
 	/* special case, every container has a /, we don't need to do anything */
 	if p == "/" {
 		return nil

--- a/lxc/image.go
+++ b/lxc/image.go
@@ -656,7 +656,7 @@ func (c *cmdImageImport) Run(cmd *cobra.Command, args []string) error {
 		rootfsFile = shared.HostPath(filepath.Clean(rootfsFile))
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/import.go
+++ b/lxc/import.go
@@ -73,7 +73,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 		Quiet:  c.global.flagQuiet,
 	}
 
-	createArgs := lxd.ContainerBackupArgs{
+	createArgs := lxd.InstanceBackupArgs{
 		BackupFile: &ioprogress.ProgressReader{
 			ReadCloser: file,
 			Tracker: &ioprogress.ProgressTracker{
@@ -86,7 +86,7 @@ func (c *cmdImport) Run(cmd *cobra.Command, args []string) error {
 		PoolName: c.flagStorage,
 	}
 
-	op, err := resource.server.CreateContainerFromBackup(createArgs)
+	op, err := resource.server.CreateInstanceFromBackup(createArgs)
 	if err != nil {
 		return err
 	}

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -69,7 +69,7 @@ func (c *cmdInfo) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}
@@ -302,7 +302,7 @@ func (c *cmdInfo) renderCPU(cpu api.ResourcesCPUSocket, prefix string) {
 	}
 }
 
-func (c *cmdInfo) remoteInfo(d lxd.ContainerServer) error {
+func (c *cmdInfo) remoteInfo(d lxd.InstanceServer) error {
 	// Targeting
 	if c.flagTarget != "" {
 		if !d.IsClustered() {
@@ -417,7 +417,7 @@ func (c *cmdInfo) remoteInfo(d lxd.ContainerServer) error {
 	return nil
 }
 
-func (c *cmdInfo) containerInfo(d lxd.ContainerServer, remote config.Remote, name string, showLog bool) error {
+func (c *cmdInfo) containerInfo(d lxd.InstanceServer, remote config.Remote, name string, showLog bool) error {
 	// Sanity checks
 	if c.flagTarget != "" {
 		return fmt.Errorf(i18n.G("--target cannot be used with containers"))

--- a/lxc/info.go
+++ b/lxc/info.go
@@ -420,15 +420,15 @@ func (c *cmdInfo) remoteInfo(d lxd.InstanceServer) error {
 func (c *cmdInfo) containerInfo(d lxd.InstanceServer, remote config.Remote, name string, showLog bool) error {
 	// Sanity checks
 	if c.flagTarget != "" {
-		return fmt.Errorf(i18n.G("--target cannot be used with containers"))
+		return fmt.Errorf(i18n.G("--target cannot be used with instances"))
 	}
 
-	ct, _, err := d.GetContainer(name)
+	ct, _, err := d.GetInstance(name)
 	if err != nil {
 		return err
 	}
 
-	cs, _, err := d.GetContainerState(name)
+	cs, _, err := d.GetInstanceState(name)
 	if err != nil {
 		return err
 	}
@@ -551,7 +551,7 @@ func (c *cmdInfo) containerInfo(d lxd.InstanceServer, remote config.Remote, name
 
 	// List snapshots
 	firstSnapshot := true
-	snaps, err := d.GetContainerSnapshots(name)
+	snaps, err := d.GetInstanceSnapshots(name)
 	if err != nil {
 		return nil
 	}
@@ -583,7 +583,7 @@ func (c *cmdInfo) containerInfo(d lxd.InstanceServer, remote config.Remote, name
 	}
 
 	if showLog {
-		log, err := d.GetContainerLogfile(name, "lxc.log")
+		log, err := d.GetInstanceLogfile(name, "lxc.log")
 		if err != nil {
 			return err
 		}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -79,7 +79,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	var remote string
 	var iremote string
 	var err error
-	var stdinData api.ContainerPut
+	var stdinData api.InstancePut
 	var devicesMap map[string]map[string]string
 	var configMap map[string]string
 
@@ -204,7 +204,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	}
 
 	// Setup container creation request
-	req := api.ContainersPost{
+	req := api.InstancesPost{
 		Name:         name,
 		InstanceType: c.flagType,
 	}
@@ -266,7 +266,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 		}
 
 		// Create the container
-		op, err := d.CreateContainerFromImage(imgRemote, *imgInfo, req)
+		op, err := d.CreateInstanceFromImage(imgRemote, *imgInfo, req)
 		if err != nil {
 			return nil, "", err
 		}
@@ -300,7 +300,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer
 	} else {
 		req.Source.Type = "none"
 
-		op, err := d.CreateContainer(req)
+		op, err := d.CreateInstance(req)
 		if err != nil {
 			return nil, "", err
 		}
@@ -356,7 +356,7 @@ func (c *cmdInit) guessImage(conf *config.Config, d lxd.InstanceServer, remote s
 }
 
 func (c *cmdInit) checkNetwork(d lxd.InstanceServer, name string) {
-	ct, _, err := d.GetContainer(name)
+	ct, _, err := d.GetInstance(name)
 	if err != nil {
 		return
 	}

--- a/lxc/init.go
+++ b/lxc/init.go
@@ -73,7 +73,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	return err
 }
 
-func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServer, string, error) {
+func (c *cmdInit) create(conf *config.Config, args []string) (lxd.InstanceServer, string, error) {
 	var name string
 	var image string
 	var remote string
@@ -134,7 +134,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 		}
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return nil, "", err
 	}
@@ -325,7 +325,7 @@ func (c *cmdInit) create(conf *config.Config, args []string) (lxd.ContainerServe
 	return d, name, nil
 }
 
-func (c *cmdInit) guessImage(conf *config.Config, d lxd.ContainerServer, remote string, iremote string, image string) (string, string) {
+func (c *cmdInit) guessImage(conf *config.Config, d lxd.InstanceServer, remote string, iremote string, image string) (string, string) {
 	if remote != iremote {
 		return iremote, image
 	}
@@ -355,7 +355,7 @@ func (c *cmdInit) guessImage(conf *config.Config, d lxd.ContainerServer, remote 
 	return fields[0], fields[1]
 }
 
-func (c *cmdInit) checkNetwork(d lxd.ContainerServer, name string) {
+func (c *cmdInit) checkNetwork(d lxd.InstanceServer, name string) {
 	ct, _, err := d.GetContainer(name)
 	if err != nil {
 		return

--- a/lxc/launch.go
+++ b/lxc/launch.go
@@ -68,12 +68,12 @@ func (c *cmdLaunch) Run(cmd *cobra.Command, args []string) error {
 		fmt.Printf(i18n.G("Starting %s")+"\n", name)
 	}
 
-	req := api.ContainerStatePut{
+	req := api.InstanceStatePut{
 		Action:  "start",
 		Timeout: -1,
 	}
 
-	op, err := d.UpdateContainerState(name, req, "")
+	op, err := d.UpdateInstanceState(name, req, "")
 	if err != nil {
 		return err
 	}

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -25,7 +25,7 @@ type column struct {
 	NeedsSnapshots bool
 }
 
-type columnData func(api.ContainerFull) string
+type columnData func(api.InstanceFull) string
 
 type cmdList struct {
 	global *cmdGlobal
@@ -136,7 +136,7 @@ func (c *cmdList) dotPrefixMatch(short string, full string) bool {
 	return true
 }
 
-func (c *cmdList) shouldShow(filters []string, state *api.Container) bool {
+func (c *cmdList) shouldShow(filters []string, state *api.Instance) bool {
 	for _, filter := range filters {
 		if strings.Contains(filter, "=") {
 			membs := strings.SplitN(filter, "=", 2)
@@ -201,18 +201,18 @@ func (c *cmdList) shouldShow(filters []string, state *api.Container) bool {
 	return true
 }
 
-func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinfos []api.Container, filters []string, columns []column) error {
+func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinfos []api.Instance, filters []string, columns []column) error {
 	threads := 10
 	if len(cinfos) < threads {
 		threads = len(cinfos)
 	}
 
-	cStates := map[string]*api.ContainerState{}
+	cStates := map[string]*api.InstanceState{}
 	cStatesLock := sync.Mutex{}
 	cStatesQueue := make(chan string, threads)
 	cStatesWg := sync.WaitGroup{}
 
-	cSnapshots := map[string][]api.ContainerSnapshot{}
+	cSnapshots := map[string][]api.InstanceSnapshot{}
 	cSnapshotsLock := sync.Mutex{}
 	cSnapshotsQueue := make(chan string, threads)
 	cSnapshotsWg := sync.WaitGroup{}
@@ -226,7 +226,7 @@ func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinf
 					break
 				}
 
-				state, _, err := d.GetContainerState(cName)
+				state, _, err := d.GetInstanceState(cName)
 				if err != nil {
 					continue
 				}
@@ -246,7 +246,7 @@ func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinf
 					break
 				}
 
-				snaps, err := d.GetContainerSnapshots(cName)
+				snaps, err := d.GetInstanceSnapshots(cName)
 				if err != nil {
 					continue
 				}
@@ -298,10 +298,10 @@ func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinf
 	cStatesWg.Wait()
 	cSnapshotsWg.Wait()
 
-	// Convert to ContainerFull
-	data := make([]api.ContainerFull, len(cinfos))
+	// Convert to Instance
+	data := make([]api.InstanceFull, len(cinfos))
 	for i := range cinfos {
-		data[i].Container = cinfos[i]
+		data[i].Instance = cinfos[i]
 		data[i].State = cStates[cinfos[i].Name]
 		data[i].Snapshots = cSnapshots[cinfos[i].Name]
 	}
@@ -309,11 +309,11 @@ func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinf
 	return c.showContainers(data, filters, columns)
 }
 
-func (c *cmdList) showContainers(cts []api.ContainerFull, filters []string, columns []column) error {
+func (c *cmdList) showContainers(cts []api.InstanceFull, filters []string, columns []column) error {
 	// Generate the table data
 	data := [][]string{}
 	for _, ct := range cts {
-		if !c.shouldShow(filters, &ct.Container) {
+		if !c.shouldShow(filters, &ct.Instance) {
 			continue
 		}
 
@@ -383,8 +383,8 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if len(filters) == 0 && needsData && d.HasExtension("container_full") {
-		// Using the GetContainersFull shortcut
-		cts, err := d.GetContainersFull()
+		// Using the GetInstancesFull shortcut
+		cts, err := d.GetInstancesFull(api.InstanceTypeAny)
 		if err != nil {
 			return err
 		}
@@ -393,8 +393,8 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the list of containers
-	var cts []api.Container
-	ctslist, err := d.GetContainers()
+	var cts []api.Instance
+	ctslist, err := d.GetInstances(api.InstanceTypeAny)
 	if err != nil {
 		return err
 	}
@@ -511,7 +511,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 				}
 			}
 
-			column.Data = func(cInfo api.ContainerFull) string {
+			column.Data = func(cInfo api.InstanceFull) string {
 				v, ok := cInfo.Config[k]
 				if !ok {
 					v, _ = cInfo.ExpandedConfig[k]
@@ -536,7 +536,7 @@ func (c *cmdList) parseColumns(clustered bool) ([]column, bool, error) {
 	return columns, needsData, nil
 }
 
-func (c *cmdList) getBaseImage(cInfo api.ContainerFull, long bool) string {
+func (c *cmdList) getBaseImage(cInfo api.InstanceFull, long bool) string {
 	v, ok := cInfo.Config["volatile.base_image"]
 	if !ok {
 		return ""
@@ -549,27 +549,27 @@ func (c *cmdList) getBaseImage(cInfo api.ContainerFull, long bool) string {
 	return v
 }
 
-func (c *cmdList) baseImageColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) baseImageColumnData(cInfo api.InstanceFull) string {
 	return c.getBaseImage(cInfo, false)
 }
 
-func (c *cmdList) baseImageFullColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) baseImageFullColumnData(cInfo api.InstanceFull) string {
 	return c.getBaseImage(cInfo, true)
 }
 
-func (c *cmdList) nameColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) nameColumnData(cInfo api.InstanceFull) string {
 	return cInfo.Name
 }
 
-func (c *cmdList) descriptionColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) descriptionColumnData(cInfo api.InstanceFull) string {
 	return cInfo.Description
 }
 
-func (c *cmdList) statusColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) statusColumnData(cInfo api.InstanceFull) string {
 	return strings.ToUpper(cInfo.Status)
 }
 
-func (c *cmdList) IP4ColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) IP4ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv4s := []string{}
 		for netName, net := range cInfo.State.Network {
@@ -594,7 +594,7 @@ func (c *cmdList) IP4ColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) IP6ColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) IP6ColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil && cInfo.State.Network != nil {
 		ipv6s := []string{}
 		for netName, net := range cInfo.State.Network {
@@ -619,7 +619,7 @@ func (c *cmdList) IP6ColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) typeColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) typeColumnData(cInfo api.InstanceFull) string {
 	if cInfo.Ephemeral {
 		return i18n.G("EPHEMERAL")
 	}
@@ -627,7 +627,7 @@ func (c *cmdList) typeColumnData(cInfo api.ContainerFull) string {
 	return i18n.G("PERSISTENT")
 }
 
-func (c *cmdList) numberSnapshotsColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) numberSnapshotsColumnData(cInfo api.InstanceFull) string {
 	if cInfo.Snapshots != nil {
 		return fmt.Sprintf("%d", len(cInfo.Snapshots))
 	}
@@ -635,7 +635,7 @@ func (c *cmdList) numberSnapshotsColumnData(cInfo api.ContainerFull) string {
 	return "0"
 }
 
-func (c *cmdList) PIDColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) PIDColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil {
 		return fmt.Sprintf("%d", cInfo.State.Pid)
 	}
@@ -643,11 +643,11 @@ func (c *cmdList) PIDColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) ArchitectureColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) ArchitectureColumnData(cInfo api.InstanceFull) string {
 	return cInfo.Architecture
 }
 
-func (c *cmdList) StoragePoolColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) StoragePoolColumnData(cInfo api.InstanceFull) string {
 	for _, v := range cInfo.ExpandedDevices {
 		if v["type"] == "disk" && v["path"] == "/" {
 			return v["pool"]
@@ -657,11 +657,11 @@ func (c *cmdList) StoragePoolColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) ProfilesColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) ProfilesColumnData(cInfo api.InstanceFull) string {
 	return strings.Join(cInfo.Profiles, "\n")
 }
 
-func (c *cmdList) CreatedColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) CreatedColumnData(cInfo api.InstanceFull) string {
 	layout := "2006/01/02 15:04 UTC"
 
 	if shared.TimeIsSet(cInfo.CreatedAt) {
@@ -671,7 +671,7 @@ func (c *cmdList) CreatedColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) LastUsedColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) LastUsedColumnData(cInfo api.InstanceFull) string {
 	layout := "2006/01/02 15:04 UTC"
 
 	if !cInfo.LastUsedAt.IsZero() && shared.TimeIsSet(cInfo.LastUsedAt) {
@@ -681,7 +681,7 @@ func (c *cmdList) LastUsedColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) NumberOfProcessesColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) NumberOfProcessesColumnData(cInfo api.InstanceFull) string {
 	if cInfo.IsActive() && cInfo.State != nil {
 		return fmt.Sprintf("%d", cInfo.State.Processes)
 	}
@@ -689,6 +689,6 @@ func (c *cmdList) NumberOfProcessesColumnData(cInfo api.ContainerFull) string {
 	return ""
 }
 
-func (c *cmdList) locationColumnData(cInfo api.ContainerFull) string {
+func (c *cmdList) locationColumnData(cInfo api.InstanceFull) string {
 	return cInfo.Location
 }

--- a/lxc/list.go
+++ b/lxc/list.go
@@ -201,7 +201,7 @@ func (c *cmdList) shouldShow(filters []string, state *api.Container) bool {
 	return true
 }
 
-func (c *cmdList) listContainers(conf *config.Config, d lxd.ContainerServer, cinfos []api.Container, filters []string, columns []column) error {
+func (c *cmdList) listContainers(conf *config.Config, d lxd.InstanceServer, cinfos []api.Container, filters []string, columns []column) error {
 	threads := 10
 	if len(cinfos) < threads {
 		threads = len(cinfos)
@@ -371,7 +371,7 @@ func (c *cmdList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Connect to LXD
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/list_test.go
+++ b/lxc/list_test.go
@@ -26,7 +26,7 @@ func TestDotPrefixMatch(t *testing.T) {
 func TestShouldShow(t *testing.T) {
 	list := cmdList{}
 
-	state := &api.Container{
+	state := &api.Instance{
 		Name: "foo",
 		ExpandedConfig: map[string]string{
 			"security.privileged": "1",

--- a/lxc/main.go
+++ b/lxc/main.go
@@ -365,12 +365,12 @@ func (c *cmdGlobal) PostRun(cmd *cobra.Command, args []string) error {
 }
 
 type remoteResource struct {
-	server lxd.ContainerServer
+	server lxd.InstanceServer
 	name   string
 }
 
 func (c *cmdGlobal) ParseServers(remotes ...string) ([]remoteResource, error) {
-	servers := map[string]lxd.ContainerServer{}
+	servers := map[string]lxd.InstanceServer{}
 	resources := []remoteResource{}
 
 	for _, remote := range remotes {
@@ -394,7 +394,7 @@ func (c *cmdGlobal) ParseServers(remotes ...string) ([]remoteResource, error) {
 		}
 
 		// New connection
-		d, err := c.conf.GetContainerServer(remoteName)
+		d, err := c.conf.GetInstanceServer(remoteName)
 		if err != nil {
 			return nil, err
 		}

--- a/lxc/monitor.go
+++ b/lxc/monitor.go
@@ -74,7 +74,7 @@ func (c *cmdMonitor) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/move.go
+++ b/lxc/move.go
@@ -108,7 +108,7 @@ func (c *cmdMove) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf(i18n.G("Can't override configuration or profiles in local rename"))
 		}
 
-		source, err := conf.GetContainerServer(sourceRemote)
+		source, err := conf.GetInstanceServer(sourceRemote)
 		if err != nil {
 			return err
 		}
@@ -212,7 +212,7 @@ func moveClusterContainer(conf *config.Config, sourceResource, destResource, tar
 	}
 
 	// Connect to the source host
-	source, err := conf.GetContainerServer(sourceRemote)
+	source, err := conf.GetInstanceServer(sourceRemote)
 	if err != nil {
 		return errors.Wrap(err, i18n.G("Failed to connect to cluster member"))
 	}

--- a/lxc/network.go
+++ b/lxc/network.go
@@ -406,7 +406,7 @@ func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the container entry
-	container, etag, err := resource.server.GetContainer(args[1])
+	container, etag, err := resource.server.GetInstance(args[1])
 	if err != nil {
 		return err
 	}
@@ -439,7 +439,7 @@ func (c *cmdNetworkDetach) Run(cmd *cobra.Command, args []string) error {
 
 	// Remove the device
 	delete(container.Devices, devName)
-	op, err := resource.server.UpdateContainer(args[1], container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(args[1], container.Writable(), etag)
 	if err != nil {
 		return err
 	}

--- a/lxc/profile.go
+++ b/lxc/profile.go
@@ -125,14 +125,14 @@ func (c *cmdProfileAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Add the profile
-	container, etag, err := resource.server.GetContainer(resource.name)
+	container, etag, err := resource.server.GetInstance(resource.name)
 	if err != nil {
 		return err
 	}
 
 	container.Profiles = append(container.Profiles, args[1])
 
-	op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 	if err != nil {
 		return err
 	}
@@ -197,7 +197,7 @@ func (c *cmdProfileAssign) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("Missing container name"))
 	}
 
-	container, etag, err := resource.server.GetContainer(resource.name)
+	container, etag, err := resource.server.GetInstance(resource.name)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *cmdProfileAssign) Run(cmd *cobra.Command, args []string) error {
 		container.Profiles = nil
 	}
 
-	op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 	if err != nil {
 		return err
 	}
@@ -660,7 +660,7 @@ func (c *cmdProfileRemove) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Remove the profile
-	container, etag, err := resource.server.GetContainer(resource.name)
+	container, etag, err := resource.server.GetInstance(resource.name)
 	if err != nil {
 		return err
 	}
@@ -680,7 +680,7 @@ func (c *cmdProfileRemove) Run(cmd *cobra.Command, args []string) error {
 
 	container.Profiles = profiles
 
-	op, err := resource.server.UpdateContainer(resource.name, container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(resource.name, container.Writable(), etag)
 	if err != nil {
 		return err
 	}

--- a/lxc/project.go
+++ b/lxc/project.go
@@ -693,7 +693,7 @@ func (c *cmdProjectSwitch) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Make sure the project exists
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -83,14 +83,14 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf(i18n.G("There is no \"image name\".  Did you want an alias?"))
 	}
 
-	d, err := conf.GetContainerServer(iRemote)
+	d, err := conf.GetInstanceServer(iRemote)
 	if err != nil {
 		return err
 	}
 
 	s := d
 	if cRemote != iRemote {
-		s, err = conf.GetContainerServer(cRemote)
+		s, err = conf.GetInstanceServer(cRemote)
 		if err != nil {
 			return err
 		}

--- a/lxc/publish.go
+++ b/lxc/publish.go
@@ -97,7 +97,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if !shared.IsSnapshot(cName) {
-		ct, etag, err := s.GetContainer(cName)
+		ct, etag, err := s.GetInstance(cName)
 		if err != nil {
 			return err
 		}
@@ -112,7 +112,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 
 			if ct.Ephemeral {
 				ct.Ephemeral = false
-				op, err := s.UpdateContainer(cName, ct.Writable(), etag)
+				op, err := s.UpdateInstance(cName, ct.Writable(), etag)
 				if err != nil {
 					return err
 				}
@@ -123,19 +123,19 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 				}
 
 				// Refresh the ETag
-				_, etag, err = s.GetContainer(cName)
+				_, etag, err = s.GetInstance(cName)
 				if err != nil {
 					return err
 				}
 			}
 
-			req := api.ContainerStatePut{
+			req := api.InstanceStatePut{
 				Action:  string(shared.Stop),
 				Timeout: -1,
 				Force:   true,
 			}
 
-			op, err := s.UpdateContainerState(cName, req, "")
+			op, err := s.UpdateInstanceState(cName, req, "")
 			if err != nil {
 				return err
 			}
@@ -147,7 +147,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 
 			defer func() {
 				req.Action = string(shared.Start)
-				op, err = s.UpdateContainerState(cName, req, "")
+				op, err = s.UpdateInstanceState(cName, req, "")
 				if err != nil {
 					return
 				}
@@ -157,7 +157,7 @@ func (c *cmdPublish) Run(cmd *cobra.Command, args []string) error {
 
 			if wasEphemeral {
 				ct.Ephemeral = true
-				op, err := s.UpdateContainer(cName, ct.Writable(), etag)
+				op, err := s.UpdateInstance(cName, ct.Writable(), etag)
 				if err != nil {
 					return err
 				}

--- a/lxc/query.go
+++ b/lxc/query.go
@@ -68,7 +68,7 @@ func (c *cmdQuery) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Attempt to connect
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/remote.go
+++ b/lxc/remote.go
@@ -225,7 +225,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 	if c.flagPublic {
 		d, err = conf.GetImageServer(server)
 	} else {
-		d, err = conf.GetContainerServer(server)
+		d, err = conf.GetInstanceServer(server)
 	}
 
 	// Handle Unix socket connections
@@ -286,7 +286,7 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		if c.flagPublic {
 			d, err = conf.GetImageServer(server)
 		} else {
-			d, err = conf.GetContainerServer(server)
+			d, err = conf.GetInstanceServer(server)
 		}
 
 		if err != nil {
@@ -301,11 +301,11 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagAuthType == "candid" {
-		d.(lxd.ContainerServer).RequireAuthenticated(false)
+		d.(lxd.InstanceServer).RequireAuthenticated(false)
 	}
 
 	// Get server information
-	srv, _, err := d.(lxd.ContainerServer).GetServer()
+	srv, _, err := d.(lxd.InstanceServer).GetServer()
 	if err != nil {
 		return err
 	}
@@ -321,14 +321,14 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 			conf.Remotes[server] = remote
 
 			// Re-setup the client
-			d, err = conf.GetContainerServer(server)
+			d, err = conf.GetInstanceServer(server)
 			if err != nil {
 				return err
 			}
 
-			d.(lxd.ContainerServer).RequireAuthenticated(false)
+			d.(lxd.InstanceServer).RequireAuthenticated(false)
 
-			srv, _, err = d.(lxd.ContainerServer).GetServer()
+			srv, _, err = d.(lxd.InstanceServer).GetServer()
 			if err != nil {
 				return err
 			}
@@ -380,16 +380,16 @@ func (c *cmdRemoteAdd) Run(cmd *cobra.Command, args []string) error {
 		}
 		req.Type = "client"
 
-		err = d.(lxd.ContainerServer).CreateCertificate(req)
+		err = d.(lxd.InstanceServer).CreateCertificate(req)
 		if err != nil {
 			return err
 		}
 	} else {
-		d.(lxd.ContainerServer).RequireAuthenticated(true)
+		d.(lxd.InstanceServer).RequireAuthenticated(true)
 	}
 
 	// And check if trusted now
-	srv, _, err = d.(lxd.ContainerServer).GetServer()
+	srv, _, err = d.(lxd.InstanceServer).GetServer()
 	if err != nil {
 		return err
 	}

--- a/lxc/restore.go
+++ b/lxc/restore.go
@@ -53,7 +53,7 @@ func (c *cmdRestore) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/restore.go
+++ b/lxc/restore.go
@@ -64,13 +64,13 @@ func (c *cmdRestore) Run(cmd *cobra.Command, args []string) error {
 		snapname = fmt.Sprintf("%s/%s", name, snapname)
 	}
 
-	req := api.ContainerPut{
+	req := api.InstancePut{
 		Restore:  snapname,
 		Stateful: c.flagStateful,
 	}
 
 	// Restore the snapshot
-	op, err := d.UpdateContainer(name, req, "")
+	op, err := d.UpdateInstance(name, req, "")
 	if err != nil {
 		return err
 	}

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -63,7 +63,7 @@ func (c *cmdSnapshot) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	req := api.ContainerSnapshotsPost{
+	req := api.InstanceSnapshotsPost{
 		Name:     snapname,
 		Stateful: c.flagStateful,
 	}
@@ -72,7 +72,7 @@ func (c *cmdSnapshot) Run(cmd *cobra.Command, args []string) error {
 		req.ExpiresAt = &time.Time{}
 	}
 
-	op, err := d.CreateContainerSnapshot(name, req)
+	op, err := d.CreateInstanceSnapshot(name, req)
 	if err != nil {
 		return err
 	}

--- a/lxc/snapshot.go
+++ b/lxc/snapshot.go
@@ -58,7 +58,7 @@ func (c *cmdSnapshot) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	d, err := conf.GetContainerServer(remote)
+	d, err := conf.GetInstanceServer(remote)
 	if err != nil {
 		return err
 	}

--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -646,7 +646,7 @@ func (c *cmdStorageVolumeDetach) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get the container entry
-	container, etag, err := resource.server.GetContainer(args[2])
+	container, etag, err := resource.server.GetInstance(args[2])
 	if err != nil {
 		return err
 	}
@@ -675,7 +675,7 @@ func (c *cmdStorageVolumeDetach) Run(cmd *cobra.Command, args []string) error {
 
 	// Remove the device
 	delete(container.Devices, devName)
-	op, err := resource.server.UpdateContainer(args[2], container.Writable(), etag)
+	op, err := resource.server.UpdateInstance(args[2], container.Writable(), etag)
 	if err != nil {
 		return err
 	}

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -56,7 +56,7 @@ func (a stringList) Less(i, j int) bool {
 	return a[i][x] < a[j][x]
 }
 
-// Container name sorting
+// Instance name sorting
 type byName [][]string
 
 func (a byName) Len() int {
@@ -132,7 +132,7 @@ func runBatch(names []string, action func(name string) error) []batchResult {
 // Add a device to a container
 func containerDeviceAdd(client lxd.InstanceServer, name string, devName string, dev map[string]string) error {
 	// Get the container entry
-	container, etag, err := client.GetContainer(name)
+	container, etag, err := client.GetInstance(name)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func containerDeviceAdd(client lxd.InstanceServer, name string, devName string, 
 
 	container.Devices[devName] = dev
 
-	op, err := client.UpdateContainer(name, container.Writable(), etag)
+	op, err := client.UpdateInstance(name, container.Writable(), etag)
 	if err != nil {
 		return err
 	}
@@ -167,7 +167,7 @@ func profileDeviceAdd(client lxd.InstanceServer, name string, devName string, de
 		return fmt.Errorf(i18n.G("Device already exists: %s"), devName)
 	}
 
-	// Add the device to the container
+	// Add the device to the instance
 	profile.Devices[devName] = dev
 
 	err = client.UpdateProfile(name, profile.Writable(), profileEtag)

--- a/lxc/utils.go
+++ b/lxc/utils.go
@@ -130,7 +130,7 @@ func runBatch(names []string, action func(name string) error) []batchResult {
 }
 
 // Add a device to a container
-func containerDeviceAdd(client lxd.ContainerServer, name string, devName string, dev map[string]string) error {
+func containerDeviceAdd(client lxd.InstanceServer, name string, devName string, dev map[string]string) error {
 	// Get the container entry
 	container, etag, err := client.GetContainer(name)
 	if err != nil {
@@ -154,7 +154,7 @@ func containerDeviceAdd(client lxd.ContainerServer, name string, devName string,
 }
 
 // Add a device to a profile
-func profileDeviceAdd(client lxd.ContainerServer, name string, devName string, dev map[string]string) error {
+func profileDeviceAdd(client lxd.InstanceServer, name string, devName string, dev map[string]string) error {
 	// Get the profile entry
 	profile, profileEtag, err := client.GetProfile(name)
 	if err != nil {
@@ -179,7 +179,7 @@ func profileDeviceAdd(client lxd.ContainerServer, name string, devName string, d
 }
 
 // Create the specified image alises, updating those that already exist
-func ensureImageAliases(client lxd.ContainerServer, aliases []api.ImageAlias, fingerprint string) error {
+func ensureImageAliases(client lxd.InstanceServer, aliases []api.ImageAlias, fingerprint string) error {
 	if len(aliases) == 0 {
 		return nil
 	}

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2018-11-30 03:10+0000\n"
 "Last-Translator: ssantos <ssantos@web.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -332,7 +332,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -340,13 +340,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -506,7 +509,7 @@ msgstr "automatisches Update: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -516,7 +519,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -527,7 +530,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Ungültige Abbild Eigenschaft: %s\n"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -608,7 +611,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -684,8 +687,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -717,7 +720,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 #, fuzzy
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -727,7 +730,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -747,7 +750,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -762,7 +765,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -770,7 +773,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Kopiere Aliasse von der Quelle"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 #, fuzzy
 msgid "Copy containers within or in between LXD instances"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -800,9 +803,15 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:49
+#: lxc/copy.go:51
 #, fuzzy
-msgid "Copy the container without its snapshots"
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr "Herunterfahren des Containers erzwingen."
+
+#: lxc/copy.go:50
+#, fuzzy
+msgid "Copy the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/storage_volume.go:306
@@ -810,7 +819,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -902,7 +911,7 @@ msgstr "Fehlerhafte Profil URL %s"
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1010,7 +1019,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -1018,7 +1027,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1228,7 +1237,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Flüchtiger Container"
 
@@ -1284,17 +1293,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export container backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1313,7 +1322,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -1323,7 +1332,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 #, fuzzy
 msgid "Failed to get the new container name"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2090,11 +2099,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2197,7 +2206,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 #, fuzzy
 msgid "Move containers within or in between LXD instances"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2207,9 +2216,15 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 #, fuzzy
-msgid "Move the container without its snapshots"
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr "Herunterfahren des Containers erzwingen."
+
+#: lxc/move.go:56
+#, fuzzy
+msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
 #: lxc/storage_volume.go:365
@@ -2310,7 +2325,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2427,7 +2442,7 @@ msgstr "Administrator Passwort für %s: "
 msgid "Pause containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2516,12 +2531,12 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 #, fuzzy
 msgid "Profile to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -2608,7 +2623,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -3158,7 +3173,7 @@ msgstr "Profil %s gelöscht\n"
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3223,15 +3238,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3275,7 +3294,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3337,7 +3356,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3355,15 +3374,15 @@ msgstr "unbekannter entfernter Instanz Name: %q"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, fuzzy, c-format
 msgid "Transferring container: %s"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -3424,7 +3443,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -3464,7 +3483,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3520,9 +3539,16 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
+#: lxc/export.go:40
 #, fuzzy
-msgid "Whether or not to only backup the container (without snapshots)"
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr "Zustand des laufenden Containers sichern oder nicht"
+
+#: lxc/export.go:42
+#, fuzzy
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
 #: lxc/restore.go:36
@@ -3551,12 +3577,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 #, fuzzy
 msgid "You must specify a destination container name when using --target"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 #, fuzzy
 msgid "You must specify a source container name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -3634,7 +3660,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3845,7 +3871,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -4026,7 +4052,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4109,7 +4135,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
@@ -4217,7 +4243,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -207,7 +207,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -215,13 +215,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -377,7 +380,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -386,7 +389,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -468,7 +471,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -539,8 +542,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -572,7 +575,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -580,7 +583,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -599,7 +602,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -614,7 +617,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -622,7 +625,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -650,15 +653,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -741,7 +749,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -843,7 +851,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -851,7 +859,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1053,7 +1061,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1105,15 +1113,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1132,7 +1140,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1141,7 +1149,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1860,11 +1868,11 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1960,7 +1968,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1968,8 +1976,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2069,7 +2082,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2182,7 +2195,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2271,11 +2284,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2357,7 +2370,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2881,7 +2894,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2942,15 +2955,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2991,7 +3008,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3049,7 +3066,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3067,15 +3084,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3136,7 +3153,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3173,7 +3190,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3225,8 +3242,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3252,11 +3275,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3332,7 +3355,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3512,7 +3535,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3676,7 +3699,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3759,7 +3782,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3863,7 +3886,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2019-06-13 16:56+0000\n"
 "Last-Translator: Alonso José Lara Plana <alonso.lara.plana@gmail.com>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -279,7 +279,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
@@ -287,13 +287,16 @@ msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -450,7 +453,7 @@ msgstr "Auto actualización: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -459,7 +462,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -470,7 +473,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Propiedad mala: %s"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -541,7 +544,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -614,8 +617,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -647,7 +650,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -655,7 +658,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -674,7 +677,7 @@ msgstr "Log de la consola:"
 msgid "Container name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr "Nombre del contenedor es: %s"
@@ -689,7 +692,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -697,7 +700,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -725,15 +728,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -819,7 +827,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -921,7 +929,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -929,7 +937,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1130,7 +1138,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1182,17 +1190,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export container backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1211,7 +1219,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1220,7 +1228,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1939,11 +1947,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2042,7 +2050,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2050,8 +2058,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2150,7 +2163,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2263,7 +2276,7 @@ msgstr "Contraseña admin para %s:"
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2352,11 +2365,11 @@ msgstr "Perfil %s eliminado de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2438,7 +2451,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -2962,7 +2975,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -3023,15 +3036,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3072,7 +3089,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3130,7 +3147,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3148,15 +3165,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3217,7 +3234,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3254,7 +3271,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3306,8 +3323,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3333,11 +3356,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3414,7 +3437,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3595,7 +3618,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr "Expira: %s"
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3759,7 +3782,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3842,7 +3865,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3946,7 +3969,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -322,7 +322,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -330,13 +330,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -497,7 +500,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -507,7 +510,7 @@ msgstr "Image copiée avec succès !"
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -518,7 +521,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Mauvaise propriété : %s"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -590,7 +593,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -666,8 +669,8 @@ msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -705,7 +708,7 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
@@ -714,7 +717,7 @@ msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 #, fuzzy
 msgid "Config key/value to apply to the target container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -734,7 +737,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr "Le nom du conteneur est : %s"
@@ -749,7 +752,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -757,7 +760,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Copier les alias depuis la source"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 #, fuzzy
 msgid "Copy containers within or in between LXD instances"
 msgstr "Copiez le conteneur sans ses instantanés"
@@ -787,8 +790,15 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+#, fuzzy
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr "Copiez le conteneur sans ses instantanés"
+
+#: lxc/copy.go:50
+#, fuzzy
+msgid "Copy the instance without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
 #: lxc/storage_volume.go:306
@@ -796,7 +806,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -904,7 +914,7 @@ msgstr "Créé : %s"
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1012,7 +1022,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -1020,7 +1030,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1227,7 +1237,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Conteneur éphémère"
 
@@ -1289,17 +1299,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export container backups"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -1319,7 +1329,7 @@ msgstr "NOM"
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -1329,7 +1339,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Failed to create alias %s"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 #, fuzzy
 msgid "Failed to get the new container name"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2139,12 +2149,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 #, fuzzy
 msgid "Migration API failure"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2250,7 +2260,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 #, fuzzy
 msgid "Move containers within or in between LXD instances"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2260,9 +2270,15 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:54
+#: lxc/move.go:55
 #, fuzzy
-msgid "Move the container without its snapshots"
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr "Forcer le conteneur à s'arrêter"
+
+#: lxc/move.go:56
+#, fuzzy
+msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
 #: lxc/storage_volume.go:365
@@ -2363,7 +2379,7 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
@@ -2487,7 +2503,7 @@ msgstr "Mot de passe administrateur pour %s : "
 msgid "Pause containers"
 msgstr "Création du conteneur"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2576,11 +2592,11 @@ msgstr "Profil %s supprimé de %s"
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 #, fuzzy
 msgid "Profile to apply to the target container"
 msgstr "Profil à appliquer au nouveau conteneur"
@@ -2668,7 +2684,7 @@ msgstr "Pousser ou récupérer des fichiers récursivement"
 msgid "Refresh images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "Ignorer l'état du conteneur (seulement pour start)"
@@ -3230,7 +3246,7 @@ msgstr "Le réseau %s a été supprimé"
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -3296,15 +3312,19 @@ msgstr ""
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3353,7 +3373,7 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3413,7 +3433,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3431,15 +3451,15 @@ msgstr "Transfert de l'image : %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, fuzzy, c-format
 msgid "Transferring container: %s"
 msgstr "Transfert de l'image : %s"
@@ -3500,7 +3520,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -3545,7 +3565,7 @@ msgstr "Clé de configuration invalide"
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3598,9 +3618,16 @@ msgstr "Nom : %s"
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
+#: lxc/export.go:40
 #, fuzzy
-msgid "Whether or not to only backup the container (without snapshots)"
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
+
+#: lxc/export.go:42
+#, fuzzy
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
 #: lxc/restore.go:36
@@ -3629,12 +3656,12 @@ msgstr "Il est impossible de passer -t et -T simultanément"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "impossible de copier vers le même nom de conteneur"
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 #, fuzzy
 msgid "You must specify a destination container name when using --target"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 #, fuzzy
 msgid "You must specify a source container name"
 msgstr "vous devez spécifier un nom de conteneur source"
@@ -3712,7 +3739,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3933,7 +3960,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr "Expire : %s"
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -4118,7 +4145,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4211,7 +4238,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
@@ -4327,7 +4354,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2017-08-18 14:22+0000\n"
 "Last-Translator: Alberto Donato <alberto.donato@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -244,7 +244,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -252,13 +252,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -415,7 +418,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -424,7 +427,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -435,7 +438,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr "Proprietà errata: %s"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -506,7 +509,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -578,8 +581,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -611,7 +614,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -619,7 +622,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -638,7 +641,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr "Il nome del container è: %s"
@@ -653,7 +656,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -661,7 +664,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -689,15 +692,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -783,7 +791,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -885,7 +893,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -893,7 +901,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1094,7 +1102,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1146,17 +1154,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export container backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -1175,7 +1183,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1184,7 +1192,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1909,11 +1917,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2011,7 +2019,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2019,8 +2027,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2119,7 +2132,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2233,7 +2246,7 @@ msgstr "Password amministratore per %s: "
 msgid "Pause containers"
 msgstr "Creazione del container in corso"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2322,11 +2335,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2408,7 +2421,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "Creazione del container in corso"
@@ -2934,7 +2947,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2996,15 +3009,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3046,7 +3063,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3104,7 +3121,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3122,15 +3139,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3191,7 +3208,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -3229,7 +3246,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3281,8 +3298,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3308,12 +3331,12 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 #, fuzzy
 msgid "You must specify a destination container name when using --target"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr "Occorre specificare un nome di container come origine"
 
@@ -3390,7 +3413,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3571,7 +3594,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3735,7 +3758,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3818,7 +3841,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3922,7 +3945,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2019-05-18 08:49+0000\n"
 "Last-Translator: KATOH Yasufumi <karma@jazz.email.ne.jp>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -208,7 +208,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only はコピー元がスナップショットの場合は指定できません"
 
@@ -217,14 +217,18 @@ msgstr "--container-only はコピー元がスナップショットの場合は�
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh はコンテナの場合のみ使えます"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr "--refresh はコンテナの場合のみ使えます"
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 #, fuzzy
 msgid "--target cannot be used with containers"
+msgstr "--refresh はコンテナの場合のみ使えます"
+
+#: lxc/info.go:423
+#, fuzzy
+msgid "--target cannot be used with instances"
 msgstr "--refresh はコンテナの場合のみ使えます"
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -384,7 +388,7 @@ msgstr "自動更新: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -393,7 +397,7 @@ msgstr "バックアップのエクスポートが成功しました!"
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -404,7 +408,7 @@ msgstr "不適切な キー=値 のペア: %s"
 msgid "Bad property: %s"
 msgstr "不正なイメージプロパティ形式: %s"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -476,7 +480,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ済: %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -550,8 +554,8 @@ msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -587,7 +591,7 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
@@ -595,7 +599,7 @@ msgstr "新しいコンテナに適用するキー/値の設定"
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr "移動先のコンテナに適用するキー/値の設定"
 
@@ -614,7 +618,7 @@ msgstr "コンソールログ:"
 msgid "Container name is mandatory"
 msgstr "コンテナ名を指定する必要があります"
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr "コンテナ名: %s"
@@ -629,7 +633,7 @@ msgstr "コンテナは以下のフィンガープリントで publish されま
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr "ステートフルなコンテナをステートレスにコピーします"
 
@@ -637,7 +641,7 @@ msgstr "ステートフルなコンテナをステートレスにコピーしま
 msgid "Copy aliases from source"
 msgstr "ソースからエイリアスをコピーしました"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr "LXD インスタンス内に、またはインスタンス間でコンテナをコピーします"
 
@@ -669,15 +673,22 @@ msgstr "プロファイルをコピーします"
 msgid "Copy storage volumes"
 msgstr "ストレージボリュームをコピーします"
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+#, fuzzy
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr "コンテナをコピーします (スナップショットはコピーしません)"
+
+#: lxc/copy.go:50
+#, fuzzy
+msgid "Copy the instance without its snapshots"
 msgstr "コンテナをコピーします (スナップショットはコピーしません)"
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -766,7 +777,7 @@ msgstr "プロジェクトを作成します"
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr "プロファイルを適用しないコンテナを作成します"
 
@@ -868,7 +879,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -876,7 +887,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1092,7 +1103,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr "Ephemeral コンテナ"
 
@@ -1158,15 +1169,15 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr "コンテナのバックアップをエクスポートします"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr "コンテナを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -1185,7 +1196,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr "クラスタメンバへの接続に失敗しました"
 
@@ -1194,7 +1205,7 @@ msgstr "クラスタメンバへの接続に失敗しました"
 msgid "Failed to create alias %s"
 msgstr "エイリアス %s の作成に失敗しました"
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr "新しいコンテナ名が取得できません"
 
@@ -2023,11 +2034,11 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ消費量:"
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr "マイグレーション API が失敗しました"
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr "マイグレーションが失敗しました"
 
@@ -2128,7 +2139,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr "LXD サーバ内もしくはサーバ間でコンテナを移動します"
 
@@ -2136,8 +2147,15 @@ msgstr "LXD サーバ内もしくはサーバ間でコンテナを移動しま�
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+#, fuzzy
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr "コンテナを移動します (スナップショットは移動しません)"
+
+#: lxc/move.go:56
+#, fuzzy
+msgid "Move the instance without its snapshots"
 msgstr "コンテナを移動します (スナップショットは移動しません)"
 
 #: lxc/storage_volume.go:365
@@ -2236,7 +2254,7 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
@@ -2350,7 +2368,7 @@ msgstr "%s のパスワード: "
 msgid "Pause containers"
 msgstr "コンテナを一時停止します"
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
@@ -2439,11 +2457,11 @@ msgstr "プロファイル %s が %s から削除されました"
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr "新しいコンテナに適用するプロファイル"
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr "移動先のコンテナに適用するプロファイル"
 
@@ -2525,7 +2543,7 @@ msgstr "再帰的にファイルを転送します"
 msgid "Refresh images"
 msgstr "イメージを更新します"
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr "コンテナの更新中: %s"
@@ -3056,7 +3074,7 @@ msgstr "ストレージプール %s を削除しました"
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -3117,15 +3135,20 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr "--container-only と --target は同時に指定できません"
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+#, fuzzy
+msgid "The --instance-only flag can't be used with --target"
+msgstr "--container-only と --target は同時に指定できません"
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr "--stateless と --target は同時に指定できません"
 
@@ -3171,7 +3194,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr "移動元の LXD インスタンスはクラスタに属していません"
 
@@ -3235,7 +3258,7 @@ msgstr ""
 "さい"
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -3255,15 +3278,15 @@ msgstr "イメージを転送中: %s"
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr "コンテナを転送中: %s"
@@ -3324,7 +3347,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr "移動先のコンテナのすべてのプロファイルを削除します"
 
@@ -3361,7 +3384,7 @@ msgstr "ストレージボリュームの設定を削除します"
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3417,8 +3440,16 @@ msgstr "名前: %s"
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+#, fuzzy
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr "スナップショットを含めずにコンテナのみをバックアップするかどうか"
+
+#: lxc/export.go:42
+#, fuzzy
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにコンテナのみをバックアップするかどうか"
 
 #: lxc/restore.go:36
@@ -3445,11 +3476,11 @@ msgstr "-t と -T は同時に指定できません"
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr "--mode と同時に -t または -T は指定できません"
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr "--target オプションを使うときはコピー先のコンテナ名を指定してください"
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr "コピー元のコンテナ名を指定してください"
 
@@ -3525,7 +3556,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3709,7 +3740,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr "失効日時: %s"
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3896,7 +3927,7 @@ msgstr ""
 "lxc config set core.trust_password blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4021,7 +4052,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -4170,7 +4201,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-09-06 02:09-0400\n"
+        "POT-Creation-Date: 2019-09-13 14:32+0100\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -196,7 +196,7 @@ msgstr  ""
 msgid   "- Port %d (%s)"
 msgstr  ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid   "--container-only can't be passed when the source is a snapshot"
 msgstr  ""
 
@@ -204,12 +204,16 @@ msgstr  ""
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid   "--refresh can only be used with containers"
 msgstr  ""
 
-#: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637 lxc/info.go:423
+#: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
 msgid   "--target cannot be used with containers"
+msgstr  ""
+
+#: lxc/info.go:423
+msgid   "--target cannot be used with instances"
 msgstr  ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -361,7 +365,7 @@ msgstr  ""
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -370,7 +374,7 @@ msgstr  ""
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176 lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176 lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -380,7 +384,7 @@ msgstr  ""
 msgid   "Bad property: %s"
 msgstr  ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid   "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr  ""
@@ -450,7 +454,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -520,7 +524,7 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53 lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729 lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145 lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1282 lxc/storage_volume.go:1361 lxc/storage_volume.go:1454
+#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53 lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729 lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145 lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1282 lxc/storage_volume.go:1361 lxc/storage_volume.go:1454
 msgid   "Cluster member name"
 msgstr  ""
 
@@ -543,7 +547,7 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
@@ -551,7 +555,7 @@ msgstr  ""
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid   "Config key/value to apply to the target container"
 msgstr  ""
 
@@ -568,7 +572,7 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid   "Container name is: %s"
 msgstr  ""
@@ -583,7 +587,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid   "Copy a stateful container stateless"
 msgstr  ""
 
@@ -591,7 +595,7 @@ msgstr  ""
 msgid   "Copy aliases from source"
 msgstr  ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid   "Copy containers within or in between LXD instances"
 msgstr  ""
 
@@ -618,15 +622,19 @@ msgstr  ""
 msgid   "Copy storage volumes"
 msgstr  ""
 
-#: lxc/copy.go:49
-msgid   "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid   "Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr  ""
+
+#: lxc/copy.go:50
+msgid   "Copy the instance without its snapshots"
 msgstr  ""
 
 #: lxc/storage_volume.go:306
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -708,7 +716,7 @@ msgstr  ""
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid   "Create the container with no profiles applied"
 msgstr  ""
 
@@ -795,7 +803,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261 lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789 lxc/image.go:903 lxc/image.go:1191 lxc/image.go:1268 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -962,7 +970,7 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid   "Ephemeral container"
 msgstr  ""
 
@@ -1011,15 +1019,15 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid   "Export container backups"
 msgstr  ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid   "Export containers as backup tarballs."
 msgstr  ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1037,7 +1045,7 @@ msgstr  ""
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid   "Failed to connect to cluster member"
 msgstr  ""
 
@@ -1046,7 +1054,7 @@ msgstr  ""
 msgid   "Failed to create alias %s"
 msgstr  ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid   "Failed to get the new container name"
 msgstr  ""
 
@@ -1740,11 +1748,11 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid   "Migration API failure"
 msgstr  ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid   "Migration operation failure"
 msgstr  ""
 
@@ -1820,7 +1828,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid   "Move containers within or in between LXD instances"
 msgstr  ""
 
@@ -1828,8 +1836,12 @@ msgstr  ""
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:54
-msgid   "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid   "Move the container without its snapshots (deprecated, use instance-only)"
+msgstr  ""
+
+#: lxc/move.go:56
+msgid   "Move the instance without its snapshots"
 msgstr  ""
 
 #: lxc/storage_volume.go:365
@@ -1925,7 +1937,7 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
@@ -2038,7 +2050,7 @@ msgstr  ""
 msgid   "Pause containers"
 msgstr  ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid   "Perform an incremental copy"
 msgstr  ""
 
@@ -2125,11 +2137,11 @@ msgstr  ""
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid   "Profile to apply to the target container"
 msgstr  ""
 
@@ -2211,7 +2223,7 @@ msgstr  ""
 msgid   "Refresh images"
 msgstr  ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid   "Refreshing container: %s"
 msgstr  ""
@@ -2716,7 +2728,7 @@ msgstr  ""
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -2776,15 +2788,19 @@ msgstr  ""
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid   "The --container-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid   "The --instance-only flag can't be used with --target"
+msgstr  ""
+
+#: lxc/move.go:162
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid   "The --stateless flag can't be used with --target"
 msgstr  ""
 
@@ -2822,7 +2838,7 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid   "The source LXD instance is not clustered"
 msgstr  ""
 
@@ -2874,7 +2890,7 @@ msgstr  ""
 msgid   "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr  ""
 
-#: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617 lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617 lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -2892,15 +2908,15 @@ msgstr  ""
 msgid   "Transfer mode, one of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid   "Transferring container: %s"
 msgstr  ""
@@ -2960,7 +2976,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid   "Unset all profiles on the target container"
 msgstr  ""
 
@@ -2997,7 +3013,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -3047,8 +3063,12 @@ msgstr  ""
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
-#: lxc/export.go:39
-msgid   "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid   "Whether or not to only backup the container (without snapshots), (deprecated, use instance-only)"
+msgstr  ""
+
+#: lxc/export.go:42
+msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
 #: lxc/restore.go:36
@@ -3071,11 +3091,11 @@ msgstr  ""
 msgid   "You can't pass -t or -T at the same time as --mode"
 msgstr  ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid   "You must specify a destination container name when using --target"
 msgstr  ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid   "You must specify a source container name"
 msgstr  ""
 
@@ -3147,7 +3167,7 @@ msgstr  ""
 msgid   "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid   "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
@@ -3325,7 +3345,7 @@ msgstr  ""
 msgid   "expires at %s"
 msgstr  ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid   "export [<remote>:]<container> [target] [--container-only] [--optimized-storage]"
 msgstr  ""
 
@@ -3477,7 +3497,7 @@ msgid   "lxc config set [<remote>:]<container> limits.cpu=2\n"
         "    Will set the server's trust password to blah."
 msgstr  ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 container."
 msgstr  ""
@@ -3547,7 +3567,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid   "lxc move [<remote>:]<source container> [<remote>:][<destination container>] [--container-only]\n"
         "    Move a container between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -3636,7 +3656,7 @@ msgstr  ""
 msgid   "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr  ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid   "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2019-02-26 09:18+0000\n"
 "Last-Translator: Heimen Stoffels <vistausss@outlook.com>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -253,7 +253,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -261,13 +261,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -423,7 +426,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -443,7 +446,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -513,7 +516,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -584,8 +587,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -617,7 +620,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -625,7 +628,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -644,7 +647,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -659,7 +662,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -667,7 +670,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -695,15 +698,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -786,7 +794,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -888,7 +896,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -896,7 +904,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1095,7 +1103,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1147,15 +1155,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1174,7 +1182,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1900,11 +1908,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2000,7 +2008,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2008,8 +2016,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2108,7 +2121,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2221,7 +2234,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2310,11 +2323,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2396,7 +2409,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2920,7 +2933,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2981,15 +2994,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3030,7 +3047,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3088,7 +3105,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3106,15 +3123,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3175,7 +3192,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3212,7 +3229,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3264,8 +3281,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3291,11 +3314,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3371,7 +3394,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3551,7 +3574,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3715,7 +3738,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3798,7 +3821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3902,7 +3925,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -253,7 +253,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -261,13 +261,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -423,7 +426,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -432,7 +435,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -443,7 +446,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -513,7 +516,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -584,8 +587,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -617,7 +620,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -625,7 +628,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -644,7 +647,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -659,7 +662,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -667,7 +670,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -695,15 +698,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -786,7 +794,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -888,7 +896,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -896,7 +904,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1095,7 +1103,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1147,15 +1155,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1174,7 +1182,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1183,7 +1191,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1900,11 +1908,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2000,7 +2008,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2008,8 +2016,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2108,7 +2121,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2221,7 +2234,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2310,11 +2323,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2396,7 +2409,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2920,7 +2933,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2981,15 +2994,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3030,7 +3047,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3088,7 +3105,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3106,15 +3123,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3175,7 +3192,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3212,7 +3229,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3264,8 +3281,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3291,11 +3314,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3371,7 +3394,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3551,7 +3574,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3715,7 +3738,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3798,7 +3821,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3902,7 +3925,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2019-08-08 18:08+0000\n"
 "Last-Translator: Tiago A. Reul <tiago@reul.space>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -323,7 +323,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
@@ -332,14 +332,18 @@ msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 #, fuzzy
 msgid "--target cannot be used with containers"
+msgstr "--refresh só pode ser usado com containers"
+
+#: lxc/info.go:423
+#, fuzzy
+msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -495,7 +499,7 @@ msgstr "Atualização automática: %s"
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -504,7 +508,7 @@ msgstr "Backup exportado com sucesso!"
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -515,7 +519,7 @@ msgstr "par de chave=valor inválido %s"
 msgid "Bad property: %s"
 msgstr "Propriedade ruim: %s"
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr "Erro de sintaxe, esperado <dispositivo>,<chave>=<valor>: %s"
@@ -586,7 +590,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -658,8 +662,8 @@ msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -696,7 +700,7 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
@@ -704,7 +708,7 @@ msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -723,7 +727,7 @@ msgstr "Log de Console:"
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -738,7 +742,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -746,7 +750,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Aliases de cópia da fonte"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -774,15 +778,20 @@ msgstr "Copiar perfis"
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -869,7 +878,7 @@ msgstr "Criar projetos"
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -971,7 +980,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -979,7 +988,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1181,7 +1190,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1233,15 +1242,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1260,7 +1269,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1269,7 +1278,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1987,11 +1996,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2087,7 +2096,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2095,8 +2104,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2195,7 +2209,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2308,7 +2322,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2397,11 +2411,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2483,7 +2497,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "Editar arquivos no container"
@@ -3008,7 +3022,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -3069,15 +3083,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3118,7 +3136,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3176,7 +3194,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3194,15 +3212,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3263,7 +3281,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3301,7 +3319,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3353,8 +3371,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3380,11 +3404,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3460,7 +3484,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3640,7 +3664,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3804,7 +3828,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3887,7 +3911,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3991,7 +4015,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -314,7 +314,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -322,13 +322,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -486,7 +489,7 @@ msgstr "Авто-обновление: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -495,7 +498,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -506,7 +509,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -578,7 +581,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -650,8 +653,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -683,7 +686,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -691,7 +694,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -710,7 +713,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr "Имя контейнера: %s"
@@ -725,7 +728,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -733,7 +736,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr "Копировать псевдонимы из источника"
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -762,15 +765,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -858,7 +866,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -964,7 +972,7 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -972,7 +980,7 @@ msgstr "Копирование образа: %s"
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1175,7 +1183,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1228,17 +1236,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid "Export container backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -1257,7 +1265,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1266,7 +1274,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1994,11 +2002,11 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2097,7 +2105,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2106,8 +2114,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2207,7 +2220,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2321,7 +2334,7 @@ msgstr "Пароль администратора для %s: "
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2410,11 +2423,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2497,7 +2510,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, fuzzy, c-format
 msgid "Refreshing container: %s"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -3030,7 +3043,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -3092,15 +3105,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3141,7 +3158,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3199,7 +3216,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3217,15 +3234,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3286,7 +3303,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3323,7 +3340,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3375,8 +3392,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3402,11 +3425,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3483,7 +3506,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3691,7 +3714,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -3871,7 +3894,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3954,7 +3977,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -4058,7 +4081,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -204,7 +204,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -212,13 +212,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -374,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -383,7 +386,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -394,7 +397,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -464,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -535,8 +538,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -568,7 +571,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -576,7 +579,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -595,7 +598,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -610,7 +613,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -618,7 +621,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -646,15 +649,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -737,7 +745,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -839,7 +847,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -847,7 +855,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1046,7 +1054,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1098,15 +1106,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1125,7 +1133,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1134,7 +1142,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1851,11 +1859,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1951,7 +1959,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1959,8 +1967,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2059,7 +2072,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2172,7 +2185,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2261,11 +2274,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2347,7 +2360,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2871,7 +2884,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2932,15 +2945,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2981,7 +2998,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3039,7 +3056,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3057,15 +3074,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3126,7 +3143,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3163,7 +3180,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3215,8 +3232,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3242,11 +3265,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3322,7 +3345,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3502,7 +3525,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3666,7 +3689,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3749,7 +3772,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,7 +3876,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-09-06 02:09-0400\n"
+"POT-Creation-Date: 2019-09-13 13:31+0000\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -207,7 +207,7 @@ msgstr ""
 msgid "- Port %d (%s)"
 msgstr ""
 
-#: lxc/copy.go:153
+#: lxc/copy.go:155
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
@@ -215,13 +215,16 @@ msgstr ""
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
-#: lxc/copy.go:164
+#: lxc/copy.go:166
 msgid "--refresh can only be used with containers"
 msgstr ""
 
 #: lxc/config.go:150 lxc/config.go:406 lxc/config.go:499 lxc/config.go:637
-#: lxc/info.go:423
 msgid "--target cannot be used with containers"
+msgstr ""
+
+#: lxc/info.go:423
+msgid "--target cannot be used with instances"
 msgstr ""
 
 #: lxc/alias.go:125 lxc/image.go:936 lxc/image_alias.go:226
@@ -377,7 +380,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:127
+#: lxc/export.go:133
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -386,7 +389,7 @@ msgstr ""
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:123 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
+#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
 #: lxc/storage.go:122 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
@@ -397,7 +400,7 @@ msgstr ""
 msgid "Bad property: %s"
 msgstr ""
 
-#: lxc/copy.go:134
+#: lxc/copy.go:136
 #, c-format
 msgid "Bad syntax, expecting <device>,<key>=<value>: %s"
 msgstr ""
@@ -467,7 +470,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:108
+#: lxc/move.go:110
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -538,8 +541,8 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:52 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:58 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
+#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
 #: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
 #: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
 #: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
@@ -571,7 +574,7 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:44 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:47
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
@@ -579,7 +582,7 @@ msgstr ""
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:50
+#: lxc/move.go:51
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
@@ -598,7 +601,7 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:420 lxc/init.go:319
+#: lxc/copy.go:422 lxc/init.go:319
 #, c-format
 msgid "Container name is: %s"
 msgstr ""
@@ -613,7 +616,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:50 lxc/move.go:56
+#: lxc/copy.go:52 lxc/move.go:58
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -621,7 +624,7 @@ msgstr ""
 msgid "Copy aliases from source"
 msgstr ""
 
-#: lxc/copy.go:39 lxc/copy.go:40
+#: lxc/copy.go:40 lxc/copy.go:41
 msgid "Copy containers within or in between LXD instances"
 msgstr ""
 
@@ -649,15 +652,20 @@ msgstr ""
 msgid "Copy storage volumes"
 msgstr ""
 
-#: lxc/copy.go:49
-msgid "Copy the container without its snapshots"
+#: lxc/copy.go:51
+msgid ""
+"Copy the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/copy.go:50
+msgid "Copy the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:306
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/move.go:59
+#: lxc/copy.go:55 lxc/move.go:61
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -740,7 +748,7 @@ msgstr ""
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:54 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:54
 msgid "Create the container with no profiles applied"
 msgstr ""
 
@@ -842,7 +850,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:40 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:31
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:127 lxc/image.go:261
 #: lxc/image.go:312 lxc/image.go:435 lxc/image.go:575 lxc/image.go:789
@@ -850,7 +858,7 @@ msgstr ""
 #: lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149
 #: lxc/image_alias.go:246 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39
 #: lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19
-#: lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:31 lxc/network.go:107
+#: lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107
 #: lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375
 #: lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726
 #: lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010
@@ -1049,7 +1057,7 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:49
 msgid "Ephemeral container"
 msgstr ""
 
@@ -1101,15 +1109,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:111
+#: lxc/export.go:117
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1128,7 +1136,7 @@ msgstr ""
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:217
+#: lxc/move.go:224
 msgid "Failed to connect to cluster member"
 msgstr ""
 
@@ -1137,7 +1145,7 @@ msgstr ""
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:415
+#: lxc/copy.go:417
 msgid "Failed to get the new container name"
 msgstr ""
 
@@ -1854,11 +1862,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:230
+#: lxc/move.go:237
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:235
+#: lxc/move.go:242
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1954,7 +1962,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:36 lxc/move.go:37
+#: lxc/move.go:37 lxc/move.go:38
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1962,8 +1970,13 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:54
-msgid "Move the container without its snapshots"
+#: lxc/move.go:55
+msgid ""
+"Move the container without its snapshots (deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/move.go:56
+msgid "Move the instance without its snapshots"
 msgstr ""
 
 #: lxc/storage_volume.go:365
@@ -2062,7 +2075,7 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:45 lxc/move.go:51
+#: lxc/copy.go:46 lxc/move.go:52
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
@@ -2175,7 +2188,7 @@ msgstr ""
 msgid "Pause containers"
 msgstr ""
 
-#: lxc/copy.go:55
+#: lxc/copy.go:57
 msgid "Perform an incremental copy"
 msgstr ""
 
@@ -2264,11 +2277,11 @@ msgstr ""
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:48
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:52
+#: lxc/move.go:53
 msgid "Profile to apply to the target container"
 msgstr ""
 
@@ -2350,7 +2363,7 @@ msgstr ""
 msgid "Refresh images"
 msgstr ""
 
-#: lxc/copy.go:385
+#: lxc/copy.go:387
 #, c-format
 msgid "Refreshing container: %s"
 msgstr ""
@@ -2874,7 +2887,7 @@ msgstr ""
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:51 lxc/import.go:35 lxc/init.go:51 lxc/move.go:57
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
 msgid "Storage pool name"
 msgstr ""
 
@@ -2935,15 +2948,19 @@ msgstr ""
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:152
+#: lxc/move.go:154
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:156
+#: lxc/move.go:158
+msgid "The --instance-only flag can't be used with --target"
+msgstr ""
+
+#: lxc/move.go:162
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:148
+#: lxc/move.go:150
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2984,7 +3001,7 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:222
+#: lxc/move.go:229
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
@@ -3042,7 +3059,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:116 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3060,15 +3077,15 @@ msgstr ""
 msgid "Transfer mode, one of pull (default), push or relay"
 msgstr ""
 
-#: lxc/copy.go:48
+#: lxc/copy.go:49
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:55 lxc/storage_volume.go:304
+#: lxc/move.go:57 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
-#: lxc/copy.go:354
+#: lxc/copy.go:356
 #, c-format
 msgid "Transferring container: %s"
 msgstr ""
@@ -3129,7 +3146,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:54
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3166,7 +3183,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:41
+#: lxc/export.go:44
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3218,8 +3235,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:39
-msgid "Whether or not to only backup the container (without snapshots)"
+#: lxc/export.go:40
+msgid ""
+"Whether or not to only backup the container (without snapshots), "
+"(deprecated, use instance-only)"
+msgstr ""
+
+#: lxc/export.go:42
+msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
 #: lxc/restore.go:36
@@ -3245,11 +3268,11 @@ msgstr ""
 msgid "You can't pass -t or -T at the same time as --mode"
 msgstr ""
 
-#: lxc/copy.go:82
+#: lxc/copy.go:84
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:77 lxc/move.go:206
+#: lxc/copy.go:79 lxc/move.go:213
 msgid "You must specify a source container name"
 msgstr ""
 
@@ -3325,7 +3348,7 @@ msgstr ""
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/copy.go:37
+#: lxc/copy.go:38
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
@@ -3505,7 +3528,7 @@ msgstr ""
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:29
+#: lxc/export.go:30
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3669,7 +3692,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:33
+#: lxc/export.go:34
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -3752,7 +3775,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:39
+#: lxc/move.go:40
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3856,7 +3879,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:34
+#: lxc/move.go:35
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"


### PR DESCRIPTION
- Switches `lxc` CLI tool to use the `client` Instance functions.
- Adds `--instance-only` command line param and updates `--container-only` help to indicate it is deprecated (both still work).