### PR TITLE
Instance Interface

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -214,122 +214,23 @@ func containerValidDevices(state *state.State, cluster *db.Cluster, instanceName
 
 // The container interface
 type container interface {
-	// Container actions
-	Freeze() error
-	Shutdown(timeout time.Duration) error
-	Start(stateful bool) error
-	Stop(stateful bool) error
-	Unfreeze() error
+	Instance
 
-	// Snapshots & migration & backups
-	Restore(sourceContainer container, stateful bool) error
 	/* actionScript here is a script called action.sh in the stateDir, to
 	 * be passed to CRIU as --action-script
 	 */
 	Migrate(args *CriuMigrationArgs) error
-	Snapshots() ([]container, error)
-	Backups() ([]backup, error)
 
-	// Config handling
-	Rename(newName string) error
-	Update(newConfig db.ContainerArgs, userRequested bool) error
-
-	Delete() error
-	Export(w io.Writer, properties map[string]string) error
-
-	// Live configuration
-	CGroupGet(key string) (string, error)
-	CGroupSet(key string, value string) error
-	VolatileSet(changes map[string]string) error
-
-	// File handling
-	FileExists(path string) error
-	FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error)
-	FilePush(type_ string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error
-	FileRemove(path string) error
-
-	// Console - Allocate and run a console tty.
-	//
-	// terminal  - Bidirectional file descriptor.
-	//
-	// This function will not return until the console has been exited by
-	// the user.
-	Console(terminal *os.File) *exec.Cmd
 	ConsoleLog(opts lxc.ConsoleLogOptions) (string, error)
-	/* Command execution:
-		 * 1. passing in false for wait
-		 *    - equivalent to calling cmd.Run()
-		 * 2. passing in true for wait
-	         *    - start the command and return its PID in the first return
-	         *      argument and the PID of the attached process in the second
-	         *      argument. It's the callers responsibility to wait on the
-	         *      command. (Note. The returned PID of the attached process can not
-	         *      be waited upon since it's a child of the lxd forkexec command
-	         *      (the PID returned in the first return argument). It can however
-	         *      be used to e.g. forward signals.)
-	*/
-	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool, cwd string, uid uint32, gid uint32) (*exec.Cmd, int, int, error)
 
 	// Status
-	Render() (interface{}, interface{}, error)
-	RenderFull() (*api.InstanceFull, interface{}, error)
-	RenderState() (*api.InstanceState, error)
-	IsPrivileged() bool
-	IsRunning() bool
-	IsFrozen() bool
-	IsEphemeral() bool
-	IsSnapshot() bool
-	IsStateful() bool
 	IsNesting() bool
 
 	// Hooks
 	OnStart() error
 	OnStopNS(target string, netns string) error
 	OnStop(target string) error
-	DeviceEventHandler(*device.RunConfig) error
 
-	// Properties
-	Id() int
-	Location() string
-	Project() string
-	Name() string
-	Type() instance.Type
-	Description() string
-	Architecture() int
-	CreationDate() time.Time
-	LastUsedDate() time.Time
-	ExpandedConfig() map[string]string
-	ExpandedDevices() config.Devices
-	LocalConfig() map[string]string
-	LocalDevices() config.Devices
-	Profiles() []string
-	InitPID() int
-	State() string
-	ExpiryDate() time.Time
-
-	// Paths
-	Path() string
-	RootfsPath() string
-	TemplatesPath() string
-	StatePath() string
-	LogFilePath() string
-	ConsoleBufferLogPath() string
-	LogPath() string
-	DevicesPath() string
-
-	// Storage
-	StoragePool() (string, error)
-
-	// Progress reporting
-	SetOperation(op *operation)
-
-	// FIXME: Those should be internal functions
-	// Needed for migration for now.
-	StorageStart() (bool, error)
-	StorageStop() (bool, error)
-	Storage() storage
-	TemplateApply(trigger string) error
-	DaemonState() *state.State
 	InsertSeccompUnixDevice(prefix string, m config.Device, pid int) error
 
 	CurrentIdmap() (*idmap.IdmapSet, error)

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -463,7 +463,7 @@ func containerCreateAsCopy(s *state.State, args db.ContainerArgs, sourceContaine
 	}
 
 	csList := []*container{}
-	var snapshots []container
+	var snapshots []Instance
 
 	if !containerOnly {
 		if refresh {
@@ -1133,7 +1133,7 @@ func containerLoadAllInternal(cts []db.Instance, s *state.State) ([]container, e
 	return containers, nil
 }
 
-func containerCompareSnapshots(source container, target container) ([]container, []container, error) {
+func containerCompareSnapshots(source Instance, target container) ([]Instance, []Instance, error) {
 	// Get the source snapshots
 	sourceSnapshots, err := source.Snapshots()
 	if err != nil {
@@ -1150,8 +1150,8 @@ func containerCompareSnapshots(source container, target container) ([]container,
 	sourceSnapshotsTime := map[string]time.Time{}
 	targetSnapshotsTime := map[string]time.Time{}
 
-	toDelete := []container{}
-	toSync := []container{}
+	toDelete := []Instance{}
+	toSync := []Instance{}
 
 	for _, snap := range sourceSnapshots {
 		_, snapName, _ := shared.ContainerGetParentAndSnapshotName(snap.Name())
@@ -1336,7 +1336,7 @@ func pruneExpiredContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 		}
 
 		// Figure out which need snapshotting (if any)
-		expiredSnapshots := []container{}
+		expiredSnapshots := []Instance{}
 		for _, c := range allContainers {
 			snapshots, err := c.Snapshots()
 			if err != nil {
@@ -1395,7 +1395,7 @@ func pruneExpiredContainerSnapshotsTask(d *Daemon) (task.Func, task.Schedule) {
 	return f, schedule
 }
 
-func pruneExpiredContainerSnapshots(ctx context.Context, d *Daemon, snapshots []container) error {
+func pruneExpiredContainerSnapshots(ctx context.Context, d *Daemon, snapshots []Instance) error {
 	// Find snapshots to delete
 	for _, snapshot := range snapshots {
 		err := snapshot.Delete()

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3369,11 +3369,11 @@ func (c *containerLXC) RenderState() (*api.InstanceState, error) {
 	return &status, nil
 }
 
-func (c *containerLXC) Snapshots() ([]container, error) {
+func (c *containerLXC) Snapshots() ([]Instance, error) {
 	var snaps []db.Instance
 
 	if c.IsSnapshot() {
-		return []container{}, nil
+		return []Instance{}, nil
 	}
 
 	// Get all the snapshots
@@ -3396,7 +3396,12 @@ func (c *containerLXC) Snapshots() ([]container, error) {
 		return nil, err
 	}
 
-	return containers, nil
+	instances := make([]Instance, len(containers))
+	for k, v := range containers {
+		instances[k] = Instance(v)
+	}
+
+	return instances, nil
 }
 
 func (c *containerLXC) Backups() ([]backup, error) {
@@ -3420,7 +3425,7 @@ func (c *containerLXC) Backups() ([]backup, error) {
 	return backups, nil
 }
 
-func (c *containerLXC) Restore(sourceContainer container, stateful bool) error {
+func (c *containerLXC) Restore(sourceContainer Instance, stateful bool) error {
 	var ctxMap log.Ctx
 
 	// Initialize storage interface for the container.

--- a/lxd/instance_interface.go
+++ b/lxd/instance_interface.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"time"
+
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/device"
+	"github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/instance"
+	"github.com/lxc/lxd/lxd/state"
+	"github.com/lxc/lxd/shared/api"
+)
+
+// The Instance interface
+type Instance interface {
+	// Instance actions
+	Freeze() error
+	Shutdown(timeout time.Duration) error
+	Start(stateful bool) error
+	Stop(stateful bool) error
+	Unfreeze() error
+
+	IsPrivileged() bool
+
+	// Snapshots & migration & backups
+	Restore(source Instance, stateful bool) error
+	Snapshots() ([]Instance, error)
+	Backups() ([]backup, error)
+
+	// Config handling
+	Rename(newName string) error
+
+	// TODO rename db.ContainerArgs to db.InstanceArgs.
+	Update(newConfig db.ContainerArgs, userRequested bool) error
+
+	Delete() error
+	Export(w io.Writer, properties map[string]string) error
+
+	// Live configuration
+	CGroupGet(key string) (string, error)
+	CGroupSet(key string, value string) error
+	VolatileSet(changes map[string]string) error
+
+	// File handling
+	FileExists(path string) error
+	FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error)
+	FilePush(type_ string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error
+	FileRemove(path string) error
+
+	// Console - Allocate and run a console tty.
+	//
+	// terminal  - Bidirectional file descriptor.
+	//
+	// This function will not return until the console has been exited by
+	// the user.
+	Console(terminal *os.File) *exec.Cmd
+	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool, cwd string, uid uint32, gid uint32) (*exec.Cmd, int, int, error)
+
+	// Status
+	Render() (interface{}, interface{}, error)
+	RenderFull() (*api.InstanceFull, interface{}, error)
+	RenderState() (*api.InstanceState, error)
+	IsRunning() bool
+	IsFrozen() bool
+	IsEphemeral() bool
+	IsSnapshot() bool
+	IsStateful() bool
+
+	// Hooks
+	DeviceEventHandler(*device.RunConfig) error
+
+	// Properties
+	Id() int
+	Location() string
+	Project() string
+	Name() string
+	Type() instance.Type
+	Description() string
+	Architecture() int
+	CreationDate() time.Time
+	LastUsedDate() time.Time
+	ExpandedConfig() map[string]string
+	ExpandedDevices() config.Devices
+	LocalConfig() map[string]string
+	LocalDevices() config.Devices
+	Profiles() []string
+	InitPID() int
+	State() string
+	ExpiryDate() time.Time
+
+	// Paths
+	Path() string
+	RootfsPath() string
+	TemplatesPath() string
+	StatePath() string
+	LogFilePath() string
+	ConsoleBufferLogPath() string
+	LogPath() string
+	DevicesPath() string
+
+	// Storage
+	StoragePool() (string, error)
+
+	// Progress reporting
+
+	SetOperation(op *operation)
+
+	// FIXME: Those should be internal functions
+	// Needed for migration for now.
+	StorageStart() (bool, error)
+	StorageStop() (bool, error)
+	Storage() storage
+	TemplateApply(trigger string) error
+	DaemonState() *state.State
+}

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -77,7 +77,7 @@ fi
 	return err
 }
 
-func snapshotToProtobuf(c container) *migration.Snapshot {
+func snapshotToProtobuf(c Instance) *migration.Snapshot {
 	config := []*migration.Config{}
 	for k, v := range c.LocalConfig() {
 		kCopy := string(k)
@@ -1137,12 +1137,12 @@ func (s *migrationSourceWs) ConnectContainerTarget(target api.InstancePostTarget
 	return s.ConnectTarget(target.Certificate, target.Operation, target.Websockets)
 }
 
-func migrationCompareSnapshots(sourceSnapshots []*migration.Snapshot, targetSnapshots []container) ([]*migration.Snapshot, []container) {
+func migrationCompareSnapshots(sourceSnapshots []*migration.Snapshot, targetSnapshots []Instance) ([]*migration.Snapshot, []Instance) {
 	// Compare source and target
 	sourceSnapshotsTime := map[string]int64{}
 	targetSnapshotsTime := map[string]int64{}
 
-	toDelete := []container{}
+	toDelete := []Instance{}
 	toSync := []*migration.Snapshot{}
 
 	for _, snap := range sourceSnapshots {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -189,32 +189,32 @@ type storage interface {
 
 	// Functions dealing with container storage volumes.
 	// ContainerCreate creates an empty container (no rootfs/metadata.yaml)
-	ContainerCreate(container container) error
+	ContainerCreate(container Instance) error
 
 	// ContainerCreateFromImage creates a container from a image.
-	ContainerCreateFromImage(c container, fingerprint string, tracker *ioprogress.ProgressTracker) error
-	ContainerDelete(c container) error
-	ContainerCopy(target container, source container, containerOnly bool) error
-	ContainerRefresh(target container, source container, snapshots []container) error
-	ContainerMount(c container) (bool, error)
-	ContainerUmount(c container, path string) (bool, error)
-	ContainerRename(container container, newName string) error
-	ContainerRestore(container container, sourceContainer container) error
-	ContainerGetUsage(container container) (int64, error)
+	ContainerCreateFromImage(c Instance, fingerprint string, tracker *ioprogress.ProgressTracker) error
+	ContainerDelete(c Instance) error
+	ContainerCopy(target Instance, source Instance, containerOnly bool) error
+	ContainerRefresh(target Instance, source Instance, snapshots []Instance) error
+	ContainerMount(c Instance) (bool, error)
+	ContainerUmount(c Instance, path string) (bool, error)
+	ContainerRename(container Instance, newName string) error
+	ContainerRestore(container Instance, sourceContainer Instance) error
+	ContainerGetUsage(container Instance) (int64, error)
 	GetContainerPoolInfo() (int64, string, string)
-	ContainerStorageReady(container container) bool
+	ContainerStorageReady(container Instance) bool
 
-	ContainerSnapshotCreate(target container, source container) error
-	ContainerSnapshotDelete(c container) error
-	ContainerSnapshotRename(c container, newName string) error
-	ContainerSnapshotStart(c container) (bool, error)
-	ContainerSnapshotStop(c container) (bool, error)
+	ContainerSnapshotCreate(target Instance, source Instance) error
+	ContainerSnapshotDelete(c Instance) error
+	ContainerSnapshotRename(c Instance, newName string) error
+	ContainerSnapshotStart(c Instance) (bool, error)
+	ContainerSnapshotStop(c Instance) (bool, error)
 
-	ContainerBackupCreate(backup backup, sourceContainer container) error
+	ContainerBackupCreate(backup backup, sourceContainer Instance) error
 	ContainerBackupLoad(info backupInfo, data io.ReadSeeker, tarArgs []string) error
 
 	// For use in migrating snapshots.
-	ContainerSnapshotCreateEmpty(c container) error
+	ContainerSnapshotCreateEmpty(c Instance) error
 
 	// Functions dealing with image storage volumes.
 	ImageCreate(fingerprint string, tracker *ioprogress.ProgressTracker) error

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -727,8 +727,7 @@ func (s *storageCeph) getRBDMountOptions() string {
 // copyWithoutSnapshotsFull creates a non-sparse copy of a container
 // This does not introduce a dependency relation between the source RBD storage
 // volume and the target RBD storage volume.
-func (s *storageCeph) copyWithoutSnapshotsFull(target container,
-	source container) error {
+func (s *storageCeph) copyWithoutSnapshotsFull(target Instance, source Instance) error {
 	logger.Debugf(`Creating non-sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(), target.Name())
 
 	sourceIsSnapshot := source.IsSnapshot()
@@ -796,8 +795,7 @@ func (s *storageCeph) copyWithoutSnapshotsFull(target container,
 // copyWithoutSnapshotsFull creates a sparse copy of a container
 // This introduces a dependency relation between the source RBD storage volume
 // and the target RBD storage volume.
-func (s *storageCeph) copyWithoutSnapshotsSparse(target container,
-	source container) error {
+func (s *storageCeph) copyWithoutSnapshotsSparse(target Instance, source Instance) error {
 	logger.Debugf(`Creating sparse copy of RBD storage volume for container "%s" to "%s" without snapshots`, source.Name(),
 		target.Name())
 
@@ -1586,7 +1584,7 @@ func (s *storageCeph) cephRBDVolumeDumpToFile(sourceVolumeName string, file stri
 }
 
 // cephRBDVolumeBackupCreate creates a backup of a container or snapshot.
-func (s *storageCeph) cephRBDVolumeBackupCreate(tmpPath string, backup backup, source container) error {
+func (s *storageCeph) cephRBDVolumeBackupCreate(tmpPath string, backup backup, source Instance) error {
 	sourceIsSnapshot := source.IsSnapshot()
 	sourceContainerName := source.Name()
 	sourceContainerOnlyName := project.Prefix(source.Project(), sourceContainerName)

--- a/lxd/storage_cephfs.go
+++ b/lxd/storage_cephfs.go
@@ -618,81 +618,81 @@ func (s *storageCephFs) StoragePoolVolumeRename(newName string) error {
 	return nil
 }
 
-func (s *storageCephFs) ContainerStorageReady(container container) bool {
+func (s *storageCephFs) ContainerStorageReady(container Instance) bool {
 	containerMntPoint := driver.GetContainerMountPoint(container.Project(), s.pool.Name, container.Name())
 	ok, _ := shared.PathIsEmpty(containerMntPoint)
 	return !ok
 }
 
-func (s *storageCephFs) ContainerCreate(container container) error {
+func (s *storageCephFs) ContainerCreate(container Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerCreateFromImage(container container, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
+func (s *storageCephFs) ContainerCreateFromImage(container Instance, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerCanRestore(container container, sourceContainer container) error {
+func (s *storageCephFs) ContainerCanRestore(container Instance, sourceContainer Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerDelete(container container) error {
+func (s *storageCephFs) ContainerDelete(container Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerCopy(target container, source container, containerOnly bool) error {
+func (s *storageCephFs) ContainerCopy(target Instance, source Instance, containerOnly bool) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerRefresh(target container, source container, snapshots []container) error {
+func (s *storageCephFs) ContainerRefresh(target Instance, source Instance, snapshots []Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerMount(c container) (bool, error) {
+func (s *storageCephFs) ContainerMount(c Instance) (bool, error) {
 	return false, fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerUmount(c container, path string) (bool, error) {
+func (s *storageCephFs) ContainerUmount(c Instance, path string) (bool, error) {
 	return false, fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerRename(container container, newName string) error {
+func (s *storageCephFs) ContainerRename(container Instance, newName string) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerRestore(container container, sourceContainer container) error {
+func (s *storageCephFs) ContainerRestore(container Instance, sourceContainer Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerGetUsage(c container) (int64, error) {
+func (s *storageCephFs) ContainerGetUsage(c Instance) (int64, error) {
 	return -1, fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+func (s *storageCephFs) ContainerSnapshotCreate(snapshotContainer Instance, sourceContainer Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+func (s *storageCephFs) ContainerSnapshotCreateEmpty(snapshotContainer Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotDelete(snapshotContainer container) error {
+func (s *storageCephFs) ContainerSnapshotDelete(snapshotContainer Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+func (s *storageCephFs) ContainerSnapshotRename(snapshotContainer Instance, newName string) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotStart(container container) (bool, error) {
+func (s *storageCephFs) ContainerSnapshotStart(container Instance) (bool, error) {
 	return false, fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerSnapshotStop(container container) (bool, error) {
+func (s *storageCephFs) ContainerSnapshotStop(container Instance) (bool, error) {
 	return false, fmt.Errorf("CEPHFS cannot be used for containers")
 }
 
-func (s *storageCephFs) ContainerBackupCreate(backup backup, source container) error {
+func (s *storageCephFs) ContainerBackupCreate(backup backup, source Instance) error {
 	return fmt.Errorf("CEPHFS cannot be used for containers")
 }
 

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -488,13 +488,13 @@ func (s *storageDir) StoragePoolVolumeRename(newName string) error {
 		storagePoolVolumeTypeCustom, s.poolID)
 }
 
-func (s *storageDir) ContainerStorageReady(container container) bool {
+func (s *storageDir) ContainerStorageReady(container Instance) bool {
 	containerMntPoint := driver.GetContainerMountPoint(container.Project(), s.pool.Name, container.Name())
 	ok, _ := shared.PathIsEmpty(containerMntPoint)
 	return !ok
 }
 
-func (s *storageDir) ContainerCreate(container container) error {
+func (s *storageDir) ContainerCreate(container Instance) error {
 	logger.Debugf("Creating empty DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -536,7 +536,7 @@ func (s *storageDir) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageDir) ContainerCreateFromImage(container container, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
+func (s *storageDir) ContainerCreateFromImage(container Instance, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf("Creating DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -586,7 +586,7 @@ func (s *storageDir) ContainerCreateFromImage(container container, imageFingerpr
 	return nil
 }
 
-func (s *storageDir) ContainerDelete(container container) error {
+func (s *storageDir) ContainerDelete(container Instance) error {
 	logger.Debugf("Deleting DIR storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	source := s.pool.Config["source"]
@@ -648,7 +648,7 @@ func (s *storageDir) ContainerDelete(container container) error {
 	return nil
 }
 
-func (s *storageDir) copyContainer(target container, source container) error {
+func (s *storageDir) copyContainer(target Instance, source Instance) error {
 	_, sourcePool, _ := source.Storage().GetContainerPoolInfo()
 	_, targetPool, _ := target.Storage().GetContainerPoolInfo()
 	sourceContainerMntPoint := driver.GetContainerMountPoint(source.Project(), sourcePool, source.Name())
@@ -705,7 +705,7 @@ func (s *storageDir) copySnapshot(target container, targetPool string, source co
 	return nil
 }
 
-func (s *storageDir) ContainerCopy(target container, source container, containerOnly bool) error {
+func (s *storageDir) ContainerCopy(target Instance, source Instance, containerOnly bool) error {
 	logger.Debugf("Copying DIR container storage %s to %s", source.Name(), target.Name())
 
 	err := s.doContainerCopy(target, source, containerOnly, false, nil)
@@ -717,7 +717,7 @@ func (s *storageDir) ContainerCopy(target container, source container, container
 	return nil
 }
 
-func (s *storageDir) doContainerCopy(target container, source container, containerOnly bool, refresh bool, refreshSnapshots []container) error {
+func (s *storageDir) doContainerCopy(target Instance, source Instance, containerOnly bool, refresh bool, refreshSnapshots []Instance) error {
 	_, err := s.StoragePoolMount()
 	if err != nil {
 		return err
@@ -767,7 +767,7 @@ func (s *storageDir) doContainerCopy(target container, source container, contain
 		return nil
 	}
 
-	var snapshots []container
+	var snapshots []Instance
 
 	if refresh {
 		snapshots = refreshSnapshots
@@ -804,7 +804,7 @@ func (s *storageDir) doContainerCopy(target container, source container, contain
 	return nil
 }
 
-func (s *storageDir) ContainerRefresh(target container, source container, snapshots []container) error {
+func (s *storageDir) ContainerRefresh(target Instance, source Instance, snapshots []Instance) error {
 	logger.Debugf("Refreshing DIR container storage for %s from %s", target.Name(), source.Name())
 
 	err := s.doContainerCopy(target, source, len(snapshots) == 0, true, snapshots)
@@ -816,15 +816,15 @@ func (s *storageDir) ContainerRefresh(target container, source container, snapsh
 	return nil
 }
 
-func (s *storageDir) ContainerMount(c container) (bool, error) {
+func (s *storageDir) ContainerMount(c Instance) (bool, error) {
 	return s.StoragePoolMount()
 }
 
-func (s *storageDir) ContainerUmount(c container, path string) (bool, error) {
+func (s *storageDir) ContainerUmount(c Instance, path string) (bool, error) {
 	return true, nil
 }
 
-func (s *storageDir) ContainerRename(container container, newName string) error {
+func (s *storageDir) ContainerRename(container Instance, newName string) error {
 	logger.Debugf("Renaming DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	_, err := s.StoragePoolMount()
@@ -879,7 +879,7 @@ func (s *storageDir) ContainerRename(container container, newName string) error 
 	return nil
 }
 
-func (s *storageDir) ContainerRestore(container container, sourceContainer container) error {
+func (s *storageDir) ContainerRestore(container Instance, sourceContainer Instance) error {
 	logger.Debugf("Restoring DIR storage volume for container \"%s\" from %s to %s", s.volume.Name, sourceContainer.Name(), container.Name())
 
 	_, err := s.StoragePoolMount()
@@ -901,7 +901,7 @@ func (s *storageDir) ContainerRestore(container container, sourceContainer conta
 	return nil
 }
 
-func (s *storageDir) ContainerGetUsage(c container) (int64, error) {
+func (s *storageDir) ContainerGetUsage(c Instance) (int64, error) {
 	path := driver.GetContainerMountPoint(c.Project(), s.pool.Name, c.Name())
 
 	ok, err := quota.Supported(path)
@@ -918,7 +918,7 @@ func (s *storageDir) ContainerGetUsage(c container) (int64, error) {
 	return size, nil
 }
 
-func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+func (s *storageDir) ContainerSnapshotCreate(snapshotContainer Instance, sourceContainer Instance) error {
 	logger.Debugf("Creating DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -934,7 +934,7 @@ func (s *storageDir) ContainerSnapshotCreate(snapshotContainer container, source
 		return err
 	}
 
-	rsync := func(snapshotContainer container, oldPath string, newPath string, bwlimit string) error {
+	rsync := func(snapshotContainer Instance, oldPath string, newPath string, bwlimit string) error {
 		output, err := rsyncLocalCopy(oldPath, newPath, bwlimit, true)
 		if err != nil {
 			s.ContainerDelete(snapshotContainer)
@@ -995,7 +995,7 @@ onSuccess:
 	return nil
 }
 
-func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+func (s *storageDir) ContainerSnapshotCreateEmpty(snapshotContainer Instance) error {
 	logger.Debugf("Creating empty DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1069,7 +1069,7 @@ func dirSnapshotDeleteInternal(projectName, poolName string, snapshotName string
 	return nil
 }
 
-func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error {
+func (s *storageDir) ContainerSnapshotDelete(snapshotContainer Instance) error {
 	logger.Debugf("Deleting DIR storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	_, err := s.StoragePoolMount()
@@ -1092,7 +1092,7 @@ func (s *storageDir) ContainerSnapshotDelete(snapshotContainer container) error 
 	return nil
 }
 
-func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newName string) error {
+func (s *storageDir) ContainerSnapshotRename(snapshotContainer Instance, newName string) error {
 	logger.Debugf("Renaming DIR storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newName)
 
 	_, err := s.StoragePoolMount()
@@ -1113,15 +1113,15 @@ func (s *storageDir) ContainerSnapshotRename(snapshotContainer container, newNam
 	return nil
 }
 
-func (s *storageDir) ContainerSnapshotStart(container container) (bool, error) {
+func (s *storageDir) ContainerSnapshotStart(container Instance) (bool, error) {
 	return s.StoragePoolMount()
 }
 
-func (s *storageDir) ContainerSnapshotStop(container container) (bool, error) {
+func (s *storageDir) ContainerSnapshotStop(container Instance) (bool, error) {
 	return true, nil
 }
 
-func (s *storageDir) ContainerBackupCreate(backup backup, source container) error {
+func (s *storageDir) ContainerBackupCreate(backup backup, source Instance) error {
 	// Start storage
 	ourStart, err := source.StorageStart()
 	if err != nil {

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -916,7 +916,7 @@ func (s *storageLvm) StoragePoolVolumeRename(newName string) error {
 		storagePoolVolumeTypeCustom, s.poolID)
 }
 
-func (s *storageLvm) ContainerStorageReady(container container) bool {
+func (s *storageLvm) ContainerStorageReady(container Instance) bool {
 	containerLvmName := containerNameToLVName(container.Name())
 	poolName := s.getOnDiskPoolName()
 	containerLvmPath := getLvmDevPath(container.Project(), poolName, storagePoolVolumeAPIEndpointContainers, containerLvmName)
@@ -924,7 +924,7 @@ func (s *storageLvm) ContainerStorageReady(container container) bool {
 	return ok
 }
 
-func (s *storageLvm) ContainerCreate(container container) error {
+func (s *storageLvm) ContainerCreate(container Instance) error {
 	logger.Debugf("Creating empty LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	tryUndo := true
@@ -988,7 +988,7 @@ func (s *storageLvm) ContainerCreate(container container) error {
 	return nil
 }
 
-func (s *storageLvm) ContainerCreateFromImage(container container, fingerprint string, tracker *ioprogress.ProgressTracker) error {
+func (s *storageLvm) ContainerCreateFromImage(container Instance, fingerprint string, tracker *ioprogress.ProgressTracker) error {
 	logger.Debugf("Creating LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	tryUndo := true
@@ -1107,7 +1107,7 @@ func lvmContainerDeleteInternal(projectName, poolName string, ctName string, isS
 	return nil
 }
 
-func (s *storageLvm) ContainerDelete(container container) error {
+func (s *storageLvm) ContainerDelete(container Instance) error {
 	logger.Debugf("Deleting LVM storage volume for container \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerName := container.Name()
@@ -1121,7 +1121,7 @@ func (s *storageLvm) ContainerDelete(container container) error {
 	return nil
 }
 
-func (s *storageLvm) ContainerCopy(target container, source container, containerOnly bool) error {
+func (s *storageLvm) ContainerCopy(target Instance, source Instance, containerOnly bool) error {
 	logger.Debugf("Copying LVM container storage for container %s to %s", source.Name(), target.Name())
 
 	err := s.doContainerCopy(target, source, containerOnly, false, nil)
@@ -1133,7 +1133,7 @@ func (s *storageLvm) ContainerCopy(target container, source container, container
 	return nil
 }
 
-func (s *storageLvm) doContainerCopy(target container, source container, containerOnly bool, refresh bool, refreshSnapshots []container) error {
+func (s *storageLvm) doContainerCopy(target Instance, source Instance, containerOnly bool, refresh bool, refreshSnapshots []Instance) error {
 	ourStart, err := source.StorageStart()
 	if err != nil {
 		return err
@@ -1177,7 +1177,7 @@ func (s *storageLvm) doContainerCopy(target container, source container, contain
 		return nil
 	}
 
-	var snapshots []container
+	var snapshots []Instance
 
 	if refresh {
 		snapshots = refreshSnapshots
@@ -1219,7 +1219,7 @@ func (s *storageLvm) doContainerCopy(target container, source container, contain
 	return nil
 }
 
-func (s *storageLvm) ContainerRefresh(target container, source container, snapshots []container) error {
+func (s *storageLvm) ContainerRefresh(target Instance, source Instance, snapshots []Instance) error {
 	logger.Debugf("Refreshing LVM container storage for %s from %s", target.Name(), source.Name())
 
 	err := s.doContainerCopy(target, source, len(snapshots) == 0, true, snapshots)
@@ -1231,7 +1231,7 @@ func (s *storageLvm) ContainerRefresh(target container, source container, snapsh
 	return nil
 }
 
-func (s *storageLvm) ContainerMount(c container) (bool, error) {
+func (s *storageLvm) ContainerMount(c Instance) (bool, error) {
 	return s.doContainerMount(c.Project(), c.Name(), false)
 }
 
@@ -1292,7 +1292,7 @@ func (s *storageLvm) doContainerMount(project, name string, snap bool) (bool, er
 	return ourMount, nil
 }
 
-func (s *storageLvm) ContainerUmount(c container, path string) (bool, error) {
+func (s *storageLvm) ContainerUmount(c Instance, path string) (bool, error) {
 	return s.umount(c.Project(), c.Name(), path)
 }
 
@@ -1340,7 +1340,7 @@ func (s *storageLvm) umount(project, name string, path string) (bool, error) {
 	return ourUmount, nil
 }
 
-func (s *storageLvm) ContainerRename(container container, newContainerName string) error {
+func (s *storageLvm) ContainerRename(container Instance, newContainerName string) error {
 	logger.Debugf("Renaming LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 
 	tryUndo := true
@@ -1421,7 +1421,7 @@ func (s *storageLvm) ContainerRename(container container, newContainerName strin
 	return nil
 }
 
-func (s *storageLvm) ContainerRestore(target container, source container) error {
+func (s *storageLvm) ContainerRestore(target Instance, source Instance) error {
 	logger.Debugf("Restoring LVM storage volume for container \"%s\" from %s to %s", s.volume.Name, source.Name(), target.Name())
 
 	_, sourcePool, _ := source.Storage().GetContainerPoolInfo()
@@ -1500,11 +1500,11 @@ func (s *storageLvm) ContainerRestore(target container, source container) error 
 	return nil
 }
 
-func (s *storageLvm) ContainerGetUsage(container container) (int64, error) {
+func (s *storageLvm) ContainerGetUsage(container Instance) (int64, error) {
 	return -1, fmt.Errorf("the LVM container backend doesn't support quotas")
 }
 
-func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer container, sourceContainer container) error {
+func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer Instance, sourceContainer Instance) error {
 	logger.Debugf("Creating LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.createSnapshotContainer(snapshotContainer, sourceContainer, true)
@@ -1516,7 +1516,7 @@ func (s *storageLvm) ContainerSnapshotCreate(snapshotContainer container, source
 	return nil
 }
 
-func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer container) error {
+func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer Instance) error {
 	logger.Debugf("Deleting LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.ContainerDelete(snapshotContainer)
@@ -1528,7 +1528,7 @@ func (s *storageLvm) ContainerSnapshotDelete(snapshotContainer container) error 
 	return nil
 }
 
-func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newContainerName string) error {
+func (s *storageLvm) ContainerSnapshotRename(snapshotContainer Instance, newContainerName string) error {
 	logger.Debugf("Renaming LVM storage volume for snapshot \"%s\" from %s to %s", s.volume.Name, s.volume.Name, newContainerName)
 
 	tryUndo := true
@@ -1560,7 +1560,7 @@ func (s *storageLvm) ContainerSnapshotRename(snapshotContainer container, newCon
 	return nil
 }
 
-func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
+func (s *storageLvm) ContainerSnapshotStart(container Instance) (bool, error) {
 	logger.Debugf(`Initializing LVM storage volume for snapshot "%s" on storage pool "%s"`, s.volume.Name, s.pool.Name)
 
 	poolName := s.getOnDiskPoolName()
@@ -1610,7 +1610,7 @@ func (s *storageLvm) ContainerSnapshotStart(container container) (bool, error) {
 	return true, nil
 }
 
-func (s *storageLvm) ContainerSnapshotStop(container container) (bool, error) {
+func (s *storageLvm) ContainerSnapshotStop(container Instance) (bool, error) {
 	logger.Debugf("Stopping LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	containerName := container.Name()
@@ -1649,7 +1649,7 @@ func (s *storageLvm) ContainerSnapshotStop(container container) (bool, error) {
 	return true, nil
 }
 
-func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer Instance) error {
 	logger.Debugf("Creating empty LVM storage volume for snapshot \"%s\" on storage pool \"%s\"", s.volume.Name, s.pool.Name)
 
 	err := s.ContainerCreate(snapshotContainer)
@@ -1661,7 +1661,7 @@ func (s *storageLvm) ContainerSnapshotCreateEmpty(snapshotContainer container) e
 	return nil
 }
 
-func (s *storageLvm) ContainerBackupCreate(backup backup, source container) error {
+func (s *storageLvm) ContainerBackupCreate(backup backup, source Instance) error {
 	poolName := s.getOnDiskPoolName()
 
 	// Start storage

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -257,7 +257,7 @@ func (s *storageLvm) createSnapshotLV(project, vgName string, origLvName string,
 	return targetLvmVolumePath, nil
 }
 
-func (s *storageLvm) createSnapshotContainer(snapshotContainer container, sourceContainer container, readonly bool) error {
+func (s *storageLvm) createSnapshotContainer(snapshotContainer Instance, sourceContainer Instance, readonly bool) error {
 	tryUndo := true
 
 	sourceContainerName := sourceContainer.Name()
@@ -304,7 +304,7 @@ func (s *storageLvm) createSnapshotContainer(snapshotContainer container, source
 }
 
 // Copy a container on a storage pool that does use a thinpool.
-func (s *storageLvm) copyContainerThinpool(target container, source container, readonly bool) error {
+func (s *storageLvm) copyContainerThinpool(target Instance, source Instance, readonly bool) error {
 	err := s.createSnapshotContainer(target, source, readonly)
 	if err != nil {
 		logger.Errorf("Error creating snapshot LV for copy: %s", err)
@@ -371,7 +371,7 @@ func (s *storageLvm) copySnapshot(target container, source container, refresh bo
 }
 
 // Copy a container on a storage pool that does not use a thinpool.
-func (s *storageLvm) copyContainerLv(target container, source container, readonly bool, refresh bool) error {
+func (s *storageLvm) copyContainerLv(target Instance, source Instance, readonly bool, refresh bool) error {
 	exists, err := storageLVExists(getLvmDevPath(target.Project(), s.getOnDiskPoolName(),
 		storagePoolVolumeAPIEndpointContainers, containerNameToLVName(target.Name())))
 	if err != nil {
@@ -446,7 +446,7 @@ func (s *storageLvm) copyContainerLv(target container, source container, readonl
 }
 
 // Copy an lvm container.
-func (s *storageLvm) copyContainer(target container, source container, refresh bool) error {
+func (s *storageLvm) copyContainer(target Instance, source Instance, refresh bool) error {
 	targetPool, err := target.StoragePool()
 	if err != nil {
 		return err
@@ -484,7 +484,7 @@ func (s *storageLvm) copyContainer(target container, source container, refresh b
 	return nil
 }
 
-func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
+func (s *storageLvm) containerCreateFromImageLv(c Instance, fp string) error {
 	containerName := c.Name()
 
 	err := s.ContainerCreate(c)
@@ -516,7 +516,7 @@ func (s *storageLvm) containerCreateFromImageLv(c container, fp string) error {
 	return nil
 }
 
-func (s *storageLvm) containerCreateFromImageThinLv(c container, fp string) error {
+func (s *storageLvm) containerCreateFromImageThinLv(c Instance, fp string) error {
 	poolName := s.getOnDiskPoolName()
 	// Check if the image already exists.
 	imageLvmDevPath := getLvmDevPath("default", poolName, storagePoolVolumeAPIEndpointImages, fp)

--- a/lxd/storage_migration.go
+++ b/lxd/storage_migration.go
@@ -41,8 +41,8 @@ type MigrationStorageSourceDriver interface {
 }
 
 type rsyncStorageSourceDriver struct {
-	container     container
-	snapshots     []container
+	container     Instance
+	snapshots     []Instance
 	rsyncFeatures []string
 }
 
@@ -145,7 +145,7 @@ func rsyncStorageMigrationSource(args MigrationSourceArgs) (MigrationStorageSour
 }
 
 func rsyncRefreshSource(refreshSnapshots []string, args MigrationSourceArgs) (MigrationStorageSourceDriver, error) {
-	var snapshots = []container{}
+	var snapshots = []Instance{}
 	if !args.InstanceOnly {
 		allSnapshots, err := args.Container.Snapshots()
 		if err != nil {
@@ -167,7 +167,7 @@ func rsyncRefreshSource(refreshSnapshots []string, args MigrationSourceArgs) (Mi
 
 func rsyncMigrationSource(args MigrationSourceArgs) (MigrationStorageSourceDriver, error) {
 	var err error
-	var snapshots = []container{}
+	var snapshots = []Instance{}
 	if !args.InstanceOnly {
 		snapshots, err = args.Container.Snapshots()
 		if err != nil {

--- a/lxd/storage_migration_btrfs.go
+++ b/lxd/storage_migration_btrfs.go
@@ -15,8 +15,8 @@ import (
 )
 
 type btrfsMigrationSourceDriver struct {
-	container          container
-	snapshots          []container
+	container          Instance
+	snapshots          []Instance
 	btrfsSnapshotNames []string
 	btrfs              *storageBtrfs
 	runningSnapName    string

--- a/lxd/storage_mock.go
+++ b/lxd/storage_mock.go
@@ -109,87 +109,73 @@ func (s *storageMock) StoragePoolUpdate(writable *api.StoragePoolPut, changedCon
 	return nil
 }
 
-func (s *storageMock) ContainerStorageReady(container container) bool {
+func (s *storageMock) ContainerStorageReady(container Instance) bool {
 	return true
 }
 
-func (s *storageMock) ContainerCreate(container container) error {
+func (s *storageMock) ContainerCreate(container Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerCreateFromImage(
-	container container, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
-
+func (s *storageMock) ContainerCreateFromImage(container Instance, imageFingerprint string, tracker *ioprogress.ProgressTracker) error {
 	return nil
 }
 
-func (s *storageMock) ContainerDelete(container container) error {
+func (s *storageMock) ContainerDelete(container Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerCopy(target container, source container, containerOnly bool) error {
+func (s *storageMock) ContainerCopy(target Instance, source Instance, containerOnly bool) error {
 	return nil
 }
 
-func (s *storageMock) ContainerRefresh(target container, source container, snapshots []container) error {
+func (s *storageMock) ContainerRefresh(target Instance, source Instance, snapshots []Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerMount(c container) (bool, error) {
+func (s *storageMock) ContainerMount(c Instance) (bool, error) {
 	return true, nil
 }
 
-func (s *storageMock) ContainerUmount(c container, path string) (bool, error) {
+func (s *storageMock) ContainerUmount(c Instance, path string) (bool, error) {
 	return true, nil
 }
 
-func (s *storageMock) ContainerRename(
-	container container, newName string) error {
-
+func (s *storageMock) ContainerRename(container Instance, newName string) error {
 	return nil
 }
 
-func (s *storageMock) ContainerRestore(
-	container container, sourceContainer container) error {
-
+func (s *storageMock) ContainerRestore(container Instance, sourceContainer Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerGetUsage(
-	container container) (int64, error) {
-
+func (s *storageMock) ContainerGetUsage(container Instance) (int64, error) {
 	return 0, nil
 }
-func (s *storageMock) ContainerSnapshotCreate(
-	snapshotContainer container, sourceContainer container) error {
-
+func (s *storageMock) ContainerSnapshotCreate(snapshotContainer Instance, sourceContainer Instance) error {
 	return nil
 }
-func (s *storageMock) ContainerSnapshotDelete(
-	snapshotContainer container) error {
-
+func (s *storageMock) ContainerSnapshotDelete(snapshotContainer Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerSnapshotRename(
-	snapshotContainer container, newName string) error {
-
+func (s *storageMock) ContainerSnapshotRename(snapshotContainer Instance, newName string) error {
 	return nil
 }
 
-func (s *storageMock) ContainerSnapshotStart(container container) (bool, error) {
+func (s *storageMock) ContainerSnapshotStart(container Instance) (bool, error) {
 	return true, nil
 }
 
-func (s *storageMock) ContainerSnapshotStop(container container) (bool, error) {
+func (s *storageMock) ContainerSnapshotStop(container Instance) (bool, error) {
 	return true, nil
 }
 
-func (s *storageMock) ContainerSnapshotCreateEmpty(snapshotContainer container) error {
+func (s *storageMock) ContainerSnapshotCreateEmpty(snapshotContainer Instance) error {
 	return nil
 }
 
-func (s *storageMock) ContainerBackupCreate(backup backup, sourceContainer container) error {
+func (s *storageMock) ContainerBackupCreate(backup backup, sourceContainer Instance) error {
 	return nil
 }
 


### PR DESCRIPTION
- Adds `Instance` interface in main package.
- Modifies `Snapshots()` and `Restore()` definitions to accept/return Interface type.
- Embeds `Instance` interface into `container` interface (and removes duplicated definitions).
- Updates Storage API to use `Instance` rather than `container` to support the `Snapshots()` and `Restore()` change.