### PR TITLE
Instances containerLoadByID and containerLoadByProjectAndName rename

### DIFF
--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -125,9 +125,14 @@ func internalContainerOnStart(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	c, err := containerLoadById(d.State(), id)
+	instance, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
+	}
+
+	c, ok := instance.(container)
+	if !ok {
+		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
 	err = c.OnStart()
@@ -151,9 +156,14 @@ func internalContainerOnStopNS(d *Daemon, r *http.Request) Response {
 	}
 	netns := queryParam(r, "netns")
 
-	c, err := containerLoadById(d.State(), id)
+	instance, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
+	}
+
+	c, ok := instance.(container)
+	if !ok {
+		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
 	err = c.OnStopNS(target, netns)
@@ -176,9 +186,14 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 		target = "unknown"
 	}
 
-	c, err := containerLoadById(d.State(), id)
+	instance, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
+	}
+
+	c, ok := instance.(container)
+	if !ok {
+		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
 	err = c.OnStop(target)

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -125,16 +125,16 @@ func internalContainerOnStart(d *Daemon, r *http.Request) Response {
 		return SmartError(err)
 	}
 
-	instance, err := instanceLoadById(d.State(), id)
+	inst, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
 	}
 
-	c, ok := instance.(container)
-	if !ok {
+	if inst.Type() != instance.TypeContainer {
 		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
+	c := inst.(container)
 	err = c.OnStart()
 	if err != nil {
 		logger.Error("The start hook failed", log.Ctx{"container": c.Name(), "err": err})
@@ -156,16 +156,16 @@ func internalContainerOnStopNS(d *Daemon, r *http.Request) Response {
 	}
 	netns := queryParam(r, "netns")
 
-	instance, err := instanceLoadById(d.State(), id)
+	inst, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
 	}
 
-	c, ok := instance.(container)
-	if !ok {
+	if inst.Type() != instance.TypeContainer {
 		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
+	c := inst.(container)
 	err = c.OnStopNS(target, netns)
 	if err != nil {
 		logger.Error("The stopns hook failed", log.Ctx{"container": c.Name(), "err": err})
@@ -186,16 +186,16 @@ func internalContainerOnStop(d *Daemon, r *http.Request) Response {
 		target = "unknown"
 	}
 
-	instance, err := instanceLoadById(d.State(), id)
+	inst, err := instanceLoadById(d.State(), id)
 	if err != nil {
 		return SmartError(err)
 	}
 
-	c, ok := instance.(container)
-	if !ok {
+	if inst.Type() != instance.TypeContainer {
 		return SmartError(fmt.Errorf("Instance is not container type"))
 	}
 
+	c := inst.(container)
 	err = c.OnStop(target)
 	if err != nil {
 		logger.Error("The stop hook failed", log.Ctx{"container": c.Name(), "err": err})

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -52,7 +52,7 @@ func backupLoadByName(s *state.State, project, name string) (*backup, error) {
 }
 
 // Create a new backup
-func backupCreate(s *state.State, args db.ContainerBackupArgs, sourceContainer container) error {
+func backupCreate(s *state.State, args db.ContainerBackupArgs, sourceContainer Instance) error {
 	// Create the database entry
 	err := s.Cluster.ContainerBackupCreate(args)
 	if err != nil {

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -933,7 +933,7 @@ func containerConfigureInternal(c container) error {
 	return nil
 }
 
-func containerLoadById(s *state.State, id int) (container, error) {
+func instanceLoadById(s *state.State, id int) (Instance, error) {
 	// Get the DB record
 	project, name, err := s.Cluster.ContainerProjectAndName(id)
 	if err != nil {

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -51,10 +51,10 @@ func init() {
 		return identifiers, nil
 	}
 
-	// Expose containerLoadByProjectAndName to the device package converting the response to an InstanceIdentifier.
+	// Expose instanceLoadByProjectAndName to the device package converting the response to an InstanceIdentifier.
 	// This is because container types are defined in the main package and are not importable.
 	device.InstanceLoadByProjectAndName = func(s *state.State, project, name string) (device.InstanceIdentifier, error) {
-		container, err := containerLoadByProjectAndName(s, project, name)
+		container, err := instanceLoadByProjectAndName(s, project, name)
 		if err != nil {
 			return nil, err
 		}
@@ -428,13 +428,13 @@ func containerCreateFromImage(d *Daemon, args db.ContainerArgs, hash string, tra
 	return c, nil
 }
 
-func containerCreateAsCopy(s *state.State, args db.ContainerArgs, sourceContainer container, containerOnly bool, refresh bool) (container, error) {
-	var ct container
+func containerCreateAsCopy(s *state.State, args db.ContainerArgs, sourceContainer Instance, containerOnly bool, refresh bool) (Instance, error) {
+	var ct Instance
 	var err error
 
 	if refresh {
 		// Load the target container
-		ct, err = containerLoadByProjectAndName(s, args.Project, args.Name)
+		ct, err = instanceLoadByProjectAndName(s, args.Project, args.Name)
 		if err != nil {
 			refresh = false
 		}
@@ -597,11 +597,15 @@ func containerCreateAsCopy(s *state.State, args db.ContainerArgs, sourceContaine
 	return ct, nil
 }
 
-func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceContainer container) (container, error) {
+func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceInstance Instance) (Instance, error) {
+	if sourceInstance.Type() != instance.TypeContainer {
+		return nil, fmt.Errorf("Instance not container type")
+	}
+
 	// Deal with state
 	if args.Stateful {
-		if !sourceContainer.IsRunning() {
-			return nil, fmt.Errorf("Unable to create a stateful snapshot. The container isn't running")
+		if !sourceInstance.IsRunning() {
+			return nil, fmt.Errorf("Unable to create a stateful snapshot. The instance isn't running")
 		}
 
 		_, err := exec.LookPath("criu")
@@ -609,7 +613,7 @@ func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceCont
 			return nil, fmt.Errorf("Unable to create a stateful snapshot. CRIU isn't installed")
 		}
 
-		stateDir := sourceContainer.StatePath()
+		stateDir := sourceInstance.StatePath()
 		err = os.MkdirAll(stateDir, 0700)
 		if err != nil {
 			return nil, err
@@ -635,9 +639,10 @@ func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceCont
 			preDumpDir:   "",
 		}
 
-		err = sourceContainer.Migrate(&criuMigrationArgs)
+		c := sourceInstance.(container)
+		err = c.Migrate(&criuMigrationArgs)
 		if err != nil {
-			os.RemoveAll(sourceContainer.StatePath())
+			os.RemoveAll(sourceInstance.StatePath())
 			return nil, err
 		}
 	}
@@ -649,23 +654,23 @@ func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceCont
 	}
 
 	// Clone the container
-	err = sourceContainer.Storage().ContainerSnapshotCreate(c, sourceContainer)
+	err = sourceInstance.Storage().ContainerSnapshotCreate(c, sourceInstance)
 	if err != nil {
 		c.Delete()
 		return nil, err
 	}
 
 	// Attempt to update backup.yaml on container
-	ourStart, err := sourceContainer.StorageStart()
+	ourStart, err := sourceInstance.StorageStart()
 	if err != nil {
 		c.Delete()
 		return nil, err
 	}
 	if ourStart {
-		defer sourceContainer.StorageStop()
+		defer sourceInstance.StorageStop()
 	}
 
-	err = writeBackupFile(sourceContainer)
+	err = writeBackupFile(sourceInstance)
 	if err != nil {
 		c.Delete()
 		return nil, err
@@ -673,11 +678,11 @@ func containerCreateAsSnapshot(s *state.State, args db.ContainerArgs, sourceCont
 
 	// Once we're done, remove the state directory
 	if args.Stateful {
-		os.RemoveAll(sourceContainer.StatePath())
+		os.RemoveAll(sourceInstance.StatePath())
 	}
 
-	eventSendLifecycle(sourceContainer.Project(), "container-snapshot-created",
-		fmt.Sprintf("/1.0/containers/%s", sourceContainer.Name()),
+	eventSendLifecycle(sourceInstance.Project(), "container-snapshot-created",
+		fmt.Sprintf("/1.0/containers/%s", sourceInstance.Name()),
 		map[string]interface{}{
 			"snapshot_name": args.Name,
 		})
@@ -887,7 +892,7 @@ func containerCreateInternal(s *state.State, args db.ContainerArgs) (container, 
 	return c, nil
 }
 
-func containerConfigureInternal(c container) error {
+func containerConfigureInternal(c Instance) error {
 	// Find the root device
 	_, rootDiskDevice, err := shared.GetRootDiskDevice(c.ExpandedDevices().CloneNative())
 	if err != nil {
@@ -940,10 +945,10 @@ func instanceLoadById(s *state.State, id int) (Instance, error) {
 		return nil, err
 	}
 
-	return containerLoadByProjectAndName(s, project, name)
+	return instanceLoadByProjectAndName(s, project, name)
 }
 
-func containerLoadByProjectAndName(s *state.State, project, name string) (container, error) {
+func instanceLoadByProjectAndName(s *state.State, project, name string) (Instance, error) {
 	// Get the DB record
 	var container *db.Instance
 	err := s.Cluster.Transaction(func(tx *db.ClusterTx) error {
@@ -1133,7 +1138,7 @@ func containerLoadAllInternal(cts []db.Instance, s *state.State) ([]container, e
 	return containers, nil
 }
 
-func containerCompareSnapshots(source Instance, target container) ([]Instance, []Instance, error) {
+func containerCompareSnapshots(source Instance, target Instance) ([]Instance, []Instance, error) {
 	// Get the source snapshots
 	sourceSnapshots, err := source.Snapshots()
 	if err != nil {
@@ -1407,7 +1412,7 @@ func pruneExpiredContainerSnapshots(ctx context.Context, d *Daemon, snapshots []
 	return nil
 }
 
-func containerDetermineNextSnapshotName(d *Daemon, c container, defaultPattern string) (string, error) {
+func containerDetermineNextSnapshotName(d *Daemon, c Instance, defaultPattern string) (string, error) {
 	var err error
 
 	pattern := c.ExpandedConfig()["snapshots.pattern"]

--- a/lxd/container_backup.go
+++ b/lxd/container_backup.go
@@ -37,7 +37,7 @@ func containerBackupsGet(d *Daemon, r *http.Request) Response {
 
 	recursion := util.IsRecursionRequest(r)
 
-	c, err := containerLoadByProjectAndName(d.State(), project, cname)
+	c, err := instanceLoadByProjectAndName(d.State(), project, cname)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -86,7 +86,7 @@ func containerBackupsPost(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_delete.go
+++ b/lxd/container_delete.go
@@ -25,7 +25,7 @@ func containerDelete(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_file.go
+++ b/lxd/container_file.go
@@ -30,7 +30,7 @@ func containerFileHandler(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -52,7 +52,7 @@ func containerFileHandler(d *Daemon, r *http.Request) Response {
 	}
 }
 
-func containerFileGet(c container, path string, r *http.Request) Response {
+func containerFileGet(c Instance, path string, r *http.Request) Response {
 	/*
 	 * Copy out of the ns to a temporary file, and then use that to serve
 	 * the request from. This prevents us from having to worry about stuff
@@ -97,7 +97,7 @@ func containerFileGet(c container, path string, r *http.Request) Response {
 	}
 }
 
-func containerFilePost(c container, path string, r *http.Request) Response {
+func containerFilePost(c Instance, path string, r *http.Request) Response {
 	// Extract file ownership and mode from headers
 	uid, gid, mode, type_, write := shared.ParseLXDFileHeaders(r.Header)
 
@@ -150,7 +150,7 @@ func containerFilePost(c container, path string, r *http.Request) Response {
 	}
 }
 
-func containerFileDelete(c container, path string, r *http.Request) Response {
+func containerFileDelete(c Instance, path string, r *http.Request) Response {
 	err := c.FileRemove(path)
 	if err != nil {
 		return SmartError(err)

--- a/lxd/container_get.go
+++ b/lxd/container_get.go
@@ -24,7 +24,7 @@ func containerGet(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -4006,7 +4006,7 @@ type backupFile struct {
 	Volume    *api.StorageVolume      `yaml:"volume"`
 }
 
-func writeBackupFile(c container) error {
+func writeBackupFile(c Instance) error {
 	// We only write backup files out for actual containers
 	if c.IsSnapshot() {
 		return nil
@@ -4971,7 +4971,7 @@ func (c *containerLXC) Export(w io.Writer, properties map[string]string) error {
 		var arch string
 		if c.IsSnapshot() {
 			parentName, _, _ := shared.ContainerGetParentAndSnapshotName(c.name)
-			parent, err := containerLoadByProjectAndName(c.state, c.project, parentName)
+			parent, err := instanceLoadByProjectAndName(c.state, c.project, parentName)
 			if err != nil {
 				ctw.Close()
 				logger.Error("Failed exporting container", ctxMap)

--- a/lxd/container_metadata.go
+++ b/lxd/container_metadata.go
@@ -36,7 +36,7 @@ func containerMetadataGet(d *Daemon, r *http.Request) Response {
 	}
 
 	// Load the container
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -97,7 +97,7 @@ func containerMetadataPut(d *Daemon, r *http.Request) Response {
 	}
 
 	// Load the container
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -151,7 +151,7 @@ func containerMetadataTemplatesGet(d *Daemon, r *http.Request) Response {
 	}
 
 	// Load the container
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -245,7 +245,7 @@ func containerMetadataTemplatesPostPut(d *Daemon, r *http.Request) Response {
 	}
 
 	// Load the container
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -318,7 +318,7 @@ func containerMetadataTemplatesDelete(d *Daemon, r *http.Request) Response {
 	}
 
 	// Load the container
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -357,7 +357,7 @@ func containerMetadataTemplatesDelete(d *Daemon, r *http.Request) Response {
 }
 
 // Return the full path of a container template.
-func getContainerTemplatePath(c container, filename string) (string, error) {
+func getContainerTemplatePath(c Instance, filename string) (string, error) {
 	if strings.Contains(filename, "/") {
 		return "", fmt.Errorf("Invalid template filename")
 	}

--- a/lxd/container_patch.go
+++ b/lxd/container_patch.go
@@ -37,7 +37,7 @@ func containerPatch(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return NotFound(err)
 	}

--- a/lxd/container_put.go
+++ b/lxd/container_put.go
@@ -40,7 +40,7 @@ func containerPut(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return NotFound(err)
 	}
@@ -113,12 +113,12 @@ func containerSnapRestore(s *state.State, project, name, snap string, stateful b
 		snap = name + shared.SnapshotDelimiter + snap
 	}
 
-	c, err := containerLoadByProjectAndName(s, project, name)
+	c, err := instanceLoadByProjectAndName(s, project, name)
 	if err != nil {
 		return err
 	}
 
-	source, err := containerLoadByProjectAndName(s, project, snap)
+	source, err := instanceLoadByProjectAndName(s, project, snap)
 	if err != nil {
 		switch err {
 		case db.ErrNoSuchObject:

--- a/lxd/container_state.go
+++ b/lxd/container_state.go
@@ -31,7 +31,7 @@ func containerState(d *Daemon, r *http.Request) Response {
 		return response
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}
@@ -74,7 +74,7 @@ func containerStatePut(d *Daemon, r *http.Request) Response {
 	// Don't mess with containers while in setup mode
 	<-d.readyChan
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return SmartError(err)
 	}

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -133,7 +133,7 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 	defer c.Delete()
 
 	// Load the container and trigger initLXC()
-	c2, err := containerLoadByProjectAndName(suite.d.State(), "default", "testFoo")
+	c2, err := instanceLoadByProjectAndName(suite.d.State(), "default", "testFoo")
 	c2.IsRunning()
 	suite.Req.Nil(err)
 	_, err = c2.StorageStart()

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -358,7 +358,7 @@ func containerDeleteSnapshots(s *state.State, project, cname string) error {
 	}
 
 	for _, sname := range results {
-		sc, err := containerLoadByProjectAndName(s, project, sname)
+		sc, err := instanceLoadByProjectAndName(s, project, sname)
 		if err != nil {
 			logger.Error(
 				"containerDeleteSnapshots: Failed to load the snapshot container",

--- a/lxd/devlxd.go
+++ b/lxd/devlxd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/gorilla/websocket"
 	"github.com/pborman/uuid"
 
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
@@ -444,7 +445,17 @@ func findContainerForPid(pid int32, d *Daemon) (container, error) {
 				project = strings.Split(name, "_")[0]
 			}
 
-			return containerLoadByProjectAndName(d.State(), project, name)
+			inst, err := instanceLoadByProjectAndName(d.State(), project, name)
+			if err != nil {
+				return nil, err
+			}
+
+			if inst.Type() != instance.TypeContainer {
+				return nil, fmt.Errorf("Instance is not container type")
+			}
+
+			c := inst.(container)
+			return c, nil
 		}
 
 		status, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/status", pid))

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -186,7 +186,7 @@ func imgPostContInfo(d *Daemon, r *http.Request, req api.ImagesPost, op *operati
 		info.Public = false
 	}
 
-	c, err := containerLoadByProjectAndName(d.State(), project, name)
+	c, err := instanceLoadByProjectAndName(d.State(), project, name)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/main_activateifneeded.go
+++ b/lxd/main_activateifneeded.go
@@ -122,7 +122,7 @@ func (c *cmdActivateifneeded) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	for _, container := range containers {
-		c, err := containerLoadByProjectAndName(d.State(), container.Project, container.Name)
+		c, err := instanceLoadByProjectAndName(d.State(), container.Project, container.Name)
 		if err != nil {
 			sqldb.Close()
 			return err

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -38,7 +38,7 @@ type migrationFields struct {
 	// container specific fields
 	live         bool
 	instanceOnly bool
-	container    container
+	instance     Instance
 
 	// storage specific fields
 	storage    storage
@@ -261,8 +261,8 @@ type MigrationSinkArgs struct {
 	Secrets map[string]string
 	Url     string
 
-	// Container specific fields
-	Container    container
+	// Instance specific fields
+	Instance     Instance
 	InstanceOnly bool
 	Idmap        *idmap.IdmapSet
 	Live         bool
@@ -278,8 +278,8 @@ type MigrationSinkArgs struct {
 }
 
 type MigrationSourceArgs struct {
-	// Container specific fields
-	Container    container
+	// Instance specific fields
+	Instance     Instance
 	InstanceOnly bool
 
 	// Transport specific fields

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -1150,7 +1150,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				}
 
 				// Load the container from the database.
-				ctStruct, err := containerLoadByProjectAndName(d.State(), "default", ct)
+				ctStruct, err := instanceLoadByProjectAndName(d.State(), "default", ct)
 				if err != nil {
 					logger.Errorf("Failed to load LVM container %s: %s", ct, err)
 					return err
@@ -1303,7 +1303,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 					}
 
 					// Load the snapshot from the database.
-					csStruct, err := containerLoadByProjectAndName(d.State(), "default", cs)
+					csStruct, err := instanceLoadByProjectAndName(d.State(), "default", cs)
 					if err != nil {
 						logger.Errorf("Failed to load LVM container %s: %s", cs, err)
 						return err
@@ -1878,7 +1878,7 @@ func updatePoolPropertyForAllObjects(d *Daemon, poolName string, allcontainers [
 
 	// Make sure all containers and snapshots have a valid disk configuration
 	for _, ct := range allcontainers {
-		c, err := containerLoadByProjectAndName(d.State(), "default", ct)
+		c, err := instanceLoadByProjectAndName(d.State(), "default", ct)
 		if err != nil {
 			continue
 		}
@@ -1981,7 +1981,7 @@ func patchContainerConfigRegen(name string, d *Daemon) error {
 
 	for _, ct := range cts {
 		// Load the container from the database.
-		c, err := containerLoadByProjectAndName(d.State(), "default", ct)
+		c, err := instanceLoadByProjectAndName(d.State(), "default", ct)
 		if err != nil {
 			logger.Errorf("Failed to open container '%s': %v", ct, err)
 			continue
@@ -2760,7 +2760,7 @@ func patchDevicesNewNamingScheme(name string, d *Daemon) error {
 		}
 
 		// Load the container from the database.
-		c, err := containerLoadByProjectAndName(d.State(), "default", ct)
+		c, err := instanceLoadByProjectAndName(d.State(), "default", ct)
 		if err != nil {
 			logger.Errorf("Failed to load container %s: %s", ct, err)
 			return err
@@ -2982,7 +2982,7 @@ func patchStorageApiPermissions(name string, d *Daemon) error {
 
 	for _, ct := range cRegular {
 		// load the container from the database
-		ctStruct, err := containerLoadByProjectAndName(d.State(), "default", ct)
+		ctStruct, err := instanceLoadByProjectAndName(d.State(), "default", ct)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/device"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/state"
 	driver "github.com/lxc/lxd/lxd/storage"
@@ -491,10 +492,16 @@ func storagePoolVolumeAttachInit(s *state.State, poolName string, volumeName str
 
 			if len(volumeUsedBy) > 1 {
 				for _, ctName := range volumeUsedBy {
-					ct, err := containerLoadByProjectAndName(s, c.Project(), ctName)
+					instt, err := instanceLoadByProjectAndName(s, c.Project(), ctName)
 					if err != nil {
 						continue
 					}
+
+					if instt.Type() != instance.TypeContainer {
+						continue
+					}
+
+					ct := instt.(container)
 
 					var ctNextIdmap *idmap.IdmapSet
 					if ct.IsRunning() {

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -681,7 +681,7 @@ func (s *storageDir) copyContainer(target Instance, source Instance) error {
 	return nil
 }
 
-func (s *storageDir) copySnapshot(target container, targetPool string, source container, sourcePool string) error {
+func (s *storageDir) copySnapshot(target Instance, targetPool string, source Instance, sourcePool string) error {
 	sourceName := source.Name()
 	targetName := target.Name()
 	sourceContainerMntPoint := driver.GetSnapshotMountPoint(source.Project(), sourcePool, sourceName)
@@ -783,14 +783,14 @@ func (s *storageDir) doContainerCopy(target Instance, source Instance, container
 	}
 
 	for _, snap := range snapshots {
-		sourceSnapshot, err := containerLoadByProjectAndName(srcState, source.Project(), snap.Name())
+		sourceSnapshot, err := instanceLoadByProjectAndName(srcState, source.Project(), snap.Name())
 		if err != nil {
 			return err
 		}
 
 		_, snapOnlyName, _ := shared.ContainerGetParentAndSnapshotName(snap.Name())
 		newSnapName := fmt.Sprintf("%s/%s", target.Name(), snapOnlyName)
-		targetSnapshot, err := containerLoadByProjectAndName(s.s, source.Project(), newSnapName)
+		targetSnapshot, err := instanceLoadByProjectAndName(s.s, source.Project(), newSnapName)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1198,12 +1198,12 @@ func (s *storageLvm) doContainerCopy(target Instance, source Instance, container
 
 		logger.Debugf("Copying LVM container storage for snapshot %s to %s", snap.Name(), newSnapName)
 
-		sourceSnapshot, err := containerLoadByProjectAndName(srcState, source.Project(), snap.Name())
+		sourceSnapshot, err := instanceLoadByProjectAndName(srcState, source.Project(), snap.Name())
 		if err != nil {
 			return err
 		}
 
-		targetSnapshot, err := containerLoadByProjectAndName(s.s, source.Project(), newSnapName)
+		targetSnapshot, err := instanceLoadByProjectAndName(s.s, source.Project(), newSnapName)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -342,7 +342,7 @@ func (s *storageLvm) copyContainerThinpool(target Instance, source Instance, rea
 	return nil
 }
 
-func (s *storageLvm) copySnapshot(target container, source container, refresh bool) error {
+func (s *storageLvm) copySnapshot(target Instance, source Instance, refresh bool) error {
 	sourcePool, err := source.StoragePool()
 	if err != nil {
 		return err

--- a/lxd/storage_migration_ceph.go
+++ b/lxd/storage_migration_ceph.go
@@ -15,15 +15,15 @@ import (
 )
 
 type rbdMigrationSourceDriver struct {
-	container        container
-	snapshots        []container
+	container        Instance
+	snapshots        []Instance
 	rbdSnapshotNames []string
 	ceph             *storageCeph
 	runningSnapName  string
 	stoppedSnapName  string
 }
 
-func (s *rbdMigrationSourceDriver) Snapshots() []container {
+func (s *rbdMigrationSourceDriver) Snapshots() []Instance {
 	return s.snapshots
 }
 

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1999,7 +1999,7 @@ func (s *storageZfs) doContainerBackupCreateVanilla(tmpPath string, backup backu
 	}
 
 	bwlimit := s.pool.Config["rsync.bwlimit"]
-	projectName := backup.container.Project()
+	projectName := backup.instance.Project()
 
 	// Handle snapshots
 	if !backup.instanceOnly {

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -1303,7 +1303,7 @@ func (s *storageZfs) ContainerCopy(target Instance, source Instance, containerOn
 				prev = snapshots[i-1].Name()
 			}
 
-			sourceSnapshot, err := containerLoadByProjectAndName(s.s, source.Project(), snap.Name())
+			sourceSnapshot, err := instanceLoadByProjectAndName(s.s, source.Project(), snap.Name())
 			if err != nil {
 				return err
 			}
@@ -1311,7 +1311,7 @@ func (s *storageZfs) ContainerCopy(target Instance, source Instance, containerOn
 			_, snapOnlyName, _ := shared.ContainerGetParentAndSnapshotName(snap.Name())
 			prevSnapOnlyName = snapOnlyName
 			newSnapName := fmt.Sprintf("%s/%s", target.Name(), snapOnlyName)
-			targetSnapshot, err := containerLoadByProjectAndName(s.s, target.Project(), newSnapName)
+			targetSnapshot, err := instanceLoadByProjectAndName(s.s, target.Project(), newSnapName)
 			if err != nil {
 				return err
 			}
@@ -1886,7 +1886,7 @@ func (s *storageZfs) doContainerOnlyBackup(tmpPath string, backup backup, source
 	return nil
 }
 
-func (s *storageZfs) doSnapshotBackup(tmpPath string, backup backup, source container, parentSnapshot string) error {
+func (s *storageZfs) doSnapshotBackup(tmpPath string, backup backup, source Instance, parentSnapshot string) error {
 	sourceName := source.Name()
 	snapshotsPath := fmt.Sprintf("%s/snapshots", tmpPath)
 
@@ -1935,7 +1935,7 @@ func (s *storageZfs) doContainerBackupCreateOptimized(tmpPath string, backup bac
 				prev = snapshots[i-1].Name()
 			}
 
-			sourceSnapshot, err := containerLoadByProjectAndName(s.s, source.Project(), snap.Name())
+			sourceSnapshot, err := instanceLoadByProjectAndName(s.s, source.Project(), snap.Name())
 			if err != nil {
 				return err
 			}
@@ -2518,13 +2518,13 @@ func (s *storageZfs) MigrationSource(args MigrationSourceArgs) (MigrationStorage
 	/* If the container is a snapshot, let's just send that; we don't need
 	* to send anything else, because that's all the user asked for.
 	 */
-	if args.Container.IsSnapshot() {
-		return &zfsMigrationSourceDriver{container: args.Container, zfs: s, zfsFeatures: args.ZfsFeatures}, nil
+	if args.Instance.IsSnapshot() {
+		return &zfsMigrationSourceDriver{instance: args.Instance, zfs: s, zfsFeatures: args.ZfsFeatures}, nil
 	}
 
 	driver := zfsMigrationSourceDriver{
-		container:        args.Container,
-		snapshots:        []container{},
+		instance:         args.Instance,
+		snapshots:        []Instance{},
 		zfsSnapshotNames: []string{},
 		zfs:              s,
 		zfsFeatures:      args.ZfsFeatures,
@@ -2538,7 +2538,7 @@ func (s *storageZfs) MigrationSource(args MigrationSourceArgs) (MigrationStorage
 	* is that we send the oldest to newest snapshot, hopefully saving on
 	* xfer costs. Then, after all that, we send the container itself.
 	 */
-	snapshots, err := zfsPoolListSnapshots(s.getOnDiskPoolName(), fmt.Sprintf("containers/%s", project.Prefix(args.Container.Project(), args.Container.Name())))
+	snapshots, err := zfsPoolListSnapshots(s.getOnDiskPoolName(), fmt.Sprintf("containers/%s", project.Prefix(args.Instance.Project(), args.Instance.Name())))
 	if err != nil {
 		return nil, err
 	}
@@ -2553,8 +2553,8 @@ func (s *storageZfs) MigrationSource(args MigrationSourceArgs) (MigrationStorage
 			continue
 		}
 
-		lxdName := fmt.Sprintf("%s%s%s", args.Container.Name(), shared.SnapshotDelimiter, snap[len("snapshot-"):])
-		snapshot, err := containerLoadByProjectAndName(s.s, args.Container.Project(), lxdName)
+		lxdName := fmt.Sprintf("%s%s%s", args.Instance.Name(), shared.SnapshotDelimiter, snap[len("snapshot-"):])
+		snapshot, err := instanceLoadByProjectAndName(s.s, args.Instance.Project(), lxdName)
 		if err != nil {
 			return nil, err
 		}
@@ -2568,7 +2568,7 @@ func (s *storageZfs) MigrationSource(args MigrationSourceArgs) (MigrationStorage
 
 func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args MigrationSinkArgs) error {
 	poolName := s.getOnDiskPoolName()
-	zfsName := fmt.Sprintf("containers/%s", project.Prefix(args.Container.Project(), args.Container.Name()))
+	zfsName := fmt.Sprintf("containers/%s", project.Prefix(args.Instance.Project(), args.Instance.Name()))
 	zfsRecv := func(zfsName string, writeWrapper func(io.WriteCloser) io.WriteCloser) error {
 		zfsFsName := fmt.Sprintf("%s/%s", poolName, zfsName)
 		args := []string{"receive", "-F", "-o", "canmount=noauto", "-o", "mountpoint=none", "-u", zfsFsName}
@@ -2614,8 +2614,8 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 	}
 
 	if len(args.Snapshots) > 0 {
-		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "containers-snapshots", project.Prefix(args.Container.Project(), s.volume.Name))
-		snapshotMntPointSymlink := shared.VarPath("snapshots", project.Prefix(args.Container.Project(), args.Container.Name()))
+		snapshotMntPointSymlinkTarget := shared.VarPath("storage-pools", s.pool.Name, "containers-snapshots", project.Prefix(args.Instance.Project(), s.volume.Name))
+		snapshotMntPointSymlink := shared.VarPath("snapshots", project.Prefix(args.Instance.Project(), args.Instance.Name()))
 		if !shared.PathExists(snapshotMntPointSymlink) {
 			err := os.Symlink(snapshotMntPointSymlinkTarget, snapshotMntPointSymlink)
 			if err != nil {
@@ -2628,7 +2628,7 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 	// container's root disk device so we can simply
 	// retrieve it from the expanded devices.
 	parentStoragePool := ""
-	parentExpandedDevices := args.Container.ExpandedDevices()
+	parentExpandedDevices := args.Instance.ExpandedDevices()
 	parentLocalRootDiskDeviceKey, parentLocalRootDiskDevice, _ := shared.GetRootDiskDevice(parentExpandedDevices.CloneNative())
 	if parentLocalRootDiskDeviceKey != "" {
 		parentStoragePool = parentLocalRootDiskDevice["pool"]
@@ -2640,7 +2640,7 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 	}
 
 	for _, snap := range args.Snapshots {
-		ctArgs := snapshotProtobufToContainerArgs(args.Container.Project(), args.Container.Name(), snap)
+		ctArgs := snapshotProtobufToContainerArgs(args.Instance.Project(), args.Instance.Name(), snap)
 
 		// Ensure that snapshot and parent container have the
 		// same storage pool in their local root disk device.
@@ -2653,18 +2653,18 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 				ctArgs.Devices[snapLocalRootDiskDeviceKey]["pool"] = parentStoragePool
 			}
 		}
-		_, err := containerCreateEmptySnapshot(args.Container.DaemonState(), ctArgs)
+		_, err := containerCreateEmptySnapshot(args.Instance.DaemonState(), ctArgs)
 		if err != nil {
 			return err
 		}
 
 		wrapper := StorageProgressWriter(op, "fs_progress", snap.GetName())
-		name := fmt.Sprintf("containers/%s@snapshot-%s", project.Prefix(args.Container.Project(), args.Container.Name()), snap.GetName())
+		name := fmt.Sprintf("containers/%s@snapshot-%s", project.Prefix(args.Instance.Project(), args.Instance.Name()), snap.GetName())
 		if err := zfsRecv(name, wrapper); err != nil {
 			return err
 		}
 
-		snapshotMntPoint := driver.GetSnapshotMountPoint(args.Container.Project(), poolName, fmt.Sprintf("%s/%s", args.Container.Name(), *snap.Name))
+		snapshotMntPoint := driver.GetSnapshotMountPoint(args.Instance.Project(), poolName, fmt.Sprintf("%s/%s", args.Instance.Name(), *snap.Name))
 		if !shared.PathExists(snapshotMntPoint) {
 			err := os.MkdirAll(snapshotMntPoint, 0700)
 			if err != nil {
@@ -2675,7 +2675,7 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 
 	defer func() {
 		/* clean up our migration-send snapshots that we got from recv. */
-		zfsSnapshots, err := zfsPoolListSnapshots(poolName, fmt.Sprintf("containers/%s", project.Prefix(args.Container.Project(), args.Container.Name())))
+		zfsSnapshots, err := zfsPoolListSnapshots(poolName, fmt.Sprintf("containers/%s", project.Prefix(args.Instance.Project(), args.Instance.Name())))
 		if err != nil {
 			logger.Errorf("Failed listing snapshots post migration: %s", err)
 			return
@@ -2687,19 +2687,19 @@ func (s *storageZfs) MigrationSink(conn *websocket.Conn, op *operation, args Mig
 				continue
 			}
 
-			zfsPoolVolumeSnapshotDestroy(poolName, fmt.Sprintf("containers/%s", project.Prefix(args.Container.Project(), args.Container.Name())), snap)
+			zfsPoolVolumeSnapshotDestroy(poolName, fmt.Sprintf("containers/%s", project.Prefix(args.Instance.Project(), args.Instance.Name())), snap)
 		}
 	}()
 
 	/* finally, do the real container */
-	wrapper := StorageProgressWriter(op, "fs_progress", args.Container.Name())
+	wrapper := StorageProgressWriter(op, "fs_progress", args.Instance.Name())
 	if err := zfsRecv(zfsName, wrapper); err != nil {
 		return err
 	}
 
 	if args.Live {
 		/* and again for the post-running snapshot if this was a live migration */
-		wrapper := StorageProgressWriter(op, "fs_progress", args.Container.Name())
+		wrapper := StorageProgressWriter(op, "fs_progress", args.Instance.Name())
 		if err := zfsRecv(zfsName, wrapper); err != nil {
 			return err
 		}


### PR DESCRIPTION
Renames containerLoadByID and containerLoadByProjectAndName to their instance equivalent and changes the return type.

If cases where `container` type is still needed, a type ascertain is done and if the type is not container then an error is returned or skip a step depending the scenario.
