### PR TITLE
Band aid for https://github.com/canonical/dqlite/issues/163

### DIFF
--- a/lxd/db/db.go
+++ b/lxd/db/db.go
@@ -213,6 +213,12 @@ func OpenCluster(name string, store driver.NodeStore, address, dir string, timeo
 		}
 	}
 
+	// FIXME: https://github.com/canonical/dqlite/issues/163
+	_, err = db.Exec("PRAGMA cache_size=-50000")
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to set page cache size")
+	}
+
 	if dump != nil {
 		logger.Infof("Migrating data from local to global database")
 		err := query.Transaction(db, func(tx *sql.Tx) error {


### PR DESCRIPTION
The above bug causes dqlite to crash when a read query issued during a big
transaction triggers a page cache spill. The value of 50M should be
enough for most users until we fix this in dqlite.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>