### PR TITLE
lxd/storage/btrfs: Fixes bug with BTRFS snapshot copy

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -1178,7 +1178,7 @@ func (s *storageBtrfs) ContainerCopy(target Instance, source Instance, container
 			return err
 		}
 
-		err = s.copySnapshot(sourceSnapshot, targetSnapshot)
+		err = s.copySnapshot(targetSnapshot, sourceSnapshot)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>