### PR TITLE
Device Instance rename

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -37,31 +37,31 @@ import (
 )
 
 func init() {
-	// Expose instanceLoadNodeAll to the device package converting the response to a slice of InstanceIdentifiers.
+	// Expose instanceLoadNodeAll to the device package converting the response to a slice of Instances.
 	// This is because container types are defined in the main package and are not importable.
-	device.InstanceLoadNodeAll = func(s *state.State) ([]device.InstanceIdentifier, error) {
+	device.InstanceLoadNodeAll = func(s *state.State) ([]device.Instance, error) {
 		containers, err := instanceLoadNodeAll(s)
 		if err != nil {
 			return nil, err
 		}
 
-		identifiers := []device.InstanceIdentifier{}
+		identifiers := []device.Instance{}
 		for _, v := range containers {
-			identifiers = append(identifiers, device.InstanceIdentifier(v))
+			identifiers = append(identifiers, device.Instance(v))
 		}
 
 		return identifiers, nil
 	}
 
-	// Expose instanceLoadByProjectAndName to the device package converting the response to an InstanceIdentifier.
+	// Expose instanceLoadByProjectAndName to the device package converting the response to an Instance.
 	// This is because container types are defined in the main package and are not importable.
-	device.InstanceLoadByProjectAndName = func(s *state.State, project, name string) (device.InstanceIdentifier, error) {
+	device.InstanceLoadByProjectAndName = func(s *state.State, project, name string) (device.Instance, error) {
 		container, err := instanceLoadByProjectAndName(s, project, name)
 		if err != nil {
 			return nil, err
 		}
 
-		return device.InstanceIdentifier(container), nil
+		return device.Instance(container), nil
 	}
 }
 

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -19,7 +19,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/device"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
@@ -176,7 +176,7 @@ func containerValidConfig(sysOS *sys.OS, config map[string]string, profile bool,
 }
 
 // containerValidDevices validate container device configs.
-func containerValidDevices(state *state.State, cluster *db.Cluster, instanceName string, devices config.Devices, expanded bool) error {
+func containerValidDevices(state *state.State, cluster *db.Cluster, instanceName string, devices deviceConfig.Devices, expanded bool) error {
 	// Empty device list
 	if devices == nil {
 		return nil
@@ -233,7 +233,7 @@ type container interface {
 	OnStopNS(target string, netns string) error
 	OnStop(target string) error
 
-	InsertSeccompUnixDevice(prefix string, m config.Device, pid int) error
+	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 
 	CurrentIdmap() (*idmap.IdmapSet, error)
 	DiskIdmap() (*idmap.IdmapSet, error)
@@ -711,7 +711,7 @@ func containerCreateInternal(s *state.State, args db.InstanceArgs) (container, e
 	}
 
 	if args.Devices == nil {
-		args.Devices = config.Devices{}
+		args.Devices = deviceConfig.Devices{}
 	}
 
 	if args.Architecture == 0 {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -30,7 +30,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/query"
 	"github.com/lxc/lxd/lxd/device"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/events"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/maas"
@@ -589,10 +589,10 @@ type containerLXC struct {
 
 	// Config
 	expandedConfig  map[string]string
-	expandedDevices config.Devices
+	expandedDevices deviceConfig.Devices
 	fromHook        bool
 	localConfig     map[string]string
-	localDevices    config.Devices
+	localDevices    deviceConfig.Devices
 	profiles        []string
 
 	// Cache
@@ -1551,8 +1551,8 @@ func (c *containerLXC) runHooks(hooks []func() error) error {
 }
 
 // deviceLoad instantiates and validates a new device and returns it along with enriched config.
-func (c *containerLXC) deviceLoad(deviceName string, rawConfig config.Device) (device.Device, config.Device, error) {
-	var configCopy config.Device
+func (c *containerLXC) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, deviceConfig.Device, error) {
+	var configCopy deviceConfig.Device
 	var err error
 
 	// Create copy of config and load some fields from volatile if device is nic or infiniband.
@@ -1573,7 +1573,7 @@ func (c *containerLXC) deviceLoad(deviceName string, rawConfig config.Device) (d
 }
 
 // deviceAdd loads a new device and calls its Add() function.
-func (c *containerLXC) deviceAdd(deviceName string, rawConfig config.Device) error {
+func (c *containerLXC) deviceAdd(deviceName string, rawConfig deviceConfig.Device) error {
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return err
@@ -1585,7 +1585,7 @@ func (c *containerLXC) deviceAdd(deviceName string, rawConfig config.Device) err
 // deviceStart loads a new device and calls its Start() function. After processing the runtime
 // config returned from Start(), it also runs the device's Register() function irrespective of
 // whether the container is running or not.
-func (c *containerLXC) deviceStart(deviceName string, rawConfig config.Device, isRunning bool) (*device.RunConfig, error) {
+func (c *containerLXC) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*device.RunConfig, error) {
 	d, configCopy, err := c.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return nil, err
@@ -1725,7 +1725,7 @@ func (c *containerLXC) deviceAttachNIC(configCopy map[string]string, netIF []dev
 }
 
 // deviceUpdate loads a new device and calls its Update() function.
-func (c *containerLXC) deviceUpdate(deviceName string, rawConfig config.Device, oldDevices config.Devices, isRunning bool) error {
+func (c *containerLXC) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, oldDevices deviceConfig.Devices, isRunning bool) error {
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return err
@@ -1740,7 +1740,7 @@ func (c *containerLXC) deviceUpdate(deviceName string, rawConfig config.Device, 
 }
 
 // deviceStop loads a new device and calls its Stop() function.
-func (c *containerLXC) deviceStop(deviceName string, rawConfig config.Device, stopHookNetnsPath string) error {
+func (c *containerLXC) deviceStop(deviceName string, rawConfig deviceConfig.Device, stopHookNetnsPath string) error {
 	d, configCopy, err := c.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -1917,7 +1917,7 @@ func (c *containerLXC) deviceHandleMounts(mounts []device.MountEntryItem) error 
 }
 
 // deviceRemove loads a new device and calls its Remove() function.
-func (c *containerLXC) deviceRemove(deviceName string, rawConfig config.Device) error {
+func (c *containerLXC) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
 	d, _, err := c.deviceLoad(deviceName, rawConfig)
 
 	// If deviceLoad fails with unsupported device type then return.
@@ -1965,7 +1965,7 @@ func (c *containerLXC) deviceVolatileSetFunc(devName string) func(save map[strin
 
 // deviceResetVolatile resets a device's volatile data when its removed or updated in such a way
 // that it is removed then added immediately afterwards.
-func (c *containerLXC) deviceResetVolatile(devName string, oldConfig, newConfig config.Device) error {
+func (c *containerLXC) deviceResetVolatile(devName string, oldConfig, newConfig deviceConfig.Device) error {
 	volatileClear := make(map[string]string)
 	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
 
@@ -4105,7 +4105,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	if args.Devices == nil {
-		args.Devices = config.Devices{}
+		args.Devices = deviceConfig.Devices{}
 	}
 
 	if args.Profiles == nil {
@@ -4188,7 +4188,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 		return err
 	}
 
-	oldExpandedDevices := config.Devices{}
+	oldExpandedDevices := deviceConfig.Devices{}
 	err = shared.DeepCopy(&c.expandedDevices, &oldExpandedDevices)
 	if err != nil {
 		return err
@@ -4200,7 +4200,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 		return err
 	}
 
-	oldLocalDevices := config.Devices{}
+	oldLocalDevices := deviceConfig.Devices{}
 	err = shared.DeepCopy(&c.localDevices, &oldLocalDevices)
 	if err != nil {
 		return err
@@ -4285,7 +4285,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Diff the devices
-	removeDevices, addDevices, updateDevices, updateDiff := oldExpandedDevices.Update(c.expandedDevices, func(oldDevice config.Device, newDevice config.Device) []string {
+	removeDevices, addDevices, updateDevices, updateDiff := oldExpandedDevices.Update(c.expandedDevices, func(oldDevice deviceConfig.Device, newDevice deviceConfig.Device) []string {
 		// This function needs to return a list of fields that are excluded from differences
 		// between oldDevice and newDevice. The result of this is that as long as the
 		// devices are otherwise identical except for the fields returned here, then the
@@ -4818,7 +4818,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 	return nil
 }
 
-func (c *containerLXC) updateDevices(removeDevices config.Devices, addDevices config.Devices, updateDevices config.Devices, oldExpandedDevices config.Devices) error {
+func (c *containerLXC) updateDevices(removeDevices deviceConfig.Devices, addDevices deviceConfig.Devices, updateDevices deviceConfig.Devices, oldExpandedDevices deviceConfig.Devices) error {
 	isRunning := c.IsRunning()
 
 	// Remove devices in reverse order to how they were added.
@@ -6352,7 +6352,7 @@ func (c *containerLXC) removeMount(mount string) error {
 	return nil
 }
 
-func (c *containerLXC) InsertSeccompUnixDevice(prefix string, m config.Device, pid int) error {
+func (c *containerLXC) InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error {
 	if pid < 0 {
 		return fmt.Errorf("Invalid request PID specified")
 	}
@@ -6439,7 +6439,7 @@ func (c *containerLXC) removeUnixDevices() error {
 
 // fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
 // generated name and hwaddr properties if these are missing from the device.
-func (c *containerLXC) fillNetworkDevice(name string, m config.Device) (config.Device, error) {
+func (c *containerLXC) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
 	newDevice := m.Clone()
 
 	// Function to try and guess an available name
@@ -6736,7 +6736,7 @@ func (c *containerLXC) ExpandedConfig() map[string]string {
 	return c.expandedConfig
 }
 
-func (c *containerLXC) ExpandedDevices() config.Devices {
+func (c *containerLXC) ExpandedDevices() deviceConfig.Devices {
 	return c.expandedDevices
 }
 
@@ -6758,7 +6758,7 @@ func (c *containerLXC) LocalConfig() map[string]string {
 	return c.localConfig
 }
 
-func (c *containerLXC) LocalDevices() config.Devices {
+func (c *containerLXC) LocalDevices() deviceConfig.Devices {
 	return c.localDevices
 }
 

--- a/lxd/container_test.go
+++ b/lxd/container_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	driver "github.com/lxc/lxd/lxd/storage"
 	"github.com/lxc/lxd/shared"
@@ -89,8 +89,8 @@ func (suite *containerTestSuite) TestContainer_ProfilesOverwriteDefaultNic() {
 		Type:      instancetype.Container,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
-		Devices: config.Devices{
-			"eth0": config.Device{
+		Devices: deviceConfig.Devices{
+			"eth0": deviceConfig.Device{
 				"type":    "nic",
 				"nictype": "bridged",
 				"parent":  "unknownbr0"}},
@@ -119,8 +119,8 @@ func (suite *containerTestSuite) TestContainer_LoadFromDB() {
 		Type:      instancetype.Container,
 		Ephemeral: false,
 		Config:    map[string]string{"security.privileged": "true"},
-		Devices: config.Devices{
-			"eth0": config.Device{
+		Devices: deviceConfig.Devices{
+			"eth0": deviceConfig.Device{
 				"type":    "nic",
 				"nictype": "bridged",
 				"parent":  "unknownbr0"}},

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/migration"
 	"github.com/lxc/lxd/lxd/operations"
@@ -106,7 +106,7 @@ func createFromImage(d *Daemon, project string, req *api.InstancesPost) response
 			Config:      req.Config,
 			Type:        dbType,
 			Description: req.Description,
-			Devices:     config.NewDevices(req.Devices),
+			Devices:     deviceConfig.NewDevices(req.Devices),
 			Ephemeral:   req.Ephemeral,
 			Name:        req.Name,
 			Profiles:    req.Profiles,
@@ -167,7 +167,7 @@ func createFromNone(d *Daemon, project string, req *api.InstancesPost) response.
 		Config:      req.Config,
 		Type:        dbType,
 		Description: req.Description,
-		Devices:     config.NewDevices(req.Devices),
+		Devices:     deviceConfig.NewDevices(req.Devices),
 		Ephemeral:   req.Ephemeral,
 		Name:        req.Name,
 		Profiles:    req.Profiles,
@@ -228,7 +228,7 @@ func createFromMigration(d *Daemon, project string, req *api.InstancesPost) resp
 		BaseImage:    req.Source.BaseImage,
 		Config:       req.Config,
 		Type:         dbType,
-		Devices:      config.NewDevices(req.Devices),
+		Devices:      deviceConfig.NewDevices(req.Devices),
 		Description:  req.Description,
 		Ephemeral:    req.Ephemeral,
 		Name:         req.Name,
@@ -265,7 +265,7 @@ func createFromMigration(d *Daemon, project string, req *api.InstancesPost) resp
 		rootDev["path"] = "/"
 		rootDev["pool"] = storagePool
 		if args.Devices == nil {
-			args.Devices = config.Devices{}
+			args.Devices = deviceConfig.Devices{}
 		}
 
 		// Make sure that we do not overwrite a device the user
@@ -591,7 +591,7 @@ func createFromCopy(d *Daemon, project string, req *api.InstancesPost) response.
 		Config:       req.Config,
 		Type:         source.Type(),
 		Description:  req.Description,
-		Devices:      config.NewDevices(req.Devices),
+		Devices:      deviceConfig.NewDevices(req.Devices),
 		Ephemeral:    req.Ephemeral,
 		Name:         req.Name,
 		Profiles:     req.Profiles,

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/lxc/lxd/lxd/db/query"
-	"github.com/lxc/lxd/lxd/device/config"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
@@ -115,7 +114,7 @@ func ContainerToArgs(container *Instance) InstanceArgs {
 	}
 
 	if args.Devices == nil {
-		args.Devices = config.Devices{}
+		args.Devices = deviceConfig.Devices{}
 	}
 
 	return args
@@ -137,7 +136,7 @@ type InstanceArgs struct {
 	Architecture int
 	Config       map[string]string
 	Description  string
-	Devices      config.Devices
+	Devices      deviceConfig.Devices
 	Ephemeral    bool
 	LastUsedDate time.Time
 	Name         string

--- a/lxd/db/db_internal_test.go
+++ b/lxd/db/db_internal_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/logging"
@@ -331,14 +331,14 @@ func (s *dbTestSuite) Test_ContainerProfiles() {
 
 func (s *dbTestSuite) Test_dbDevices_profiles() {
 	var err error
-	var result config.Devices
-	var subresult config.Device
-	var expected config.Device
+	var result deviceConfig.Devices
+	var subresult deviceConfig.Device
+	var expected deviceConfig.Device
 
 	result, err = s.db.Devices("default", "theprofile", true)
 	s.Nil(err)
 
-	expected = config.Device{"type": "nic", "devicekey": "devicevalue"}
+	expected = deviceConfig.Device{"type": "nic", "devicekey": "devicevalue"}
 	subresult = result["devicename"]
 
 	for key, value := range expected {
@@ -349,14 +349,14 @@ func (s *dbTestSuite) Test_dbDevices_profiles() {
 
 func (s *dbTestSuite) Test_dbDevices_containers() {
 	var err error
-	var result config.Devices
-	var subresult config.Device
-	var expected config.Device
+	var result deviceConfig.Devices
+	var subresult deviceConfig.Device
+	var expected deviceConfig.Device
 
 	result, err = s.db.Devices("default", "thename", false)
 	s.Nil(err)
 
-	expected = config.Device{"type": "nic", "configkey": "configvalue"}
+	expected = deviceConfig.Device{"type": "nic", "configkey": "configvalue"}
 	subresult = result["somename"]
 
 	for key, value := range expected {

--- a/lxd/db/devices.go
+++ b/lxd/db/devices.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 )
 
 func dbDeviceTypeToString(t int) (string, error) {
@@ -58,7 +58,7 @@ func dbDeviceTypeToInt(t string) (int, error) {
 }
 
 // DevicesAdd adds a new device.
-func DevicesAdd(tx *sql.Tx, w string, cID int64, devices config.Devices) error {
+func DevicesAdd(tx *sql.Tx, w string, cID int64, devices deviceConfig.Devices) error {
 	// Prepare the devices entry SQL
 	str1 := fmt.Sprintf("INSERT INTO %ss_devices (%s_id, name, type) VALUES (?, ?, ?)", w, w)
 	stmt1, err := tx.Prepare(str1)
@@ -109,10 +109,10 @@ func DevicesAdd(tx *sql.Tx, w string, cID int64, devices config.Devices) error {
 	return nil
 }
 
-func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (config.Device, error) {
+func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (deviceConfig.Device, error) {
 	var query string
 	var key, value string
-	newdev := config.Device{} // That's a map[string]string
+	newdev := deviceConfig.Device{} // That's a map[string]string
 	inargs := []interface{}{id}
 	outfmt := []interface{}{key, value}
 
@@ -138,7 +138,7 @@ func dbDeviceConfig(db *sql.DB, id int, isprofile bool) (config.Device, error) {
 }
 
 // Devices returns the devices matching the given filters.
-func (c *Cluster) Devices(project, qName string, isprofile bool) (config.Devices, error) {
+func (c *Cluster) Devices(project, qName string, isprofile bool) (deviceConfig.Devices, error) {
 	err := c.Transaction(func(tx *ClusterTx) error {
 		enabled, err := tx.ProjectHasProfiles(project)
 		if err != nil {
@@ -176,7 +176,7 @@ func (c *Cluster) Devices(project, qName string, isprofile bool) (config.Devices
 		return nil, err
 	}
 
-	devices := config.Devices{}
+	devices := deviceConfig.Devices{}
 	for _, r := range results {
 		id = r[0].(int)
 		name = r[1].(string)

--- a/lxd/db/profiles.go
+++ b/lxd/db/profiles.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/lxc/lxd/lxd/device/config"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/pkg/errors"
@@ -379,11 +378,11 @@ func ProfilesExpandConfig(config map[string]string, profiles []api.Profile) map[
 
 // ProfilesExpandDevices expands the given container devices with the devices
 // defined in the given profiles.
-func ProfilesExpandDevices(devices config.Devices, profiles []api.Profile) config.Devices {
-	expandedDevices := config.Devices{}
+func ProfilesExpandDevices(devices deviceConfig.Devices, profiles []api.Profile) deviceConfig.Devices {
+	expandedDevices := deviceConfig.Devices{}
 
 	// Apply all the profiles
-	profileDevices := make([]config.Devices, len(profiles))
+	profileDevices := make([]deviceConfig.Devices, len(profiles))
 	for i, profile := range profiles {
 		profileDevices[i] = deviceConfig.NewDevices(profile.Devices)
 	}

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -72,8 +72,8 @@ type Device interface {
 type device interface {
 	Device
 
-	// init stores the InstanceIdentifier, daemon State and Config into device and performs any setup.
-	init(InstanceIdentifier, *state.State, string, config.Device, VolatileGetter, VolatileSetter)
+	// init stores the Instance, daemon State and Config into device and performs any setup.
+	init(Instance, *state.State, string, config.Device, VolatileGetter, VolatileSetter)
 
 	// validateConfig checks Config stored by init() is valid for the instance type.
 	validateConfig() error
@@ -81,7 +81,7 @@ type device interface {
 
 // deviceCommon represents the common struct for all devices.
 type deviceCommon struct {
-	instance    InstanceIdentifier
+	instance    Instance
 	name        string
 	config      config.Device
 	state       *state.State
@@ -89,11 +89,11 @@ type deviceCommon struct {
 	volatileSet func(map[string]string) error
 }
 
-// init stores the InstanceIdentifier, daemon state, device name and config into device.
+// init stores the Instance, daemon state, device name and config into device.
 // It also needs to be provided with volatile get and set functions for the device to allow
 // persistent data to be accessed. This is implemented as part of deviceCommon so that the majority
 // of devices don't need to implement it and can just embed deviceCommon.
-func (d *deviceCommon) init(instance InstanceIdentifier, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) {
+func (d *deviceCommon) init(instance Instance, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) {
 	d.instance = instance
 	d.name = name
 	d.config = conf
@@ -132,7 +132,7 @@ func (d *deviceCommon) Remove() error {
 // If the device type is valid, but the other config validation fails then an instantiated device
 // is still returned with the validation error. If an unknown device is requested or the device is
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
-func New(instance InstanceIdentifier, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
+func New(instance Instance, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
 	if conf["type"] == "" {
 		return nil, fmt.Errorf("Missing device type for device '%s'", name)
 	}

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -3,21 +3,21 @@ package device
 import (
 	"fmt"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 )
 
 // devTypes defines supported top-level device type creation functions.
-var devTypes = map[string]func(config.Device) device{
+var devTypes = map[string]func(deviceConfig.Device) device{
 	"nic":        nicLoadByType,
 	"infiniband": infinibandLoadByType,
-	"proxy":      func(c config.Device) device { return &proxy{} },
-	"gpu":        func(c config.Device) device { return &gpu{} },
-	"usb":        func(c config.Device) device { return &usb{} },
-	"unix-char":  func(c config.Device) device { return &unixCommon{} },
-	"unix-block": func(c config.Device) device { return &unixCommon{} },
-	"disk":       func(c config.Device) device { return &disk{} },
-	"none":       func(c config.Device) device { return &none{} },
+	"proxy":      func(c deviceConfig.Device) device { return &proxy{} },
+	"gpu":        func(c deviceConfig.Device) device { return &gpu{} },
+	"usb":        func(c deviceConfig.Device) device { return &usb{} },
+	"unix-char":  func(c deviceConfig.Device) device { return &unixCommon{} },
+	"unix-block": func(c deviceConfig.Device) device { return &unixCommon{} },
+	"disk":       func(c deviceConfig.Device) device { return &disk{} },
+	"none":       func(c deviceConfig.Device) device { return &none{} },
 }
 
 // VolatileSetter is a function that accepts one or more key/value strings to save into the LXD
@@ -53,7 +53,7 @@ type Device interface {
 	// current config and previous devices config supplied as an argument. This called if the
 	// only config fields that have changed are supplied in the list returned from CanHotPlug().
 	// The function also accepts a boolean indicating whether the instance is running or not.
-	Update(oldDevices config.Devices, running bool) error
+	Update(oldDevices deviceConfig.Devices, running bool) error
 
 	// Stop performs any host-side cleanup required when a device is removed from an instance,
 	// either due to unplugging it from a running instance or instance is being shutdown.
@@ -73,7 +73,7 @@ type device interface {
 	Device
 
 	// init stores the Instance, daemon State and Config into device and performs any setup.
-	init(Instance, *state.State, string, config.Device, VolatileGetter, VolatileSetter)
+	init(Instance, *state.State, string, deviceConfig.Device, VolatileGetter, VolatileSetter)
 
 	// validateConfig checks Config stored by init() is valid for the instance type.
 	validateConfig() error
@@ -83,7 +83,7 @@ type device interface {
 type deviceCommon struct {
 	instance    Instance
 	name        string
-	config      config.Device
+	config      deviceConfig.Device
 	state       *state.State
 	volatileGet func() map[string]string
 	volatileSet func(map[string]string) error
@@ -93,7 +93,7 @@ type deviceCommon struct {
 // It also needs to be provided with volatile get and set functions for the device to allow
 // persistent data to be accessed. This is implemented as part of deviceCommon so that the majority
 // of devices don't need to implement it and can just embed deviceCommon.
-func (d *deviceCommon) init(instance Instance, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) {
+func (d *deviceCommon) init(instance Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) {
 	d.instance = instance
 	d.name = name
 	d.config = conf
@@ -119,7 +119,7 @@ func (d *deviceCommon) CanHotPlug() (bool, []string) {
 }
 
 // Update returns an error as most devices do not support live updates without being restarted.
-func (d *deviceCommon) Update(oldDevices config.Devices, isRunning bool) error {
+func (d *deviceCommon) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	return fmt.Errorf("Device does not support updates whilst started")
 }
 
@@ -132,7 +132,7 @@ func (d *deviceCommon) Remove() error {
 // If the device type is valid, but the other config validation fails then an instantiated device
 // is still returned with the validation error. If an unknown device is requested or the device is
 // not compatible with the instance type then an ErrUnsupportedDevType error is returned.
-func New(instance Instance, state *state.State, name string, conf config.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
+func New(instance Instance, state *state.State, name string, conf deviceConfig.Device, volatileGet VolatileGetter, volatileSet VolatileSetter) (Device, error) {
 	if conf["type"] == "" {
 		return nil, fmt.Errorf("Missing device type for device '%s'", name)
 	}

--- a/lxd/device/device_instance.go
+++ b/lxd/device/device_instance.go
@@ -1,7 +1,7 @@
 package device
 
 import (
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 )
 
@@ -16,7 +16,7 @@ type Instance interface {
 	RootfsPath() string
 	LogPath() string
 	ExpandedConfig() map[string]string
-	LocalDevices() config.Devices
-	ExpandedDevices() config.Devices
+	LocalDevices() deviceConfig.Devices
+	ExpandedDevices() deviceConfig.Devices
 	DeviceEventHandler(*RunConfig) error
 }

--- a/lxd/device/device_instance.go
+++ b/lxd/device/device_instance.go
@@ -5,10 +5,10 @@ import (
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 )
 
-// InstanceIdentifier is an interface that allows us to identify an Instance and its properties.
+// Instance is an interface that allows us to identify an Instance and its properties.
 // It is intended that this interface be entirely comprised of functions which cannot be blocking
-// independent of when they're called in the instance lifecycle.
-type InstanceIdentifier interface {
+// irrespective of when they're called in the instance lifecycle.
+type Instance interface {
 	Name() string
 	Type() instancetype.Type
 	Project() string

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -11,13 +11,13 @@ import (
 )
 
 // StorageVolumeMount checks if storage volume is mounted and if not tries to mount it.
-var StorageVolumeMount func(s *state.State, poolName string, volumeName string, volumeTypeName string, instance InstanceIdentifier) error
+var StorageVolumeMount func(s *state.State, poolName string, volumeName string, volumeTypeName string, instance Instance) error
 
 // StorageVolumeUmount unmounts a storage volume.
 var StorageVolumeUmount func(s *state.State, poolName string, volumeName string, volumeType int) error
 
 // StorageRootFSApplyQuota applies a new quota.
-var StorageRootFSApplyQuota func(instance InstanceIdentifier, newSize int64) (bool, error)
+var StorageRootFSApplyQuota func(instance Instance, newSize int64) (bool, error)
 
 // BlockFsDetect detects the type of block device.
 func BlockFsDetect(dev string) (string, error) {

--- a/lxd/device/device_utils_infiniband.go
+++ b/lxd/device/device_utils_infiniband.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared/api"
 )
@@ -77,7 +77,7 @@ func infinibandAddDevices(s *state.State, devicesPath string, deviceName string,
 
 	// Add IsSM device if defined.
 	if ibDev.Infiniband.IsSMName != "" {
-		dummyDevice := config.Device{
+		dummyDevice := deviceConfig.Device{
 			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.IsSMName),
 		}
 
@@ -89,7 +89,7 @@ func infinibandAddDevices(s *state.State, devicesPath string, deviceName string,
 
 	// Add MAD device if defined.
 	if ibDev.Infiniband.MADName != "" {
-		dummyDevice := config.Device{
+		dummyDevice := deviceConfig.Device{
 			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.MADName),
 		}
 
@@ -101,7 +101,7 @@ func infinibandAddDevices(s *state.State, devicesPath string, deviceName string,
 
 	// Add Verb device if defined.
 	if ibDev.Infiniband.VerbName != "" {
-		dummyDevice := config.Device{
+		dummyDevice := deviceConfig.Device{
 			"source": fmt.Sprintf("/dev/infiniband/%s", ibDev.Infiniband.VerbName),
 		}
 

--- a/lxd/device/device_utils_instance.go
+++ b/lxd/device/device_utils_instance.go
@@ -9,10 +9,10 @@ import (
 )
 
 // InstanceLoadNodeAll returns all local instance configs.
-var InstanceLoadNodeAll func(s *state.State) ([]InstanceIdentifier, error)
+var InstanceLoadNodeAll func(s *state.State) ([]Instance, error)
 
 // InstanceLoadByProjectAndName returns instance config by project and name.
-var InstanceLoadByProjectAndName func(s *state.State, project, name string) (InstanceIdentifier, error)
+var InstanceLoadByProjectAndName func(s *state.State, project, name string) (Instance, error)
 
 // reservedDevicesMutex used to coordinate access for checking reserved devices.
 var reservedDevicesMutex sync.Mutex

--- a/lxd/device/device_utils_instance.go
+++ b/lxd/device/device_utils_instance.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 )
 
@@ -19,7 +19,7 @@ var reservedDevicesMutex sync.Mutex
 
 // instanceGetReservedDevices returns a map of host device names that have been used by devices in
 // other instances on the local node. Used for selecting physical and SR-IOV VF devices.
-func instanceGetReservedDevices(s *state.State, m config.Device) (map[string]struct{}, error) {
+func instanceGetReservedDevices(s *state.State, m deviceConfig.Device) (map[string]struct{}, error) {
 	reservedDevicesMutex.Lock()
 	defer reservedDevicesMutex.Unlock()
 

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -12,7 +12,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 	"github.com/lxc/lxd/shared/units"
@@ -272,7 +272,7 @@ func NetworkAttachInterface(netName string, devName string) error {
 // in the supplied config to the newly created peer interface. If mtu is not specified, but parent
 // is supplied in config, then the MTU of the new peer interface will inherit the parent MTU.
 // Accepts the name of the host side interface as a parameter and returns the peer interface name.
-func networkCreateVethPair(hostName string, m config.Device) (string, error) {
+func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, error) {
 	peerName := NetworkRandomDevName("veth")
 
 	_, err := shared.RunCommand("ip", "link", "add", "dev", hostName, "type", "veth", "peer", "name", peerName)
@@ -324,7 +324,7 @@ func networkCreateVethPair(hostName string, m config.Device) (string, error) {
 }
 
 // networkSetupHostVethDevice configures a nic device's host side veth settings.
-func networkSetupHostVethDevice(device config.Device, oldDevice config.Device, v map[string]string) error {
+func networkSetupHostVethDevice(device deviceConfig.Device, oldDevice deviceConfig.Device, v map[string]string) error {
 	// If not configured, check if volatile data contains the most recently added host_name.
 	if device["host_name"] == "" {
 		device["host_name"] = v["host_name"]
@@ -371,7 +371,7 @@ func networkSetupHostVethDevice(device config.Device, oldDevice config.Device, v
 }
 
 // networkSetVethRoutes applies any static routes configured from the host to the container nic.
-func networkSetVethRoutes(m config.Device) error {
+func networkSetVethRoutes(m deviceConfig.Device) error {
 	// Decide whether the route should point to the veth parent or the bridge parent.
 	routeDev := m["host_name"]
 	if m["nictype"] == "bridged" {
@@ -409,7 +409,7 @@ func networkSetVethRoutes(m config.Device) error {
 
 // networkRemoveVethRoutes removes any routes created for this device on the host that were first added
 // with networkSetVethRoutes(). Expects to be passed the device config from the oldExpandedDevices.
-func networkRemoveVethRoutes(m config.Device) {
+func networkRemoveVethRoutes(m deviceConfig.Device) {
 	// Decide whether the route should point to the veth parent or the bridge parent
 	routeDev := m["host_name"]
 	if m["nictype"] == "bridged" {
@@ -451,7 +451,7 @@ func networkRemoveVethRoutes(m config.Device) {
 }
 
 // networkSetVethLimits applies any network rate limits to the veth device specified in the config.
-func networkSetVethLimits(m config.Device) error {
+func networkSetVethLimits(m deviceConfig.Device) error {
 	var err error
 
 	veth := m["host_name"]

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -10,7 +10,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/idmap"
@@ -23,7 +23,7 @@ const unixDefaultMode = 0660
 // unixDeviceInstanceAttributes returns the UNIX device attributes for an instance device.
 // Uses supplied device config for device properties, and if they haven't been set, falls back to
 // using UnixGetDeviceAttributes() to directly query an existing device file.
-func unixDeviceInstanceAttributes(devicesPath string, prefix string, config config.Device) (string, uint32, uint32, error) {
+func unixDeviceInstanceAttributes(devicesPath string, prefix string, config deviceConfig.Device) (string, uint32, uint32, error) {
 	// Check if we've been passed major and minor numbers already.
 	var err error
 	var dMajor, dMinor uint32
@@ -117,7 +117,7 @@ type UnixDevice struct {
 // unixDeviceSourcePath returns the absolute path for a device on the host.
 // This is based on the "source" property of the device's config, or the "path" property if "source"
 // not define. This uses the shared.HostPath function so works when running in a snap environment.
-func unixDeviceSourcePath(m config.Device) string {
+func unixDeviceSourcePath(m deviceConfig.Device) string {
 	srcPath := m["source"]
 	if srcPath == "" {
 		srcPath = m["path"]
@@ -128,7 +128,7 @@ func unixDeviceSourcePath(m config.Device) string {
 // unixDeviceDestPath returns the absolute path for a device inside an instance.
 // This is based on the "path" property of the device's config, or the "source" property if "path"
 // not defined.
-func unixDeviceDestPath(m config.Device) string {
+func unixDeviceDestPath(m deviceConfig.Device) string {
 	destPath := m["path"]
 	if destPath == "" {
 		destPath = m["source"]
@@ -145,7 +145,7 @@ func unixDeviceDestPath(m config.Device) string {
 // type field then it defaults to created a unix-char device. The ownership of the created device
 // defaults to root (0) but can be specified with the uid and gid fields in the device config map.
 // It returns a UnixDevice containing information about the device created.
-func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath string, prefix string, m config.Device, defaultMode bool) (*UnixDevice, error) {
+func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath string, prefix string, m deviceConfig.Device, defaultMode bool) (*UnixDevice, error) {
 	var err error
 	d := UnixDevice{}
 
@@ -288,7 +288,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 // mount and cgroup rule instructions to have it be attached to the instance. If defaultMode is true
 // or mode is supplied in the device config then the origin device does not need to be accessed for
 // its file mode.
-func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, deviceName string, m config.Device, defaultMode bool, runConf *RunConfig) error {
+func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, deviceName string, m deviceConfig.Device, defaultMode bool, runConf *RunConfig) error {
 	// Before creating the device, check that another existing device isn't using the same mount
 	// path inside the instance as our device. If we find an existing device with the same mount
 	// path we will skip mounting our device inside the instance. This can happen when multiple
@@ -362,8 +362,8 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 // already know the device's major and minor numbers to avoid unixDeviceSetup() having to stat the
 // device to ascertain these attributes. If defaultMode is true or mode is supplied in the device
 // config then the origin device does not need to be accessed for its file mode.
-func unixDeviceSetupCharNum(s *state.State, devicesPath string, typePrefix string, deviceName string, m config.Device, major uint32, minor uint32, path string, defaultMode bool, runConf *RunConfig) error {
-	configCopy := config.Device{}
+func unixDeviceSetupCharNum(s *state.State, devicesPath string, typePrefix string, deviceName string, m deviceConfig.Device, major uint32, minor uint32, path string, defaultMode bool, runConf *RunConfig) error {
+	configCopy := deviceConfig.Device{}
 	for k, v := range m {
 		configCopy[k] = v
 	}

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -31,7 +31,7 @@ var unixHandlers = map[string]UnixSubscription{}
 var unixMutex sync.Mutex
 
 // unixRegisterHandler registers a handler function to be called whenever a Unix device event occurs.
-func unixRegisterHandler(s *state.State, instance InstanceIdentifier, deviceName, path string, handler func(UnixEvent) (*RunConfig, error)) error {
+func unixRegisterHandler(s *state.State, instance Instance, deviceName, path string, handler func(UnixEvent) (*RunConfig, error)) error {
 	if path == "" || handler == nil {
 		return fmt.Errorf("Invalid subscription")
 	}
@@ -58,7 +58,7 @@ func unixRegisterHandler(s *state.State, instance InstanceIdentifier, deviceName
 }
 
 // unixUnregisterHandler removes a registered Unix handler function for a device.
-func unixUnregisterHandler(s *state.State, instance InstanceIdentifier, deviceName string) error {
+func unixUnregisterHandler(s *state.State, instance Instance, deviceName string) error {
 	unixMutex.Lock()
 	defer unixMutex.Unlock()
 

--- a/lxd/device/device_utils_usb_events.go
+++ b/lxd/device/device_utils_usb_events.go
@@ -33,7 +33,7 @@ var usbHandlers = map[string]func(USBEvent) (*RunConfig, error){}
 var usbMutex sync.Mutex
 
 // usbRegisterHandler registers a handler function to be called whenever a USB device event occurs.
-func usbRegisterHandler(instance InstanceIdentifier, deviceName string, handler func(USBEvent) (*RunConfig, error)) {
+func usbRegisterHandler(instance Instance, deviceName string, handler func(USBEvent) (*RunConfig, error)) {
 	usbMutex.Lock()
 	defer usbMutex.Unlock()
 
@@ -43,7 +43,7 @@ func usbRegisterHandler(instance InstanceIdentifier, deviceName string, handler 
 }
 
 // usbUnregisterHandler removes a registered USB handler function for a device.
-func usbUnregisterHandler(instance InstanceIdentifier, deviceName string) {
+func usbUnregisterHandler(instance Instance, deviceName string) {
 	usbMutex.Lock()
 	defer usbMutex.Unlock()
 

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -326,7 +326,7 @@ func (d *disk) postStart() error {
 }
 
 // Update applies configuration changes to a started device.
-func (d *disk) Update(oldDevices config.Devices, isRunning bool) error {
+func (d *disk) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	if shared.IsRootDiskDevice(d.config) {
 		// Make sure we have a valid root disk device (and only one).
 		expandedDevices := d.instance.ExpandedDevices()

--- a/lxd/device/infiniband.go
+++ b/lxd/device/infiniband.go
@@ -1,7 +1,7 @@
 package device
 
 import (
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 )
 
 // infinibandTypes defines the supported infiniband type devices and defines their creation functions.
@@ -11,7 +11,7 @@ var infinibandTypes = map[string]func() device{
 }
 
 // infinibandLoadByType returns an Infiniband device instantiated with supplied config.
-func infinibandLoadByType(c config.Device) device {
+func infinibandLoadByType(c deviceConfig.Device) device {
 	f := infinibandTypes[c["nictype"]]
 	if f != nil {
 		return f()

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -1,7 +1,7 @@
 package device
 
 import (
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -16,7 +16,7 @@ var nicTypes = map[string]func() device{
 }
 
 // nicLoadByType returns a NIC device instantiated with supplied config.
-func nicLoadByType(c config.Device) device {
+func nicLoadByType(c deviceConfig.Device) device {
 	f := nicTypes[c["nictype"]]
 	if f != nil {
 		return f()

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/gopacket/layers"
 	"github.com/mdlayher/eui64"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/dnsmasq"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/iptables"
@@ -172,7 +172,7 @@ func (d *nicBridged) Start() (*RunConfig, error) {
 }
 
 // Update applies configuration changes to a started device.
-func (d *nicBridged) Update(oldDevices config.Devices, isRunning bool) error {
+func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
 
 	// If an IPv6 address has changed, flush all existing IPv6 leases for instance so instance
@@ -351,7 +351,7 @@ func (d *nicBridged) rebuildDnsmasqEntry() error {
 }
 
 // setupHostFilters applies any host side network filters.
-func (d *nicBridged) setupHostFilters(oldConfig config.Device) error {
+func (d *nicBridged) setupHostFilters(oldConfig deviceConfig.Device) error {
 	// Remove any old network filters if non-empty oldConfig supplied as part of update.
 	if oldConfig != nil && (shared.IsTrue(oldConfig["security.mac_filtering"]) || shared.IsTrue(oldConfig["security.ipv4_filtering"]) || shared.IsTrue(oldConfig["security.ipv6_filtering"])) {
 		d.removeFilters(oldConfig)
@@ -369,7 +369,7 @@ func (d *nicBridged) setupHostFilters(oldConfig config.Device) error {
 }
 
 // removeFilters removes any network level filters defined for the instance.
-func (d *nicBridged) removeFilters(m config.Device) error {
+func (d *nicBridged) removeFilters(m deviceConfig.Device) error {
 	if m["hwaddr"] == "" {
 		return fmt.Errorf("Failed to remove network filters for %s: hwaddr not defined", m["name"])
 	}
@@ -475,7 +475,7 @@ func (d *nicBridged) getDHCPStaticIPs(network string, instanceName string) (dhcp
 }
 
 // generateFilterEbtablesRules returns a customised set of ebtables filter rules based on the device.
-func (d *nicBridged) generateFilterEbtablesRules(m config.Device, IPv4 net.IP, IPv6 net.IP) [][]string {
+func (d *nicBridged) generateFilterEbtablesRules(m deviceConfig.Device, IPv4 net.IP, IPv6 net.IP) [][]string {
 	// MAC source filtering rules. Blocks any packet coming from instance with an incorrect Ethernet source MAC.
 	// This is required for IP filtering too.
 	rules := [][]string{
@@ -733,7 +733,7 @@ func (d *nicBridged) allocateFilterIPs() (net.IP, net.IP, error) {
 }
 
 // generateFilterIptablesRules returns a customised set of iptables filter rules based on the device.
-func (d *nicBridged) generateFilterIptablesRules(m config.Device, IPv6 net.IP) (rules [][]string, err error) {
+func (d *nicBridged) generateFilterIptablesRules(m deviceConfig.Device, IPv6 net.IP) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(m["hwaddr"])
 	if err != nil {
 		return

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -3,7 +3,7 @@ package device
 import (
 	"fmt"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -95,7 +95,7 @@ func (d *nicP2P) Start() (*RunConfig, error) {
 }
 
 // Update applies configuration changes to a started device.
-func (d *nicP2P) Update(oldDevices config.Devices, isRunning bool) error {
+func (d *nicP2P) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 	oldConfig := oldDevices[d.name]
 
 	if !isRunning {

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -5,13 +5,13 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
 
 // unixIsOurDeviceType checks that device file type matches what we are expecting in the config.
-func unixIsOurDeviceType(config config.Device, dType string) bool {
+func unixIsOurDeviceType(config deviceConfig.Device, dType string) bool {
 	if config["type"] == "unix-char" && dType == "c" {
 		return true
 	}

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -7,7 +7,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -18,7 +18,7 @@ const usbDevPath = "/sys/bus/usb/devices"
 // usbIsOurDevice indicates whether the USB device event qualifies as part of our device.
 // This function is not defined against the usb struct type so that it can be used in event
 // callbacks without needing to keep a reference to the usb device struct.
-func usbIsOurDevice(config config.Device, usb *USBEvent) bool {
+func usbIsOurDevice(config deviceConfig.Device, usb *USBEvent) bool {
 	// Check if event matches criteria for this device, if not return.
 	if (config["vendorid"] != "" && config["vendorid"] != usb.Vendor) || (config["productid"] != "" && config["productid"] != usb.Product) {
 		return false

--- a/lxd/instance_interface.go
+++ b/lxd/instance_interface.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/device"
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/state"
@@ -84,9 +84,9 @@ type Instance interface {
 	CreationDate() time.Time
 	LastUsedDate() time.Time
 	ExpandedConfig() map[string]string
-	ExpandedDevices() config.Devices
+	ExpandedDevices() deviceConfig.Devices
 	LocalConfig() map[string]string
-	LocalDevices() config.Devices
+	LocalDevices() deviceConfig.Devices
 	Profiles() []string
 	InitPID() int
 	State() string

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -19,7 +19,7 @@ import (
 	"golang.org/x/sys/unix"
 	lxc "gopkg.in/lxc/go-lxc.v2"
 
-	"github.com/lxc/lxd/lxd/device/config"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/lxd/ucred"
 	"github.com/lxc/lxd/lxd/util"
@@ -347,7 +347,7 @@ type Instance interface {
 	Architecture() int
 	RootfsPath() string
 	CurrentIdmap() (*idmap.IdmapSet, error)
-	InsertSeccompUnixDevice(prefix string, m config.Device, pid int) error
+	InsertSeccompUnixDevice(prefix string, m deviceConfig.Device, pid int) error
 }
 
 var seccompPath = shared.VarPath("security", "seccomp")
@@ -833,7 +833,7 @@ func TaskIDs(pid int) (int64, int64, int64, int64, error) {
 }
 
 // CallForkmknod executes fork mknod.
-func CallForkmknod(c Instance, dev config.Device, requestPID int) int {
+func CallForkmknod(c Instance, dev deviceConfig.Device, requestPID int) int {
 	rootLink := fmt.Sprintf("/proc/%d/root", requestPID)
 	rootPath, err := os.Readlink(rootLink)
 	if err != nil {
@@ -892,7 +892,7 @@ type MknodArgs struct {
 }
 
 func (s *Server) doDeviceSyscall(c Instance, args *MknodArgs, siov *Iovec) int {
-	dev := config.Device{}
+	dev := deviceConfig.Device{}
 	dev["type"] = "unix-char"
 	dev["mode"] = fmt.Sprintf("%#o", args.cMode)
 	dev["major"] = fmt.Sprintf("%d", unix.Major(uint64(args.cDev)))

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -895,7 +895,7 @@ func storagePoolDriversCacheUpdate(cluster *db.Cluster) {
 
 // storageVolumeMount initialises a new storage interface and checks the pool and volume are
 // mounted. If they are not then they are mounted.
-func storageVolumeMount(state *state.State, poolName string, volumeName string, volumeTypeName string, instance device.InstanceIdentifier) error {
+func storageVolumeMount(state *state.State, poolName string, volumeName string, volumeTypeName string, instance device.Instance) error {
 	c, ok := instance.(*containerLXC)
 	if !ok {
 		return fmt.Errorf("Received non-LXC container instance")
@@ -933,7 +933,7 @@ func storageVolumeUmount(state *state.State, poolName string, volumeName string,
 
 // storageRootFSApplyQuota applies a quota to an instance if it can, if it cannot then it will
 // return false indicating that the quota needs to be stored in volatile to be applied on next boot.
-func storageRootFSApplyQuota(instance device.InstanceIdentifier, newSizeBytes int64) (bool, error) {
+func storageRootFSApplyQuota(instance device.Instance, newSizeBytes int64) (bool, error) {
 	c, ok := instance.(*containerLXC)
 	if !ok {
 		return false, fmt.Errorf("Received non-LXC container instance")


### PR DESCRIPTION
Also makes import alias of device config package consistent throughout codebase as `deviceConfig`.