### PR TITLE
lxd/images: Fix image type during refresh

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1085,7 +1085,7 @@ func autoUpdateImage(d *Daemon, op *operations.Operation, id int, info *api.Imag
 	// Update the image on each pool where it currently exists.
 	hash := fingerprint
 	for _, poolName := range poolNames {
-		newInfo, err := d.ImageDownload(op, source.Server, source.Protocol, source.Certificate, "", source.Alias, source.ImageType, false, true, poolName, false, project)
+		newInfo, err := d.ImageDownload(op, source.Server, source.Protocol, source.Certificate, "", source.Alias, info.Type, false, true, poolName, false, project)
 
 		if err != nil {
 			logger.Error("Failed to update the image", log.Ctx{"err": err, "fp": fingerprint})


### PR DESCRIPTION
The DB record of the image source does not include the image type, this
needs to be instead retrieved from the image info itself.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>