### PR TITLE
Adds instanceLoad function

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -986,13 +986,12 @@ func instanceLoadByProjectAndName(s *state.State, project, name string) (Instanc
 	}
 
 	args := db.ContainerToArgs(container)
-
-	c, err := containerLXCLoad(s, args, nil)
+	inst, err := instanceLoad(s, args, nil)
 	if err != nil {
 		return nil, errors.Wrap(err, "Failed to load container")
 	}
 
-	return c, nil
+	return inst, nil
 }
 
 func instanceLoadByProject(s *state.State, project string) ([]Instance, error) {
@@ -1126,18 +1125,13 @@ func instanceLoadAllInternal(dbInstances []db.Instance, s *state.State) ([]Insta
 			cProfiles = append(cProfiles, profiles[dbInstance.Project][name])
 		}
 
-		if dbInstance.Type == instancetype.Container {
-			args := db.ContainerToArgs(&dbInstance)
-			ct, err := containerLXCLoad(s, args, cProfiles)
-			if err != nil {
-				return nil, err
-			}
-			instances = append(instances, ct)
-		} else {
-			// TODO add virtual machine load here.
-			continue
+		args := db.ContainerToArgs(&dbInstance)
+		inst, err := instanceLoad(s, args, cProfiles)
+		if err != nil {
+			return nil, err
 		}
 
+		instances = append(instances, inst)
 	}
 
 	return instances, nil

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1143,6 +1143,24 @@ func instanceLoadAllInternal(dbInstances []db.Instance, s *state.State) ([]Insta
 	return instances, nil
 }
 
+// instanceLoad creates the underlying instance type struct and returns it as an Instance.
+func instanceLoad(s *state.State, args db.InstanceArgs, cProfiles []api.Profile) (Instance, error) {
+	var inst Instance
+	var err error
+
+	if args.Type == instancetype.Container {
+		inst, err = containerLXCLoad(s, args, cProfiles)
+	} else {
+		return nil, fmt.Errorf("Invalid instance type for instance %s", args.Name)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return inst, nil
+}
+
 func containerCompareSnapshots(source Instance, target Instance) ([]Instance, []Instance, error) {
 	// Get the source snapshots
 	sourceSnapshots, err := source.Snapshots()

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -278,7 +278,7 @@ func containersShutdown(s *state.State) error {
 
 		for project, names := range cnames {
 			for _, name := range names {
-				c, err := containerLXCLoad(s, db.InstanceArgs{
+				inst, err := instanceLoad(s, db.InstanceArgs{
 					Project: project,
 					Name:    name,
 					Config:  make(map[string]string),
@@ -287,7 +287,7 @@ func containersShutdown(s *state.State) error {
 					return err
 				}
 
-				instances = append(instances, c)
+				instances = append(instances, inst)
 			}
 		}
 	}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -323,12 +323,12 @@ func createFromMigration(d *Daemon, project string, req *api.InstancesPost) resp
 			}
 		} else {
 			// Retrieve the future storage pool
-			cM, err := containerLXCLoad(d.State(), args, nil)
+			inst, err := instanceLoad(d.State(), args, nil)
 			if err != nil {
 				return response.InternalError(err)
 			}
 
-			_, rootDiskDevice, err := shared.GetRootDiskDevice(cM.ExpandedDevices().CloneNative())
+			_, rootDiskDevice, err := shared.GetRootDiskDevice(inst.ExpandedDevices().CloneNative())
 			if err != nil {
 				return response.InternalError(err)
 			}


### PR DESCRIPTION
Adds `instanceInstantiate` function and replaces use of `containerLXCLoad` with it.

This function will then detect the instance type and call `containerLXCLoad` for containers and will then be modified in the future to instantiate VM instance types.