### PR TITLE
lxd: Updates error output of MakeFSType

### DIFF
--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -160,7 +160,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 
 		output, err := driver.MakeFSType(source, "btrfs", &driver.MkfsOptions{Label: s.pool.Name})
 		if err != nil {
-			return fmt.Errorf("Failed to create the BTRFS pool: %s", output)
+			return fmt.Errorf("Failed to create the BTRFS pool: %v (%s)", err, output)
 		}
 	} else {
 		// Unset size property since it doesn't make sense.
@@ -171,7 +171,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 			if isBlockDev {
 				output, err := driver.MakeFSType(source, "btrfs", &driver.MkfsOptions{Label: s.pool.Name})
 				if err != nil {
-					return fmt.Errorf("Failed to create the BTRFS pool: %s", output)
+					return fmt.Errorf("Failed to create the BTRFS pool: %v (%s)", err, output)
 				}
 			} else {
 				if isBtrfsSubVolume(source) {

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -362,9 +362,9 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 	RBDFilesystem := s.getRBDFilesystem()
 	logger.Debugf(`Retrieved filesystem type "%s" of RBD storage volume "%s" on storage pool "%s"`, RBDFilesystem, s.volume.Name, s.pool.Name)
 
-	msg, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
+	output, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
 	if err != nil {
-		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume "%s" on storage pool "%s": %s`, RBDFilesystem, RBDDevPath, s.volume.Name, s.pool.Name, msg)
+		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume "%s" on storage pool "%s": %v (%s)`, RBDFilesystem, RBDDevPath, s.volume.Name, s.pool.Name, err, output)
 		return err
 	}
 	logger.Debugf(`Created filesystem type "%s" on device path "%s" for RBD storage volume "%s" on storage pool "%s"`, RBDFilesystem, RBDDevPath, s.volume.Name, s.pool.Name)
@@ -2106,10 +2106,9 @@ func (s *storageCeph) ImageCreate(fingerprint string, tracker *ioprogress.Progre
 
 		// get filesystem
 		RBDFilesystem := s.getRBDFilesystem()
-		msg, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
+		output, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
 		if err != nil {
-			logger.Errorf(`Failed to create filesystem "%s" for RBD storage volume for image "%s" on storage pool "%s": %s`, RBDFilesystem, fingerprint,
-				s.pool.Name, msg)
+			logger.Errorf(`Failed to create filesystem "%s" for RBD storage volume for image "%s" on storage pool "%s": %v (%s)`, RBDFilesystem, fingerprint, s.pool.Name, err, output)
 			return err
 		}
 		logger.Debugf(`Created filesystem "%s" for RBD storage volume for image "%s" on storage pool "%s"`, RBDFilesystem, fingerprint, s.pool.Name)

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -1752,9 +1752,9 @@ func (s *storageCeph) doContainerCreate(projectName, name string, privileged boo
 
 	// get filesystem
 	RBDFilesystem := s.getRBDFilesystem()
-	msg, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
+	output, err := driver.MakeFSType(RBDDevPath, RBDFilesystem, nil)
 	if err != nil {
-		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume for container "%s" on storage pool "%s": %s`, RBDFilesystem, RBDDevPath, name, s.pool.Name, msg)
+		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume for container "%s" on storage pool "%s": %v (%s)`, RBDFilesystem, RBDDevPath, name, s.pool.Name, err, output)
 		return err
 	}
 	logger.Debugf(`Created filesystem type "%s" on device path "%s" for RBD storage volume for container "%s" on storage pool "%s"`, RBDFilesystem, RBDDevPath, name, s.pool.Name)

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -856,8 +856,8 @@ func lvmCreateLv(projectName, vgName string, thinPoolName string, lvName string,
 
 	output, err = driver.MakeFSType(fsPath, lvFsType, nil)
 	if err != nil {
-		logger.Errorf("Filesystem creation failed: %s: %v", output, err)
-		return fmt.Errorf("Error making filesystem on image LV: %s: %v", output, err)
+		logger.Errorf("Filesystem creation failed: %v (%s)", err, output)
+		return fmt.Errorf("Error making filesystem on image LV: %v (%s)", err, output)
 	}
 
 	return nil


### PR DESCRIPTION
lxd: Updates error handling of MakeFSType after stderr split of RunCommand.

- Adds stdout output in brackets after error.
- Makes lvmCreateLv error output consistent with other uses of MakeFSType.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>