### PR TITLE
Implements support for `--compression` in `lxc export`

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -848,3 +848,8 @@ This allows for editing of the expiry date on images.
 
 ## resources\_network\_firmware
 Adds a FirmwareVersion field to network card entries.
+
+## backup\_compression\_algorithm
+This adds support for a `compression_algorithm` property when creating a backup (`POST /1.0/containers/<name>/backups`).
+
+Setting this property overrides the server default value (`backups.compression_algorithm`).

--- a/lxc/export.go
+++ b/lxc/export.go
@@ -20,9 +20,10 @@ import (
 type cmdExport struct {
 	global *cmdGlobal
 
-	flagContainerOnly    bool
-	flagInstanceOnly     bool
-	flagOptimizedStorage bool
+	flagContainerOnly        bool
+	flagInstanceOnly         bool
+	flagOptimizedStorage     bool
+	flagCompressionAlgorithm string
 }
 
 func (c *cmdExport) Command() *cobra.Command {
@@ -42,6 +43,7 @@ func (c *cmdExport) Command() *cobra.Command {
 		i18n.G("Whether or not to only backup the instance (without snapshots)"))
 	cmd.Flags().BoolVar(&c.flagOptimizedStorage, "optimized-storage", false,
 		i18n.G("Use storage driver optimized format (can only be restored on a similar pool)"))
+	cmd.Flags().StringVar(&c.flagCompressionAlgorithm, "compression", "", i18n.G("Define a compression algorithm: for backup or none")+"``")
 
 	return cmd
 }
@@ -69,11 +71,12 @@ func (c *cmdExport) Run(cmd *cobra.Command, args []string) error {
 	instanceOnly := c.flagContainerOnly || c.flagInstanceOnly
 
 	req := api.InstanceBackupsPost{
-		Name:             "",
-		ExpiresAt:        time.Now().Add(24 * time.Hour),
-		ContainerOnly:    instanceOnly,
-		InstanceOnly:     instanceOnly,
-		OptimizedStorage: c.flagOptimizedStorage,
+		Name:                 "",
+		ExpiresAt:            time.Now().Add(24 * time.Hour),
+		ContainerOnly:        instanceOnly,
+		InstanceOnly:         instanceOnly,
+		OptimizedStorage:     c.flagOptimizedStorage,
+		CompressionAlgorithm: c.flagCompressionAlgorithm,
 	}
 
 	op, err := d.CreateInstanceBackup(name, req)

--- a/lxd/container_backup.go
+++ b/lxd/container_backup.go
@@ -159,12 +159,13 @@ func containerBackupsPost(d *Daemon, r *http.Request) response.Response {
 
 	backup := func(op *operations.Operation) error {
 		args := db.InstanceBackupArgs{
-			Name:             fullName,
-			InstanceID:       c.ID(),
-			CreationDate:     time.Now(),
-			ExpiryDate:       req.ExpiresAt,
-			InstanceOnly:     instanceOnly,
-			OptimizedStorage: req.OptimizedStorage,
+			Name:                 fullName,
+			InstanceID:           c.ID(),
+			CreationDate:         time.Now(),
+			ExpiryDate:           req.ExpiresAt,
+			InstanceOnly:         instanceOnly,
+			OptimizedStorage:     req.OptimizedStorage,
+			CompressionAlgorithm: req.CompressionAlgorithm,
 		}
 
 		err := backupCreate(d.State(), args, c)

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -150,12 +150,13 @@ type InstanceBackupArgs struct {
 	// Don't set manually
 	ID int
 
-	InstanceID       int
-	Name             string
-	CreationDate     time.Time
-	ExpiryDate       time.Time
-	InstanceOnly     bool
-	OptimizedStorage bool
+	InstanceID           int
+	Name                 string
+	CreationDate         time.Time
+	ExpiryDate           time.Time
+	InstanceOnly         bool
+	OptimizedStorage     bool
+	CompressionAlgorithm string
 }
 
 // ContainerNames returns the names of all containers the given project.

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-21 20:27+0000\n"
 "Last-Translator: Joshua Dietz <jospam@dietz-ulm.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -510,7 +510,7 @@ msgstr "automatisches Update: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
@@ -545,11 +545,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
@@ -566,11 +566,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Prozessorauslastung:"
@@ -958,6 +958,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -1024,7 +1028,7 @@ msgstr "Kein Zertifikat für diese Verbindung"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1134,7 +1138,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Prozessorauslastung:"
@@ -1162,7 +1166,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1302,17 +1306,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export container backups"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -1684,7 +1688,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1929,7 +1933,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -2089,15 +2093,15 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2318,7 +2322,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -2422,11 +2426,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2448,7 +2452,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2488,7 +2492,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, fuzzy, c-format
 msgid "Processes: %d"
 msgstr "Profil %s erstellt\n"
@@ -2548,7 +2552,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, fuzzy, c-format
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
@@ -2767,7 +2771,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -3108,7 +3112,7 @@ msgstr "Erstellt: %s"
 msgid "Snapshot storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -3219,11 +3223,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3403,12 +3407,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3486,7 +3490,7 @@ msgstr "Alternatives config Verzeichnis."
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3542,14 +3546,14 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 #, fuzzy
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
@@ -3869,12 +3873,12 @@ msgstr "Fehler: %v\n"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -4055,7 +4059,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4579,11 +4583,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4607,7 +4611,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -380,7 +380,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -414,11 +414,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -435,11 +435,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 #, fuzzy
 msgid "CPU usage:"
 msgstr "  Χρήση CPU:"
@@ -793,6 +793,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -855,7 +859,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -959,7 +963,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Χρήση CPU:"
@@ -987,7 +991,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1121,15 +1125,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1489,7 +1493,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1710,7 +1714,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1855,15 +1859,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Χρήση μνήμης:"
@@ -2074,7 +2078,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -2175,11 +2179,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2200,7 +2204,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2240,7 +2244,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2298,7 +2302,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2504,7 +2508,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2830,7 +2834,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2935,11 +2939,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3112,12 +3116,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3192,7 +3196,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3244,13 +3248,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3532,12 +3536,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3701,7 +3705,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4134,11 +4138,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4158,7 +4162,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -453,7 +453,7 @@ msgstr "Auto actualización: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -487,11 +487,11 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
@@ -508,11 +508,11 @@ msgstr "NOMBRE COMÚN"
 msgid "CPU (%s):"
 msgstr "Uso de CPU:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Uso de CPU (en segundos)"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr "Uso de CPU:"
 
@@ -872,6 +872,10 @@ msgstr "CONTROLADOR"
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -934,7 +938,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1038,7 +1042,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Uso del disco:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr "Uso del disco:"
 
@@ -1065,7 +1069,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1199,17 +1203,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export container backups"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "No se puede proveer el nombre del container a la lista"
@@ -1570,7 +1574,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1792,7 +1796,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr "Registro:"
 
@@ -1937,15 +1941,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2157,7 +2161,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2257,11 +2261,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2282,7 +2286,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2322,7 +2326,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr "Procesos: %d"
@@ -2380,7 +2384,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2586,7 +2590,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2912,7 +2916,7 @@ msgstr "Auto actualización: %s"
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -3017,11 +3021,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3194,12 +3198,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expira: %s"
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3274,7 +3278,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3326,13 +3330,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3616,12 +3620,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, fuzzy, c-format
 msgid "expires at %s"
 msgstr "Expira: %s"
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3785,7 +3789,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4220,11 +4224,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4244,7 +4248,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -500,7 +500,7 @@ msgstr "Mise à jour auto. : %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 #, fuzzy
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
@@ -535,11 +535,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Octets émis"
 
@@ -556,11 +556,11 @@ msgstr "COMMON NAME"
 msgid "CPU (%s):"
 msgstr "CPU utilisé :"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "CPU utilisé (en secondes)"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr "CPU utilisé :"
 
@@ -960,6 +960,11 @@ msgstr "PILOTE"
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+#, fuzzy
+msgid "Define a compression algorithm: for backup or none"
+msgstr "Définir un algorithme de compression : pour image ou aucun"
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
@@ -1027,7 +1032,7 @@ msgstr "Copie de l'image : %s"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1132,7 +1137,7 @@ msgstr "Désactiver stdin (lecture à partir de /dev/null)"
 msgid "Disk %d:"
 msgstr "  Disque utilisé :"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 #, fuzzy
 msgid "Disk usage:"
 msgstr "  Disque utilisé :"
@@ -1161,7 +1166,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
@@ -1308,17 +1313,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export container backups"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Import de l'image : %s"
@@ -1698,7 +1703,7 @@ msgstr "Source invalide %s"
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr "IPs :"
 
@@ -1984,7 +1989,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr "Journal : "
 
@@ -2137,15 +2142,15 @@ msgstr "Profil %s supprimé de %s"
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr "Mémoire (courante)"
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr "Mémoire (pointe)"
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 #, fuzzy
 msgid "Memory usage:"
 msgstr "  Mémoire utilisée :"
@@ -2371,7 +2376,7 @@ msgstr "Le réseau %s a été créé"
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -2482,11 +2487,11 @@ msgstr "PROTOCOLE"
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -2509,7 +2514,7 @@ msgstr "Création du conteneur"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid : %d"
@@ -2549,7 +2554,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr "Processus : %d"
@@ -2608,7 +2613,7 @@ msgstr "Profil à appliquer au nouveau conteneur"
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr "Profils : %s"
@@ -2827,7 +2832,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "Requérir une confirmation de l'utilisateur"
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr "Ressources :"
 
@@ -3181,7 +3186,7 @@ msgstr "État : %s"
 msgid "Snapshot storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr "Instantanés :"
 
@@ -3291,11 +3296,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr "Swap (courant)"
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
@@ -3480,12 +3485,12 @@ msgstr "Transfert de l'image : %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "Essayer `lxc info --show-log %s` pour plus d'informations"
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, fuzzy, c-format
 msgid "Type: %s"
 msgstr "Expire : %s"
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "Type : éphémère"
@@ -3568,7 +3573,7 @@ msgstr "Clé de configuration invalide"
 msgid "Uploaded: %s"
 msgstr "Publié : %s"
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3621,14 +3626,14 @@ msgstr "Nom : %s"
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 #, fuzzy
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
@@ -3958,12 +3963,12 @@ msgstr "erreur : %v"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, fuzzy, c-format
 msgid "expires at %s"
 msgstr "Expire : %s"
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -4148,7 +4153,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4720,11 +4725,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr "à suivi d'état"
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr "sans suivi d'état"
 
@@ -4750,7 +4755,7 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "switch [<remote>:] <project>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr "pris à %s"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -417,7 +417,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -451,11 +451,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
@@ -472,11 +472,11 @@ msgstr "NOME COMUNE"
 msgid "CPU (%s):"
 msgstr "Utilizzo CPU:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Utilizzo CPU (in secondi)"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr "Utilizzo CPU:"
 
@@ -834,6 +834,10 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -896,7 +900,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1000,7 +1004,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr "Utilizzo disco:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr "Utilizzo disco:"
 
@@ -1027,7 +1031,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1161,17 +1165,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export container backups"
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Creazione del container in corso"
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Creazione del container in corso"
@@ -1535,7 +1539,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1758,7 +1762,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1905,15 +1909,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2224,11 +2228,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2250,7 +2254,7 @@ msgstr "Creazione del container in corso"
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2290,7 +2294,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2348,7 +2352,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2554,7 +2558,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2881,7 +2885,7 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2988,11 +2992,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3166,12 +3170,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3247,7 +3251,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3299,13 +3303,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3590,12 +3594,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3759,7 +3763,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4194,11 +4198,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr "senza stato"
 
@@ -4218,7 +4222,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr "salvato alle %s"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-20 11:43+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -393,7 +393,7 @@ msgstr "自動更新: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
@@ -428,11 +428,11 @@ msgstr "--all とコンテナ名を両方同時に指定することはできま
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
@@ -449,11 +449,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr "CPU (%s):"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "CPU使用量（秒）"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr "CPU使用量:"
 
@@ -823,6 +823,11 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+#, fuzzy
+msgid "Define a compression algorithm: for backup or none"
+msgstr "圧縮アルゴリズムを指定します: 圧縮アルゴリズム名 or none"
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr "圧縮アルゴリズムを指定します: 圧縮アルゴリズム名 or none"
@@ -885,7 +890,7 @@ msgstr "ストレージボリュームを削除します"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -992,7 +997,7 @@ msgstr "標準入力を無効にします (/dev/null から読み込みます)"
 msgid "Disk %d:"
 msgstr "ディスク %d:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr "ディスク使用量:"
 
@@ -1017,7 +1022,7 @@ msgstr "進捗情報を表示しません"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1178,15 +1183,15 @@ msgstr ""
 "\n"
 "出力先はオプショナルで、デフォルトは現在のディレクトリです。"
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr "コンテナのバックアップをエクスポートします"
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr "コンテナを tarball 形式のバックアップとしてエクスポートします。"
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr "バックアップのエクスポート中: %s"
@@ -1570,7 +1575,7 @@ msgstr "不正なソース %s"
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr "IPアドレス:"
 
@@ -1879,7 +1884,7 @@ msgstr "バックグラウンド操作の一覧表示、表示、削除を行い
 msgid "Location: %s"
 msgstr "ロケーション: %s"
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr "ログ:"
 
@@ -2041,15 +2046,15 @@ msgstr "メンバ %s が削除されました"
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr "メモリ (現在値)"
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr "メモリ (ピーク)"
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr "メモリ消費量:"
 
@@ -2265,7 +2270,7 @@ msgstr "ネットワーク名 %s を %s に変更しました"
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -2365,11 +2370,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -2390,7 +2395,7 @@ msgstr "コンテナを一時停止します"
 msgid "Perform an incremental copy"
 msgstr "インクリメンタルコピーを実行します"
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr "Pid: %d"
@@ -2430,7 +2435,7 @@ msgstr "レスポンスをそのまま表示します"
 msgid "Print version number"
 msgstr "バージョン番号を表示します"
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr "プロセス数: %d"
@@ -2488,7 +2493,7 @@ msgstr "移動先のコンテナに適用するプロファイル"
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
@@ -2695,7 +2700,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr "ユーザの確認を要求する"
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr "リソース:"
 
@@ -3056,7 +3061,7 @@ msgstr "サイズ: %s"
 msgid "Snapshot storage volumes"
 msgstr "ストレージボリュームのスナップショットを取得します"
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr "スナップショット:"
 
@@ -3161,11 +3166,11 @@ msgstr "サポートするモード: %s"
 msgid "Supported ports: %s"
 msgstr "サポートするポート: %s"
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr "Swap (現在値)"
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
@@ -3361,12 +3366,12 @@ msgstr "イメージを転送中: %s"
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr "更に情報を得るために `lxc info --show-log %s` を実行してみてください"
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr "タイプ: %s"
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, fuzzy, c-format
 msgid "Type: %s (ephemeral)"
 msgstr "タイプ: ephemeral"
@@ -3441,7 +3446,7 @@ msgstr "ストレージボリュームの設定を削除します"
 msgid "Uploaded: %s"
 msgstr "アップロード日時: %s"
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3497,14 +3502,14 @@ msgstr "WWN: %s"
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 #, fuzzy
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr "スナップショットを含めずにコンテナのみをバックアップするかどうか"
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 #, fuzzy
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr "スナップショットを含めずにコンテナのみをバックアップするかどうか"
@@ -3791,12 +3796,12 @@ msgstr "エラー: %v"
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr "%s に失効"
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3981,7 +3986,7 @@ msgstr ""
 "lxc config set core.trust_password=blah\n"
 "    サーバの認証パスワードを blah に設定します。"
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4513,11 +4518,11 @@ msgstr "使用量"
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr "start [<remote>:]<container> [[<remote>:]<container>...]"
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr "ステートフル"
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr "ステートレス"
 
@@ -4537,7 +4542,7 @@ msgstr "switch <remote>"
 msgid "switch [<remote>:] <project>"
 msgstr "switch [<remote>:] <project>"
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr "%s に取得しました"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-10-07 17:23+0100\n"
+        "POT-Creation-Date: 2019-10-08 20:20+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -365,7 +365,7 @@ msgstr  ""
 msgid   "BASE IMAGE"
 msgstr  ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid   "Backup exported successfully!"
 msgstr  ""
 
@@ -398,11 +398,11 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid   "Bytes sent"
 msgstr  ""
 
@@ -419,11 +419,11 @@ msgstr  ""
 msgid   "CPU (%s):"
 msgstr  ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid   "CPU usage (in seconds)"
 msgstr  ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid   "CPU usage:"
 msgstr  ""
 
@@ -759,6 +759,10 @@ msgstr  ""
 msgid   "DRM:"
 msgstr  ""
 
+#: lxc/export.go:46
+msgid   "Define a compression algorithm: for backup or none"
+msgstr  ""
+
 #: lxc/publish.go:42
 msgid   "Define a compression algorithm: for image or none"
 msgstr  ""
@@ -807,7 +811,7 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:182 lxc/config_device.go:255 lxc/config_device.go:321 lxc/config_device.go:410 lxc/config_device.go:500 lxc/config_device.go:599 lxc/config_device.go:667 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1276 lxc/storage_volume.go:1352 lxc/storage_volume.go:1451 lxc/storage_volume.go:1482 lxc/storage_volume.go:1553 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
@@ -877,7 +881,7 @@ msgstr  ""
 msgid   "Disk %d:"
 msgstr  ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid   "Disk usage:"
 msgstr  ""
 
@@ -902,7 +906,7 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid   "EPHEMERAL"
 msgstr  ""
 
@@ -1027,15 +1031,15 @@ msgid   "Export and download images\n"
         "The output target is optional and defaults to the working directory."
 msgstr  ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid   "Export container backups"
 msgstr  ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid   "Export containers as backup tarballs."
 msgstr  ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid   "Exporting the backup: %s"
 msgstr  ""
@@ -1381,7 +1385,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid   "Ips:"
 msgstr  ""
 
@@ -1595,7 +1599,7 @@ msgstr  ""
 msgid   "Location: %s"
 msgstr  ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid   "Log:"
 msgstr  ""
 
@@ -1737,15 +1741,15 @@ msgstr  ""
 msgid   "Member %s renamed to %s"
 msgstr  ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid   "Memory (current)"
 msgstr  ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid   "Memory (peak)"
 msgstr  ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid   "Memory usage:"
 msgstr  ""
 
@@ -1930,7 +1934,7 @@ msgstr  ""
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid   "Network usage:"
 msgstr  ""
 
@@ -2030,11 +2034,11 @@ msgstr  ""
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid   "Packets sent"
 msgstr  ""
 
@@ -2055,7 +2059,7 @@ msgstr  ""
 msgid   "Perform an incremental copy"
 msgstr  ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid   "Pid: %d"
 msgstr  ""
@@ -2093,7 +2097,7 @@ msgstr  ""
 msgid   "Print version number"
 msgstr  ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid   "Processes: %d"
 msgstr  ""
@@ -2151,7 +2155,7 @@ msgstr  ""
 msgid   "Profiles %s applied to %s"
 msgstr  ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid   "Profiles: %s"
 msgstr  ""
@@ -2355,7 +2359,7 @@ msgstr  ""
 msgid   "Require user confirmation"
 msgstr  ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid   "Resources:"
 msgstr  ""
 
@@ -2664,7 +2668,7 @@ msgstr  ""
 msgid   "Snapshot storage volumes"
 msgstr  ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid   "Snapshots:"
 msgstr  ""
 
@@ -2769,11 +2773,11 @@ msgstr  ""
 msgid   "Supported ports: %s"
 msgstr  ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid   "Swap (current)"
 msgstr  ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid   "Swap (peak)"
 msgstr  ""
 
@@ -2936,12 +2940,12 @@ msgstr  ""
 msgid   "Try `lxc info --show-log %s` for more info"
 msgstr  ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid   "Type: %s"
 msgstr  ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid   "Type: %s (ephemeral)"
 msgstr  ""
@@ -3015,7 +3019,7 @@ msgstr  ""
 msgid   "Uploaded: %s"
 msgstr  ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid   "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr  ""
 
@@ -3065,11 +3069,11 @@ msgstr  ""
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid   "Whether or not to only backup the container (without snapshots), (deprecated, use instance-only)"
 msgstr  ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid   "Whether or not to only backup the instance (without snapshots)"
 msgstr  ""
 
@@ -3342,12 +3346,12 @@ msgstr  ""
 msgid   "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr  ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid   "expires at %s"
 msgstr  ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid   "export [<remote>:]<container> [target] [--container-only] [--optimized-storage]"
 msgstr  ""
 
@@ -3499,7 +3503,7 @@ msgid   "lxc config set [<remote>:]<container> limits.cpu=2\n"
         "    Will set the server's trust password to blah."
 msgstr  ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid   "lxc export u1 backup0.tar.gz\n"
         "    Download a backup tarball of the u1 container."
 msgstr  ""
@@ -3894,11 +3898,11 @@ msgstr  ""
 msgid   "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr  ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid   "stateful"
 msgstr  ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid   "stateless"
 msgstr  ""
 
@@ -3918,7 +3922,7 @@ msgstr  ""
 msgid   "switch [<remote>:] <project>"
 msgstr  ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid   "taken at %s"
 msgstr  ""

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -426,7 +426,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -460,11 +460,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -481,11 +481,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -838,6 +838,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -900,7 +904,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -1029,7 +1033,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1163,15 +1167,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1531,7 +1535,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1752,7 +1756,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1897,15 +1901,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2114,7 +2118,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2214,11 +2218,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2279,7 +2283,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2337,7 +2341,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2543,7 +2547,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2869,7 +2873,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2974,11 +2978,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3151,12 +3155,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3231,7 +3235,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3283,13 +3287,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3571,12 +3575,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3740,7 +3744,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4173,11 +4177,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4197,7 +4201,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -426,7 +426,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -460,11 +460,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -481,11 +481,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -838,6 +838,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -900,7 +904,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1004,7 +1008,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -1029,7 +1033,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1163,15 +1167,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1531,7 +1535,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1752,7 +1756,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1897,15 +1901,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2114,7 +2118,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2214,11 +2218,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2239,7 +2243,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2279,7 +2283,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2337,7 +2341,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2543,7 +2547,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2869,7 +2873,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2974,11 +2978,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3151,12 +3155,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3231,7 +3235,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3283,13 +3287,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3571,12 +3575,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3740,7 +3744,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4173,11 +4177,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4197,7 +4201,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -499,7 +499,7 @@ msgstr "Atualização automática: %s"
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
@@ -533,11 +533,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
@@ -554,11 +554,11 @@ msgstr "NOME COMUM"
 msgid "CPU (%s):"
 msgstr "Utilização do CPU:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Utilização do CPU (em segundos)"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr "Utilização do CPU:"
 
@@ -923,6 +923,11 @@ msgstr "DRIVER"
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+#, fuzzy
+msgid "Define a compression algorithm: for backup or none"
+msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
@@ -985,7 +990,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1089,7 +1094,7 @@ msgstr "Desabilitar stdin (ler de /dev/null)"
 msgid "Disk %d:"
 msgstr "Uso de disco:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr "Uso de disco:"
 
@@ -1116,7 +1121,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
@@ -1251,15 +1256,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1620,7 +1625,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1841,7 +1846,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1986,15 +1991,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2203,7 +2208,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2303,11 +2308,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2328,7 +2333,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2368,7 +2373,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2426,7 +2431,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2632,7 +2637,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2959,7 +2964,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -3064,11 +3069,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3241,12 +3246,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3322,7 +3327,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3374,13 +3379,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3662,12 +3667,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3831,7 +3836,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4264,11 +4269,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4288,7 +4293,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -489,7 +489,7 @@ msgstr "Авто-обновление: %s"
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -523,11 +523,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
@@ -544,11 +544,11 @@ msgstr "ОБЩЕЕ ИМЯ"
 msgid "CPU (%s):"
 msgstr " Использование ЦП:"
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr "Использование ЦП (в секундах)"
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 #, fuzzy
 msgid "CPU usage:"
 msgstr " Использование ЦП:"
@@ -912,6 +912,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -977,7 +981,7 @@ msgstr "Копирование образа: %s"
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -1081,7 +1085,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr " Использование диска:"
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 #, fuzzy
 msgid "Disk usage:"
 msgstr " Использование диска:"
@@ -1109,7 +1113,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1245,17 +1249,17 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 #, fuzzy
 msgid "Export container backups"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 #, fuzzy
 msgid "Export containers as backup tarballs."
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, fuzzy, c-format
 msgid "Exporting the backup: %s"
 msgstr "Копирование образа: %s"
@@ -1618,7 +1622,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1842,7 +1846,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1990,15 +1994,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 #, fuzzy
 msgid "Memory usage:"
 msgstr " Использование памяти:"
@@ -2213,7 +2217,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -2315,11 +2319,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2340,7 +2344,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2380,7 +2384,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2438,7 +2442,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2649,7 +2653,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2979,7 +2983,7 @@ msgstr "Авто-обновление: %s"
 msgid "Snapshot storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -3086,11 +3090,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3263,12 +3267,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3343,7 +3347,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3395,13 +3399,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3712,12 +3716,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 #, fuzzy
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
@@ -3897,7 +3901,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4406,11 +4410,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4434,7 +4438,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -377,7 +377,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -411,11 +411,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -432,11 +432,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -789,6 +789,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -851,7 +855,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -955,7 +959,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -980,7 +984,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1114,15 +1118,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1482,7 +1486,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1703,7 +1707,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1848,15 +1852,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2065,7 +2069,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2165,11 +2169,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2190,7 +2194,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2230,7 +2234,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2288,7 +2292,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2494,7 +2498,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2820,7 +2824,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2925,11 +2929,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3102,12 +3106,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3182,7 +3186,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3234,13 +3238,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3522,12 +3526,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3691,7 +3695,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4124,11 +4128,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4148,7 +4152,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-07 17:23+0100\n"
+"POT-Creation-Date: 2019-10-08 20:20+0000\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -380,7 +380,7 @@ msgstr ""
 msgid "BASE IMAGE"
 msgstr ""
 
-#: lxc/export.go:133
+#: lxc/export.go:136
 msgid "Backup exported successfully!"
 msgstr ""
 
@@ -414,11 +414,11 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:541 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:785
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:542 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:786
 msgid "Bytes sent"
 msgstr ""
 
@@ -435,11 +435,11 @@ msgstr ""
 msgid "CPU (%s):"
 msgstr ""
 
-#: lxc/info.go:505
+#: lxc/info.go:509
 msgid "CPU usage (in seconds)"
 msgstr ""
 
-#: lxc/info.go:509
+#: lxc/info.go:513
 msgid "CPU usage:"
 msgstr ""
 
@@ -792,6 +792,10 @@ msgstr ""
 msgid "DRM:"
 msgstr ""
 
+#: lxc/export.go:46
+msgid "Define a compression algorithm: for backup or none"
+msgstr ""
+
 #: lxc/publish.go:42
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
@@ -854,7 +858,7 @@ msgstr ""
 #: lxc/config_template.go:150 lxc/config_template.go:236
 #: lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57
 #: lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32
-#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:32
+#: lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33
 #: lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217
 #: lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270
 #: lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808
@@ -958,7 +962,7 @@ msgstr ""
 msgid "Disk %d:"
 msgstr ""
 
-#: lxc/info.go:498
+#: lxc/info.go:502
 msgid "Disk usage:"
 msgstr ""
 
@@ -983,7 +987,7 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:624
+#: lxc/list.go:628
 msgid "EPHEMERAL"
 msgstr ""
 
@@ -1117,15 +1121,15 @@ msgid ""
 "The output target is optional and defaults to the working directory."
 msgstr ""
 
-#: lxc/export.go:31
+#: lxc/export.go:32
 msgid "Export container backups"
 msgstr ""
 
-#: lxc/export.go:32
+#: lxc/export.go:33
 msgid "Export containers as backup tarballs."
 msgstr ""
 
-#: lxc/export.go:117
+#: lxc/export.go:120
 #, c-format
 msgid "Exporting the backup: %s"
 msgstr ""
@@ -1485,7 +1489,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:479 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:777
 msgid "Ips:"
 msgstr ""
 
@@ -1706,7 +1710,7 @@ msgstr ""
 msgid "Location: %s"
 msgstr ""
 
-#: lxc/info.go:598
+#: lxc/info.go:602
 msgid "Log:"
 msgstr ""
 
@@ -1851,15 +1855,15 @@ msgstr ""
 msgid "Member %s renamed to %s"
 msgstr ""
 
-#: lxc/info.go:516
+#: lxc/info.go:520
 msgid "Memory (current)"
 msgstr ""
 
-#: lxc/info.go:520
+#: lxc/info.go:524
 msgid "Memory (peak)"
 msgstr ""
 
-#: lxc/info.go:532
+#: lxc/info.go:536
 msgid "Memory usage:"
 msgstr ""
 
@@ -2068,7 +2072,7 @@ msgstr ""
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:549 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:784
 msgid "Network usage:"
 msgstr ""
 
@@ -2168,11 +2172,11 @@ msgstr ""
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:543 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:787
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:544 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:788
 msgid "Packets sent"
 msgstr ""
 
@@ -2193,7 +2197,7 @@ msgstr ""
 msgid "Perform an incremental copy"
 msgstr ""
 
-#: lxc/info.go:461
+#: lxc/info.go:465
 #, c-format
 msgid "Pid: %d"
 msgstr ""
@@ -2233,7 +2237,7 @@ msgstr ""
 msgid "Print version number"
 msgstr ""
 
-#: lxc/info.go:485
+#: lxc/info.go:489
 #, c-format
 msgid "Processes: %d"
 msgstr ""
@@ -2291,7 +2295,7 @@ msgstr ""
 msgid "Profiles %s applied to %s"
 msgstr ""
 
-#: lxc/info.go:459
+#: lxc/info.go:463
 #, c-format
 msgid "Profiles: %s"
 msgstr ""
@@ -2497,7 +2501,7 @@ msgstr ""
 msgid "Require user confirmation"
 msgstr ""
 
-#: lxc/info.go:482
+#: lxc/info.go:486
 msgid "Resources:"
 msgstr ""
 
@@ -2823,7 +2827,7 @@ msgstr ""
 msgid "Snapshot storage volumes"
 msgstr ""
 
-#: lxc/info.go:563
+#: lxc/info.go:567
 msgid "Snapshots:"
 msgstr ""
 
@@ -2928,11 +2932,11 @@ msgstr ""
 msgid "Supported ports: %s"
 msgstr ""
 
-#: lxc/info.go:524
+#: lxc/info.go:528
 msgid "Swap (current)"
 msgstr ""
 
-#: lxc/info.go:528
+#: lxc/info.go:532
 msgid "Swap (peak)"
 msgstr ""
 
@@ -3105,12 +3109,12 @@ msgstr ""
 msgid "Try `lxc info --show-log %s` for more info"
 msgstr ""
 
-#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:456
+#: lxc/image.go:870 lxc/info.go:245 lxc/info.go:460
 #, c-format
 msgid "Type: %s"
 msgstr ""
 
-#: lxc/info.go:454
+#: lxc/info.go:458
 #, c-format
 msgid "Type: %s (ephemeral)"
 msgstr ""
@@ -3185,7 +3189,7 @@ msgstr ""
 msgid "Uploaded: %s"
 msgstr ""
 
-#: lxc/export.go:44
+#: lxc/export.go:45
 msgid ""
 "Use storage driver optimized format (can only be restored on a similar pool)"
 msgstr ""
@@ -3237,13 +3241,13 @@ msgstr ""
 msgid "Wait for the operation to complete"
 msgstr ""
 
-#: lxc/export.go:40
+#: lxc/export.go:41
 msgid ""
 "Whether or not to only backup the container (without snapshots), "
 "(deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/export.go:42
+#: lxc/export.go:43
 msgid "Whether or not to only backup the instance (without snapshots)"
 msgstr ""
 
@@ -3525,12 +3529,12 @@ msgstr ""
 msgid "exec [<remote>:]<container> [flags] [--] <command line>"
 msgstr ""
 
-#: lxc/info.go:574
+#: lxc/info.go:578
 #, c-format
 msgid "expires at %s"
 msgstr ""
 
-#: lxc/export.go:30
+#: lxc/export.go:31
 msgid ""
 "export [<remote>:]<container> [target] [--container-only] [--optimized-"
 "storage]"
@@ -3694,7 +3698,7 @@ msgid ""
 "    Will set the server's trust password to blah."
 msgstr ""
 
-#: lxc/export.go:34
+#: lxc/export.go:35
 msgid ""
 "lxc export u1 backup0.tar.gz\n"
 "    Download a backup tarball of the u1 container."
@@ -4127,11 +4131,11 @@ msgstr ""
 msgid "start [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/info.go:578
+#: lxc/info.go:582
 msgid "stateful"
 msgstr ""
 
-#: lxc/info.go:580
+#: lxc/info.go:584
 msgid "stateless"
 msgstr ""
 
@@ -4151,7 +4155,7 @@ msgstr ""
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
-#: lxc/info.go:570
+#: lxc/info.go:574
 #, c-format
 msgid "taken at %s"
 msgstr ""

--- a/shared/api/instance_backup.go
+++ b/shared/api/instance_backup.go
@@ -11,6 +11,9 @@ type InstanceBackupsPost struct {
 	InstanceOnly     bool      `json:"instance_only" yaml:"instance_only"`
 	ContainerOnly    bool      `json:"container_only" yaml:"container_only"` // Deprecated, use InstanceOnly.
 	OptimizedStorage bool      `json:"optimized_storage" yaml:"optimized_storage"`
+
+	// API extension: backup_compression_algorithm
+	CompressionAlgorithm string `json:"compression_algorithm" yaml:"compression_algorithm"`
 }
 
 // InstanceBackup represents a LXD instance backup.

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -170,6 +170,7 @@ var APIExtensions = []string{
 	"clustering_roles",
 	"images_expiry",
 	"resources_network_firmware",
+	"backup_compression_algorithm",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This adds support support for `--compression` in `lxc export` as described in #6284.
User is able to specify compression algorithm that will be used to compress the exported backup. If the compression algorithm is `none` then no compression will be used