### PR TITLE
lxd/storage/ceph: Implement --data-pool argument.

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -853,3 +853,9 @@ Adds a FirmwareVersion field to network card entries.
 This adds support for a `compression_algorithm` property when creating a backup (`POST /1.0/containers/<name>/backups`).
 
 Setting this property overrides the server default value (`backups.compression_algorithm`).
+
+## ceph\_data\_pool\_name
+This adds support for an optional argument (`ceph.osd.data_pool_name`) when creating
+storage pools using Ceph RBD, when this argument is used the pool will store it's
+actual data in the pool specified with `data_pool_name` while keeping the metadata
+in the pool specified by `pool_name`.

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -14,6 +14,7 @@ ceph.cluster\_name              | string    | ceph driver                       
 ceph.osd.force\_reuse           | bool      | ceph driver                       | false                      | storage\_ceph\_force\_osd\_reuse   | Force using an osd storage pool that is already in use by another LXD instance.
 ceph.osd.pg\_num                | string    | ceph driver                       | 32                         | storage\_driver\_ceph              | Number of placement groups for the osd storage pool.
 ceph.osd.pool\_name             | string    | ceph driver                       | name of the pool           | storage\_driver\_ceph              | Name of the osd storage pool.
+ceph.osd.data\_pool\_name       | string    | ceph driver                       | -                          | storage\_driver\_ceph              | Name of the osd data pool.
 ceph.rbd.clone\_copy            | string    | ceph driver                       | true                       | storage\_driver\_ceph              | Whether to use RBD lightweight clones rather than full dataset copies.
 ceph.user.name                  | string    | ceph driver                       | admin                      | storage\_ceph\_user\_name          | The ceph user to use when creating storage pools and volumes.
 cephfs.cluster\_name            | string    | cephfs driver                     | ceph                       | storage\_driver\_cephfs            | Name of the ceph cluster in which to create new storage pools.

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -27,10 +27,11 @@ import (
 )
 
 type storageCeph struct {
-	ClusterName string
-	OSDPoolName string
-	UserName    string
-	PGNum       string
+	ClusterName     string
+	OSDPoolName     string
+	OSDDataPoolName string
+	UserName        string
+	PGNum           string
 	storageShared
 }
 
@@ -77,6 +78,11 @@ func (s *storageCeph) StoragePoolInit() error {
 	// set osd pool name
 	if s.pool.Config["ceph.osd.pool_name"] != "" {
 		s.OSDPoolName = s.pool.Config["ceph.osd.pool_name"]
+	}
+
+	// set osd data pool name
+	if s.pool.Config["ceph.osd.data_pool_name"] != "" {
+		s.OSDDataPoolName = s.pool.Config["ceph.osd.data_pool_name"]
 	}
 
 	// set ceph user name
@@ -159,7 +165,7 @@ func (s *storageCeph) StoragePoolCreate() error {
 		}()
 
 		// Create dummy storage volume. Other LXD instances will use this to detect whether this osd pool is already in use by another LXD instance.
-		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, s.OSDPoolName, "lxd", "0", s.UserName)
+		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, s.OSDPoolName, "lxd", "0", s.UserName, s.OSDDataPoolName)
 		if err != nil {
 			logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, s.pool.Name, s.pool.Name, err)
 			return err
@@ -320,7 +326,7 @@ func (s *storageCeph) StoragePoolVolumeCreate() error {
 
 	// create volume
 	err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, s.volume.Name,
-		storagePoolVolumeTypeNameCustom, RBDSize, s.UserName)
+		storagePoolVolumeTypeNameCustom, RBDSize, s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 		return err
@@ -852,7 +858,7 @@ func (s *storageCeph) ContainerCreateFromImage(container Instance, fingerprint s
 	volumeName := project.Prefix(container.Project(), containerName)
 	err := cephRBDCloneCreate(s.ClusterName, s.OSDPoolName, fingerprint,
 		storagePoolVolumeTypeNameImage, "readonly", s.OSDPoolName,
-		volumeName, storagePoolVolumeTypeNameContainer, s.UserName)
+		volumeName, storagePoolVolumeTypeNameContainer, s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf(`Failed to clone new RBD storage volume for container "%s": %s`, containerName, err)
 		return err
@@ -1164,7 +1170,7 @@ func (s *storageCeph) ContainerCopy(target Instance, source Instance, containerO
 		// create empty dummy volume
 		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName,
 			project.Prefix(target.Project(), targetContainerName), storagePoolVolumeTypeNameContainer,
-			"0", s.UserName)
+			"0", s.UserName, s.OSDDataPoolName)
 		if err != nil {
 			logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, targetContainerName, s.pool.Name, err)
 			return err
@@ -1758,7 +1764,7 @@ func (s *storageCeph) ContainerSnapshotStart(c Instance) (bool, error) {
 	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName,
 		containerOnlyName, storagePoolVolumeTypeNameContainer,
 		prefixedSnapOnlyName, s.OSDPoolName, cloneName, "snapshots",
-		s.UserName)
+		s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf(`Failed to create clone of RBD storage volume for container "%s" on storage pool "%s": %s`, containerName, s.pool.Name, err)
 		return false, err
@@ -2062,7 +2068,7 @@ func (s *storageCeph) ImageCreate(fingerprint string, tracker *ioprogress.Progre
 		// create volume
 		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName,
 			fingerprint, storagePoolVolumeTypeNameImage, RBDSize,
-			s.UserName)
+			s.UserName, s.OSDDataPoolName)
 		if err != nil {
 			logger.Errorf(`Failed to create RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 			return err
@@ -2570,7 +2576,7 @@ func (s *storageCeph) StoragePoolVolumeCopy(source *api.StorageVolumeSource) err
 		// create empty dummy volume
 		err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName,
 			s.volume.Name, storagePoolVolumeTypeNameCustom,
-			"0", s.UserName)
+			"0", s.UserName, s.OSDDataPoolName)
 		if err != nil {
 			logger.Errorf(`Failed to create RBD storage volume "%s" on storage pool "%s": %s`, s.volume.Name, s.pool.Name, err)
 			return err
@@ -2907,7 +2913,7 @@ func (s *storageCeph) MigrationSink(conn *websocket.Conn, op *operations.Operati
 	// that's actually correct.
 	instanceName := args.Instance.Name()
 	if !cephRBDVolumeExists(s.ClusterName, s.OSDPoolName, project.Prefix(args.Instance.Project(), instanceName), storagePoolVolumeTypeNameContainer, s.UserName) {
-		err := cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, project.Prefix(args.Instance.Project(), instanceName), storagePoolVolumeTypeNameContainer, "0", s.UserName)
+		err := cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, project.Prefix(args.Instance.Project(), instanceName), storagePoolVolumeTypeNameContainer, "0", s.UserName, s.OSDDataPoolName)
 		if err != nil {
 			logger.Errorf(`Failed to create RBD storage volume "%s" for cluster "%s" in OSD pool "%s" on storage pool "%s": %s`, instanceName, s.ClusterName, s.OSDPoolName, s.pool.Name, err)
 			return err

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -72,13 +72,14 @@ func cephOSDPoolDestroy(clusterName string, poolName string, userName string) er
 // library and the kernel module are minimized. Otherwise random panics might
 // occur.
 func cephRBDVolumeCreate(clusterName string, poolName string, volumeName string,
-	volumeType string, size string, userName string) error {
+	volumeType string, size string, userName string, dataPoolName string) error {
 	_, err := shared.RunCommand(
 		"rbd",
 		"--id", userName,
 		"--image-feature", "layering,",
 		"--cluster", clusterName,
 		"--pool", poolName,
+		"--data-pool", dataPoolName,
 		"--size", size,
 		"create",
 		fmt.Sprintf("%s_%s", volumeType, volumeName))
@@ -364,12 +365,13 @@ func cephRBDCloneCreate(sourceClusterName string, sourcePoolName string,
 	sourceVolumeName string, sourceVolumeType string,
 	sourceSnapshotName string, targetPoolName string,
 	targetVolumeName string, targetVolumeType string,
-	userName string) error {
+	userName string, targetDataPoolName string) error {
 	_, err := shared.RunCommand(
 		"rbd",
 		"--id", userName,
 		"--cluster", sourceClusterName,
 		"--image-feature", "layering",
+		"--data-pool", targetDataPoolName,
 		"clone",
 		fmt.Sprintf("%s/%s_%s@%s", sourcePoolName, sourceVolumeType,
 			sourceVolumeName, sourceSnapshotName),
@@ -833,7 +835,7 @@ func (s *storageCeph) copyWithoutSnapshotsSparse(target Instance, source Instanc
 	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName,
 		sourceContainerOnlyName, storagePoolVolumeTypeNameContainer,
 		snapshotName, s.OSDPoolName, targetContainerName,
-		storagePoolVolumeTypeNameContainer, s.UserName)
+		storagePoolVolumeTypeNameContainer, s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf(`Failed to clone new RBD storage volume for container "%s": %s`, targetContainerName, err)
 		return err
@@ -1631,7 +1633,7 @@ func (s *storageCeph) cephRBDVolumeBackupCreate(tmpPath string, backup backup, s
 
 	// Create a new volume from the snapshot
 	cloneName := uuid.NewRandom().String()
-	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName, sourceContainerOnlyName, storagePoolVolumeTypeNameContainer, snapshotName, s.OSDPoolName, cloneName, "backup", s.UserName)
+	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName, sourceContainerOnlyName, storagePoolVolumeTypeNameContainer, snapshotName, s.OSDPoolName, cloneName, "backup", s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		return err
 	}
@@ -1714,7 +1716,7 @@ func (s *storageCeph) doContainerCreate(projectName, name string, privileged boo
 
 	// create volume
 	volumeName := project.Prefix(projectName, name)
-	err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, volumeName, storagePoolVolumeTypeNameContainer, RBDSize, s.UserName)
+	err = cephRBDVolumeCreate(s.ClusterName, s.OSDPoolName, volumeName, storagePoolVolumeTypeNameContainer, RBDSize, s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf(`Failed to create RBD storage volume for container "%s" on storage pool "%s": %s`, name, s.pool.Name, err)
 		return err
@@ -2026,7 +2028,7 @@ func (s *storageCeph) copyVolumeWithoutSnapshotsSparse(source *api.StorageVolume
 	}
 
 	// create new clone
-	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName, sourceOnlyName, storagePoolVolumeTypeNameCustom, snapshotOnlyName, s.OSDPoolName, s.volume.Name, storagePoolVolumeTypeNameCustom, s.UserName)
+	err = cephRBDCloneCreate(s.ClusterName, s.OSDPoolName, sourceOnlyName, storagePoolVolumeTypeNameCustom, snapshotOnlyName, s.OSDPoolName, s.volume.Name, storagePoolVolumeTypeNameCustom, s.UserName, s.OSDDataPoolName)
 	if err != nil {
 		logger.Errorf("Failed to clone RBD storage volume \"%s\" on storage pool \"%s\": %s", source.Name, source.Pool, err)
 		return err

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -55,9 +55,10 @@ var storagePoolConfigKeys = map[string]func(value string) error{
 	"btrfs.mount_options": shared.IsAny,
 
 	// valid drivers: ceph
-	"ceph.cluster_name":    shared.IsAny,
-	"ceph.osd.force_reuse": shared.IsBool,
-	"ceph.osd.pool_name":   shared.IsAny,
+	"ceph.cluster_name":       shared.IsAny,
+	"ceph.osd.force_reuse":    shared.IsBool,
+	"ceph.osd.pool_name":      shared.IsAny,
+	"ceph.osd.data_pool_name": shared.IsAny,
 	"ceph.osd.pg_num": func(value string) error {
 		if value == "" {
 			return nil

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -119,7 +119,7 @@ _have lxc && {
       ipv6.routes ipv6.routing raw.dnsmasq"
 
     storage_pool_keys="source size btrfs.mount_options ceph.cluster_name \
-      ceph.osd.force_reuse ceph.osd.pg_num ceph.osd.pool_name \
+      ceph.osd.force_reuse ceph.osd.pg_num ceph.osd.pool_name ceph.osd.data_pool_name \
       ceph.rbd.clone_copy ceph.user.name cephfs.cluster_name cephfs.path \
       cephfs.vg_name lvm.thinpool_name lvm.use_thinpool \
       lvm.vg_name rsync.bwlimit volatile.initial_source \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -171,6 +171,7 @@ var APIExtensions = []string{
 	"images_expiry",
 	"resources_network_firmware",
 	"backup_compression_algorithm",
+	"ceph_data_pool_name",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
It's now possible to create a lxd storage pool that's backed by a Ceph erasure encoded pool. To do so supply both the `ceph.osd.pool_name` (this will be used to store the metadata about the rbd image) and the `ceph.osd.data_pool_name` (this is where the actual data will be stored). 

For example `storage create erasure-pool ceph ceph.osd.pool_name=rbd ceph.osd.data_pool_name=k2m1-pool`

