### PR TITLE
lxd/device/nic: Pass --concurrent to ebtables

### DIFF
--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -391,7 +391,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) error {
 	}
 
 	// Get a current list of rules active on the host.
-	out, err := shared.RunCommand("ebtables", "-L", "--Lmac2", "--Lx")
+	out, err := shared.RunCommand("ebtables", "--concurrent", "-L", "--Lmac2", "--Lx")
 	if err != nil {
 		return fmt.Errorf("Failed to remove network filters for %s: %v", m["name"], err)
 	}
@@ -419,7 +419,7 @@ func (d *nicBridged) removeFilters(m deviceConfig.Device) error {
 
 			// If we get this far, then the current host rule matches one of our LXD
 			// rules, so we should run the modified command to delete it.
-			_, err = shared.RunCommand(fields[0], fields[1:]...)
+			_, err = shared.RunCommand(fields[0], append([]string{"--concurrent"}, fields[1:]...)...)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -579,7 +579,7 @@ func (d *nicBridged) setFilters() (err error) {
 
 	rules := d.generateFilterEbtablesRules(d.config, IPv4, IPv6)
 	for _, rule := range rules {
-		_, err = shared.RunCommand(rule[0], rule[1:]...)
+		_, err = shared.RunCommand(rule[0], append([]string{"--concurrent"}, rule[1:]...)...)
 		if err != nil {
 			return err
 		}

--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -53,7 +53,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Check MAC filter is present in ebtables.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
-  if ! ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter not applied in ebtables"
       false
   fi
@@ -82,7 +82,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
-  if ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+  if ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter still applied in ebtables"
       false
   fi
@@ -101,13 +101,13 @@ test_container_devices_nic_bridged_filtering() {
 
   # Check MAC filter is present in ebtables.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
-  if ! ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "mac filter not applied as part of ipv4_filtering in ebtables"
       false
   fi
 
   # Check IPv4 filter is present in ebtables.
-  if ! ebtables -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
       echo "IPv4 filter not applied as part of ipv4_filtering in ebtables"
       false
   fi
@@ -140,7 +140,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
-  if ebtables -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+  if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
       echo "IP filter still applied as part of ipv4_filtering in ebtables"
       false
   fi
@@ -207,7 +207,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Check MAC filter is present in ebtables.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
-  if ! ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC filter not applied as part of ipv6_filtering in ebtables"
       false
   fi
@@ -220,7 +220,7 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Check IPv6 filter is present in ebtables.
-  if ! ebtables -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
        echo "IPv6 ebtables filter not applied as part of ipv6_filtering in ebtables"
       false
   fi
@@ -269,7 +269,7 @@ test_container_devices_nic_bridged_filtering() {
 
   # Stop CT A and check filters are cleaned up.
   lxc stop -f "${ctPrefix}A"
-  if ebtables -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+  if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
       echo "IP filter still applied as part of ipv6_filtering in ebtables"
       false
   fi
@@ -344,7 +344,7 @@ test_container_devices_nic_bridged_filtering() {
   # Check MAC filter is present in ebtables.
   ctAHost=$(lxc config get "${ctPrefix}A" volatile.eth0.host_name)
   ctAMAC=$(lxc config get "${ctPrefix}A" volatile.eth0.hwaddr)
-  if ! ebtables -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "-s ! ${ctAMAC} -i ${ctAHost} -j DROP" ; then
       echo "MAC ebtables filter not applied as part of ipv6_filtering in ebtables"
       false
   fi
@@ -357,13 +357,13 @@ test_container_devices_nic_bridged_filtering() {
   fi
 
   # Check IPv4 filter is present in ebtables.
-  if ! ebtables -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "192.0.2.2" ; then
       echo "IPv4 filter not applied as part of ipv4_filtering in ebtables"
       false
   fi
 
   # Check IPv6 filter is present in ebtables.
-  if ! ebtables -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
+  if ! ebtables --concurrent -L --Lmac2 --Lx | grep -e "2001:db8::2" ; then
        echo "IPv6 filter not applied as part of ipv6_filtering in ebtables"
       false
   fi


### PR DESCRIPTION
This fixes failures during concurrent runs of ebtables by LXD.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>