### PR TITLE
Replaces ExtractSnapshotName with ContainerGetParentAndSnapshotName

### DIFF
--- a/lxc/storage_volume.go
+++ b/lxc/storage_volume.go
@@ -1214,7 +1214,13 @@ func (c *cmdStorageVolumeRename) Run(cmd *cobra.Command, args []string) error {
 	if isSnapshot {
 		// Create the storage volume entry
 		vol := api.StorageVolumeSnapshotPost{}
-		vol.Name = shared.ExtractSnapshotName(args[2])
+		_, dstSnapName, dstIsSnap := shared.ContainerGetParentAndSnapshotName(args[2])
+
+		if !dstIsSnap {
+			return fmt.Errorf("Invalid new snapshot name")
+		}
+
+		vol.Name = dstSnapName
 
 		// If a target member was specified, get the volume with the matching
 		// name on that member, if any.

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -386,7 +386,8 @@ func (s *migrationSourceWs) Do(migrateOp *operations.Operation) error {
 		if err == nil {
 			for _, snap := range fullSnaps {
 				snapshots = append(snapshots, snapshotToProtobuf(snap))
-				snapshotNames = append(snapshotNames, shared.ExtractSnapshotName(snap.Name()))
+				_, snapName, _ := shared.ContainerGetParentAndSnapshotName(snap.Name())
+				snapshotNames = append(snapshotNames, snapName)
 			}
 		}
 	}

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -69,7 +69,8 @@ func (s *migrationSourceWs) DoStorage(migrateOp *operations.Operation) error {
 					}
 
 					snapshots = append(snapshots, volumeSnapshotToProtobuf(snapVolume))
-					snapshotNames = append(snapshotNames, shared.ExtractSnapshotName(name))
+					_, snapName, _ := shared.ContainerGetParentAndSnapshotName(name)
+					snapshotNames = append(snapshotNames, snapName)
 				}
 			}
 
@@ -429,7 +430,7 @@ func volumeSnapshotToProtobuf(vol *api.StorageVolume) *migration.Snapshot {
 		config = append(config, &migration.Config{Key: &kCopy, Value: &vCopy})
 	}
 
-	snapOnlyName := shared.ExtractSnapshotName(vol.Name)
+	_, snapOnlyName, _ := shared.ContainerGetParentAndSnapshotName(vol.Name)
 
 	return &migration.Snapshot{
 		Name:         &snapOnlyName,

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -647,7 +647,8 @@ func storagePoolVolumeCreateInternal(state *state.State, poolName string, vol *a
 			}
 
 			for _, snap := range snapshots {
-				_, err := storagePoolVolumeSnapshotCopyInternal(state, poolName, vol, shared.ExtractSnapshotName(snap))
+				_, snapName, _ := shared.ContainerGetParentAndSnapshotName(snap)
+				_, err := storagePoolVolumeSnapshotCopyInternal(state, poolName, vol, snapName)
 				if err != nil {
 					return err
 				}

--- a/shared/util.go
+++ b/shared/util.go
@@ -483,10 +483,6 @@ func IsSnapshot(name string) bool {
 	return strings.Contains(name, SnapshotDelimiter)
 }
 
-func ExtractSnapshotName(name string) string {
-	return strings.SplitN(name, SnapshotDelimiter, 2)[1]
-}
-
 func MkdirAllOwner(path string, perm os.FileMode, uid int, gid int) error {
 	// This function is a slightly modified version of MkdirAll from the Go standard library.
 	// https://golang.org/src/os/path.go?s=488:535#L9


### PR DESCRIPTION
- Fixes LXC snapshot rename crash
- Replaces ExtractSnapshotName with ContainerGetParentAndSnapshotName