### PR TITLE
Add step to trigger re-read on loopback device in BTRFS resize

### DIFF
--- a/doc/storage.md
+++ b/doc/storage.md
@@ -274,6 +274,7 @@ LXD doesn't let you directly grow a loop backed btrfs pool, but you can do so wi
 
 ```bash
 sudo truncate -s +5G /var/lib/lxd/disks/<POOL>.img
+sudo losetup -c <LOOPDEV>
 sudo btrfs filesystem resize max /var/lib/lxd/storage-pools/<POOL>/
 ```
 


### PR DESCRIPTION
I have to trigger a loopback resize in addition to the steps included in the documentation on both Ubuntu (snap) and Fedora 30 (dnf). After growing the relevant storage pool's `img` file, I have to re-read the file with `losetup -c` before attempting to grow the loop backed BTRFS filesystem. I have otherwise been unsuccessful in following this documentation without `losetup -c`.