### PR TITLE
seccomp: implement mount syscall interception

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -859,3 +859,10 @@ This adds support for an optional argument (`ceph.osd.data_pool_name`) when crea
 storage pools using Ceph RBD, when this argument is used the pool will store it's
 actual data in the pool specified with `data_pool_name` while keeping the metadata
 in the pool specified by `pool_name`.
+
+## container\_syscall\_intercept\_mount
+Adds the `security.syscalls.intercept.mount`,
+`security.syscalls.intercept.mount.allowed`, and
+`security.syscalls.intercept.mount.shift` configuration keys to control whether
+and how the mount system call will be interecepted by LXD and processed with
+elevated permissions.

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -34,57 +34,60 @@ currently supported:
 
 The currently supported keys are:
 
-Key                                     | Type      | Default           | Live update   | API extension                        | Description
-:--                                     | :---      | :------           | :----------   | :------------                        | :----------
-boot.autostart                          | boolean   | -                 | n/a           | -                                    | Always start the container when LXD starts (if not set, restore last state)
-boot.autostart.delay                    | integer   | 0                 | n/a           | -                                    | Number of seconds to wait after the container started before starting the next one
-boot.autostart.priority                 | integer   | 0                 | n/a           | -                                    | What order to start the containers in (starting with highest)
-boot.host\_shutdown\_timeout            | integer   | 30                | yes           | container\_host\_shutdown\_timeout   | Seconds to wait for container to shutdown before it is force stopped
-boot.stop.priority                      | integer   | 0                 | n/a           | container\_stop\_priority            | What order to shutdown the containers (starting with highest)
-environment.\*                          | string    | -                 | yes (exec)    | -                                    | key/value environment variables to export to the container and set on exec
-limits.cpu                              | string    | - (all)           | yes           | -                                    | Number or range of CPUs to expose to the container
-limits.cpu.allowance                    | string    | 100%              | yes           | -                                    | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
-limits.cpu.priority                     | integer   | 10 (maximum)      | yes           | -                                    | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit) (integer between 0 and 10)
-limits.disk.priority                    | integer   | 5 (medium)        | yes           | -                                    | When under load, how much priority to give to the container's I/O requests (integer between 0 and 10)
-limits.kernel.\*                        | string    | -                 | no            | kernel\_limits                       | This limits kernel resources per container (e.g. number of open files)
-limits.memory                           | string    | - (all)           | yes           | -                                    | Percentage of the host's memory or fixed value in bytes (various suffixes supported, see below)
-limits.memory.enforce                   | string    | hard              | yes           | -                                    | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
-limits.memory.swap                      | boolean   | true              | yes           | -                                    | Whether to allow some of the container's memory to be swapped out to disk
-limits.memory.swap.priority             | integer   | 10 (maximum)      | yes           | -                                    | The higher this is set, the least likely the container is to be swapped to disk (integer between 0 and 10)
-limits.network.priority                 | integer   | 0 (minimum)       | yes           | -                                    | When under load, how much priority to give to the container's network requests (integer between 0 and 10)
-limits.processes                        | integer   | - (max)           | yes           | -                                    | Maximum number of processes that can run in the container
-linux.kernel\_modules                   | string    | -                 | yes           | -                                    | Comma separated list of kernel modules to load before starting the container
-migration.incremental.memory            | boolean   | false             | yes           | migration\_pre\_copy                 | Incremental memory transfer of the container's memory to reduce downtime.
-migration.incremental.memory.goal       | integer   | 70                | yes           | migration\_pre\_copy                 | Percentage of memory to have in sync before stopping the container.
-migration.incremental.memory.iterations | integer   | 10                | yes           | migration\_pre\_copy                 | Maximum number of transfer operations to go through before stopping the container.
-nvidia.driver.capabilities              | string    | compute,utility   | no            | nvidia\_runtime\_config              | What driver capabilities the container needs (sets libnvidia-container NVIDIA\_DRIVER\_CAPABILITIES)
-nvidia.runtime                          | boolean   | false             | no            | nvidia\_runtime                      | Pass the host NVIDIA and CUDA runtime libraries into the container
-nvidia.require.cuda                     | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required CUDA version (sets libnvidia-container NVIDIA\_REQUIRE\_CUDA)
-nvidia.require.driver                   | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required driver version (sets libnvidia-container NVIDIA\_REQUIRE\_DRIVER)
-raw.apparmor                            | blob      | -                 | yes           | -                                    | Apparmor profile entries to be appended to the generated profile
-raw.idmap                               | blob      | -                 | no            | id\_map                              | Raw idmap configuration (e.g. "both 1000 1000")
-raw.lxc                                 | blob      | -                 | no            | -                                    | Raw LXC configuration to be appended to the generated one
-raw.seccomp                             | blob      | -                 | no            | container\_syscall\_filtering        | Raw Seccomp configuration
-security.devlxd                         | boolean   | true              | no            | restrict\_devlxd                     | Controls the presence of /dev/lxd in the container
-security.devlxd.images                  | boolean   | false             | no            | devlxd\_images                       | Controls the availability of the /1.0/images API over devlxd
-security.idmap.base                     | integer   | -                 | no            | id\_map\_base                        | The base host ID to use for the allocation (overrides auto-detection)
-security.idmap.isolated                 | boolean   | false             | no            | id\_map                              | Use an idmap for this container that is unique among containers with isolated set.
-security.idmap.size                     | integer   | -                 | no            | id\_map                              | The size of the idmap to use
-security.nesting                        | boolean   | false             | yes           | -                                    | Support running lxd (nested) inside the container
-security.privileged                     | boolean   | false             | no            | -                                    | Runs the container in privileged mode
-security.protection.delete              | boolean   | false             | yes           | container\_protection\_delete        | Prevents the container from being deleted
-security.protection.shift               | boolean   | false             | yes           | container\_protection\_shift         | Prevents the container's filesystem from being uid/gid shifted on startup
-security.syscalls.blacklist             | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to blacklist
-security.syscalls.blacklist\_compat     | boolean   | false             | no            | container\_syscall\_filtering        | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
-security.syscalls.blacklist\_default    | boolean   | true              | no            | container\_syscall\_filtering        | Enables the default syscall blacklist
-security.syscalls.intercept.mknod       | boolean   | false             | no            | container\_syscall\_intercept        | Handles the `mknod` and `mknodat` system calls (allows creation of a limited subset of char/block devices)
-security.syscalls.intercept.setxattr    | boolean   | false             | no            | container\_syscall\_intercept        | Handles the `setxattr` system call (allows setting a limited subset of restricted extended attributes)
-security.syscalls.whitelist             | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to whitelist (mutually exclusive with security.syscalls.blacklist\*)
-snapshots.schedule                      | string    | -                 | no            | snapshot\_scheduling                 | Cron expression (`<minute> <hour> <dom> <month> <dow>`)
-snapshots.schedule.stopped              | bool      | false             | no            | snapshot\_scheduling                 | Controls whether or not stopped containers are to be snapshoted automatically
-snapshots.pattern                       | string    | snap%d            | no            | snapshot\_scheduling                 | Pongo2 template string which represents the snapshot name (used for scheduled snapshots and unnamed snapshots)
-snapshots.expiry                        | string    | -                 | no            | snapshot\_expiry                     | Controls when snapshots are to be deleted (expects expression like `1M 2H 3d 4w 5m 6y`)
-user.\*                                 | string    | -                 | n/a           | -                                    | Free form user key/value storage (can be used in search)
+Key                                             | Type      | Default           | Live update   | API extension                        | Description
+:--                                             | :---      | :------           | :----------   | :------------                        | :----------
+boot.autostart                                  | boolean   | -                 | n/a           | -                                    | Always start the container when LXD starts (if not set, restore last state)
+boot.autostart.delay                            | integer   | 0                 | n/a           | -                                    | Number of seconds to wait after the container started before starting the next one
+boot.autostart.priority                         | integer   | 0                 | n/a           | -                                    | What order to start the containers in (starting with highest)
+boot.host\_shutdown\_timeout                    | integer   | 30                | yes           | container\_host\_shutdown\_timeout   | Seconds to wait for container to shutdown before it is force stopped
+boot.stop.priority                              | integer   | 0                 | n/a           | container\_stop\_priority            | What order to shutdown the containers (starting with highest)
+environment.\*                                  | string    | -                 | yes (exec)    | -                                    | key/value environment variables to export to the container and set on exec
+limits.cpu                                      | string    | - (all)           | yes           | -                                    | Number or range of CPUs to expose to the container
+limits.cpu.allowance                            | string    | 100%              | yes           | -                                    | How much of the CPU can be used. Can be a percentage (e.g. 50%) for a soft limit or hard a chunk of time (25ms/100ms)
+limits.cpu.priority                             | integer   | 10 (maximum)      | yes           | -                                    | CPU scheduling priority compared to other containers sharing the same CPUs (overcommit) (integer between 0 and 10)
+limits.disk.priority                            | integer   | 5 (medium)        | yes           | -                                    | When under load, how much priority to give to the container's I/O requests (integer between 0 and 10)
+limits.kernel.\*                                | string    | -                 | no            | kernel\_limits                       | This limits kernel resources per container (e.g. number of open files)
+limits.memory                                   | string    | - (all)           | yes           | -                                    | Percentage of the host's memory or fixed value in bytes (various suffixes supported, see below)
+limits.memory.enforce                           | string    | hard              | yes           | -                                    | If hard, container can't exceed its memory limit. If soft, the container can exceed its memory limit when extra host memory is available.
+limits.memory.swap                              | boolean   | true              | yes           | -                                    | Whether to allow some of the container's memory to be swapped out to disk
+limits.memory.swap.priority                     | integer   | 10 (maximum)      | yes           | -                                    | The higher this is set, the least likely the container is to be swapped to disk (integer between 0 and 10)
+limits.network.priority                         | integer   | 0 (minimum)       | yes           | -                                    | When under load, how much priority to give to the container's network requests (integer between 0 and 10)
+limits.processes                                | integer   | - (max)           | yes           | -                                    | Maximum number of processes that can run in the container
+linux.kernel\_modules                           | string    | -                 | yes           | -                                    | Comma separated list of kernel modules to load before starting the container
+migration.incremental.memory                    | boolean   | false             | yes           | migration\_pre\_copy                 | Incremental memory transfer of the container's memory to reduce downtime.
+migration.incremental.memory.goal               | integer   | 70                | yes           | migration\_pre\_copy                 | Percentage of memory to have in sync before stopping the container.
+migration.incremental.memory.iterations         | integer   | 10                | yes           | migration\_pre\_copy                 | Maximum number of transfer operations to go through before stopping the container.
+nvidia.driver.capabilities                      | string    | compute,utility   | no            | nvidia\_runtime\_config              | What driver capabilities the container needs (sets libnvidia-container NVIDIA\_DRIVER\_CAPABILITIES)
+nvidia.runtime                                  | boolean   | false             | no            | nvidia\_runtime                      | Pass the host NVIDIA and CUDA runtime libraries into the container
+nvidia.require.cuda                             | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required CUDA version (sets libnvidia-container NVIDIA\_REQUIRE\_CUDA)
+nvidia.require.driver                           | string    | -                 | no            | nvidia\_runtime\_config              | Version expression for the required driver version (sets libnvidia-container NVIDIA\_REQUIRE\_DRIVER)
+raw.apparmor                                    | blob      | -                 | yes           | -                                    | Apparmor profile entries to be appended to the generated profile
+raw.idmap                                       | blob      | -                 | no            | id\_map                              | Raw idmap configuration (e.g. "both 1000 1000")
+raw.lxc                                         | blob      | -                 | no            | -                                    | Raw LXC configuration to be appended to the generated one
+raw.seccomp                                     | blob      | -                 | no            | container\_syscall\_filtering        | Raw Seccomp configuration
+security.devlxd                                 | boolean   | true              | no            | restrict\_devlxd                     | Controls the presence of /dev/lxd in the container
+security.devlxd.images                          | boolean   | false             | no            | devlxd\_images                       | Controls the availability of the /1.0/images API over devlxd
+security.idmap.base                             | integer   | -                 | no            | id\_map\_base                        | The base host ID to use for the allocation (overrides auto-detection)
+security.idmap.isolated                         | boolean   | false             | no            | id\_map                              | Use an idmap for this container that is unique among containers with isolated set.
+security.idmap.size                             | integer   | -                 | no            | id\_map                              | The size of the idmap to use
+security.nesting                                | boolean   | false             | yes           | -                                    | Support running lxd (nested) inside the container
+security.privileged                             | boolean   | false             | no            | -                                    | Runs the container in privileged mode
+security.protection.delete                      | boolean   | false             | yes           | container\_protection\_delete        | Prevents the container from being deleted
+security.protection.shift                       | boolean   | false             | yes           | container\_protection\_shift         | Prevents the container's filesystem from being uid/gid shifted on startup
+security.syscalls.blacklist                     | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to blacklist
+security.syscalls.blacklist\_compat             | boolean   | false             | no            | container\_syscall\_filtering        | On x86\_64 this enables blocking of compat\_\* syscalls, it is a no-op on other arches
+security.syscalls.blacklist\_default            | boolean   | true              | no            | container\_syscall\_filtering        | Enables the default syscall blacklist
+security.syscalls.intercept.mknod               | boolean   | false             | no            | container\_syscall\_intercept        | Handles the `mknod` and `mknodat` system calls (allows creation of a limited subset of char/block devices)
+security.syscalls.intercept.mount               | boolean   | false             | no            | container\_syscall\_intercept\_mount | Handles the `mount` system call
+security.syscalls.intercept.mount.allowed       | string    | -                 | yes           | container\_syscall\_intercept\_mount | Specify a comma-separated list of filesystems that are safe to mount for processes inside the container.
+security.syscalls.intercept.mount.shift         | boolean   | false             | yes           | container\_syscall\_intercept\_mount | Whether to mount shiftfs on top of filesystems handled through mount syscall interception.
+security.syscalls.intercept.setxattr            | boolean   | false             | no            | container\_syscall\_intercept        | Handles the `setxattr` system call (allows setting a limited subset of restricted extended attributes)
+security.syscalls.whitelist                     | string    | -                 | no            | container\_syscall\_filtering        | A '\n' separated list of syscalls to whitelist (mutually exclusive with security.syscalls.blacklist\*)
+snapshots.schedule                              | string    | -                 | no            | snapshot\_scheduling                 | Cron expression (`<minute> <hour> <dom> <month> <dow>`)
+snapshots.schedule.stopped                      | bool      | false             | no            | snapshot\_scheduling                 | Controls whether or not stopped containers are to be snapshoted automatically
+snapshots.pattern                               | string    | snap%d            | no            | snapshot\_scheduling                 | Pongo2 template string which represents the snapshot name (used for scheduled snapshots and unnamed snapshots)
+snapshots.expiry                                | string    | -                 | no            | snapshot\_expiry                     | Controls when snapshots are to be deleted (expects expression like `1M 2H 3d 4w 5m 6y`)
+user.\*                                         | string    | -                 | n/a           | -                                    | Free form user key/value storage (can be used in search)
 
 The following volatile keys are currently internally used by LXD:
 

--- a/lxd/main_forksyscall.go
+++ b/lxd/main_forksyscall.go
@@ -28,6 +28,7 @@ import (
 
 #include "include/memory_utils.h"
 
+extern void attach_userns(int pid);
 extern char* advance_arg(bool required);
 extern int dosetns(int pid, char *nstype);
 
@@ -135,7 +136,7 @@ static bool acquire_final_creds(pid_t pid, uid_t uid, gid_t gid, uid_t fsuid, gi
 
 // Expects command line to be in the form:
 // <PID> <root-uid> <root-gid> <path> <mode> <dev>
-static void forkmknod(void)
+static void mknod_emulate(void)
 {
 	__do_close_prot_errno int target_dir_fd = -EBADF;
 	char *target = NULL, *target_dir = NULL;
@@ -243,7 +244,7 @@ static bool change_creds(int ns_fd, cap_t caps, uid_t nsuid, gid_t nsgid, uid_t 
 	return true;
 }
 
-static void forksetxattr(void)
+static void setxattr_emulate(void)
 {
 	__do_close_prot_errno int ns_fd = -EBADF, target_fd = -EBADF;
 	int flags = 0;
@@ -324,6 +325,169 @@ static void forksetxattr(void)
 	}
 }
 
+static bool is_dir(const char *path)
+{
+	struct stat statbuf;
+	int ret;
+
+	ret = stat(path, &statbuf);
+	if (ret == 0 && S_ISDIR(statbuf.st_mode))
+		return true;
+
+	return false;
+}
+
+static int make_tmpfile(char *template, bool dir)
+{
+	__do_close_prot_errno int fd = -EBADF;
+
+	if (dir) {
+		if (!mkdtemp(template))
+			return -1;
+
+		return 0;
+	}
+
+	fd = mkstemp(template);
+	if (fd < 0)
+		return -1;
+
+	return 0;
+}
+
+static int preserve_ns(const int pid, const char *ns)
+{
+	int ret;
+// 5 /proc + 21 /int_as_str + 3 /ns + 20 /NS_NAME + 1 \0
+#define __NS_PATH_LEN 50
+	char path[__NS_PATH_LEN];
+
+	// This way we can use this function to also check whether namespaces
+	// are supported by the kernel by passing in the NULL or the empty
+	// string.
+	ret = snprintf(path, __NS_PATH_LEN, "/proc/%d/ns%s%s", pid,
+		       !ns || strcmp(ns, "") == 0 ? "" : "/",
+		       !ns || strcmp(ns, "") == 0 ? "" : ns);
+	if (ret < 0 || (size_t)ret >= __NS_PATH_LEN) {
+		errno = EFBIG;
+		return -1;
+	}
+
+	return open(path, O_RDONLY | O_CLOEXEC);
+}
+
+static void mount_emulate(void)
+{
+	__do_close_prot_errno int mnt_fd = -EBADF;
+	char *source = NULL, *shiftfs = NULL, *target = NULL, *fstype = NULL;
+	uid_t uid = -1, fsuid = -1;
+	gid_t gid = -1, fsgid = -1;
+	int ret;
+	pid_t pid = -1;
+	unsigned long flags = 0;
+	const void *data;
+
+	pid = atoi(advance_arg(true));
+	source = advance_arg(true);
+	target = advance_arg(true);
+	fstype = advance_arg(true);
+	flags = atoi(advance_arg(true));
+	shiftfs = advance_arg(true);
+	uid = atoi(advance_arg(true));
+	gid = atoi(advance_arg(true));
+	fsuid = atoi(advance_arg(true));
+	fsgid = atoi(advance_arg(true));
+	data = advance_arg(false);
+
+	mnt_fd = preserve_ns(getpid(), "mnt");
+	if (mnt_fd < 0)
+		_exit(EXIT_FAILURE);
+
+	if (!acquire_basic_creds(pid))
+		_exit(EXIT_FAILURE);
+
+	if (!acquire_final_creds(pid, uid, gid, fsuid, fsgid))
+		_exit(EXIT_FAILURE);
+
+	if (strcmp(shiftfs, "true") == 0) {
+		char template[] = P_tmpdir "/.lxd_tmp_mount_XXXXXX";
+
+		// Create basic mount in container's mount namespace.
+		ret = mount(source, target, fstype, flags, data);
+		if (ret)
+			_exit(EXIT_FAILURE);
+
+		// Mark the mount as shiftable.
+		ret = mount(target, target, "shiftfs", 0, "mark,passthrough=3");
+		if (ret) {
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		// We need to reattach to the old mount namespace, then attach
+		// to the user namespace of the container, and then attach to
+		// the mount namespace again to get the ownership right when
+		// creating our final shiftfs mount.
+		ret = setns(mnt_fd, CLONE_NEWNS);
+		if (ret) {
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		attach_userns(pid);
+		if (!acquire_basic_creds(pid)) {
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		if (!acquire_final_creds(pid, uid, gid, fsuid, fsgid)) {
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		ret = mount(target, target, "shiftfs", 0, "passthrough=3");
+		if (ret) {
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		ret = make_tmpfile(template, is_dir(target));
+		if (ret) {
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		ret = mount(target, template, "none", MS_MOVE | MS_REC, NULL);
+		if (ret) {
+			remove(template);
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			umount2(target, MNT_DETACH);
+			_exit(EXIT_FAILURE);
+		}
+
+		umount2(target, MNT_DETACH);
+		umount2(target, MNT_DETACH);
+
+		ret = mount(template, target, "none", MS_MOVE | MS_REC, NULL);
+		if (ret) {
+			umount2(template, MNT_DETACH);
+			remove(template);
+			_exit(EXIT_FAILURE);
+		}
+		remove(template);
+	} else {
+		if (mount(source, target, fstype, flags, data) < 0)
+			_exit(EXIT_FAILURE);
+	}
+}
+
 void forksyscall(void)
 {
 	char *syscall = NULL;
@@ -340,9 +504,11 @@ void forksyscall(void)
 		_exit(EXIT_SUCCESS);
 
 	if (strcmp(syscall, "mknod") == 0)
-		forkmknod();
+		mknod_emulate();
 	else if (strcmp(syscall, "setxattr") == 0)
-		forksetxattr();
+		setxattr_emulate();
+	else if (strcmp(syscall, "mount") == 0)
+		mount_emulate();
 	else
 		_exit(EXIT_FAILURE);
 

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -94,7 +94,10 @@ _have lxc && {
       security.nesting security.privileged security.protection.delete \
       security.protection.shift security.syscalls.blacklist \
       security.syscalls.blacklist_compat security.syscalls.blacklist_default \
-      security.syscalls.intercept.mknod security.syscalls.intercept.setxattr \
+      security.syscalls.intercept.mknod security.syscalls.intercept.mount \
+      security.syscalls.intercept.mount.allowed \
+      security.syscalls.intercept.setxattr \
+      security.syscall.intercept.mount.shift \
       snapshots.schedule snapshots.schedule.stopped snapshots.pattern \
       snapshots.expiry \
       volatile.apply_quota volatile.apply_template volatile.base_image \

--- a/shared/container.go
+++ b/shared/container.go
@@ -294,12 +294,15 @@ var KnownContainerConfigKeys = map[string]func(value string) error{
 	"security.idmap.isolated": IsBool,
 	"security.idmap.size":     IsUint32,
 
-	"security.syscalls.blacklist_default":  IsBool,
-	"security.syscalls.blacklist_compat":   IsBool,
-	"security.syscalls.blacklist":          IsAny,
-	"security.syscalls.intercept.mknod":    IsBool,
-	"security.syscalls.intercept.setxattr": IsBool,
-	"security.syscalls.whitelist":          IsAny,
+	"security.syscalls.blacklist_default":       IsBool,
+	"security.syscalls.blacklist_compat":        IsBool,
+	"security.syscalls.blacklist":               IsAny,
+	"security.syscalls.intercept.mknod":         IsBool,
+	"security.syscalls.intercept.mount":         IsBool,
+	"security.syscalls.intercept.mount.allowed": IsAny,
+	"security.syscalls.intercept.mount.shift":   IsBool,
+	"security.syscalls.intercept.setxattr":      IsBool,
+	"security.syscalls.whitelist":               IsAny,
 
 	"snapshots.schedule": func(value string) error {
 		if value == "" {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -172,6 +172,7 @@ var APIExtensions = []string{
 	"resources_network_firmware",
 	"backup_compression_algorithm",
 	"ceph_data_pool_name",
+	"container_syscall_intercept_mount",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This allows to intercept and subsequently to emulate the mount syscall.
To implement an efficient seccomp filter, we filter based on the flags
argument of the mount syscall. We don't want to filter any of the
following flag combinations since they do not cause the creation of a
new superblock:

```
MS_REMOUNT
MS_BIND
MS_MOVE
MS_UNBINDABLE
MS_PRIVATE
MS_SLAVE
MS_SHARED
MS_KERNMOUNT
MS_I_VERSION

So define the following mask of allowed flags:

long unsigned int mask = MS_MGC_VAL | MS_RDONLY | MS_NOSUID | MS_NODEV |
                         MS_NOEXEC | MS_SYNCHRONOUS | MS_MANDLOCK |
                         MS_DIRSYNC | MS_NOATIME | MS_NODIRATIME | MS_REC |
                         MS_VERBOSE | MS_SILENT | MS_POSIXACL | MS_RELATIME |
                         MS_STRICTATIME | MS_LAZYTIME;

Now we inverse the flag:

inverse_mask ~= mask;
```

Seccomp will now only intercept these flags if they do not contain any of
the allowed flags, i.e. we only intercept combinations were a new superblock
is created.

Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>