### PR TITLE
Client migration existing volume check bug

### DIFF
--- a/client/lxd_storage_volumes.go
+++ b/client/lxd_storage_volumes.go
@@ -323,6 +323,7 @@ func (r *ProtocolLXD) tryCreateStoragePoolVolume(pool string, req api.StorageVol
 			path := fmt.Sprintf("/storage-pools/%s/volumes/%s", url.PathEscape(pool), url.PathEscape(req.Type))
 			top, _, err := r.queryOperation("POST", path, req, "")
 			if err != nil {
+				errors[serverURL] = err
 				continue
 			}
 


### PR DESCRIPTION
Fixes bug in client migration code that failed to respond to remote API errors when migrating a volume to a machine where a volume of the same name exists.

During a `move` operation this would cause the local volume to be removed even though it hadn't been transferred to the far side.

During a `copy` operation this would give the illusion that the copy had been successful even though it hadn't been.