### PR TITLE
Migration using ReadWriteCloser

### DIFF
--- a/lxd/events/events.go
+++ b/lxd/events/events.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -213,9 +214,12 @@ func (e *Listener) ID() string {
 	return e.id
 }
 
-// Wait waits for a message on its active channel, then returns.
-func (e *Listener) Wait() {
-	<-e.active
+// Wait waits for a message on its active channel or the context is cancelled, then returns.
+func (e *Listener) Wait(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+	case <-e.active:
+	}
 }
 
 // Lock locks the internal mutex.

--- a/lxd/migrate.go
+++ b/lxd/migrate.go
@@ -79,6 +79,7 @@ func (c *migrationFields) disconnect() {
 	c.controlLock.Lock()
 	if c.controlConn != nil {
 		c.controlConn.WriteMessage(websocket.CloseMessage, closeMsg)
+		c.controlConn.Close()
 		c.controlConn = nil /* don't close twice */
 	}
 	c.controlLock.Unlock()

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -267,7 +267,7 @@ func (s *migrationSourceWs) preDumpLoop(args *preDumpLoopArgs) (bool, error) {
 	// Send the pre-dump.
 	ctName, _, _ := shared.ContainerGetParentAndSnapshotName(s.instance.Name())
 	state := s.instance.DaemonState()
-	err = rsync.Send(ctName, shared.AddSlash(args.checkpointDir), s.criuConn, nil, args.rsyncFeatures, args.bwlimit, state.OS.ExecPath)
+	err = rsync.Send(ctName, shared.AddSlash(args.checkpointDir), &shared.WebsocketIO{Conn: s.criuConn}, nil, args.rsyncFeatures, args.bwlimit, state.OS.ExecPath)
 	if err != nil {
 		return final, err
 	}
@@ -682,7 +682,7 @@ func (s *migrationSourceWs) Do(migrateOp *operations.Operation) error {
 		 */
 		ctName, _, _ := shared.ContainerGetParentAndSnapshotName(s.instance.Name())
 		state := s.instance.DaemonState()
-		err = rsync.Send(ctName, shared.AddSlash(checkpointDir), s.criuConn, nil, rsyncFeatures, bwlimit, state.OS.ExecPath)
+		err = rsync.Send(ctName, shared.AddSlash(checkpointDir), &shared.WebsocketIO{Conn: s.criuConn}, nil, rsyncFeatures, bwlimit, state.OS.ExecPath)
 		if err != nil {
 			return abort(err)
 		}
@@ -1062,7 +1062,7 @@ func (c *migrationSink) Do(migrateOp *operations.Operation) error {
 				for !sync.GetFinalPreDump() {
 					logger.Debugf("About to receive rsync")
 					// Transfer a CRIU pre-dump
-					err = rsync.Recv(shared.AddSlash(imagesDir), criuConn, nil, rsyncFeatures)
+					err = rsync.Recv(shared.AddSlash(imagesDir), &shared.WebsocketIO{Conn: criuConn}, nil, rsyncFeatures)
 					if err != nil {
 						restore <- err
 						return
@@ -1090,7 +1090,7 @@ func (c *migrationSink) Do(migrateOp *operations.Operation) error {
 			}
 
 			// Final CRIU dump
-			err = rsync.Recv(shared.AddSlash(imagesDir), criuConn, nil, rsyncFeatures)
+			err = rsync.Recv(shared.AddSlash(imagesDir), &shared.WebsocketIO{Conn: criuConn}, nil, rsyncFeatures)
 			if err != nil {
 				restore <- err
 				return

--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -36,6 +36,7 @@ func NewStorageMigrationSource(storage storage, volumeOnly bool) (*migrationSour
 
 func (s *migrationSourceWs) DoStorage(migrateOp *operations.Operation) error {
 	<-s.allConnected
+	defer s.disconnect()
 
 	// Storage needs to start unconditionally now, since we need to
 	// initialize a new storage interface.
@@ -169,7 +170,6 @@ func (s *migrationSourceWs) DoStorage(migrateOp *operations.Operation) error {
 	err = s.recv(&msg)
 	if err != nil {
 		logger.Errorf("Failed to receive storage volume migration control message")
-		s.disconnect()
 		return err
 	}
 

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -188,3 +188,16 @@ func ProgressWriter(op *operations.Operation, key string, description string) fu
 		return writePipe
 	}
 }
+
+// ProgressTracker returns a migration I/O tracker
+func ProgressTracker(op *operations.Operation, key string, description string) *ioprogress.ProgressTracker {
+	progress := func(progressInt int64, speedInt int64) {
+		progressWrapperRender(op, key, description, progressInt, speedInt)
+	}
+
+	tracker := &ioprogress.ProgressTracker{
+		Handler: progress,
+	}
+
+	return tracker
+}


### PR DESCRIPTION
This PR modifies the migration code and rsync package to use a ReadWriteCloser for remote connection rather than a web socket. The intention for this is to allow the re-use of migration code for copying local volumes between different storage pools.