### PR TITLE
Storage Volume Copy using in-memory pipe and migration logic

### DIFF
--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -154,6 +154,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, poolName string, volNa
 			Name:          volName,
 			MigrationType: migrationType,
 			Snapshots:     snapshotNames,
+			TrackProgress: true,
 		}
 
 		err = pool.MigrateCustomVolume(&shared.WebsocketIO{Conn: s.fsConn}, volSourceArgs, migrateOp)
@@ -360,6 +361,7 @@ func (c *migrationSink) DoStorage(state *state.State, poolName string, req *api.
 				Config:        req.Config,
 				Description:   req.Description,
 				MigrationType: respType,
+				TrackProgress: true,
 			}
 
 			// A zero length Snapshots slice indicates volume only migration in

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -22,6 +22,7 @@ type VolumeSourceArgs struct {
 	Name          string
 	Snapshots     []string
 	MigrationType Type
+	TrackProgress bool
 }
 
 // VolumeTargetArgs represents the arguments needed to setup a volume migration sink.
@@ -31,6 +32,7 @@ type VolumeTargetArgs struct {
 	Config        map[string]string
 	Snapshots     []string
 	MigrationType Type
+	TrackProgress bool
 }
 
 // TypesToHeader converts one or more Types to a MigrationHeader. It uses the first type argument

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -70,8 +70,8 @@ func (d *common) validateVolume(volConfig map[string]string, driverRules map[str
 	return nil
 }
 
-// MigrationType returns the type of transfer method used when doing migrations between pools
-// of the same type.
+// MigrationType returns the type of transfer methods to be used when doing migrations between pools
+// in preference order.
 func (d *common) MigrationTypes(contentType ContentType) []migration.Type {
 	if contentType != ContentTypeFS {
 		return nil

--- a/lxd/storage/memorypipe/memory_pipe.go
+++ b/lxd/storage/memorypipe/memory_pipe.go
@@ -1,0 +1,72 @@
+package memorypipe
+
+import (
+	"io"
+)
+
+// msg represents an internal structure sent between the pipes.
+type msg struct {
+	data []byte
+	err  error
+}
+
+// pipe provides a bidirectional pipe compatible with io.ReadWriteCloser interface.
+// Note, however, that it does not behave exactly how one would expect an io.ReadWriteCloser to
+// behave. Specifically the Close() function does not close the pipe, but instead delivers an io.EOF
+// error to the next reader. After which it can be read again to receive new data. This means the
+// pipe can be closed multiple times. Each time it indicates that one particular session has ended.
+// The reason for this is to emulate the WebsocketIO's behaviour by allowing a single persistent
+// connection to be used for multiple sessions.
+type pipe struct {
+	ch       chan msg
+	otherEnd *pipe
+}
+
+// Read reads from the pipe into p. Returns number of bytes read and any errors.
+func (p *pipe) Read(b []byte) (int, error) {
+	msg := <-p.ch
+	if msg.err == io.EOF {
+		return -1, msg.err
+	}
+	n := copy(b, msg.data)
+	return n, msg.err
+}
+
+// Write writes to the pipe from p. Returns number of bytes written and any errors.
+func (p *pipe) Write(b []byte) (int, error) {
+	msg := msg{
+		data: append(b[:0:0], b...), // Create copy of b in case it is modified externally.
+		err:  nil,
+	}
+	p.otherEnd.ch <- msg // Send msg to the other side's Read function.
+	return len(msg.data), msg.err
+}
+
+// Close is unusual in that it doesn't actually close the pipe. Instead it sends an io.EOF error
+// to the other side's Read function. This is so the other side can detect that a session has ended.
+// Each call to Close will indicate to the other side that a session has ended, whilst allowing the
+// reuse of a single persistent pipe for multiple sessions.
+func (p *pipe) Close() error {
+	p.otherEnd.ch <- msg{
+		data: nil,
+		err:  io.EOF, // Indicates to the other side's Read function that session has ended.
+	}
+	return nil
+}
+
+// NewPipePair returns a pair of io.ReadWriterCloser pipes that are connected together such that
+// writes to one will appear as reads on the other and vice versa. Calling Close() on one end will
+// indicate to the other end that the session has ended.
+func NewPipePair() (io.ReadWriteCloser, io.ReadWriteCloser) {
+	aEnd := &pipe{
+		ch: make(chan msg, 1),
+	}
+
+	bEnd := &pipe{
+		ch: make(chan msg, 1),
+	}
+
+	aEnd.otherEnd = bEnd
+	bEnd.otherEnd = aEnd
+	return aEnd, bEnd
+}


### PR DESCRIPTION
- Updates Storage volume copy to use the migration logic with a bi-directional in-memory pipe.
- Adds progress tracker indicator to storage migration functions so that when doing a local copy one can disable the progress tracker on one side.