### PR TITLE
Storage Volume Validation to use Volume struct

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -247,8 +247,14 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 
 // CreateCustomVolume creates an empty custom volume.
 func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error {
+	// Validate config.
+	err := b.driver.ValidateVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config), false)
+	if err != nil {
+		return err
+	}
+
 	// Create database entry for new storage volume.
-	err := VolumeDBCreate(b.state, b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, config)
+	err = VolumeDBCreate(b.state, b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, config)
 	if err != nil {
 		return err
 	}
@@ -409,7 +415,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 	}()
 
 	// Check the supplied config and remove any fields not relevant for destination pool type.
-	err := b.driver.ValidateVolume(args.Config, true)
+	err := b.driver.ValidateVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, args.Config), true)
 	if err != nil {
 		return err
 	}
@@ -511,7 +517,8 @@ func (b *lxdBackend) RenameCustomVolume(volName string, newVolName string, op *o
 
 // UpdateCustomVolume applies the supplied config to the volume.
 func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
-	err := b.driver.ValidateVolume(newConfig, false)
+	// Validate config.
+	err := b.driver.ValidateVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, newConfig), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -28,7 +28,7 @@ func (d *common) init(state *state.State, name string, config map[string]string,
 // This functions has a removeUnknownKeys option that if set to true will remove any unknown fields
 // (excluding those starting with "user.") which can be used when translating a volume config to a
 // different storage driver that has different options.
-func (d *common) validateVolume(volConfig map[string]string, driverRules map[string]func(value string) error, removeUnknownKeys bool) error {
+func (d *common) validateVolume(vol Volume, driverRules map[string]func(value string) error, removeUnknownKeys bool) error {
 	checkedFields := map[string]struct{}{}
 
 	// Get rules common for all drivers.
@@ -42,14 +42,14 @@ func (d *common) validateVolume(volConfig map[string]string, driverRules map[str
 	// Run the validator against each field.
 	for k, validator := range rules {
 		checkedFields[k] = struct{}{} //Mark field as checked.
-		err := validator(volConfig[k])
+		err := validator(vol.config[k])
 		if err != nil {
 			return fmt.Errorf("Invalid value for volume option %s: %v", k, err)
 		}
 	}
 
 	// Look for any unchecked fields, as these are unknown fields and validation should fail.
-	for k := range volConfig {
+	for k := range vol.config {
 		_, checked := checkedFields[k]
 		if checked {
 			continue
@@ -61,7 +61,7 @@ func (d *common) validateVolume(volConfig map[string]string, driverRules map[str
 		}
 
 		if removeUnknownKeys {
-			delete(volConfig, k)
+			delete(vol.config, k)
 		} else {
 			return fmt.Errorf("Invalid volume option: %s", k)
 		}

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -120,8 +120,8 @@ func (d *dir) GetResources() (*api.ResourcesStoragePool, error) {
 }
 
 // ValidateVolume validates the supplied volume config.
-func (d *dir) ValidateVolume(volConfig map[string]string, removeUnknownKeys bool) error {
-	return d.validateVolume(volConfig, nil, removeUnknownKeys)
+func (d *dir) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
+	return d.validateVolume(vol, nil, removeUnknownKeys)
 }
 
 // HasVolume indicates whether a specific volume exists on the storage pool.

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -30,7 +30,7 @@ type Driver interface {
 	GetResources() (*api.ResourcesStoragePool, error)
 
 	// Volumes.
-	ValidateVolume(volConfig map[string]string, removeUnknownKeys bool) error
+	ValidateVolume(vol Volume, removeUnknownKeys bool) error
 	CreateVolume(vol Volume, filler func(path string) error, op *operations.Operation) error
 	CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, op *operations.Operation) error
 	DeleteVolume(volType VolumeType, volName string, op *operations.Operation) error

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -525,7 +525,9 @@ func VolumeValidateConfig(name string, config map[string]string, parentPool *api
 	// Validate volume config using the new driver interface if supported.
 	driver, err := drivers.Load(nil, parentPool.Driver, parentPool.Name, parentPool.Config, nil, validateVolumeCommonRules)
 	if err != drivers.ErrUnknownDriver {
-		return driver.ValidateVolume(config, false)
+		// Note: This legacy validation function doesn't have the concept of validating
+		// different volumes types, so the types are hard coded as Custom and FS.
+		return driver.ValidateVolume(drivers.NewVolume(driver, parentPool.Name, drivers.VolumeTypeCustom, drivers.ContentTypeFS, name, config), false)
 	}
 
 	// Otherwise fallback to doing legacy validation.


### PR DESCRIPTION
Moves Volume validation to use a Volume struct so that volume type and content type can be used during validation if needed.