### PR TITLE
Storage Migration Types - accept fallback type

### DIFF
--- a/lxd/migrate_storage_volumes.go
+++ b/lxd/migrate_storage_volumes.go
@@ -143,7 +143,7 @@ func (s *migrationSourceWs) DoStorage(state *state.State, poolName string, volNa
 
 	// Use new storage layer for migration if supported.
 	if pool != nil {
-		migrationType, err := migration.MatchTypes(respHeader, poolMigrationTypes)
+		migrationType, err := migration.MatchTypes(respHeader, migration.MigrationFSType_RSYNC, poolMigrationTypes)
 		if err != nil {
 			logger.Errorf("Failed to neogotiate migration type: %v", err)
 			s.sendControl(err)
@@ -343,7 +343,7 @@ func (c *migrationSink) DoStorage(state *state.State, poolName string, req *api.
 		// Extract the source's migration type and then match it against our pool's
 		// supported types and features. If a match is found the combined features list
 		// will be sent back to requester.
-		respType, err := migration.MatchTypes(offerHeader, pool.MigrationTypes(storageDrivers.ContentTypeFS))
+		respType, err := migration.MatchTypes(offerHeader, migration.MigrationFSType_RSYNC, pool.MigrationTypes(storageDrivers.ContentTypeFS))
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -340,7 +340,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 	// Negotiate the migration type to use.
 	offeredTypes := srcPool.MigrationTypes(drivers.ContentTypeFS)
 	offerHeader := migration.TypesToHeader(offeredTypes...)
-	migrationType, err := migration.MatchTypes(offerHeader, b.MigrationTypes(drivers.ContentTypeFS))
+	migrationType, err := migration.MatchTypes(offerHeader, migration.MigrationFSType_RSYNC, b.MigrationTypes(drivers.ContentTypeFS))
 	if err != nil {
 		return fmt.Errorf("Failed to neogotiate copy migration type: %v", err)
 	}


### PR DESCRIPTION
Modifies MatchTypes to accept a fallback type which is used when doing cross-pool migrations on different backend drivers.