### PR TITLE
Storage Update Snapshot

### DIFF
--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -976,9 +976,13 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string)
 			// means that modifying a snapshot's description gets routed here rather
 			// than the dedicated snapshot editing route. So need to handle snapshot
 			// volumes here too.
-			err = d.cluster.StoragePoolVolumeUpdate(vol.Name, volumeType, poolID, req.Description, req.Config)
-			if err != nil {
-				return response.SmartError(err)
+
+			// Update the database if description changed.
+			if req.Description != vol.Description {
+				err = d.cluster.StoragePoolVolumeUpdate(vol.Name, volumeType, poolID, req.Description, vol.Config)
+				if err != nil {
+					response.SmartError(err)
+				}
 			}
 		}
 	} else {

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -207,28 +207,6 @@ func storagePoolVolumeUpdate(state *state.State, poolName string, volumeName str
 	return nil
 }
 
-func storagePoolVolumeSnapshotUpdate(state *state.State, poolName string, volumeName string, volumeType int, newDescription string) error {
-	s, err := storagePoolVolumeInit(state, "default", poolName, volumeName, volumeType)
-	if err != nil {
-		return err
-	}
-
-	oldWritable := s.GetStoragePoolVolumeWritable()
-	oldDescription := oldWritable.Description
-
-	poolID, err := state.Cluster.StoragePoolGetID(poolName)
-	if err != nil {
-		return err
-	}
-
-	// Update the database if something changed
-	if newDescription != oldDescription {
-		return state.Cluster.StoragePoolVolumeUpdate(volumeName, volumeType, poolID, newDescription, oldWritable.Config)
-	}
-
-	return nil
-}
-
 func storagePoolVolumeUsedByContainersGet(s *state.State, project, poolName string, volumeName string) ([]string, error) {
 	insts, err := instanceLoadByProject(s, project)
 	if err != nil {


### PR DESCRIPTION
Moves the DB logic from the legacy storage functions directly into the API (which is similar to existing functions that do DB lookups and modifications for simple cases). This way the legacy storage function can be removed and it does fewer DB queries.

Includes https://github.com/lxc/lxd/pull/6371