### PR TITLE
lxd/rsync: Tweaks Recv's internal synchronisation to avoid race

### DIFF
--- a/lxd/rsync/rsync.go
+++ b/lxd/rsync/rsync.go
@@ -276,9 +276,9 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 	chCopyRsync := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(conn, stdout)
-		chCopyRsync <- err
 		stdout.Close()
 		conn.Close() // sends barrier message.
+		chCopyRsync <- err
 	}()
 
 	// Forward from source to rsync.
@@ -298,8 +298,8 @@ func Recv(path string, conn io.ReadWriteCloser, tracker *ioprogress.ProgressTrac
 	chCopySource := make(chan error, 1)
 	go func() {
 		_, err := io.Copy(stdin, readSourcePipe)
-		chCopySource <- err
 		stdin.Close()
+		chCopySource <- err
 	}()
 
 	stderr, err := cmd.StderrPipe()


### PR DESCRIPTION
This is just a hunch as to the possible cause of the race condition in rsync.Recv.

I believe the function go be exiting early (because the 2 synchronisation channels are filled with an error value) meaning the Recv function exists before the go routines, and in the situation where the Recv function is called immediately afterwards (when transferring multiple volume snapshots) and using a new wrapper of WebsocketIO (with its own lock) this could cause multiple writers to the parent websocket conn concurrently. 

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>