### PR TITLE
lxd/storage: Fix custom volume with underscores

### DIFF
--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -34,10 +34,12 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		// encoding format, so if there is no underscore in the volume name then we assume
 		// the project is default.
 		project := "default"
-		volParts := strings.SplitN(volName, "_", 2)
-		if len(volParts) > 1 {
-			project = volParts[0]
-			volName = volParts[1]
+		if volType == drivers.VolumeTypeContainer || volType == drivers.VolumeTypeVM {
+			volParts := strings.SplitN(volName, "_", 2)
+			if len(volParts) > 1 {
+				project = volParts[0]
+				volName = volParts[1]
+			}
 		}
 
 		volID, _, err := state.Cluster.StoragePoolNodeVolumeGetTypeByProject(project, volName, volTypeID, poolID)


### PR DESCRIPTION
The recently added project logic in the volume code incorrectly assumes
that underscores are only valid as separate between project names and
volume names.

This isn't true for custom volumes which may already have undercores in
their names despite us not having support for custom volumes in projects.

When we do implement custom volumes in projects, we will rename all
volumes to include the project prefix at which point we will be able to
always split those and extract the project. Until then, only do project
splitting on containers.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>