### PR TITLE
Storage Backend EnsureImage

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -634,7 +634,7 @@ func imageCreateInPool(d *Daemon, info *api.Image, storagePool string) error {
 			return err
 		}
 
-		err = pool.CreateImage(info.Fingerprint, nil)
+		err = pool.EnsureImage(info.Fingerprint, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -142,7 +142,7 @@ func (b *mockBackend) UnmountInstanceSnapshot(i Instance) (bool, error) {
 	return true, nil
 }
 
-func (b *mockBackend) CreateImage(fingerprint string, op *operations.Operation) error {
+func (b *mockBackend) EnsureImage(fingerprint string, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/interfaces.go
+++ b/lxd/storage/interfaces.go
@@ -67,7 +67,7 @@ type Pool interface {
 	UnmountInstanceSnapshot(i Instance) (bool, error)
 
 	// Images.
-	CreateImage(fingerprint string, op *operations.Operation) error
+	EnsureImage(fingerprint string, op *operations.Operation) error
 	DeleteImage(fingerprint string, op *operations.Operation) error
 
 	// Custom volumes.

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -34,6 +34,10 @@ func volIDFuncMake(state *state.State, poolID int64) func(volType drivers.Volume
 		// encoding format, so if there is no underscore in the volume name then we assume
 		// the project is default.
 		project := "default"
+
+		// Currently only Containers and VMs support project level volumes.
+		// This means that other volume types may have underscores in their names that don't
+		// indicate the project name.
 		if volType == drivers.VolumeTypeContainer || volType == drivers.VolumeTypeVM {
 			volParts := strings.SplitN(volName, "_", 2)
 			if len(volParts) > 1 {


### PR DESCRIPTION
- Renames `CreateImage` to `EnsureImage` to indicate that it can (and will) be called multiple times but that it will only actually do something (create an optimized image volume in the storage pool) if needed.
- Removes duplicated `HasVolume` check in `CreateInstanceFromImage`.
- Adds some more comments.