### PR TITLE
Storage Pool Load By Instance

### DIFF
--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -304,13 +304,13 @@ func (d *dir) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, vol
 				return err
 			}
 
-			// Create the snapshot itself
+			// Create the snapshot itself.
 			err = d.CreateVolumeSnapshot(vol.volType, vol.name, snapName, op)
 			if err != nil {
 				return err
 			}
 
-			// Setup the revert
+			// Setup the revert.
 			snapPath := GetVolumeMountPath(d.name, vol.volType, GetSnapshotVolumeName(vol.name, snapName))
 			revertPaths = append(revertPaths, snapPath)
 		}
@@ -389,20 +389,20 @@ func (d *dir) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 			for _, srcSnapshot := range srcSnapshots {
 				_, snapName, _ := shared.ContainerGetParentAndSnapshotName(srcSnapshot.name)
 
-				// Mount the source snapshot
+				// Mount the source snapshot.
 				err = srcSnapshot.MountTask(func(srcMountPath string, op *operations.Operation) error {
-					// Copy the snapshot
+					// Copy the snapshot.
 					_, err = rsync.LocalCopy(srcMountPath, mountPath, bwlimit, true)
 					return err
 				}, op)
 
-				// Create the snapshot itself
+				// Create the snapshot itself.
 				err = d.CreateVolumeSnapshot(vol.volType, vol.name, snapName, op)
 				if err != nil {
 					return err
 				}
 
-				// Setup the revert
+				// Setup the revert.
 				snapPath := GetVolumeMountPath(d.name, vol.volType, GetSnapshotVolumeName(vol.name, snapName))
 				revertPaths = append(revertPaths, snapPath)
 			}

--- a/lxd/storage/drivers/errors.go
+++ b/lxd/storage/drivers/errors.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 )
 
-// ErrNilValue is the "Nil value provided" error
-var ErrNilValue = fmt.Errorf("Nil value provided")
-
 // ErrNotImplemented is the "Not implemented" error
 var ErrNotImplemented = fmt.Errorf("Not implemented")
 


### PR DESCRIPTION
- Renames `GetPoolByInstanceName` to `GetPoolByInstance` - now accepts an Instance type directly.
- This allows it to inspect the Instance's Type and check it is supported by the underlying storage pool driver.
- If not it returns `drivers.ErrNotImplemented` if the instance type is not supported by the storage pool's driver.
- This allows us to cleanly fail operations where the storage driver hasn't implemented VM support yet.
- It also allows a nice side effect of allowing new storage drivers to be merged and used when they only support custom volumes, allowing for new drivers to be implemented in smaller testable chunks.