### PR TITLE
VM Create and Launch

### DIFF
--- a/lxc/console.go
+++ b/lxc/console.go
@@ -145,12 +145,12 @@ func (c *cmdConsole) Run(cmd *cobra.Command, args []string) error {
 	// Configure the terminal
 	cfd := int(os.Stdin.Fd())
 
-	var oldttystate *termios.State
-	oldttystate, err = termios.MakeRaw(cfd)
+	var oldTTYstate *termios.State
+	oldTTYstate, err = termios.MakeRaw(cfd)
 	if err != nil {
 		return err
 	}
-	defer termios.Restore(cfd, oldttystate)
+	defer termios.Restore(cfd, oldTTYstate)
 
 	handler := c.controlSocketHandler
 

--- a/lxc/copy.go
+++ b/lxc/copy.go
@@ -411,15 +411,19 @@ func (c *cmdCopy) copyContainer(conf *config.Config, sourceResource string,
 			return err
 		}
 
-		// Extract the list of affected containers
-		containers, ok := opInfo.Resources["containers"]
-		if !ok || len(containers) != 1 {
-			return fmt.Errorf(i18n.G("Failed to get the new container name"))
+		// Extract the list of affected instances
+		instances, ok := opInfo.Resources["instances"]
+		if !ok || len(instances) != 1 {
+			// Extract the list of affected instances using old "containers" field
+			instances, ok = opInfo.Resources["containers"]
+			if !ok || len(instances) != 1 {
+				return fmt.Errorf(i18n.G("Failed to get the new instance name"))
+			}
 		}
 
-		// Extract the name of the container
-		fields := strings.Split(containers[0], "/")
-		fmt.Printf(i18n.G("Container name is: %s")+"\n", fields[len(fields)-1])
+		// Extract the name of the instance
+		fields := strings.Split(instances[0], "/")
+		fmt.Printf(i18n.G("Instance name is: %s")+"\n", fields[len(fields)-1])
 	}
 
 	// Start the container if needed

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1294,12 +1294,14 @@ func instanceLoadAllInternal(dbInstances []db.Instance, s *state.State) ([]Insta
 }
 
 // instanceLoad creates the underlying instance type struct and returns it as an Instance.
-func instanceLoad(s *state.State, args db.InstanceArgs, cProfiles []api.Profile) (Instance, error) {
+func instanceLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error) {
 	var inst Instance
 	var err error
 
 	if args.Type == instancetype.Container {
-		inst, err = containerLXCLoad(s, args, cProfiles)
+		inst, err = containerLXCLoad(s, args, profiles)
+	} else if args.Type == instancetype.VM {
+		inst, err = vmQemuLoad(s, args, profiles)
 	} else {
 		return nil, fmt.Errorf("Invalid instance type for instance %s", args.Name)
 	}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -1011,6 +1011,8 @@ func instanceCreateInternal(s *state.State, args db.InstanceArgs) (Instance, err
 
 	if args.Type == instancetype.Container {
 		inst, err = containerLXCCreate(s, args)
+	} else if args.Type == instancetype.VM {
+		inst, err = vmQemuCreate(s, args)
 	} else {
 		return nil, fmt.Errorf("Instance type invalid")
 	}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -443,7 +443,7 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 	}
 
 	if imgType != args.Type {
-		return nil, fmt.Errorf("Requested image doesn't match instance type")
+		return nil, fmt.Errorf("Requested image's type '%s' doesn't match instance type '%s'", imgType, args.Type)
 	}
 
 	// Check if the image is available locally or it's on another node.

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -519,8 +519,7 @@ func instanceCreateFromImage(d *Daemon, args db.InstanceArgs, hash string, op *o
 		if op != nil {
 			tracker = &ioprogress.ProgressTracker{
 				Handler: func(percent, speed int64) {
-					// tomp TODO should the container reference here be removed?
-					shared.SetProgressMetadata(metadata, "create_container_from_image_unpack", "Unpack", percent, 0, speed)
+					shared.SetProgressMetadata(metadata, "create_instance_from_image_unpack", "Unpack", percent, 0, speed)
 					op.UpdateMetadata(metadata)
 				}}
 		}

--- a/lxd/container_console.go
+++ b/lxd/container_console.go
@@ -236,7 +236,15 @@ func (s *consoleWs) Do(op *operations.Operation) error {
 	}
 
 	consCmd := s.instance.Console(slave)
-	consCmd.Start()
+	if consCmd == nil {
+		return fmt.Errorf("Failed to start console")
+	}
+
+	err = consCmd.Start()
+	if err != nil {
+		return err
+	}
+
 	consolePidChan <- consCmd.Process.Pid
 	err = consCmd.Wait()
 	if err == nil {

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3567,7 +3567,7 @@ func (c *containerLXC) Delete() error {
 		} else {
 			// Remove all snapshots by initialising each snapshot as an Instance and
 			// calling its Delete function.
-			err := containerDeleteSnapshots(c.state, c.Project(), c.Name())
+			err := instanceDeleteSnapshots(c.state, c.Project(), c.Name())
 			if err != nil {
 				logger.Error("Failed to delete instance snapshots", log.Ctx{"project": c.Project(), "instance": c.Name(), "err": err})
 				return err
@@ -3636,7 +3636,7 @@ func (c *containerLXC) Delete() error {
 			}
 		} else {
 			// Remove all snapshots
-			err := containerDeleteSnapshots(c.state, c.Project(), c.Name())
+			err := instanceDeleteSnapshots(c.state, c.Project(), c.Name())
 			if err != nil {
 				logger.Warn("Failed to delete snapshots", log.Ctx{"name": c.Name(), "err": err})
 				return err

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -5845,7 +5845,7 @@ func (c *containerLXC) FileRemove(path string) error {
 	return nil
 }
 
-func (c *containerLXC) Console(terminal *os.File) *exec.Cmd {
+func (c *containerLXC) Console() (*os.File, error) {
 	args := []string{
 		c.state.OS.ExecPath,
 		"forkconsole",
@@ -5855,13 +5855,34 @@ func (c *containerLXC) Console(terminal *os.File) *exec.Cmd {
 		"tty=0",
 		"escape=-1"}
 
+	idmapset, err := c.CurrentIdmap()
+	if err != nil {
+		return nil, err
+	}
+
+	var rootUID, rootGID int64
+	if idmapset != nil {
+		rootUID, rootGID = idmapset.ShiftIntoNs(0, 0)
+	}
+
+	master, slave, err := shared.OpenPty(rootUID, rootGID)
+	if err != nil {
+		return nil, err
+	}
+
 	cmd := exec.Cmd{}
 	cmd.Path = c.state.OS.ExecPath
 	cmd.Args = args
-	cmd.Stdin = terminal
-	cmd.Stdout = terminal
-	cmd.Stderr = terminal
-	return &cmd
+	cmd.Stdin = slave
+	cmd.Stdout = slave
+	cmd.Stderr = slave
+
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return master, nil
 }
 
 func (c *containerLXC) ConsoleLog(opts lxc.ConsoleLogOptions) (string, error) {

--- a/lxd/containers.go
+++ b/lxd/containers.go
@@ -351,26 +351,22 @@ func containersShutdown(s *state.State) error {
 	return nil
 }
 
-func containerDeleteSnapshots(s *state.State, project, cname string) error {
-	results, err := s.Cluster.ContainerGetSnapshots(project, cname)
+// instanceDeleteSnapshots calls the Delete() function on each of the supplied instance's snapshots.
+func instanceDeleteSnapshots(s *state.State, projectName, instanceName string) error {
+	results, err := s.Cluster.ContainerGetSnapshots(projectName, instanceName)
 	if err != nil {
 		return err
 	}
 
-	for _, sname := range results {
-		sc, err := instanceLoadByProjectAndName(s, project, sname)
+	for _, snapName := range results {
+		snapInst, err := instanceLoadByProjectAndName(s, projectName, snapName)
 		if err != nil {
-			logger.Error(
-				"containerDeleteSnapshots: Failed to load the snapshot container",
-				log.Ctx{"container": cname, "snapshot": sname, "err": err})
-
+			logger.Error("instanceDeleteSnapshots: Failed to load the snapshot", log.Ctx{"project": projectName, "instance": instanceName, "snapshot": snapName, "err": err})
 			continue
 		}
 
-		if err := sc.Delete(); err != nil {
-			logger.Error(
-				"containerDeleteSnapshots: Failed to delete a snapshot container",
-				log.Ctx{"container": cname, "snapshot": sname, "err": err})
+		if err := snapInst.Delete(); err != nil {
+			logger.Error("instanceDeleteSnapshots: Failed to delete the snapshot", log.Ctx{"project": projectName, "instance": instanceName, "snapshot": snapName, "err": err})
 		}
 	}
 

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -190,7 +190,8 @@ func createFromNone(d *Daemon, project string, req *api.InstancesPost) response.
 	}
 
 	resources := map[string][]string{}
-	resources["containers"] = []string{req.Name}
+	resources["instances"] = []string{req.Name}
+	resources["containers"] = resources["instances"] // Populate old field name.
 
 	op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -148,8 +148,8 @@ func createFromImage(d *Daemon, project string, req *api.InstancesPost) response
 	}
 
 	resources := map[string][]string{}
-	// tomp TODO should this be renamed/added to?
-	resources["containers"] = []string{req.Name}
+	resources["instances"] = []string{req.Name}
+	resources["containers"] = resources["instances"] // Populate old field name.
 
 	op, err := operations.OperationCreate(d.State(), project, operations.OperationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {

--- a/lxd/db/images.go
+++ b/lxd/db/images.go
@@ -185,7 +185,7 @@ func (c *Cluster) ImageSourceGetCachedFingerprint(server string, protocol string
 `
 
 	arg1 := []interface{}{server, protocolInt, alias}
-	if imageType > 0 {
+	if imageType != instancetype.Any {
 		q += "AND images.type=?\n"
 		arg1 = []interface{}{server, protocolInt, alias, imageType}
 	}

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -387,6 +387,22 @@ func networkCreateVethPair(hostName string, m deviceConfig.Device) (string, erro
 	return peerName, nil
 }
 
+// networkCreateTap creates and configures a TAP device.
+func networkCreateTap(hostName string) error {
+	_, err := shared.RunCommand("ip", "tuntap", "add", "name", hostName, "mode", "tap")
+	if err != nil {
+		return fmt.Errorf("Failed to create the tap interfaces %s: %v", hostName, err)
+	}
+
+	_, err = shared.RunCommand("ip", "link", "set", "dev", hostName, "up")
+	if err != nil {
+		NetworkRemoveInterface(hostName)
+		return fmt.Errorf("Failed to bring up the tap interface %s: %v", hostName, err)
+	}
+
+	return nil
+}
+
 // networkSetupHostVethDevice configures a nic device's host side veth settings.
 func networkSetupHostVethDevice(device deviceConfig.Device, oldDevice deviceConfig.Device, v map[string]string) error {
 	// If not configured, check if volatile data contains the most recently added host_name.

--- a/lxd/instance_interface.go
+++ b/lxd/instance_interface.go
@@ -49,16 +49,11 @@ type Instance interface {
 	// File handling
 	FileExists(path string) error
 	FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error)
-	FilePush(type_ string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error
+	FilePush(fileType string, srcpath string, dstpath string, uid int64, gid int64, mode int, write string) error
 	FileRemove(path string) error
 
 	// Console - Allocate and run a console tty.
-	//
-	// terminal  - Bidirectional file descriptor.
-	//
-	// This function will not return until the console has been exited by
-	// the user.
-	Console(terminal *os.File) *exec.Cmd
+	Console() (*os.File, error)
 	Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool, cwd string, uid uint32, gid uint32) (*exec.Cmd, int, int, error)
 
 	// Status

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -332,7 +332,7 @@ func (b *lxdBackend) CreateInstanceFromCopy(inst Instance, src Instance, snapsho
 
 // imageFiller returns a function that can be used as a filler function with CreateVolume().
 // The function returned will unpack the specified image archive into the specified mount path
-// provided, and for VM images, a raw root block path is required to unpack the qcow image into.
+// provided, and for VM images, a raw root block path is required to unpack the qcow2 image into.
 func (b *lxdBackend) imageFiller(fingerprint string, op *operations.Operation) func(mountPath, rootBlockPath string) error {
 	return func(mountPath, rootBlockPath string) error {
 		var tracker *ioprogress.ProgressTracker

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -308,6 +308,11 @@ func (d *cephfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	return d.validateVolume(vol, nil, removeUnknownKeys)
 }
 
+// GetVolumeDiskPath returns the location of a root disk block device and its type.
+func (d *cephfs) GetVolumeDiskPath(volType VolumeType, volName string) (string, string, error) {
+	return "", "", ErrNotImplemented
+}
+
 func (d *cephfs) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error {
 	if vol.volType != VolumeTypeCustom {
 		return fmt.Errorf("Volume type not supported")

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -308,7 +308,7 @@ func (d *cephfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	return d.validateVolume(vol, nil, removeUnknownKeys)
 }
 
-func (d *cephfs) CreateVolume(vol Volume, filler func(path string) error, op *operations.Operation) error {
+func (d *cephfs) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error {
 	if vol.volType != VolumeTypeCustom {
 		return fmt.Errorf("Volume type not supported")
 	}
@@ -332,7 +332,7 @@ func (d *cephfs) CreateVolume(vol Volume, filler func(path string) error, op *op
 	}()
 
 	if filler != nil {
-		err = filler(volPath)
+		err = filler(volPath, "")
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -266,6 +266,10 @@ func (d *dir) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath stri
 
 // MigrateVolume sends a volume for migration.
 func (d *dir) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs migration.VolumeSourceArgs, op *operations.Operation) error {
+	if vol.contentType != ContentTypeFS {
+		return fmt.Errorf("Content type not supported")
+	}
+
 	if volSrcArgs.MigrationType.FSType != migration.MigrationFSType_RSYNC {
 		return fmt.Errorf("Migration type not supported")
 	}
@@ -528,6 +532,10 @@ func (d *dir) VolumeSnapshots(volType VolumeType, volName string, op *operations
 
 // UpdateVolume applies config changes to the volume.
 func (d *dir) UpdateVolume(vol Volume, changedConfig map[string]string) error {
+	if vol.contentType != ContentTypeFS {
+		return fmt.Errorf("Content type not supported")
+	}
+
 	if _, changed := changedConfig["size"]; changed {
 		volID, err := d.getVolID(vol.volType, vol.name)
 		if err != nil {

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -167,6 +167,11 @@ func (d *dir) HasVolume(volType VolumeType, volName string) bool {
 	return false
 }
 
+// GetVolumeDiskPath returns the location and file format of a disk volume.
+func (d *dir) GetVolumeDiskPath(volType VolumeType, volName string) (string, string, error) {
+	return filepath.Join(GetVolumeMountPath(d.name, volType, volName), "root.img"), "qcow2", nil
+}
+
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
 // filler function.
 func (d *dir) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error {

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -33,7 +33,7 @@ type Driver interface {
 
 	// Volumes.
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
-	CreateVolume(vol Volume, filler func(path string) error, op *operations.Operation) error
+	CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error
 	CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, op *operations.Operation) error
 	DeleteVolume(volType VolumeType, volName string, op *operations.Operation) error
 	RenameVolume(volType VolumeType, volName string, newName string, op *operations.Operation) error

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -40,6 +40,7 @@ type Driver interface {
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
 	GetVolumeUsage(volType VolumeType, volName string) (int64, error)
 	SetVolumeQuota(volType VolumeType, volName, size string, op *operations.Operation) error
+	GetVolumeDiskPath(volType VolumeType, volName string) (string, string, error)
 
 	// MountVolume mounts a storage volume, returns true if we caused a new mount, false if
 	// already mounted.

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -217,3 +217,24 @@ func deleteParentSnapshotDirIfEmpty(poolName string, volType VolumeType, volName
 
 	return nil
 }
+
+// createSparseFile creates a sparse empty file at specified location with specified size.
+func createSparseFile(filePath string, sizeBytes int64) error {
+	f, err := os.Create(filePath)
+	if err != nil {
+		return fmt.Errorf("Failed to open %s: %s", filePath, err)
+	}
+	defer f.Close()
+
+	err = f.Chmod(0600)
+	if err != nil {
+		return fmt.Errorf("Failed to chmod %s: %s", filePath, err)
+	}
+
+	err = f.Truncate(sizeBytes)
+	if err != nil {
+		return fmt.Errorf("Failed to create sparse file %s: %s", filePath, err)
+	}
+
+	return nil
+}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -381,6 +381,8 @@ func VolumeTypeNameToType(volumeTypeName string) (int, error) {
 	switch volumeTypeName {
 	case db.StoragePoolVolumeTypeNameContainer:
 		return db.StoragePoolVolumeTypeContainer, nil
+	case db.StoragePoolVolumeTypeNameVM:
+		return db.StoragePoolVolumeTypeVM, nil
 	case db.StoragePoolVolumeTypeNameImage:
 		return db.StoragePoolVolumeTypeImage, nil
 	case db.StoragePoolVolumeTypeNameCustom:
@@ -395,6 +397,8 @@ func VolumeTypeToDBType(volType drivers.VolumeType) (int, error) {
 	switch volType {
 	case drivers.VolumeTypeContainer:
 		return db.StoragePoolVolumeTypeContainer, nil
+	case drivers.VolumeTypeVM:
+		return db.StoragePoolVolumeTypeVM, nil
 	case drivers.VolumeTypeImage:
 		return db.StoragePoolVolumeTypeImage, nil
 	case drivers.VolumeTypeCustom:

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -2008,7 +2008,7 @@ func (s *storageBtrfs) ImageCreate(fingerprint string, tracker *ioprogress.Progr
 
 	// Unpack the image in imageMntPoint.
 	imagePath := shared.VarPath("images", fingerprint)
-	err = driver.ImageUnpack(imagePath, tmpImageSubvolumeName, false, s.s.OS.RunningInUserNS, tracker)
+	err = driver.ImageUnpack(imagePath, tmpImageSubvolumeName, "", false, s.s.OS.RunningInUserNS, tracker)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -2102,7 +2102,7 @@ func (s *storageCeph) ImageCreate(fingerprint string, tracker *ioprogress.Progre
 
 		// rsync contents into image
 		imagePath := shared.VarPath("images", fingerprint)
-		err = driver.ImageUnpack(imagePath, imageMntPoint, true, s.s.OS.RunningInUserNS, nil)
+		err = driver.ImageUnpack(imagePath, imageMntPoint, "", true, s.s.OS.RunningInUserNS, nil)
 		if err != nil {
 			logger.Errorf(`Failed to unpack image for RBD storage volume for image "%s" on storage pool "%s": %s`, fingerprint, s.pool.Name, err)
 

--- a/lxd/storage_dir.go
+++ b/lxd/storage_dir.go
@@ -573,7 +573,7 @@ func (s *storageDir) ContainerCreateFromImage(container Instance, imageFingerpri
 	}
 
 	imagePath := shared.VarPath("images", imageFingerprint)
-	err = driver.ImageUnpack(imagePath, containerMntPoint, false, s.s.OS.RunningInUserNS, nil)
+	err = driver.ImageUnpack(imagePath, containerMntPoint, "", false, s.s.OS.RunningInUserNS, nil)
 	if err != nil {
 		return errors.Wrap(err, "Unpack image")
 	}

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -1940,7 +1940,7 @@ func (s *storageLvm) ImageCreate(fingerprint string, tracker *ioprogress.Progres
 		}
 
 		imagePath := shared.VarPath("images", fingerprint)
-		err = driver.ImageUnpack(imagePath, imageMntPoint, true, s.s.OS.RunningInUserNS, nil)
+		err = driver.ImageUnpack(imagePath, imageMntPoint, "", true, s.s.OS.RunningInUserNS, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -504,7 +504,7 @@ func (s *storageLvm) containerCreateFromImageLv(c Instance, fp string) error {
 
 	imagePath := shared.VarPath("images", fp)
 	containerMntPoint := driver.GetContainerMountPoint(c.Project(), s.pool.Name, containerName)
-	err = driver.ImageUnpack(imagePath, containerMntPoint, true, s.s.OS.RunningInUserNS, nil)
+	err = driver.ImageUnpack(imagePath, containerMntPoint, "", true, s.s.OS.RunningInUserNS, nil)
 	if err != nil {
 		logger.Errorf(`Failed to unpack image "%s" into non-thinpool LVM storage volume "%s" for container "%s" on storage pool "%s": %s`, imagePath, containerMntPoint, containerName, s.pool.Name, err)
 		return err

--- a/lxd/storage_zfs.go
+++ b/lxd/storage_zfs.go
@@ -2407,7 +2407,7 @@ func (s *storageZfs) ImageCreate(fingerprint string, tracker *ioprogress.Progres
 	}
 
 	// Unpack the image into the temporary mountpoint.
-	err = driver.ImageUnpack(imagePath, tmpImageDir, false, s.s.OS.RunningInUserNS, nil)
+	err = driver.ImageUnpack(imagePath, tmpImageDir, "", false, s.s.OS.RunningInUserNS, nil)
 	if err != nil {
 		return err
 	}

--- a/lxd/sys/fs.go
+++ b/lxd/sys/fs.go
@@ -42,7 +42,9 @@ func (s *OS) initDirs() error {
 		{s.VarDir, 0711},
 		{filepath.Join(s.VarDir, "backups"), 0700},
 		{s.CacheDir, 0700},
+		// containers is 0711 because liblxc needs to traverse dir to get to each container.
 		{filepath.Join(s.VarDir, "containers"), 0711},
+		{filepath.Join(s.VarDir, "virtual-machines"), 0711},
 		{filepath.Join(s.VarDir, "database"), 0700},
 		{filepath.Join(s.VarDir, "devices"), 0711},
 		{filepath.Join(s.VarDir, "devlxd"), 0755},
@@ -52,7 +54,9 @@ func (s *OS) initDirs() error {
 		{filepath.Join(s.VarDir, "networks"), 0711},
 		{filepath.Join(s.VarDir, "security"), 0700},
 		{filepath.Join(s.VarDir, "shmounts"), 0711},
+		// snapshots is 0700 as liblxc does not need to access this.
 		{filepath.Join(s.VarDir, "snapshots"), 0700},
+		{filepath.Join(s.VarDir, "virtual-machines-snapshots"), 0700},
 		{filepath.Join(s.VarDir, "storage-pools"), 0711},
 	}
 

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -1,0 +1,2471 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitalocean/go-qemu/qmp"
+	"github.com/linuxkit/virtsock/pkg/vsock"
+	"github.com/pborman/uuid"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
+	"github.com/lxc/lxd/lxd/backup"
+	"github.com/lxc/lxd/lxd/cluster"
+	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/lxd/device"
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/lxd/maas"
+	"github.com/lxc/lxd/lxd/operations"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/lxd/state"
+	storagePools "github.com/lxc/lxd/lxd/storage"
+	"github.com/lxc/lxd/lxd/util"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/api"
+	log "github.com/lxc/lxd/shared/log15"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/osarch"
+	"github.com/lxc/lxd/shared/units"
+)
+
+var vmVsockTimeout time.Duration = time.Second
+
+func vmQemuLoad(s *state.State, args db.InstanceArgs, profiles []api.Profile) (Instance, error) {
+	// Create the container struct.
+	vm := vmQemuInstantiate(s, args)
+
+	// Expand config and devices.
+	err := vm.expandConfig(profiles)
+	if err != nil {
+		return nil, err
+	}
+
+	err = vm.expandDevices(profiles)
+	if err != nil {
+		return nil, err
+	}
+
+	return vm, nil
+}
+
+// vmQemuInstantiate creates a vmQemu struct without initializing it.
+func vmQemuInstantiate(s *state.State, args db.InstanceArgs) *vmQemu {
+	vm := &vmQemu{
+		state:        s,
+		id:           args.ID,
+		project:      args.Project,
+		name:         args.Name,
+		description:  args.Description,
+		ephemeral:    args.Ephemeral,
+		architecture: args.Architecture,
+		dbType:       args.Type,
+		snapshot:     args.Snapshot,
+		creationDate: args.CreationDate,
+		lastUsedDate: args.LastUsedDate,
+		profiles:     args.Profiles,
+		localConfig:  args.Config,
+		localDevices: args.Devices,
+		stateful:     args.Stateful,
+		node:         args.Node,
+		expiryDate:   args.ExpiryDate,
+	}
+
+	// Cleanup the zero values.
+	if vm.expiryDate.IsZero() {
+		vm.expiryDate = time.Time{}
+	}
+
+	if vm.creationDate.IsZero() {
+		vm.creationDate = time.Time{}
+	}
+
+	if vm.lastUsedDate.IsZero() {
+		vm.lastUsedDate = time.Time{}
+	}
+
+	return vm
+}
+
+// vmQemuCreate creates a new storage volume record and returns an initialised Instance.
+func vmQemuCreate(s *state.State, args db.InstanceArgs) (Instance, error) {
+	// Create the instance struct.
+	vm := &vmQemu{
+		state:        s,
+		id:           args.ID,
+		project:      args.Project,
+		name:         args.Name,
+		node:         args.Node,
+		description:  args.Description,
+		ephemeral:    args.Ephemeral,
+		architecture: args.Architecture,
+		dbType:       args.Type,
+		snapshot:     args.Snapshot,
+		stateful:     args.Stateful,
+		creationDate: args.CreationDate,
+		lastUsedDate: args.LastUsedDate,
+		profiles:     args.Profiles,
+		localConfig:  args.Config,
+		localDevices: args.Devices,
+		expiryDate:   args.ExpiryDate,
+	}
+
+	// Cleanup the zero values.
+	if vm.expiryDate.IsZero() {
+		vm.expiryDate = time.Time{}
+	}
+
+	if vm.creationDate.IsZero() {
+		vm.creationDate = time.Time{}
+	}
+
+	if vm.lastUsedDate.IsZero() {
+		vm.lastUsedDate = time.Time{}
+	}
+
+	ctxMap := log.Ctx{
+		"project":   args.Project,
+		"name":      vm.name,
+		"ephemeral": vm.ephemeral,
+	}
+
+	logger.Info("Creating instance", ctxMap)
+
+	revert := true
+	defer func() {
+		if !revert {
+			return
+		}
+
+		vm.Delete()
+	}()
+
+	// Load the config.
+	err := vm.init()
+	if err != nil {
+		logger.Error("Failed creating instance", ctxMap)
+		return nil, err
+	}
+
+	// Validate expanded config
+	err = containerValidConfig(s.OS, vm.expandedConfig, false, true)
+	if err != nil {
+		logger.Error("Failed creating instance", ctxMap)
+		return nil, err
+	}
+
+	err = containerValidDevices(s, s.Cluster, vm.Name(), vm.expandedDevices, true)
+	if err != nil {
+		logger.Error("Failed creating instance", ctxMap)
+		return nil, errors.Wrap(err, "Invalid devices")
+	}
+
+	// Retrieve the instance's storage pool
+	_, rootDiskDevice, err := shared.GetRootDiskDevice(vm.expandedDevices.CloneNative())
+	if err != nil {
+		return nil, err
+	}
+
+	if rootDiskDevice["pool"] == "" {
+		return nil, fmt.Errorf("The instances's root device is missing the pool property")
+	}
+
+	storagePool := rootDiskDevice["pool"]
+
+	// Get the storage pool ID for the instance.
+	poolID, pool, err := s.Cluster.StoragePoolGet(storagePool)
+	if err != nil {
+		return nil, err
+	}
+
+	// Fill in any default volume config.
+	volumeConfig := map[string]string{}
+	err = storagePools.VolumeFillDefault(storagePool, volumeConfig, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new database entry for the instance's storage volume.
+	_, err = s.Cluster.StoragePoolVolumeCreate(args.Project, args.Name, "", db.StoragePoolVolumeTypeVM, false, poolID, volumeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if !vm.IsSnapshot() {
+		// Update MAAS.
+		err = vm.maasUpdate(nil)
+		if err != nil {
+			logger.Error("Failed creating instance", ctxMap)
+			return nil, err
+		}
+
+		// Add devices to instance.
+		for k, m := range vm.expandedDevices {
+			err = vm.deviceAdd(k, m)
+			if err != nil && err != device.ErrUnsupportedDevType {
+				return nil, errors.Wrapf(err, "Failed to add device '%s'", k)
+			}
+		}
+	}
+
+	logger.Info("Created instance", ctxMap)
+	vm.state.Events.SendLifecycle(vm.project, "virtual-machine-created",
+		fmt.Sprintf("/1.0/virtual-machines/%s", vm.name), nil)
+
+	revert = false
+	return vm, nil
+}
+
+// The QEMU virtual machine driver.
+type vmQemu struct {
+	// Properties.
+	architecture int
+	dbType       instancetype.Type
+	snapshot     bool
+	creationDate time.Time
+	lastUsedDate time.Time
+	ephemeral    bool
+	id           int
+	project      string
+	name         string
+	description  string
+	stateful     bool
+
+	// Config.
+	expandedConfig  map[string]string
+	expandedDevices deviceConfig.Devices
+	localConfig     map[string]string
+	localDevices    deviceConfig.Devices
+	profiles        []string
+
+	state *state.State
+
+	// Clustering.
+	node string
+
+	// Progress tracking.
+	op *operations.Operation
+
+	expiryDate time.Time
+}
+
+func (vm *vmQemu) Freeze() error {
+	return nil
+}
+
+func (vm *vmQemu) Shutdown(timeout time.Duration) error {
+	if !vm.IsRunning() {
+		return fmt.Errorf("The instance is already stopped")
+	}
+
+	// Connect to the monitor.
+	monitor, err := qmp.NewSocketMonitor("unix", vm.getMonitorPath(), vmVsockTimeout)
+	if err != nil {
+		return err
+	}
+
+	err = monitor.Connect()
+	if err != nil {
+		return err
+	}
+	defer monitor.Disconnect()
+
+	// Send the system_powerdown command.
+	_, err = monitor.Run([]byte("{'execute': 'system_powerdown'}"))
+	if err != nil {
+		return err
+	}
+	monitor.Disconnect()
+
+	// Deal with the timeout.
+	chShutdown := make(chan struct{}, 1)
+	go func() {
+		for {
+			// Connect to socket, check if still running, then disconnect so we don't
+			// block the qemu monitor socket for other users (such as lxc list).
+			if !vm.IsRunning() {
+				close(chShutdown)
+				return
+			}
+
+			time.Sleep(500 * time.Millisecond) // Don't consume too many resources.
+		}
+	}()
+
+	// If timeout provided, block until the VM is not running or the timeout has elapsed.
+	if timeout > 0 {
+		select {
+		case <-chShutdown:
+			return nil
+		case <-time.After(timeout):
+			return fmt.Errorf("Instance was not shutdown after timeout")
+		}
+	} else {
+		<-chShutdown // Block until VM is not running if no timeout provided.
+	}
+
+	vm.cleanupDevices()
+	os.Remove(vm.pidFilePath())
+	os.Remove(vm.getMonitorPath())
+
+	return nil
+}
+
+func (vm *vmQemu) Start(stateful bool) error {
+	// Ensure the correct vhost_vsock kernel module is loaded before establishing the vsock.
+	err := util.LoadModule("vhost_vsock")
+	if err != nil {
+		return err
+	}
+
+	if vm.IsRunning() {
+		return fmt.Errorf("The instance is already running")
+	}
+
+	pidFile := vm.DevicesPath() + "/qemu.pid"
+	configISOPath, err := vm.generateConfigDrive()
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(vm.LogPath(), 0700)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(vm.DevicesPath(), 0711)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(vm.ShmountsPath(), 0711)
+	if err != nil {
+		return err
+	}
+
+	// Get a UUID for Qemu.
+	vmUUID := vm.localConfig["volatile.vm.uuid"]
+	if vmUUID == "" {
+		vmUUID = uuid.New()
+		vm.VolatileSet(map[string]string{"volatile.vm.uuid": vmUUID})
+	}
+
+	// Generate an empty nvram file.
+	nvramFile, err := os.OpenFile(vm.getNvramPath(), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0640)
+	if err != nil {
+		return err
+	}
+	err = nvramFile.Truncate(131072)
+	if err != nil {
+		return err
+	}
+	nvramFile.Close()
+
+	tapDev := map[string]string{}
+
+	// Setup devices in sorted order, this ensures that device mounts are added in path order.
+	for _, dev := range vm.expandedDevices.Sorted() {
+		// Start the device.
+		runConf, err := vm.deviceStart(dev.Name, dev.Config, false)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+		}
+
+		if runConf == nil {
+			continue
+		}
+
+		if len(runConf.NetworkInterface) > 0 {
+			for _, nicItem := range runConf.NetworkInterface {
+				if nicItem.Key == "link" {
+					tapDev["tap"] = nicItem.Value
+					tapDev["hwaddr"] = vm.localConfig[fmt.Sprintf("volatile.%s.hwaddr", dev.Name)]
+				}
+			}
+
+		}
+	}
+
+	confFile, err := vm.generateQemuConfigFile(configISOPath, tapDev)
+	if err != nil {
+		return err
+	}
+
+	// Check qemu is installed.
+	_, err = exec.LookPath("qemu-system-x86_64")
+	if err != nil {
+		return err
+	}
+
+	_, err = shared.RunCommand("qemu-system-x86_64", "-name", vm.Name(), "-uuid", vmUUID, "-daemonize", "-cpu", "host", "-nographic", "-serial", "chardev:console", "-nodefaults", "-readconfig", confFile, "-pidfile", pidFile)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deviceVolatileGetFunc returns a function that retrieves a named device's volatile config and
+// removes its device prefix from the keys.
+func (vm *vmQemu) deviceVolatileGetFunc(devName string) func() map[string]string {
+	return func() map[string]string {
+		volatile := make(map[string]string)
+		prefix := fmt.Sprintf("volatile.%s.", devName)
+		for k, v := range vm.localConfig {
+			if strings.HasPrefix(k, prefix) {
+				volatile[strings.TrimPrefix(k, prefix)] = v
+			}
+		}
+		return volatile
+	}
+}
+
+// deviceVolatileSetFunc returns a function that can be called to save a named device's volatile
+// config using keys that do not have the device's name prefixed.
+func (vm *vmQemu) deviceVolatileSetFunc(devName string) func(save map[string]string) error {
+	return func(save map[string]string) error {
+		volatileSave := make(map[string]string)
+		for k, v := range save {
+			volatileSave[fmt.Sprintf("volatile.%s.%s", devName, k)] = v
+		}
+
+		return vm.VolatileSet(volatileSave)
+	}
+}
+
+// deviceLoad instantiates and validates a new device and returns it along with enriched config.
+func (vm *vmQemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (device.Device, deviceConfig.Device, error) {
+	var configCopy deviceConfig.Device
+	var err error
+
+	// Create copy of config and load some fields from volatile if device is nic or infiniband.
+	if shared.StringInSlice(rawConfig["type"], []string{"nic", "infiniband"}) {
+		configCopy, err = vm.fillNetworkDevice(deviceName, rawConfig)
+		if err != nil {
+			return nil, nil, err
+		}
+	} else {
+		// Othewise copy the config so it cannot be modified by device.
+		configCopy = rawConfig.Clone()
+	}
+
+	d, err := device.New(vm, vm.state, deviceName, configCopy, vm.deviceVolatileGetFunc(deviceName), vm.deviceVolatileSetFunc(deviceName))
+
+	// Return device and config copy even if error occurs as caller may still use device.
+	return d, configCopy, err
+}
+
+// deviceStart loads a new device and calls its Start() function. After processing the runtime
+// config returned from Start(), it also runs the device's Register() function irrespective of
+// whether the instance is running or not.
+func (vm *vmQemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*device.RunConfig, error) {
+	d, _, err := vm.deviceLoad(deviceName, rawConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	if canHotPlug, _ := d.CanHotPlug(); isRunning && !canHotPlug {
+		return nil, fmt.Errorf("Device cannot be started when instance is running")
+	}
+
+	runConf, err := d.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	return runConf, nil
+}
+
+// deviceStop loads a new device and calls its Stop() function.
+func (vm *vmQemu) deviceStop(deviceName string, rawConfig deviceConfig.Device) error {
+	d, _, err := vm.deviceLoad(deviceName, rawConfig)
+
+	// If deviceLoad fails with unsupported device type then return.
+	if err == device.ErrUnsupportedDevType {
+		return err
+	}
+
+	// If deviceLoad fails for any other reason then just log the error and proceed, as in the
+	// scenario that a new version of LXD has additional validation restrictions than older
+	// versions we still need to allow previously valid devices to be stopped.
+	if err != nil {
+		// If there is no device returned, then we cannot proceed, so return as error.
+		if d == nil {
+			return fmt.Errorf("Device stop validation failed for '%s': %v", deviceName, err)
+
+		}
+
+		logger.Errorf("Device stop validation failed for '%s': %v", deviceName, err)
+	}
+
+	canHotPlug, _ := d.CanHotPlug()
+
+	// An empty netns path means we haven't been called from the LXC stop hook, so are running.
+	if vm.IsRunning() && !canHotPlug {
+		return fmt.Errorf("Device cannot be stopped when instance is running")
+	}
+
+	runConf, err := d.Stop()
+	if err != nil {
+		return err
+	}
+
+	if runConf != nil {
+		// Run post stop hooks irrespective of run state of instance.
+		err = vm.runHooks(runConf.PostHooks)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// runHooks executes the callback functions returned from a function.
+func (vm *vmQemu) runHooks(hooks []func() error) error {
+	// Run any post start hooks.
+	if len(hooks) > 0 {
+		for _, hook := range hooks {
+			err := hook()
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) getMonitorPath() string {
+	return vm.DevicesPath() + "/qemu.monitor"
+}
+
+func (vm *vmQemu) getNvramPath() string {
+	return vm.DevicesPath() + "/qemu.nvram"
+}
+
+func (vm *vmQemu) generateConfigDrive() (string, error) {
+	configDrivePath := vm.Path() + "/config"
+
+	// Create config drive dir.
+	err := os.MkdirAll(configDrivePath, 0100)
+	if err != nil {
+		return "", err
+	}
+
+	// Add config drive mount instructions to cloud init.
+	vendorData := `#cloud-config
+runcmd:
+ - "mkdir /media/lxd_config"
+ - "mount -o ro -t iso9660 /dev/disk/by-label/cidata /media/lxd_config"
+ - "cp /media/lxd_config/media-lxd_config.mount /etc/systemd/system/"
+ - "systemctl enable media-lxd_config.mount"`
+
+	path, err := exec.LookPath("lxd-agent")
+	if err != nil {
+		logger.Warnf("lxd-agent not found, skipping its inclusion in the VM config drive: %v", err)
+	} else {
+		// Install agent into config drive dir if found.
+		_, err = shared.RunCommand("cp", path, configDrivePath+"/lxd-agent")
+		if err != nil {
+			return "", err
+		}
+
+		os.Chmod(configDrivePath+"/lxd-agent", 0700)
+
+		// Add agent install and startup config to cloud init.
+		vendorData += `
+ - "cp /media/lxd_config/lxd-agent.service /etc/systemd/system/"
+ - "systemctl enable lxd-agent.service"
+ - "systemctl start lxd-agent"`
+	}
+
+	err = ioutil.WriteFile(configDrivePath+"/vendor-data", []byte(vendorData), 0400)
+	if err != nil {
+		return "", err
+	}
+
+	userData := vm.expandedConfig["user.user-data"]
+
+	// Use an empty user-data file if no custom user-data supplied.
+	if userData == "" {
+		userData = "#cloud-config"
+	}
+
+	err = ioutil.WriteFile(configDrivePath+"/user-data", []byte(userData), 0400)
+	if err != nil {
+		return "", err
+	}
+
+	metaData := fmt.Sprintf(`instance-id: %s
+local-hostname: %s
+`, vm.Name(), vm.Name())
+
+	err = ioutil.WriteFile(configDrivePath+"/meta-data", []byte(metaData), 0400)
+	if err != nil {
+		return "", err
+	}
+
+	lxdAgentServiceUnit := `[Unit]
+Description=LXD - agent
+After=media-lxd_config.mount
+[Service]
+Type=simple
+ExecStart=/media/lxd_config/lxd-agent
+[Install]
+WantedBy=multi-user.target
+`
+
+	err = ioutil.WriteFile(configDrivePath+"/lxd-agent.service", []byte(lxdAgentServiceUnit), 0400)
+	if err != nil {
+		return "", err
+	}
+
+	lxdConfigDriveMountUnit := `[Unit]
+Description = LXD - config drive
+Before=local-fs.target
+[Mount]
+Where=/media/lxd_config
+What=/dev/disk/by-label/cidata
+Type=iso9660
+[Install]
+WantedBy=multi-user.target
+`
+
+	err = ioutil.WriteFile(configDrivePath+"/media-lxd_config.mount", []byte(lxdConfigDriveMountUnit), 0400)
+	if err != nil {
+		return "", err
+	}
+
+	// Copy the LXD's server.crt file for use with the lxd-agent.
+	serverCrt, err := ioutil.ReadFile(shared.VarPath("server.crt"))
+	if err != nil {
+		return "", err
+	}
+	err = ioutil.WriteFile(configDrivePath+"/server.crt", serverCrt, 0400)
+	if err != nil {
+		return "", err
+	}
+
+	// Check if we have both agent.crt and agent.key and if not generate a new set.
+	agentCertFile := filepath.Join(vm.Path(), "agent.cert")
+	agentKeyFile := filepath.Join(vm.Path(), "agent.key")
+	err = shared.FindOrGenCert(agentCertFile, agentKeyFile, true)
+	if err != nil {
+		return "", err
+	}
+
+	// Copy the VM's LXD agent.crt file for use with the lxd-agent.
+	agentCrt, err := ioutil.ReadFile(agentCertFile)
+	if err != nil {
+		return "", err
+	}
+	err = ioutil.WriteFile(configDrivePath+"/agent.crt", agentCrt, 0400)
+	if err != nil {
+		return "", err
+	}
+
+	// Copy the VM's LXD agent.crt file for use with the lxd-agent.
+	agentKey, err := ioutil.ReadFile(agentKeyFile)
+	if err != nil {
+		return "", err
+	}
+	err = ioutil.WriteFile(configDrivePath+"/agent.key", agentKey, 0400)
+	if err != nil {
+		return "", err
+	}
+
+	// Finally convert the config drive dir into an ISO file. The cidata label is important
+	// as this is what cloud-init uses to detect, mount the drive and run the cloud-init
+	// templates on first boot. The vendor-data template then modifies the system so that the
+	// config drive is mounted and the agent is started on subsequent boots.
+	isoPath := vm.Path() + "/config.iso"
+	_, err = shared.RunCommand("mkisofs", "-R", "-V", "cidata", "-o", isoPath, configDrivePath)
+	if err != nil {
+		return "", err
+	}
+
+	return isoPath, nil
+}
+
+// generateQemuConfigFile writes the qemu config file and returns its location.
+func (vm *vmQemu) generateQemuConfigFile(configISOPath string, tapDev map[string]string) (string, error) {
+	var sb *strings.Builder = &strings.Builder{}
+
+	// Base config. This is common for all VMs and has no variables in it.
+	sb.WriteString(`
+# Machine
+[machine]
+graphics = "off"
+type = "q35"
+accel = "kvm"
+usb = "off"
+graphics = "off"
+[global]
+driver = "ICH9-LPC"
+property = "disable_s3"
+value = "1"
+[global]
+driver = "ICH9-LPC"
+property = "disable_s4"
+value = "1"
+[boot-opts]
+strict = "on"
+# SCSI root
+[device "qemu_pcie1"]
+driver = "pcie-root-port"
+port = "0x10"
+chassis = "1"
+bus = "pcie.0"
+multifunction = "on"
+addr = "0x2"
+[device "qemu_scsi"]
+driver = "virtio-scsi-pci"
+bus = "qemu_pcie1"
+addr = "0x0"
+# Balloon driver
+[device "qemu_pcie2"]
+driver = "pcie-root-port"
+port = "0x12"
+chassis = "2"
+bus = "pcie.0"
+addr = "0x2.0x1"
+[device "qemu_ballon"]
+driver = "virtio-balloon-pci"
+bus = "qemu_pcie2"
+addr = "0x0"
+# Random number generator
+[object "qemu_rng"]
+qom-type = "rng-random"
+filename = "/dev/urandom"
+[device "qemu_pcie3"]
+driver = "pcie-root-port"
+port = "0x13"
+chassis = "3"
+bus = "pcie.0"
+addr = "0x2.0x2"
+[device "dev-qemu_rng"]
+driver = "virtio-rng-pci"
+rng = "qemu_rng"
+bus = "qemu_pcie3"
+addr = "0x0"
+# Console
+[chardev "console"]
+backend = "pty"
+`)
+
+	// Now add the dynamic parts of the config.
+	err := vm.addMemoryConfig(sb)
+	if err != nil {
+		return "", err
+	}
+
+	err = vm.addRootDriveConfig(sb)
+	if err != nil {
+		return "", err
+	}
+
+	err = vm.addCPUConfig(sb)
+	if err != nil {
+		return "", err
+	}
+
+	vm.addFirmwareConfig(sb)
+	vm.addVsockConfig(sb)
+	vm.addMonitorConfig(sb)
+	vm.addConfDriveConfig(sb, configISOPath)
+	vm.addNetConfig(sb, tapDev)
+
+	// Write the config file to disk.
+	configPath := filepath.Join(vm.LogPath(), "qemu.conf")
+	return configPath, ioutil.WriteFile(configPath, []byte(sb.String()), 0640)
+}
+
+func (vm *vmQemu) addMemoryConfig(sb *strings.Builder) error {
+	// Configure memory limit.
+	memSize := vm.expandedConfig["limits.memory"]
+	if memSize == "" {
+		memSize = "1GB" // Default to 1GB if no memory limit specified.
+	}
+
+	memSizeBytes, err := units.ParseByteSizeString(memSize)
+	if err != nil {
+		return fmt.Errorf("limits.memory invalid: %v", err)
+	}
+
+	memKB := memSizeBytes / 1000
+
+	sb.WriteString(fmt.Sprintf(`
+# Memory
+[memory]
+size = "%dK"
+`, memKB))
+
+	return nil
+}
+
+func (vm *vmQemu) addVsockConfig(sb *strings.Builder) {
+	vsockID := vm.vsockID()
+
+	sb.WriteString(fmt.Sprintf(`
+# Vsock
+[device "qemu_pcie4"]
+driver = "pcie-root-port"
+port = "0x13"
+chassis = "4"
+bus = "pcie.0"
+addr = "0x2.0x3"
+[device]
+driver = "vhost-vsock-pci"
+guest-cid = "%d"
+bus = "qemu_pcie4"
+addr = "0x0"
+`, vsockID))
+
+	return
+}
+
+func (vm *vmQemu) addCPUConfig(sb *strings.Builder) error {
+	// Configure CPU limit. TODO add control of sockets, cores and threads.
+	cpus := vm.expandedConfig["limits.cpu"]
+	if cpus == "" {
+		cpus = "1"
+	}
+
+	cpuCount, err := strconv.Atoi(cpus)
+	if err != nil {
+		return fmt.Errorf("limits.cpu invalid: %v", err)
+	}
+
+	sb.WriteString(fmt.Sprintf(`
+# CPU
+[smp-opts]
+cpus = "%d"
+#sockets = "1"
+#cores = "1"
+#threads = "1"
+`, cpuCount))
+
+	return nil
+}
+
+func (vm *vmQemu) addMonitorConfig(sb *strings.Builder) {
+	monitorPath := vm.getMonitorPath()
+
+	sb.WriteString(fmt.Sprintf(`
+# Qemu control
+[chardev "monitor"]
+backend = "socket"
+path = "%s"
+server = "on"
+wait = "off"
+[mon]
+chardev = "monitor"
+mode = "control"
+`, monitorPath))
+
+	return
+}
+
+func (vm *vmQemu) addFirmwareConfig(sb *strings.Builder) {
+	nvramPath := vm.getNvramPath()
+
+	sb.WriteString(fmt.Sprintf(`
+# Firmware
+[drive]
+file = "/usr/share/OVMF/OVMF_CODE.fd"
+if = "pflash"
+format = "raw"
+unit = "0"
+readonly = "on"
+[drive]
+file = "%s"
+if = "pflash"
+format = "raw"
+unit = "1"
+`, nvramPath))
+
+	return
+}
+
+func (vm *vmQemu) addRootDriveConfig(sb *strings.Builder) error {
+	pool, err := storagePools.GetPoolByInstance(vm.state, vm)
+	if err != nil {
+		return err
+	}
+
+	rootDrivePath, rootDriveType, err := pool.GetInstanceDisk(vm)
+	if err != nil {
+		return err
+	}
+
+	sb.WriteString(fmt.Sprintf(`
+# Root drive ("root" device)
+[drive "lxd_root"]
+file = "%s"
+format = "%s"
+if = "none"
+cache = "none"
+aio = "native"
+[device "dev-lxd_root"]
+driver = "scsi-hd"
+bus = "qemu_scsi.0"
+channel = "0"
+scsi-id = "0"
+lun = "1"
+drive = "lxd_root"
+bootindex = "1"
+`, rootDrivePath, rootDriveType))
+
+	return nil
+}
+
+func (vm *vmQemu) addConfDriveConfig(sb *strings.Builder, configISOPath string) {
+	sb.WriteString(fmt.Sprintf(`
+# Config drive (set to last lun)
+[drive "qemu_config"]
+file = "%s"
+format = "raw"
+if = "none"
+cache = "none"
+aio = "native"
+readonly = "on"
+[device "dev-qemu_config"]
+driver = "scsi-hd"
+bus = "qemu_scsi.0"
+channel = "0"
+scsi-id = "1"
+lun = "1"
+drive = "qemu_config"
+`, configISOPath))
+
+	return
+}
+
+func (vm *vmQemu) addNetConfig(sb *strings.Builder, tapDev map[string]string) {
+	sb.WriteString(fmt.Sprintf(`
+# Network card ("eth0" device)
+[netdev "lxd_eth0"]
+type = "tap"
+ifname = "%s"
+script = "no"
+downscript = "no"
+[device "qemu_pcie5"]
+driver = "pcie-root-port"
+port = "0x11"
+chassis = "5"
+bus = "pcie.0"
+addr = "0x2.0x4"
+[device "dev-lxd_eth0"]
+driver = "virtio-net-pci"
+netdev = "lxd_eth0"
+mac = "%s"
+bus = "qemu_pcie5"
+addr = "0x0"
+bootindex = "2""
+`, tapDev["tap"], tapDev["hwaddr"]))
+
+	return
+}
+
+func (vm *vmQemu) pidFilePath() string {
+	return vm.DevicesPath() + "/qemu.pid"
+}
+
+func (vm *vmQemu) pid() (int, error) {
+	pidStr, err := ioutil.ReadFile(vm.pidFilePath())
+	if os.IsNotExist(err) {
+		return 0, nil
+	}
+
+	if err != nil {
+		return -1, err
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(pidStr)))
+	if err != nil {
+		return -1, err
+	}
+
+	return pid, nil
+}
+
+func (vm *vmQemu) Stop(stateful bool) error {
+	if stateful {
+		return fmt.Errorf("Stateful stop isn't supported for VMs at this time")
+	}
+
+	if !vm.IsRunning() {
+		return fmt.Errorf("Instance is not running")
+	}
+
+	// Connect to the monitor.
+	monitor, err := qmp.NewSocketMonitor("unix", vm.getMonitorPath(), vmVsockTimeout)
+	if err != nil {
+		return err
+	}
+
+	err = monitor.Connect()
+	if err != nil {
+		return err
+	}
+	defer monitor.Disconnect()
+
+	// Send the quit command.
+	_, err = monitor.Run([]byte("{'execute': 'quit'}"))
+	if err != nil {
+		return err
+	}
+	monitor.Disconnect()
+
+	pid, err := vm.pid()
+	if err != nil {
+		return err
+	}
+
+	// No PID found, qemu not running.
+	if pid < 0 {
+		return nil
+	}
+
+	// Check if qemu process still running, if so wait.
+	for {
+		procPath := fmt.Sprintf("/proc/%d", pid)
+		if shared.PathExists(procPath) {
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		break
+	}
+
+	vm.cleanupDevices()
+	os.Remove(vm.pidFilePath())
+	os.Remove(vm.getMonitorPath())
+
+	return nil
+}
+
+func (vm *vmQemu) Unfreeze() error {
+	return fmt.Errorf("Unfreeze Not implemented")
+}
+
+func (vm *vmQemu) IsPrivileged() bool {
+	return shared.IsTrue(vm.expandedConfig["security.privileged"])
+}
+
+func (vm *vmQemu) Restore(source Instance, stateful bool) error {
+	return fmt.Errorf("Restore Not implemented")
+}
+
+func (vm *vmQemu) Snapshots() ([]Instance, error) {
+	return []Instance{}, nil
+}
+
+func (vm *vmQemu) Backups() ([]backup.Backup, error) {
+	return []backup.Backup{}, nil
+}
+
+func (vm *vmQemu) Rename(newName string) error {
+	return fmt.Errorf("Rename Not implemented")
+}
+
+func (vm *vmQemu) Update(args db.InstanceArgs, userRequested bool) error {
+	if vm.IsRunning() {
+		return fmt.Errorf("Update whilst running not supported")
+	}
+
+	// Set sane defaults for unset keys.
+	if args.Project == "" {
+		args.Project = "default"
+	}
+
+	if args.Architecture == 0 {
+		args.Architecture = vm.architecture
+	}
+
+	if args.Config == nil {
+		args.Config = map[string]string{}
+	}
+
+	if args.Devices == nil {
+		args.Devices = deviceConfig.Devices{}
+	}
+
+	if args.Profiles == nil {
+		args.Profiles = []string{}
+	}
+
+	// Validate the new config.
+	err := containerValidConfig(vm.state.OS, args.Config, false, false)
+	if err != nil {
+		return errors.Wrap(err, "Invalid config")
+	}
+
+	// Validate the new devices without using expanded devices validation (expensive checks disabled).
+	err = containerValidDevices(vm.state, vm.state.Cluster, vm.Name(), args.Devices, false)
+	if err != nil {
+		return errors.Wrap(err, "Invalid devices")
+	}
+
+	// Validate the new profiles.
+	profiles, err := vm.state.Cluster.Profiles(args.Project)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get profiles")
+	}
+
+	checkedProfiles := []string{}
+	for _, profile := range args.Profiles {
+		if !shared.StringInSlice(profile, profiles) {
+			return fmt.Errorf("Requested profile '%s' doesn't exist", profile)
+		}
+
+		if shared.StringInSlice(profile, checkedProfiles) {
+			return fmt.Errorf("Duplicate profile found in request")
+		}
+
+		checkedProfiles = append(checkedProfiles, profile)
+	}
+
+	// Validate the new architecture.
+	if args.Architecture != 0 {
+		_, err = osarch.ArchitectureName(args.Architecture)
+		if err != nil {
+			return fmt.Errorf("Invalid architecture ID: %s", err)
+		}
+	}
+
+	// Check that volatile and image keys weren't modified.
+	if userRequested {
+		for k, v := range args.Config {
+			if strings.HasPrefix(k, "volatile.") && vm.localConfig[k] != v {
+				return fmt.Errorf("Volatile keys are read-only")
+			}
+
+			if strings.HasPrefix(k, "image.") && vm.localConfig[k] != v {
+				return fmt.Errorf("Image keys are read-only")
+			}
+		}
+
+		for k, v := range vm.localConfig {
+			if strings.HasPrefix(k, "volatile.") && args.Config[k] != v {
+				return fmt.Errorf("Volatile keys are read-only")
+			}
+
+			if strings.HasPrefix(k, "image.") && args.Config[k] != v {
+				return fmt.Errorf("Image keys are read-only")
+			}
+		}
+	}
+
+	// Get a copy of the old configuration.
+	oldDescription := vm.Description()
+	oldArchitecture := 0
+	err = shared.DeepCopy(&vm.architecture, &oldArchitecture)
+	if err != nil {
+		return err
+	}
+
+	oldEphemeral := false
+	err = shared.DeepCopy(&vm.ephemeral, &oldEphemeral)
+	if err != nil {
+		return err
+	}
+
+	oldExpandedDevices := deviceConfig.Devices{}
+	err = shared.DeepCopy(&vm.expandedDevices, &oldExpandedDevices)
+	if err != nil {
+		return err
+	}
+
+	oldExpandedConfig := map[string]string{}
+	err = shared.DeepCopy(&vm.expandedConfig, &oldExpandedConfig)
+	if err != nil {
+		return err
+	}
+
+	oldLocalDevices := deviceConfig.Devices{}
+	err = shared.DeepCopy(&vm.localDevices, &oldLocalDevices)
+	if err != nil {
+		return err
+	}
+
+	oldLocalConfig := map[string]string{}
+	err = shared.DeepCopy(&vm.localConfig, &oldLocalConfig)
+	if err != nil {
+		return err
+	}
+
+	oldProfiles := []string{}
+	err = shared.DeepCopy(&vm.profiles, &oldProfiles)
+	if err != nil {
+		return err
+	}
+
+	oldExpiryDate := vm.expiryDate
+
+	// Define a function which reverts everything.  Defer this function
+	// so that it doesn't need to be explicitly called in every failing
+	// return path.  Track whether or not we want to undo the changes
+	// using a closure.
+	undoChanges := true
+	defer func() {
+		if undoChanges {
+			vm.description = oldDescription
+			vm.architecture = oldArchitecture
+			vm.ephemeral = oldEphemeral
+			vm.expandedConfig = oldExpandedConfig
+			vm.expandedDevices = oldExpandedDevices
+			vm.localConfig = oldLocalConfig
+			vm.localDevices = oldLocalDevices
+			vm.profiles = oldProfiles
+			vm.expiryDate = oldExpiryDate
+		}
+	}()
+
+	// Apply the various changes.
+	vm.description = args.Description
+	vm.architecture = args.Architecture
+	vm.ephemeral = args.Ephemeral
+	vm.localConfig = args.Config
+	vm.localDevices = args.Devices
+	vm.profiles = args.Profiles
+	vm.expiryDate = args.ExpiryDate
+
+	// Expand the config and refresh the LXC config.
+	err = vm.expandConfig(nil)
+	if err != nil {
+		return errors.Wrap(err, "Expand config")
+	}
+
+	err = vm.expandDevices(nil)
+	if err != nil {
+		return errors.Wrap(err, "Expand devices")
+	}
+
+	// Diff the configurations.
+	changedConfig := []string{}
+	for key := range oldExpandedConfig {
+		if oldExpandedConfig[key] != vm.expandedConfig[key] {
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	for key := range vm.expandedConfig {
+		if oldExpandedConfig[key] != vm.expandedConfig[key] {
+			if !shared.StringInSlice(key, changedConfig) {
+				changedConfig = append(changedConfig, key)
+			}
+		}
+	}
+
+	// Diff the devices.
+	removeDevices, addDevices, updateDevices, updateDiff := oldExpandedDevices.Update(vm.expandedDevices, func(oldDevice deviceConfig.Device, newDevice deviceConfig.Device) []string {
+		// This function needs to return a list of fields that are excluded from differences
+		// between oldDevice and newDevice. The result of this is that as long as the
+		// devices are otherwise identical except for the fields returned here, then the
+		// device is considered to be being "updated" rather than "added & removed".
+		if oldDevice["type"] != newDevice["type"] || oldDevice["nictype"] != newDevice["nictype"] {
+			return []string{} // Device types aren't the same, so this cannot be an update.
+		}
+
+		d, err := device.New(vm, vm.state, "", newDevice, nil, nil)
+		if err != nil {
+			return []string{} // Couldn't create Device, so this cannot be an update.
+		}
+
+		_, updateFields := d.CanHotPlug()
+		return updateFields
+	})
+
+	// Do some validation of the config diff.
+	err = containerValidConfig(vm.state.OS, vm.expandedConfig, false, true)
+	if err != nil {
+		return errors.Wrap(err, "Invalid expanded config")
+	}
+
+	// Do full expanded validation of the devices diff.
+	err = containerValidDevices(vm.state, vm.state.Cluster, vm.Name(), vm.expandedDevices, true)
+	if err != nil {
+		return errors.Wrap(err, "Invalid expanded devices")
+	}
+
+	// Use the device interface to apply update changes.
+	err = vm.updateDevices(removeDevices, addDevices, updateDevices, oldExpandedDevices)
+	if err != nil {
+		return err
+	}
+
+	// Update MAAS (must run after the MAC addresses have been generated).
+	updateMAAS := false
+	for _, key := range []string{"maas.subnet.ipv4", "maas.subnet.ipv6", "ipv4.address", "ipv6.address"} {
+		if shared.StringInSlice(key, updateDiff) {
+			updateMAAS = true
+			break
+		}
+	}
+
+	if !vm.IsSnapshot() && updateMAAS {
+		err = vm.maasUpdate(oldExpandedDevices.CloneNative())
+		if err != nil {
+			return err
+		}
+	}
+
+	// Finally, apply the changes to the database
+	err = query.Retry(func() error {
+		tx, err := vm.state.Cluster.Begin()
+		if err != nil {
+			return err
+		}
+
+		// Snapshots should update only their descriptions and expiry date.
+		if vm.IsSnapshot() {
+			err = db.InstanceSnapshotUpdate(tx, vm.id, vm.description, vm.expiryDate)
+			if err != nil {
+				tx.Rollback()
+				return errors.Wrap(err, "Snapshot update")
+			}
+		} else {
+			err = db.ContainerConfigClear(tx, vm.id)
+			if err != nil {
+				tx.Rollback()
+				return err
+
+			}
+			err = db.ContainerConfigInsert(tx, vm.id, vm.localConfig)
+			if err != nil {
+				tx.Rollback()
+				return errors.Wrap(err, "Config insert")
+			}
+
+			err = db.ContainerProfilesInsert(tx, vm.id, vm.project, vm.profiles)
+			if err != nil {
+				tx.Rollback()
+				return errors.Wrap(err, "Profiles insert")
+			}
+
+			err = db.DevicesAdd(tx, "instance", int64(vm.id), vm.localDevices)
+			if err != nil {
+				tx.Rollback()
+				return errors.Wrap(err, "Device add")
+			}
+
+			err = db.ContainerUpdate(tx, vm.id, vm.description, vm.architecture, vm.ephemeral, vm.expiryDate)
+			if err != nil {
+				tx.Rollback()
+				return errors.Wrap(err, "Container update")
+			}
+
+		}
+
+		if err := db.TxCommit(tx); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return errors.Wrap(err, "Failed to update database")
+	}
+
+	err = writeBackupFile(vm)
+	if err != nil && !os.IsNotExist(err) {
+		return errors.Wrap(err, "Failed to write backup file")
+	}
+
+	// Success, update the closure to mark that the changes should be kept.
+	undoChanges = false
+
+	var endpoint string
+
+	if vm.IsSnapshot() {
+		parentName, snapName, _ := shared.ContainerGetParentAndSnapshotName(vm.name)
+		endpoint = fmt.Sprintf("/1.0/virtual-machines/%s/snapshots/%s", parentName, snapName)
+	} else {
+		endpoint = fmt.Sprintf("/1.0/virtual-machines/%s", vm.name)
+	}
+
+	vm.state.Events.SendLifecycle(vm.project, "virtual-machine-updated", endpoint, nil)
+	return nil
+}
+
+func (vm *vmQemu) updateDevices(removeDevices deviceConfig.Devices, addDevices deviceConfig.Devices, updateDevices deviceConfig.Devices, oldExpandedDevices deviceConfig.Devices) error {
+	isRunning := vm.IsRunning()
+
+	// Remove devices in reverse order to how they were added.
+	for _, dev := range removeDevices.Reversed() {
+		if isRunning {
+			err := vm.deviceStop(dev.Name, dev.Config)
+			if err == device.ErrUnsupportedDevType {
+				continue // No point in trying to remove device below.
+			} else if err != nil {
+				return errors.Wrapf(err, "Failed to stop device '%s'", dev.Name)
+			}
+		}
+
+		err := vm.deviceRemove(dev.Name, dev.Config)
+		if err != nil && err != device.ErrUnsupportedDevType {
+			return errors.Wrapf(err, "Failed to remove device '%s'", dev.Name)
+		}
+
+		// Check whether we are about to add the same device back with updated config and
+		// if not, or if the device type has changed, then remove all volatile keys for
+		// this device (as its an actual removal or a device type change).
+		err = vm.deviceResetVolatile(dev.Name, dev.Config, addDevices[dev.Name])
+		if err != nil {
+			return errors.Wrapf(err, "Failed to reset volatile data for device '%s'", dev.Name)
+		}
+	}
+
+	// Add devices in sorted order, this ensures that device mounts are added in path order.
+	for _, dev := range addDevices.Sorted() {
+		err := vm.deviceAdd(dev.Name, dev.Config)
+		if err == device.ErrUnsupportedDevType {
+			continue // No point in trying to start device below.
+		} else if err != nil {
+			return errors.Wrapf(err, "Failed to add device '%s'", dev.Name)
+		}
+
+		if isRunning {
+			_, err := vm.deviceStart(dev.Name, dev.Config, isRunning)
+			if err != nil && err != device.ErrUnsupportedDevType {
+				return errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+			}
+		}
+	}
+
+	for _, dev := range updateDevices.Sorted() {
+		err := vm.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices, isRunning)
+		if err != nil && err != device.ErrUnsupportedDevType {
+			return errors.Wrapf(err, "Failed to update device '%s'", dev.Name)
+		}
+	}
+
+	return nil
+}
+
+// deviceUpdate loads a new device and calls its Update() function.
+func (vm *vmQemu) deviceUpdate(deviceName string, rawConfig deviceConfig.Device, oldDevices deviceConfig.Devices, isRunning bool) error {
+	d, _, err := vm.deviceLoad(deviceName, rawConfig)
+	if err != nil {
+		return err
+	}
+
+	err = d.Update(oldDevices, isRunning)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// deviceResetVolatile resets a device's volatile data when its removed or updated in such a way
+// that it is removed then added immediately afterwards.
+func (vm *vmQemu) deviceResetVolatile(devName string, oldConfig, newConfig deviceConfig.Device) error {
+	volatileClear := make(map[string]string)
+	devicePrefix := fmt.Sprintf("volatile.%s.", devName)
+
+	// If the device type has changed, remove all old volatile keys.
+	// This will occur if the newConfig is empty (i.e the device is actually being removed) or
+	// if the device type is being changed but keeping the same name.
+	if newConfig["type"] != oldConfig["type"] || newConfig["nictype"] != oldConfig["nictype"] {
+		for k := range vm.localConfig {
+			if !strings.HasPrefix(k, devicePrefix) {
+				continue
+			}
+
+			volatileClear[k] = ""
+		}
+
+		return vm.VolatileSet(volatileClear)
+	}
+
+	// If the device type remains the same, then just remove any volatile keys that have
+	// the same key name present in the new config (i.e the new config is replacing the
+	// old volatile key).
+	for k := range vm.localConfig {
+		if !strings.HasPrefix(k, devicePrefix) {
+			continue
+		}
+
+		devKey := strings.TrimPrefix(k, devicePrefix)
+		if _, found := newConfig[devKey]; found {
+			volatileClear[k] = ""
+		}
+	}
+
+	return vm.VolatileSet(volatileClear)
+}
+
+func (vm *vmQemu) removeUnixDevices() error {
+	// Check that we indeed have devices to remove.
+	if !shared.PathExists(vm.DevicesPath()) {
+		return nil
+	}
+
+	// Load the directory listing.
+	dents, err := ioutil.ReadDir(vm.DevicesPath())
+	if err != nil {
+		return err
+	}
+
+	// Go through all the unix devices.
+	for _, f := range dents {
+		// Skip non-Unix devices.
+		if !strings.HasPrefix(f.Name(), "forkmknod.unix.") && !strings.HasPrefix(f.Name(), "unix.") && !strings.HasPrefix(f.Name(), "infiniband.unix.") {
+			continue
+		}
+
+		// Remove the entry
+		devicePath := filepath.Join(vm.DevicesPath(), f.Name())
+		err := os.Remove(devicePath)
+		if err != nil {
+			logger.Error("Failed removing unix device", log.Ctx{"err": err, "path": devicePath})
+		}
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) removeDiskDevices() error {
+	// Check that we indeed have devices to remove.vm
+	if !shared.PathExists(vm.DevicesPath()) {
+		return nil
+	}
+
+	// Load the directory listing.
+	dents, err := ioutil.ReadDir(vm.DevicesPath())
+	if err != nil {
+		return err
+	}
+
+	// Go through all the unix devices
+	for _, f := range dents {
+		// Skip non-disk devices
+		if !strings.HasPrefix(f.Name(), "disk.") {
+			continue
+		}
+
+		// Always try to unmount the host side
+		_ = unix.Unmount(filepath.Join(vm.DevicesPath(), f.Name()), unix.MNT_DETACH)
+
+		// Remove the entry
+		diskPath := filepath.Join(vm.DevicesPath(), f.Name())
+		err := os.Remove(diskPath)
+		if err != nil {
+			logger.Error("Failed to remove disk device path", log.Ctx{"err": err, "path": diskPath})
+		}
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) cleanup() {
+	// Unmount any leftovers
+	vm.removeUnixDevices()
+	vm.removeDiskDevices()
+
+	// Remove the devices path
+	os.Remove(vm.DevicesPath())
+
+	// Remove the shmounts path
+	os.RemoveAll(vm.ShmountsPath())
+}
+
+// cleanupDevices performs any needed device cleanup steps when instance is stopped.
+func (vm *vmQemu) cleanupDevices() {
+	for _, dev := range vm.expandedDevices.Sorted() {
+		// Use the device interface if device supports it.
+		err := vm.deviceStop(dev.Name, dev.Config)
+		if err == device.ErrUnsupportedDevType {
+			continue
+		} else if err != nil {
+			logger.Errorf("Failed to stop device '%s': %v", dev.Name, err)
+		}
+	}
+}
+
+func (vm *vmQemu) init() error {
+	// Compute the expanded config and device list.
+	err := vm.expandConfig(nil)
+	if err != nil {
+		return err
+	}
+
+	err = vm.expandDevices(nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) Delete() error {
+	ctxMap := log.Ctx{
+		"project":   vm.project,
+		"name":      vm.name,
+		"created":   vm.creationDate,
+		"ephemeral": vm.ephemeral,
+		"used":      vm.lastUsedDate}
+
+	logger.Info("Deleting instance", ctxMap)
+
+	// Check if instance is delete protected.
+	if shared.IsTrue(vm.expandedConfig["security.protection.delete"]) && !vm.IsSnapshot() {
+		return fmt.Errorf("Instance is protected")
+	}
+
+	// Check if we're dealing with "lxd import".
+	// TODO consider lxd import detection for VMs.
+	isImport := false
+
+	// Remove all backups if not snapshot.
+	if !vm.IsSnapshot() {
+		backups, err := vm.Backups()
+		if err != nil {
+			logger.Error("Failed to load backups", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+		}
+
+		for _, backup := range backups {
+			err = backup.Delete()
+			if err != nil {
+				logger.Error("Failed to delete backup", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "backup": backup.Name, "err": err})
+			}
+		}
+	}
+
+	// Attempt to initialize storage interface for the instance.
+	pool, err := storagePools.GetPoolByInstance(vm.state, vm)
+	if err != nil {
+		logger.Error("Failed to init storage pool", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+	}
+
+	if pool != nil {
+		if vm.IsSnapshot() {
+			if !isImport {
+				// Remove snapshot volume and database record.
+				err = pool.DeleteInstanceSnapshot(vm, nil)
+				if err != nil {
+					logger.Error("Failed to delete instance snapshot volume", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+				}
+			}
+		} else {
+			// Remove all snapshots by initialising each snapshot as an Instance and
+			// calling its Delete function.
+			err := instanceDeleteSnapshots(vm.state, vm.Project(), vm.Name())
+			if err != nil {
+				logger.Error("Failed to delete instance snapshot volumes", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+			}
+
+			if !isImport {
+				// Remove the storage volume, snapshot volumes and database records.
+				err = pool.DeleteInstance(vm, nil)
+				if err != nil {
+					logger.Error("Failed to delete instance volume", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+				}
+			}
+		}
+	}
+
+	// Perform other cleanup steps if not snapshot.
+	if !vm.IsSnapshot() {
+		// Clean things up.
+		vm.cleanup()
+
+		// Delete the MAAS entry.
+		err = vm.maasDelete()
+		if err != nil {
+			logger.Error("Failed deleting instance MAAS record", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+		}
+
+		// Run device removal function for each device.
+		for k, m := range vm.expandedDevices {
+			err = vm.deviceRemove(k, m)
+			if err != nil && err != device.ErrUnsupportedDevType {
+				logger.Error("Failed to remove device", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "device": k, "err": err})
+			}
+		}
+	}
+
+	// Remove the database record of the instance or snapshot instance.
+	if err := vm.state.Cluster.InstanceRemove(vm.Project(), vm.Name()); err != nil {
+		logger.Error("Failed deleting instance entry", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+		return err // This is the only step we should return prematurely at.
+	}
+
+	logger.Info("Deleted instance", ctxMap)
+
+	if vm.IsSnapshot() {
+		vm.state.Events.SendLifecycle(vm.project, "virtual-machine-snapshot-deleted",
+			fmt.Sprintf("/1.0/virtual-machines/%s", vm.name), map[string]interface{}{
+				"snapshot_name": vm.name,
+			})
+	} else {
+		vm.state.Events.SendLifecycle(vm.project, "virtual-machine-deleted",
+			fmt.Sprintf("/1.0/virtual-machines/%s", vm.name), nil)
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) deviceAdd(deviceName string, rawConfig deviceConfig.Device) error {
+	return nil
+}
+
+func (vm *vmQemu) deviceRemove(deviceName string, rawConfig deviceConfig.Device) error {
+	return nil
+}
+
+func (vm *vmQemu) Export(w io.Writer, properties map[string]string) error {
+	return fmt.Errorf("Export Not implemented")
+}
+
+func (vm *vmQemu) CGroupGet(key string) (string, error) {
+	return "", fmt.Errorf("CGroupGet Not implemented")
+}
+
+func (vm *vmQemu) CGroupSet(key string, value string) error {
+	return fmt.Errorf("CGroupSet Not implemented")
+}
+
+func (vm *vmQemu) VolatileSet(changes map[string]string) error {
+	// Sanity check.
+	for key := range changes {
+		if !strings.HasPrefix(key, "volatile.") {
+			return fmt.Errorf("Only volatile keys can be modified with VolatileSet")
+		}
+	}
+
+	// Update the database.
+	var err error
+	if vm.IsSnapshot() {
+		err = vm.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			return tx.InstanceSnapshotConfigUpdate(vm.id, changes)
+		})
+	} else {
+		err = vm.state.Cluster.Transaction(func(tx *db.ClusterTx) error {
+			return tx.ContainerConfigUpdate(vm.id, changes)
+		})
+	}
+	if err != nil {
+		return errors.Wrap(err, "Failed to volatile config")
+	}
+
+	// Apply the change locally.
+	for key, value := range changes {
+		if value == "" {
+			delete(vm.expandedConfig, key)
+			delete(vm.localConfig, key)
+			continue
+		}
+
+		vm.expandedConfig[key] = value
+		vm.localConfig[key] = value
+	}
+
+	return nil
+}
+
+func (vm *vmQemu) FileExists(path string) error {
+	return fmt.Errorf("FileExists Not implemented")
+}
+
+func (vm *vmQemu) FilePull(srcpath string, dstpath string) (int64, int64, os.FileMode, string, []string, error) {
+	return 0, 0, 0, "", nil, fmt.Errorf("FilePull Not implemented")
+}
+
+func (vm *vmQemu) FilePush(fileType string, srcPath string, dstPath string, uid int64, gid int64, mode int, write string) error {
+	return fmt.Errorf("FilePush Not implemented")
+}
+
+func (vm *vmQemu) FileRemove(path string) error {
+	return fmt.Errorf("FileRemove Not implemented")
+}
+
+func (vm *vmQemu) Console() (*os.File, error) {
+	// Connect to the monitor.
+	monitor, err := qmp.NewSocketMonitor("unix", vm.getMonitorPath(), vmVsockTimeout)
+	if err != nil {
+		return nil, err // The VM isn't running as no monitor socket available.
+	}
+
+	err = monitor.Connect()
+	if err != nil {
+		return nil, err // The capabilities handshake failed.
+	}
+	defer monitor.Disconnect()
+
+	// Send the status command.
+	respRaw, err := monitor.Run([]byte("{'execute': 'query-chardev'}"))
+	if err != nil {
+		return nil, err // Status command failed.
+	}
+
+	var respDecoded struct {
+		Return []struct {
+			Label    string `json:"label"`
+			Filename string `json:"filename"`
+		} `json:"return"`
+	}
+
+	err = json.Unmarshal(respRaw, &respDecoded)
+	if err != nil {
+		return nil, err // JSON decode failed.
+	}
+
+	var ptsPath string
+
+	for _, v := range respDecoded.Return {
+		if v.Label == "console" {
+			ptsPath = strings.TrimPrefix(v.Filename, "pty:")
+		}
+	}
+
+	if ptsPath == "" {
+		return nil, fmt.Errorf("No PTS path found")
+	}
+
+	console, err := os.OpenFile(ptsPath, os.O_RDWR, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	return console, nil
+}
+
+func (vm *vmQemu) Exec(command []string, env map[string]string, stdin *os.File, stdout *os.File, stderr *os.File, wait bool, cwd string, uid uint32, gid uint32) (*exec.Cmd, int, int, error) {
+	return nil, 0, 0, fmt.Errorf("Exec Not implemented")
+
+}
+
+func (vm *vmQemu) Render() (interface{}, interface{}, error) {
+	// Ignore err as the arch string on error is correct (unknown)
+	architectureName, _ := osarch.ArchitectureName(vm.architecture)
+
+	if vm.IsSnapshot() {
+		// Prepare the ETag
+		etag := []interface{}{vm.expiryDate}
+
+		vmSnap := api.InstanceSnapshot{
+			CreatedAt:       vm.creationDate,
+			ExpandedConfig:  vm.expandedConfig,
+			ExpandedDevices: vm.expandedDevices.CloneNative(),
+			LastUsedAt:      vm.lastUsedDate,
+			Name:            strings.SplitN(vm.name, "/", 2)[1],
+			Stateful:        vm.stateful,
+		}
+		vmSnap.Architecture = architectureName
+		vmSnap.Config = vm.localConfig
+		vmSnap.Devices = vm.localDevices.CloneNative()
+		vmSnap.Ephemeral = vm.ephemeral
+		vmSnap.Profiles = vm.profiles
+		vmSnap.ExpiresAt = vm.expiryDate
+
+		return &vmSnap, etag, nil
+	}
+
+	// Prepare the ETag
+	etag := []interface{}{vm.architecture, vm.localConfig, vm.localDevices, vm.ephemeral, vm.profiles}
+
+	vmState := api.Instance{
+		ExpandedConfig:  vm.expandedConfig,
+		ExpandedDevices: vm.expandedDevices.CloneNative(),
+		Name:            vm.name,
+		Status:          vm.statusCode().String(),
+		StatusCode:      vm.statusCode(),
+		Location:        vm.node,
+		Type:            vm.Type().String(),
+	}
+
+	vmState.Description = vm.description
+	vmState.Architecture = architectureName
+	vmState.Config = vm.localConfig
+	vmState.CreatedAt = vm.creationDate
+	vmState.Devices = vm.localDevices.CloneNative()
+	vmState.Ephemeral = vm.ephemeral
+	vmState.LastUsedAt = vm.lastUsedDate
+	vmState.Profiles = vm.profiles
+	vmState.Stateful = vm.stateful
+
+	return &vmState, etag, nil
+}
+
+func (vm *vmQemu) RenderFull() (*api.InstanceFull, interface{}, error) {
+	if vm.IsSnapshot() {
+		return nil, nil, fmt.Errorf("RenderFull doesn't work with snapshots")
+	}
+
+	// Get the Instance struct.
+	base, etag, err := vm.Render()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Convert to InstanceFull.
+	vmState := api.InstanceFull{Instance: *base.(*api.Instance)}
+
+	// Add the InstanceState.
+	vmState.State, err = vm.RenderState()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Add the InstanceSnapshots.
+	snaps, err := vm.Snapshots()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, snap := range snaps {
+		render, _, err := snap.Render()
+		if err != nil {
+			return nil, nil, err
+		}
+
+		if vmState.Snapshots == nil {
+			vmState.Snapshots = []api.InstanceSnapshot{}
+		}
+
+		vmState.Snapshots = append(vmState.Snapshots, *render.(*api.InstanceSnapshot))
+	}
+
+	// Add the InstanceBackups.
+	backups, err := vm.Backups()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	for _, backup := range backups {
+		render := backup.Render()
+
+		if vmState.Backups == nil {
+			vmState.Backups = []api.InstanceBackup{}
+		}
+
+		vmState.Backups = append(vmState.Backups, *render)
+	}
+
+	return &vmState, etag, nil
+}
+
+func (vm *vmQemu) RenderState() (*api.InstanceState, error) {
+	statusCode := vm.statusCode()
+	pid, _ := vm.pid()
+
+	status, err := vm.agentGetState()
+	if err == nil {
+		status.Pid = int64(pid)
+		status.Status = statusCode.String()
+		status.StatusCode = statusCode
+
+		return status, nil
+	}
+
+	// At least return the Status and StatusCode if we couldn't get any
+	// information for the VM agent.
+	return &api.InstanceState{
+		Pid:        int64(pid),
+		Status:     statusCode.String(),
+		StatusCode: statusCode,
+	}, nil
+}
+
+// agentGetState connects to the agent inside of the VM and does
+// an API call to get the current state.
+func (vm *vmQemu) agentGetState() (*api.InstanceState, error) {
+	var status api.InstanceState
+
+	// Ensure the correct vhost_vsock kernel module is loaded before establishing the vsock.
+	err := util.LoadModule("vhost_vsock")
+	if err != nil {
+		return nil, err
+	}
+
+	client := http.Client{
+		Transport: &http.Transport{
+			Dial: func(network, addr string) (net.Conn, error) {
+				return vsock.Dial(uint32(vm.vsockID()), 8443)
+			},
+		},
+	}
+
+	resp, err := client.Get("http://vm.socket/state")
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	err = json.NewDecoder(resp.Body).Decode(&status)
+	if err != nil {
+		return nil, err
+	}
+
+	return &status, nil
+}
+
+func (vm *vmQemu) IsRunning() bool {
+	state := vm.State()
+	return state != "BROKEN" && state != "STOPPED"
+}
+
+func (vm *vmQemu) IsFrozen() bool {
+	return vm.State() == "FROZEN"
+}
+
+func (vm *vmQemu) IsEphemeral() bool {
+	return vm.ephemeral
+}
+
+func (vm *vmQemu) IsSnapshot() bool {
+	return vm.snapshot
+}
+
+func (vm *vmQemu) IsStateful() bool {
+	return vm.stateful
+}
+
+func (vm *vmQemu) DeviceEventHandler(runConf *device.RunConfig) error {
+	return fmt.Errorf("DeviceEventHandler Not implemented")
+}
+
+func (vm *vmQemu) ID() int {
+	return vm.id
+}
+
+// vsockID returns the vsock context ID, 3 being the first ID that can be used.
+func (vm *vmQemu) vsockID() int {
+	return vm.id + 3
+}
+
+func (vm *vmQemu) Location() string {
+	return vm.node
+}
+
+func (vm *vmQemu) Project() string {
+	return vm.project
+}
+
+func (vm *vmQemu) Name() string {
+	return vm.name
+}
+
+func (vm *vmQemu) Type() instancetype.Type {
+	return vm.dbType
+}
+
+func (vm *vmQemu) Description() string {
+	return vm.description
+}
+
+func (vm *vmQemu) Architecture() int {
+	return vm.architecture
+}
+
+func (vm *vmQemu) CreationDate() time.Time {
+	return vm.creationDate
+}
+func (vm *vmQemu) LastUsedDate() time.Time {
+	return vm.lastUsedDate
+}
+
+func (vm *vmQemu) expandConfig(profiles []api.Profile) error {
+	if profiles == nil && len(vm.profiles) > 0 {
+		var err error
+		profiles, err = vm.state.Cluster.ProfilesGet(vm.project, vm.profiles)
+		if err != nil {
+			return err
+		}
+	}
+
+	vm.expandedConfig = db.ProfilesExpandConfig(vm.localConfig, profiles)
+
+	return nil
+}
+
+func (vm *vmQemu) expandDevices(profiles []api.Profile) error {
+	if profiles == nil && len(vm.profiles) > 0 {
+		var err error
+		profiles, err = vm.state.Cluster.ProfilesGet(vm.project, vm.profiles)
+		if err != nil {
+			return err
+		}
+	}
+
+	vm.expandedDevices = db.ProfilesExpandDevices(vm.localDevices, profiles)
+
+	return nil
+}
+
+func (vm *vmQemu) ExpandedConfig() map[string]string {
+	return vm.expandedConfig
+}
+
+func (vm *vmQemu) ExpandedDevices() deviceConfig.Devices {
+	return vm.expandedDevices
+}
+
+func (vm *vmQemu) LocalConfig() map[string]string {
+	return vm.localConfig
+}
+
+func (vm *vmQemu) LocalDevices() deviceConfig.Devices {
+	return vm.localDevices
+}
+
+func (vm *vmQemu) Profiles() []string {
+	return vm.profiles
+}
+
+func (vm *vmQemu) InitPID() int {
+	pid, _ := vm.pid()
+	return pid
+}
+
+func (vm *vmQemu) statusCode() api.StatusCode {
+	// Connect to the monitor.
+	monitor, err := qmp.NewSocketMonitor("unix", vm.getMonitorPath(), vmVsockTimeout)
+	if err != nil {
+		return api.Stopped // The VM isn't running as no monitor socket available.
+	}
+
+	err = monitor.Connect()
+	if err != nil {
+		return api.Error // The capabilities handshake failed.
+	}
+	defer monitor.Disconnect()
+
+	// Send the status command.
+	respRaw, err := monitor.Run([]byte("{'execute': 'query-status'}"))
+	if err != nil {
+		return api.Error // Status command failed.
+	}
+
+	var respDecoded struct {
+		ID     string `json:"id"`
+		Return struct {
+			Running    bool   `json:"running"`
+			Singlestep bool   `json:"singlestep"`
+			Status     string `json:"status"`
+		} `json:"return"`
+	}
+
+	err = json.Unmarshal(respRaw, &respDecoded)
+	if err != nil {
+		return api.Error // JSON decode failed.
+	}
+
+	if respDecoded.Return.Status == "running" {
+		return api.Running
+	}
+
+	return api.Stopped
+}
+
+func (vm *vmQemu) State() string {
+	return strings.ToUpper(vm.statusCode().String())
+}
+
+func (vm *vmQemu) ExpiryDate() time.Time {
+	if vm.IsSnapshot() {
+		return vm.expiryDate
+	}
+
+	// Return zero time if the container is not a snapshot.
+	return time.Time{}
+}
+
+func (vm *vmQemu) Path() string {
+	return storagePools.InstancePath(vm.Type(), vm.Project(), vm.Name(), vm.IsSnapshot())
+}
+
+func (vm *vmQemu) DevicesPath() string {
+	name := project.Prefix(vm.Project(), vm.Name())
+	return shared.VarPath("devices", name)
+}
+
+func (vm *vmQemu) ShmountsPath() string {
+	name := project.Prefix(vm.Project(), vm.Name())
+	return shared.VarPath("shmounts", name)
+}
+
+func (vm *vmQemu) LogPath() string {
+	name := project.Prefix(vm.Project(), vm.Name())
+	return shared.LogPath(name)
+}
+
+func (vm *vmQemu) LogFilePath() string {
+	return filepath.Join(vm.LogPath(), "lxvm.log")
+}
+
+func (vm *vmQemu) ConsoleBufferLogPath() string {
+	return filepath.Join(vm.LogPath(), "console.log")
+}
+
+func (vm *vmQemu) RootfsPath() string {
+	return filepath.Join(vm.Path(), "rootfs")
+}
+
+func (vm *vmQemu) TemplatesPath() string {
+	return filepath.Join(vm.Path(), "templates")
+}
+
+func (vm *vmQemu) StatePath() string {
+	return filepath.Join(vm.Path(), "state")
+}
+
+func (vm *vmQemu) StoragePool() (string, error) {
+	poolName, err := vm.state.Cluster.InstancePool(vm.Project(), vm.Name())
+	if err != nil {
+		return "", err
+	}
+
+	return poolName, nil
+}
+
+func (vm *vmQemu) SetOperation(op *operations.Operation) {
+	vm.op = op
+}
+
+// StorageStart deprecated.
+func (vm *vmQemu) StorageStart() (bool, error) {
+	return false, storagePools.ErrNotImplemented
+}
+
+// StorageStop deprecated.
+func (vm *vmQemu) StorageStop() (bool, error) {
+	return false, storagePools.ErrNotImplemented
+}
+
+// Storage is deprecated will always return nil.
+// It is here just to satisfy the Instance interface (which will be updated in the future).
+func (vm *vmQemu) Storage() storage {
+	return nil
+}
+
+func (vm *vmQemu) DeferTemplateApply(trigger string) error {
+	return nil
+}
+
+func (vm *vmQemu) DaemonState() *state.State {
+	// FIXME: This function should go away, since the abstract container
+	//        interface should not be coupled with internal state details.
+	//        However this is not currently possible, because many
+	//        higher-level APIs use container variables as "implicit
+	//        handles" to database/OS state and then need a way to get a
+	//        reference to it.
+	return vm.state
+}
+
+// fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
+// generated name and hwaddr properties if these are missing from the device.
+func (vm *vmQemu) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
+	newDevice := m.Clone()
+	updateKey := func(key string, value string) error {
+		tx, err := vm.state.Cluster.Begin()
+		if err != nil {
+			return err
+		}
+
+		err = db.ContainerConfigInsert(tx, vm.id, map[string]string{key: value})
+		if err != nil {
+			tx.Rollback()
+			return err
+		}
+
+		err = db.TxCommit(tx)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	// Fill in the MAC address
+	if !shared.StringInSlice(m["nictype"], []string{"physical", "ipvlan", "sriov"}) && m["hwaddr"] == "" {
+		configKey := fmt.Sprintf("volatile.%s.hwaddr", name)
+		volatileHwaddr := vm.localConfig[configKey]
+		if volatileHwaddr == "" {
+			// Generate a new MAC address
+			volatileHwaddr, err := deviceNextInterfaceHWAddr()
+			if err != nil {
+				return nil, err
+			}
+
+			// Update the database
+			err = query.Retry(func() error {
+				err := updateKey(configKey, volatileHwaddr)
+				if err != nil {
+					// Check if something else filled it in behind our back
+					value, err1 := vm.state.Cluster.ContainerConfigGet(vm.id, configKey)
+					if err1 != nil || value == "" {
+						return err
+					}
+
+					vm.localConfig[configKey] = value
+					vm.expandedConfig[configKey] = value
+					return nil
+				}
+
+				vm.localConfig[configKey] = volatileHwaddr
+				vm.expandedConfig[configKey] = volatileHwaddr
+				return nil
+			})
+			if err != nil {
+				return nil, err
+			}
+		}
+		newDevice["hwaddr"] = volatileHwaddr
+	}
+
+	return newDevice, nil
+}
+
+// Internal MAAS handling.
+func (vm *vmQemu) maasInterfaces(devices map[string]map[string]string) ([]maas.ContainerInterface, error) {
+	interfaces := []maas.ContainerInterface{}
+	for k, m := range devices {
+		if m["type"] != "nic" {
+			continue
+		}
+
+		if m["maas.subnet.ipv4"] == "" && m["maas.subnet.ipv6"] == "" {
+			continue
+		}
+
+		m, err := vm.fillNetworkDevice(k, m)
+		if err != nil {
+			return nil, err
+		}
+
+		subnets := []maas.ContainerInterfaceSubnet{}
+
+		// IPv4
+		if m["maas.subnet.ipv4"] != "" {
+			subnet := maas.ContainerInterfaceSubnet{
+				Name:    m["maas.subnet.ipv4"],
+				Address: m["ipv4.address"],
+			}
+
+			subnets = append(subnets, subnet)
+		}
+
+		// IPv6
+		if m["maas.subnet.ipv6"] != "" {
+			subnet := maas.ContainerInterfaceSubnet{
+				Name:    m["maas.subnet.ipv6"],
+				Address: m["ipv6.address"],
+			}
+
+			subnets = append(subnets, subnet)
+		}
+
+		iface := maas.ContainerInterface{
+			Name:       m["name"],
+			MACAddress: m["hwaddr"],
+			Subnets:    subnets,
+		}
+
+		interfaces = append(interfaces, iface)
+	}
+
+	return interfaces, nil
+}
+
+func (vm *vmQemu) maasDelete() error {
+	maasURL, err := cluster.ConfigGetString(vm.state.Cluster, "maas.api.url")
+	if err != nil {
+		return err
+	}
+
+	if maasURL == "" {
+		return nil
+	}
+
+	interfaces, err := vm.maasInterfaces(vm.expandedDevices.CloneNative())
+	if err != nil {
+		return err
+	}
+
+	if len(interfaces) == 0 {
+		return nil
+	}
+
+	if vm.state.MAAS == nil {
+		return fmt.Errorf("Can't perform the operation because MAAS is currently unavailable")
+	}
+
+	exists, err := vm.state.MAAS.DefinedContainer(project.Prefix(vm.project, vm.name))
+	if err != nil {
+		return err
+	}
+
+	if !exists {
+		return nil
+	}
+
+	return vm.state.MAAS.DeleteContainer(project.Prefix(vm.project, vm.name))
+}
+
+func (vm *vmQemu) maasUpdate(oldDevices map[string]map[string]string) error {
+	// Check if MAAS is configured
+	maasURL, err := cluster.ConfigGetString(vm.state.Cluster, "maas.api.url")
+	if err != nil {
+		return err
+	}
+
+	if maasURL == "" {
+		return nil
+	}
+
+	// Check if there's something that uses MAAS
+	interfaces, err := vm.maasInterfaces(vm.expandedDevices.CloneNative())
+	if err != nil {
+		return err
+	}
+
+	var oldInterfaces []maas.ContainerInterface
+	if oldDevices != nil {
+		oldInterfaces, err = vm.maasInterfaces(oldDevices)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(interfaces) == 0 && len(oldInterfaces) == 0 {
+		return nil
+	}
+
+	// See if we're connected to MAAS
+	if vm.state.MAAS == nil {
+		return fmt.Errorf("Can't perform the operation because MAAS is currently unavailable")
+	}
+
+	exists, err := vm.state.MAAS.DefinedContainer(project.Prefix(vm.project, vm.name))
+	if err != nil {
+		return err
+	}
+
+	if exists {
+		if len(interfaces) == 0 && len(oldInterfaces) > 0 {
+			return vm.state.MAAS.DeleteContainer(project.Prefix(vm.project, vm.name))
+		}
+
+		return vm.state.MAAS.UpdateContainer(project.Prefix(vm.project, vm.name), interfaces)
+	}
+
+	return vm.state.MAAS.CreateContainer(project.Prefix(vm.project, vm.name), interfaces)
+}

--- a/po/bg.po
+++ b/po/bg.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/de.po
+++ b/po/de.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-21 20:27+0000\n"
 "Last-Translator: Joshua Dietz <jospam@dietz-ulm.de>\n"
 "Language-Team: German <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
@@ -176,7 +176,7 @@ msgstr ""
 "### Zum Beispiel:\n"
 "###  description: Mein eigenes Abbild"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the network.\n"
@@ -214,7 +214,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the profile.\n"
@@ -253,7 +253,7 @@ msgstr ""
 "###\n"
 "### Der Name wird zwar angezeigt, lässt sich jedoch nicht ändern.\n"
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -313,7 +313,7 @@ msgstr "%v (zwei weitere Male unterbrechen, um zu erzwingen)"
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(kein Wert)"
 
@@ -336,7 +336,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -353,7 +353,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr "--refresh kann nur mit Containern verwendet werden"
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -365,19 +365,19 @@ msgstr "ALIASES"
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARCHITEKTUR"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "Aktion (Standard: GET)"
 
@@ -385,16 +385,16 @@ msgstr "Aktion (Standard: GET)"
 msgid "Add devices to containers or profiles"
 msgstr "Geräte zu Containern oder Profilen hinzufügen"
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr "Neue entfernte Server hinzufügen"
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -406,11 +406,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 #, fuzzy
 msgid "Add profiles to containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -420,22 +420,22 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Address: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Administrator Passwort für %s: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr "Aliasname fehlt"
 
@@ -454,19 +454,19 @@ msgstr "Architektur: %s\n"
 msgid "Architecture: %v"
 msgstr "Architektur: %s\n"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr "Netzwerkschnittstellen an Container anbinden"
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -491,7 +491,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -506,7 +506,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "automatisches Update: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -515,13 +515,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -545,19 +545,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Erstellt: %s"
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Bytes empfangen"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Bytes gesendet"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -580,12 +580,12 @@ msgstr " Prozessorauslastung:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 #, fuzzy
 msgid "CREATED"
 msgstr "ERSTELLT AM"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "ERSTELLT AM"
 
@@ -612,7 +612,7 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -624,16 +624,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -641,7 +641,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -654,7 +654,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -672,12 +672,12 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, fuzzy, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Fingerabdruck des Zertifikats: % x\n"
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Gespeichertes Nutzerzertifikat auf dem Server: "
@@ -688,11 +688,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -701,11 +701,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Spalten"
 
@@ -721,24 +721,24 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 #, fuzzy
 msgid "Config key/value to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 #, fuzzy
 msgid "Config key/value to apply to the target container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, fuzzy, c-format
 msgid "Config parsing error: %s"
 msgstr "YAML Analyse Fehler %v\n"
@@ -751,11 +751,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, fuzzy, c-format
 msgid "Container published with fingerprint: %s"
@@ -766,7 +761,7 @@ msgstr "Abbild mit Fingerabdruck %s importiert\n"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -795,7 +790,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -820,7 +815,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Copy the volume without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -848,15 +843,15 @@ msgstr "Fehler: %v\n"
 msgid "Cores:"
 msgstr "Fehler: %v\n"
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr "Kann Verzeichnis für Zertifikate auf dem Server nicht erstellen"
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 #, fuzzy
 msgid "Create an empty container"
 msgstr "kann nicht zum selben Container Namen kopieren"
@@ -882,12 +877,12 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create containers from images"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 #, fuzzy
 msgid "Create new container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -897,43 +892,47 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Create new custom storage volumes"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 #, fuzzy
 msgid "Create profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 #, fuzzy
 msgid "Create projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Anhalten des Containers fehlgeschlagen!"
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
+msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr "Erstellt: %s"
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "Erstelle %s"
 
-#: lxc/init.go:153
+#: lxc/init.go:155
 #, fuzzy
-msgid "Creating the container"
+msgid "Creating the instance"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -941,16 +940,16 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr "BESCHREIBUNG"
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -966,11 +965,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 #, fuzzy
 msgid "Delete container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -984,7 +983,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -992,20 +991,20 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 #, fuzzy
 msgid "Delete projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -1015,46 +1014,46 @@ msgid "Delete storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -1066,11 +1065,11 @@ msgstr "Kein Zertifikat für diese Verbindung"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1097,7 +1096,7 @@ msgstr "Gerät %s wurde von %s entfernt\n"
 msgid "Device %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "entfernte Instanz %s existiert bereits"
@@ -1111,9 +1110,9 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/init.go:313
+#: lxc/init.go:330
 #, fuzzy
-msgid "Didn't get any affected image, container or snapshot from server"
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "Falsche Anzahl an Objekten im Abbild, Container oder Sicherungspunkt gelesen."
 
@@ -1153,7 +1152,7 @@ msgstr " Prozessorauslastung:"
 msgid "Disks:"
 msgstr " Prozessorauslastung:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1166,11 +1165,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr "ABLAUFDATUM"
 
@@ -1180,7 +1179,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 #, fuzzy
 msgid "Edit container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -1202,19 +1201,19 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1222,16 +1221,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1250,11 +1249,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr "Flüchtiger Container"
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Fehler beim hinzufügen des Alias %s\n"
@@ -1326,31 +1325,31 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr "FINGERABDRUCK"
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
+#: lxc/copy.go:420
 #, fuzzy
-msgid "Failed to get the new container name"
+msgid "Failed to get the new instance name"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1360,11 +1359,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr ""
@@ -1380,7 +1379,7 @@ msgstr "Fingerabdruck: %s\n"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1397,7 +1396,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1421,10 +1420,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1456,12 +1455,12 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 #, fuzzy
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Generiere Nutzerzertifikat. Dies kann wenige Minuten dauern...\n"
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1473,20 +1472,20 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1498,7 +1497,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1506,7 +1505,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1520,23 +1519,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1614,50 +1613,55 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 #, fuzzy
 msgid "Invalid certificate"
 msgstr "Akzeptiere Zertifikat"
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1673,7 +1677,7 @@ msgstr "ungültiges Argument %s"
 msgid "Invalid path %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Ungültiges Ziel %s"
@@ -1688,7 +1692,7 @@ msgstr "Ungültige Quelle %s"
 msgid "Invalid target %s"
 msgstr "Ungültiges Ziel %s"
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1705,11 +1709,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1718,7 +1722,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1741,28 +1745,28 @@ msgstr "Architektur: %s\n"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliasse:\n"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1771,17 +1775,17 @@ msgstr ""
 msgid "List container devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 #, fuzzy
 msgid "List container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 #, fuzzy
 msgid "List containers"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 #, fuzzy
 msgid ""
 "List containers\n"
@@ -1863,11 +1867,11 @@ msgstr ""
 "* \"security.privileged=1\" listet alle privilegierten Container\n"
 "* \"s.privileged=1\" ebenfalls\n"
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1905,11 +1909,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1918,15 +1922,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1939,11 +1943,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1957,15 +1961,15 @@ msgstr ""
 "Optionen:\n"
 "\n"
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1979,15 +1983,15 @@ msgstr "Veröffentliche Abbild"
 msgid "Make the image public"
 msgstr "Veröffentliche Abbild"
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 #, fuzzy
 msgid "Manage command aliases"
 msgstr "Unbekannter Befehl %s für Abbild"
@@ -2001,7 +2005,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 #, fuzzy
 msgid "Manage container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
@@ -2015,7 +2019,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Veröffentliche Abbild"
@@ -2044,17 +2048,17 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 #, fuzzy
 msgid "Manage profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 #, fuzzy
 msgid "Manage projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2072,11 +2076,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -2085,12 +2089,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2111,11 +2115,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2124,14 +2128,14 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 #, fuzzy
 msgid "Missing container name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 #, fuzzy
 msgid "Missing container.name name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
@@ -2143,15 +2147,15 @@ msgstr "der Name des Ursprung Containers muss angegeben werden"
 msgid "Missing name"
 msgstr "Fehlende Zusammenfassung."
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2163,18 +2167,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 #, fuzzy
 msgid "Missing project name"
 msgstr "Profilname kann nicht geändert werden"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2208,7 +2212,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2218,7 +2222,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Mehr als eine Datei herunterzuladen, aber das Ziel ist kein Verzeichnis"
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 #, fuzzy
 msgid "Move containers within or in between LXD instances"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2228,13 +2232,13 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Move storage volumes between pools"
 msgstr "Kein Zertifikat für diese Verbindung"
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 #, fuzzy
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
@@ -2253,8 +2257,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2267,8 +2271,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2290,7 +2294,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2300,31 +2304,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, fuzzy, c-format
 msgid "Network %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, fuzzy, c-format
 msgid "Network %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 #, fuzzy
 msgid "Network usage:"
 msgstr "Profil %s erstellt\n"
@@ -2337,12 +2341,12 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 #, fuzzy
 msgid "No device found for this network"
 msgstr "Kein Zertifikat für diese Verbindung"
@@ -2378,7 +2382,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2386,11 +2390,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Profil %s gelöscht\n"
@@ -2408,31 +2412,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2468,13 +2472,13 @@ msgstr "Erstellt: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2486,7 +2490,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2509,47 +2513,47 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, fuzzy, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, fuzzy, c-format
 msgid "Profile %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, fuzzy, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, fuzzy, c-format
 msgid "Profile %s removed from %s"
 msgstr "Gerät %s wurde von %s entfernt\n"
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 #, fuzzy
 msgid "Profile to apply to the new container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 #, fuzzy
 msgid "Profile to apply to the target container"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, fuzzy, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2559,17 +2563,17 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Profiles: %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s wurde auf %s angewandt\n"
@@ -2579,7 +2583,7 @@ msgstr "Profil %s wurde auf %s angewandt\n"
 msgid "Properties:"
 msgstr "Eigenschaften:\n"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2645,28 +2649,28 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "entfernte Instanz %s existiert bereits"
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "entfernte Instanz %s existiert als <%s>"
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr "Entferntes Administrator Passwort"
 
@@ -2690,11 +2694,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Entferntes Administrator Passwort"
@@ -2704,25 +2708,25 @@ msgstr "Entferntes Administrator Passwort"
 msgid "Remove container devices"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 #, fuzzy
 msgid "Remove profiles from containers"
 msgstr "kann nicht zum selben Container Namen kopieren"
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2731,21 +2735,21 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 #, fuzzy
 msgid "Rename profiles"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 #, fuzzy
 msgid "Rename projects"
 msgstr "Fehlerhafte Profil URL %s"
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2811,7 +2815,7 @@ msgstr "Herunterfahren des Containers erzwingen."
 msgid "Retrieve the container's console log"
 msgstr "Herunterfahren des Containers erzwingen."
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2824,11 +2828,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2836,41 +2840,41 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr "Server Zertifikat vom Benutzer nicht akzeptiert"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Der Server vertraut uns nicht nachdem er unser Zertifikat hinzugefügt hat"
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2915,11 +2919,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2928,11 +2932,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2941,12 +2945,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2955,12 +2959,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2983,7 +2987,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3020,16 +3024,16 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 #, fuzzy
 msgid "Show content of container file templates"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -3049,19 +3053,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -3079,7 +3083,7 @@ msgstr "Profil %s erstellt\n"
 msgid "Show the container's last 100 log lines?"
 msgstr "Zeige die letzten 100 Zeilen Protokoll des Containers?"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -3091,11 +3095,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -3103,7 +3107,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -3150,7 +3154,7 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Erstellt: %s"
@@ -3178,22 +3182,22 @@ msgstr "Anhalten des Containers fehlgeschlagen!"
 msgid "Stopping the container failed: %s"
 msgstr "Anhalten des Containers fehlgeschlagen!"
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Profil %s gelöscht\n"
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 #, fuzzy
 msgid "Storage pool name"
 msgstr "Profilname kann nicht geändert werden"
@@ -3241,36 +3245,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3284,7 +3288,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3299,12 +3303,12 @@ msgstr "entfernte Instanz %s existiert bereits"
 msgid "The device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3314,17 +3318,17 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 #, fuzzy
 msgid "The specified device doesn't exist"
 msgstr "entfernte Instanz %s existiert nicht"
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 #, fuzzy
 msgid "The specified device doesn't match the network"
 msgstr "entfernte Instanz %s existiert nicht"
@@ -3359,11 +3363,11 @@ msgstr "Wartezeit bevor der Container gestoppt wird."
 msgid "Timestamps:"
 msgstr "Zeitstempel:\n"
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3376,7 +3380,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3398,7 +3402,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3431,11 +3435,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3450,7 +3454,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3460,7 +3464,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr "Unbekannter Befehl %s für Abbild"
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "nicht alle Profile der Quelle sind am Ziel vorhanden."
@@ -3473,20 +3477,20 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3514,7 +3518,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3552,7 +3556,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3580,8 +3584,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Zustand des laufenden Containers sichern oder nicht"
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3599,20 +3603,20 @@ msgstr "kann nicht zum selben Container Namen kopieren"
 msgid "You must specify a destination container name when using --target"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 #, fuzzy
 msgid "You must specify a source container name"
 msgstr "der Name des Ursprung Containers muss angegeben werden"
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3620,20 +3624,20 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 #, fuzzy
 msgid "alias"
 msgstr "Aliasse:\n"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3647,13 +3651,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3673,7 +3677,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3681,19 +3685,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3701,27 +3705,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3752,15 +3756,15 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3772,11 +3776,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 #, fuzzy
 msgid "delete [<remote>:]<project>"
 msgstr ""
@@ -3784,11 +3788,11 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3800,7 +3804,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3812,7 +3816,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3820,7 +3824,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3832,11 +3836,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3849,11 +3853,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3866,7 +3870,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3910,11 +3914,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3927,11 +3931,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 #, fuzzy
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
@@ -3943,7 +3947,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3961,7 +3965,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3969,11 +3973,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3981,7 +3985,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 #, fuzzy
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
@@ -3993,24 +3997,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -4022,23 +4026,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -4112,7 +4116,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -4128,7 +4132,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -4154,7 +4158,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
@@ -4172,13 +4176,13 @@ msgstr ""
 "\n"
 "lxc move <Quelle> <Ziel>\n"
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -4197,19 +4201,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -4230,7 +4234,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -4269,7 +4273,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
@@ -4280,11 +4284,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -4292,12 +4296,12 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 #, fuzzy
 msgid "ok (y/n)?"
 msgstr "OK (y/n)? "
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 #, fuzzy
 msgid "operation"
 msgstr "Eigenschaften:\n"
@@ -4318,12 +4322,12 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 #, fuzzy
 msgid "profile"
 msgstr "Profil %s erstellt\n"
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4354,7 +4358,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4366,23 +4370,23 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4390,19 +4394,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4415,11 +4419,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4434,11 +4438,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4471,7 +4475,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 #, fuzzy
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4479,7 +4483,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4491,7 +4495,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 #, fuzzy
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -4499,7 +4503,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4515,7 +4519,7 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4523,7 +4527,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4535,19 +4539,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4560,11 +4564,11 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4590,7 +4594,7 @@ msgstr ""
 "Entfernt einen Container (oder Sicherungspunkt) und alle dazugehörigen\n"
 "Daten (Konfiguration, Sicherungspunkte, ...).\n"
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4618,15 +4622,15 @@ msgstr ""
 "\n"
 "lxd %s <Name>\n"
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4635,15 +4639,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4655,11 +4659,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4667,11 +4671,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
@@ -4683,7 +4687,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4695,11 +4699,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/el.po
+++ b/po/el.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2017-02-14 08:00+0000\n"
 "Last-Translator: Simos Xenitellis <simos.65@gmail.com>\n"
 "Language-Team: Greek <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 2.12-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -105,7 +105,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -125,7 +125,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -227,7 +227,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -239,19 +239,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -259,15 +259,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -279,11 +279,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -292,22 +292,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -325,19 +325,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -376,7 +376,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -384,13 +384,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -414,19 +414,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -449,11 +449,11 @@ msgstr "  Χρήση CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -471,7 +471,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -483,16 +483,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -500,7 +500,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -513,7 +513,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -527,12 +527,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -542,11 +542,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -555,11 +555,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -575,21 +575,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -602,11 +602,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -617,7 +612,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -645,7 +640,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -666,7 +661,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -693,15 +688,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -725,11 +720,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -737,24 +732,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -762,13 +761,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -776,16 +775,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -801,11 +800,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -817,7 +816,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -825,19 +824,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -846,46 +845,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -897,11 +896,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -928,7 +927,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -938,8 +937,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -978,7 +977,7 @@ msgstr "  Χρήση CPU:"
 msgid "Disks:"
 msgstr "  Χρήση CPU:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -991,11 +990,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1005,7 +1004,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1025,19 +1024,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1045,16 +1044,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1073,11 +1072,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1143,29 +1142,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1175,11 +1174,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1192,7 +1191,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1208,7 +1207,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1232,10 +1231,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1267,11 +1266,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1283,19 +1282,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1307,7 +1306,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1315,7 +1314,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1329,23 +1328,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1421,49 +1420,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1478,7 +1482,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1493,7 +1497,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1506,11 +1510,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1519,7 +1523,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1542,27 +1546,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1570,15 +1574,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1645,11 +1649,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1687,11 +1691,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1699,15 +1703,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1720,11 +1724,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1734,15 +1738,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1755,15 +1759,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1775,7 +1779,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1787,7 +1791,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1814,15 +1818,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1838,11 +1842,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1851,12 +1855,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1879,11 +1883,11 @@ msgstr "  Χρήση μνήμης:"
 msgid "Memory:"
 msgstr "  Χρήση μνήμης:"
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1892,13 +1896,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1908,15 +1912,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1927,17 +1931,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1970,7 +1974,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1979,7 +1983,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1987,12 +1991,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2009,8 +2013,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2023,8 +2027,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2046,7 +2050,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2056,31 +2060,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Χρήση δικτύου:"
@@ -2093,11 +2097,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2131,7 +2135,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2139,11 +2143,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2161,31 +2165,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2220,13 +2224,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2238,7 +2242,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2261,45 +2265,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2309,17 +2313,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2328,7 +2332,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2391,28 +2395,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2435,11 +2439,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2447,24 +2451,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2472,19 +2476,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2544,7 +2548,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2557,11 +2561,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2569,39 +2573,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2645,11 +2649,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2658,11 +2662,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2671,11 +2675,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2684,11 +2688,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2710,7 +2714,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2746,15 +2750,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2774,19 +2778,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2802,7 +2806,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2814,11 +2818,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2826,7 +2830,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2871,7 +2875,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2898,22 +2902,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2957,36 +2961,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3000,7 +3004,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3013,12 +3017,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3027,16 +3031,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3068,11 +3072,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3085,7 +3089,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3107,7 +3111,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3140,11 +3144,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3169,7 +3173,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3181,19 +3185,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3220,7 +3224,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3254,7 +3258,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3278,8 +3282,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3295,19 +3299,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3315,19 +3319,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3341,13 +3345,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3367,7 +3371,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3375,19 +3379,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3395,27 +3399,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3433,15 +3437,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3449,19 +3453,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3473,7 +3477,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3485,7 +3489,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3493,7 +3497,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3505,11 +3509,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3517,11 +3521,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3529,7 +3533,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3569,11 +3573,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3581,11 +3585,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3593,7 +3597,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3611,7 +3615,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3619,11 +3623,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3631,7 +3635,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3639,24 +3643,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3668,23 +3672,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3758,7 +3762,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3774,7 +3778,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3800,7 +3804,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3814,13 +3818,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3839,19 +3843,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3872,7 +3876,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3911,17 +3915,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3929,11 +3933,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3949,11 +3953,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3975,7 +3979,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3983,23 +3987,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4007,19 +4011,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4027,11 +4031,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4041,11 +4045,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4065,11 +4069,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4077,11 +4081,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4089,7 +4093,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4097,7 +4101,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4109,19 +4113,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4129,11 +4133,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4149,7 +4153,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4169,15 +4173,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4186,15 +4190,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4206,11 +4210,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4218,11 +4222,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4230,7 +4234,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4242,11 +4246,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/es.po
+++ b/po/es.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Spanish <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -162,7 +162,7 @@ msgstr ""
 "### Un ejemplo sería:\n"
 "###  description: My custom image"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -182,7 +182,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -203,7 +203,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -260,7 +260,7 @@ msgstr "%v (interrumpe dos o más tiempos a la fuerza)"
 msgid "'%s' isn't a supported file type"
 msgstr "%s no es un tipo de archivo soportado."
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(ninguno)"
 
@@ -283,7 +283,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only no se puede pasar cuando la fuente es una instantánea"
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -299,7 +299,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -311,19 +311,19 @@ msgstr "ALIASES"
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARQUITECTURA"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Acepta certificado"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "Accion (predeterminados a GET)"
 
@@ -331,16 +331,16 @@ msgstr "Accion (predeterminados a GET)"
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Aliases:"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -352,11 +352,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -365,22 +365,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Contraseña admin para %s: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -398,19 +398,19 @@ msgstr "Arquitectura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitectura: %s"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticación %s no está soportada por el servidor"
@@ -449,7 +449,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Auto actualización: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -457,13 +457,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -487,19 +487,19 @@ msgstr "Ambas: todas y el nombre del contenedor dado"
 msgid "Brand: %v"
 msgstr "Creado: %s"
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Bytes recibidos"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Bytes enviados"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr "NOMBRE COMÚN"
 
@@ -521,11 +521,11 @@ msgstr "Uso de CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr "CREADO"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "CREADO EN"
 
@@ -544,7 +544,7 @@ msgstr "Cacheado: %s"
 msgid "Caches:"
 msgstr "Cacheado: %s"
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -556,16 +556,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "No se puede jalar un directorio sin - recursivo"
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "No se peude leer desde stdin: %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -574,7 +574,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr "No se puede especificar un remote diferente para renombrar."
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -587,7 +587,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -601,12 +601,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado de la huella digital: %s"
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificado del cliente almacenado en el servidor: "
@@ -617,11 +617,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -630,11 +630,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr "Nombre del Miembro del Cluster"
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Columnas"
 
@@ -650,21 +650,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -677,11 +677,6 @@ msgstr "Log de la consola:"
 msgid "Container name is mandatory"
 msgstr "Nombre del contenedor es obligatorio"
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr "Nombre del contenedor es: %s"
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -692,7 +687,7 @@ msgstr "Contenedor publicado con huella digital: %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -720,7 +715,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -741,7 +736,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -770,15 +765,15 @@ msgstr "Expira: %s"
 msgid "Cores:"
 msgstr "Expira: %s"
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Creando el contenedor"
@@ -804,11 +799,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -816,38 +811,44 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
 msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
+msgid "Create virtual machine"
+msgstr "Copiando la imagen: %s"
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr "Creado: %s"
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "Creando %s"
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
 msgstr "Creando el contenedor"
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -855,16 +856,16 @@ msgstr "Creando el contenedor"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr "DESCRIPCIÓN"
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr "CONTROLADOR"
 
@@ -880,11 +881,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -896,7 +897,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -904,19 +905,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -925,46 +926,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -976,11 +977,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1007,7 +1008,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr "El dispostivo ya existe: %s"
@@ -1017,8 +1018,8 @@ msgstr "El dispostivo ya existe: %s"
 msgid "Device: %s"
 msgstr "Cacheado: %s"
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1056,7 +1057,7 @@ msgstr "Uso del disco:"
 msgid "Disks:"
 msgstr "Uso del disco:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1069,11 +1070,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr "FECHA DE EXPIRACIÓN"
 
@@ -1083,7 +1084,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1103,19 +1104,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1123,16 +1124,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1151,11 +1152,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Error actualizando el archivo de plantilla: %s"
@@ -1223,29 +1224,30 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Exporting the image: %s"
 msgstr "Exportando la imagen: %s"
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr "HUELLA DIGITAL"
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
-msgstr ""
+#: lxc/copy.go:420
+#, fuzzy
+msgid "Failed to get the new instance name"
+msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1255,11 +1257,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr "El filtrado no está soportado aún"
 
@@ -1272,7 +1274,7 @@ msgstr "Huella dactilar: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1288,7 +1290,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1312,10 +1314,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1347,11 +1349,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1363,19 +1365,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1387,7 +1389,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1395,7 +1397,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1409,23 +1411,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1502,49 +1504,54 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, fuzzy, c-format
+msgid "Instance name is: %s"
+msgstr "Nombre del contenedor es: %s"
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1559,7 +1566,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1574,7 +1581,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1587,11 +1594,11 @@ msgstr "Cacheado: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1600,7 +1607,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1623,28 +1630,28 @@ msgstr "Arquitectura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 #, fuzzy
 msgid "List aliases"
 msgstr "Aliases:"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1652,15 +1659,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1727,11 +1734,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1769,11 +1776,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1781,15 +1788,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1802,11 +1809,11 @@ msgstr ""
 msgid "Log:"
 msgstr "Registro:"
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1816,15 +1823,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Cacheado: %s"
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1837,15 +1844,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1857,7 +1864,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1869,7 +1876,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1896,15 +1903,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1920,11 +1927,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1933,12 +1940,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1959,11 +1966,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1972,14 +1979,14 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 #, fuzzy
 msgid "Missing container name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1989,15 +1996,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2008,18 +2015,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nombre del contenedor es: %s"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2053,7 +2060,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2062,7 +2069,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2070,12 +2077,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2092,8 +2099,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2106,8 +2113,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2129,7 +2136,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2139,31 +2146,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2175,11 +2182,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2213,7 +2220,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2221,11 +2228,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2243,31 +2250,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2302,13 +2309,13 @@ msgstr "Auto actualización: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2320,7 +2327,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2343,45 +2350,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Perfil %s añadido a %s"
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr "Perfil %s creado"
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Perfil %s eliminado"
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Perfil %s eliminado de %s"
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Perfil %s renombrado a %s"
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr "Perfil para aplicar al nuevo contenedor"
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2391,17 +2398,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2410,7 +2417,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2473,28 +2480,28 @@ msgstr "No se puede proveer el nombre del container a la lista"
 msgid "Refreshing the image: %s"
 msgstr "Refrescando la imagen: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2517,11 +2524,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2529,24 +2536,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2554,19 +2561,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2626,7 +2633,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2639,11 +2646,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2651,39 +2658,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2727,11 +2734,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2740,11 +2747,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2753,11 +2760,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2766,11 +2773,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2792,7 +2799,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2828,15 +2835,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2856,19 +2863,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2884,7 +2891,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2896,11 +2903,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2908,7 +2915,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2953,7 +2960,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Auto actualización: %s"
@@ -2980,22 +2987,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -3039,36 +3046,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3082,7 +3089,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3095,12 +3102,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3109,16 +3116,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3150,11 +3157,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3167,7 +3174,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3189,7 +3196,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3222,11 +3229,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3241,7 +3248,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3251,7 +3258,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3263,19 +3270,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3302,7 +3309,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3336,7 +3343,7 @@ msgstr "Cacheado: %s"
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3360,8 +3367,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3377,19 +3384,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3397,20 +3404,20 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 #, fuzzy
 msgid "alias"
 msgstr "Aliases:"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3424,13 +3431,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3450,7 +3457,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3458,19 +3465,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3478,27 +3485,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3516,15 +3523,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3532,19 +3539,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3556,7 +3563,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3568,7 +3575,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3576,7 +3583,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3588,11 +3595,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3600,11 +3607,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3613,7 +3620,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3653,11 +3660,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3665,11 +3672,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3677,7 +3684,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3695,7 +3702,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3703,11 +3710,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3715,7 +3722,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3723,24 +3730,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3752,23 +3759,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3842,7 +3849,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3858,7 +3865,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3884,7 +3891,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3898,13 +3905,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3923,19 +3930,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3956,7 +3963,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3995,17 +4002,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -4013,11 +4020,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -4033,11 +4040,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4059,7 +4066,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4067,23 +4074,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4091,19 +4098,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4111,11 +4118,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4125,11 +4132,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4149,11 +4156,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4161,11 +4168,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4174,7 +4181,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr "No se puede proveer el nombre del container a la lista"
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4182,7 +4189,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4194,19 +4201,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4214,11 +4221,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4235,7 +4242,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4255,15 +4262,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4272,15 +4279,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4292,11 +4299,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4304,11 +4311,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4316,7 +4323,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4329,14 +4336,17 @@ msgstr ""
 msgid "volume"
 msgstr "Columnas"
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""
+
+#~ msgid "Container name is: %s"
+#~ msgstr "Nombre del contenedor es: %s"
 
 #~ msgid "Commands:"
 #~ msgstr "Comandos:"

--- a/po/fa.po
+++ b/po/fa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/fi.po
+++ b/po/fi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/fr.po
+++ b/po/fr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-01-04 18:07+0000\n"
 "Last-Translator: Deleted User <noreply+12102@weblate.org>\n"
 "Language-Team: French <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.4-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -170,7 +170,7 @@ msgstr ""
 "### Un exemple serait :\n"
 "###  description: Mon image personnalisée"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -207,7 +207,7 @@ msgstr ""
 "###\n"
 "### Notez que seule la configuration peut être modifiée."
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -244,7 +244,7 @@ msgstr ""
 "###\n"
 "### Notez que le nom est affiché mais ne peut être modifié"
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -303,7 +303,7 @@ msgstr "%v (interrompre encore deux fois pour forcer)"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' n'est pas un format de fichier pris en charge."
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(aucun)"
 
@@ -326,7 +326,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -342,7 +342,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -355,20 +355,20 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTURE"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 #, fuzzy
 msgid "AUTH TYPE"
 msgstr "TYPE"
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Accepter le certificat"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "Action (GET par défaut)"
 
@@ -376,16 +376,16 @@ msgstr "Action (GET par défaut)"
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Alias :"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -397,11 +397,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 #, fuzzy
 msgid "Add profiles to containers"
 msgstr "Création du conteneur"
@@ -411,22 +411,22 @@ msgstr "Création du conteneur"
 msgid "Address: %s"
 msgstr "Expire : %s"
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Mot de passe administrateur pour %s : "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -444,19 +444,19 @@ msgstr "Architecture : %s"
 msgid "Architecture: %v"
 msgstr "Architecture : %s"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -481,7 +481,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Le type d'authentification '%s' n'est pas supporté par le serveur"
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Mise à jour auto. : %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -505,13 +505,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr "Image copiée avec succès !"
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -535,19 +535,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Créé : %s"
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Octets reçus"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Octets émis"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr "COMMON NAME"
 
@@ -569,12 +569,12 @@ msgstr "CPU utilisé :"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 #, fuzzy
 msgid "CREATED"
 msgstr "CRÉÉ À"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "CRÉÉ À"
 
@@ -593,7 +593,7 @@ msgstr "Créé : %s"
 msgid "Caches:"
 msgstr "Créé : %s"
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -606,17 +606,17 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "impossible de récupérer un répertoire sans --recursive"
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible de lire depuis stdin : %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 #, fuzzy
 msgid "Can't remove the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -624,7 +624,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -639,7 +639,7 @@ msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 "Impossible de désaffecter la clé '%s', elle n'est pas définie actuellement."
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -653,12 +653,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Empreinte du certificat : %s"
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificat client enregistré sur le serveur : "
@@ -669,11 +669,11 @@ msgid "Client version: %s\n"
 msgstr "Afficher la version du client"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -682,11 +682,11 @@ msgstr "Afficher la version du client"
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Colonnes"
 
@@ -708,23 +708,23 @@ msgstr ""
 "commandes ci-dessous.\n"
 "Pour de l'aide avec l'une des commandes, simplement les utiliser avec --help."
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 #, fuzzy
 msgid "Config key/value to apply to the new project"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 #, fuzzy
 msgid "Config key/value to apply to the target container"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erreur lors de la lecture de la configuration : %s"
@@ -737,11 +737,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Le nom du conteneur est obligatoire"
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr "Le nom du conteneur est : %s"
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -752,7 +747,7 @@ msgstr "Conteneur publié avec l'empreinte : %s"
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -781,7 +776,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -806,7 +801,7 @@ msgstr "Copiez le conteneur sans ses instantanés"
 msgid "Copy the volume without its snapshots"
 msgstr "Copiez le conteneur sans ses instantanés"
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -835,15 +830,15 @@ msgstr "erreur : %v"
 msgid "Cores:"
 msgstr "erreur : %v"
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr "Impossible de créer le dossier de stockage des certificats serveurs"
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Création du conteneur"
@@ -885,12 +880,12 @@ msgstr ""
 "Exemple :\n"
 "    lxc snapshot u1 snap0"
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create containers from images"
 msgstr "Création du conteneur"
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 #, fuzzy
 msgid "Create new container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -900,42 +895,48 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Create new custom storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 #, fuzzy
 msgid "Create profiles"
 msgstr "Créé : %s"
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 #, fuzzy
 msgid "Create projects"
 msgstr "Créé : %s"
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "L'arrêt du conteneur a échoué !"
+
+#: lxc/init.go:57
+#, fuzzy
+msgid "Create virtual machine"
+msgstr "Copie de l'image : %s"
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr "Créé : %s"
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "Création de %s"
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
 msgstr "Création du conteneur"
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -943,16 +944,16 @@ msgstr "Création du conteneur"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr "DESCRIPTION"
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr "PILOTE"
 
@@ -969,11 +970,11 @@ msgstr "Définir un algorithme de compression : pour image ou aucun"
 msgid "Define a compression algorithm: for image or none"
 msgstr "Définir un algorithme de compression : pour image ou aucun"
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 #, fuzzy
 msgid "Delete container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -987,7 +988,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -996,20 +997,20 @@ msgstr ""
 msgid "Delete images"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 #, fuzzy
 msgid "Delete projects"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -1019,46 +1020,46 @@ msgid "Delete storage volumes"
 msgstr "Copie de l'image : %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -1070,11 +1071,11 @@ msgstr "Copie de l'image : %s"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1101,7 +1102,7 @@ msgstr "Périphérique %s retiré de %s"
 msgid "Device %s removed from %s"
 msgstr "Périphérique %s retiré de %s"
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, fuzzy, c-format
 msgid "Device already exists: %s"
 msgstr "le serveur distant %s existe déjà"
@@ -1111,9 +1112,9 @@ msgstr "le serveur distant %s existe déjà"
 msgid "Device: %s"
 msgstr "Serveur distant : %s"
 
-#: lxc/init.go:313
+#: lxc/init.go:330
 #, fuzzy
-msgid "Didn't get any affected image, container or snapshot from server"
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr "pas d'image, conteneur ou instantané affecté sur ce serveur"
 
 #: lxc/image.go:607
@@ -1152,7 +1153,7 @@ msgstr "  Disque utilisé :"
 msgid "Disks:"
 msgstr "  Disque utilisé :"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 #, fuzzy
 msgid "Don't require user confirmation for using --force"
 msgstr "Requérir une confirmation de l'utilisateur"
@@ -1166,11 +1167,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr "ÉPHÉMÈRE"
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr "DATE D'EXPIRATION"
 
@@ -1180,7 +1181,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 #, fuzzy
 msgid "Edit container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -1202,20 +1203,20 @@ msgstr "Création du conteneur"
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1223,16 +1224,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1251,11 +1252,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "Variable d'environnement (de la forme HOME=/home/foo) à positionner"
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr "Conteneur éphémère"
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "Erreur de mise à jour du modèle de fichier : %s"
@@ -1333,32 +1334,32 @@ msgstr "Import de l'image : %s"
 msgid "Exporting the image: %s"
 msgstr "Import de l'image : %s"
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 #, fuzzy
 msgid "FILENAME"
 msgstr "NOM"
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr "EMPREINTE"
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 #, fuzzy
 msgid "Failed to connect to cluster member"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, fuzzy, c-format
 msgid "Failed to create alias %s"
 msgstr "Échec lors de la génération de 'lxc.%s.1': %v"
 
-#: lxc/copy.go:417
+#: lxc/copy.go:420
 #, fuzzy
-msgid "Failed to get the new container name"
+msgid "Failed to get the new instance name"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1368,12 +1369,12 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 #, fuzzy
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Mode rapide (identique à --columns=nsacPt"
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1386,7 +1387,7 @@ msgstr "Empreinte : %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "Forcer l'allocation d'un pseudo-terminal"
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1403,7 +1404,7 @@ msgstr "Forcer la suppression des conteneurs arrêtés"
 msgid "Force using the local unix socket"
 msgstr "Forcer l'utilisation de la socket unix locale"
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1427,10 +1428,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1462,11 +1463,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "Génération d'un certificat client. Ceci peut prendre une minute…"
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1479,22 +1480,22 @@ msgstr "Clé de configuration invalide"
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 #, fuzzy
 msgid "Get values for network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 #, fuzzy
 msgid "Get values for profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1506,7 +1507,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 #, fuzzy
 msgid "HOSTNAME"
 msgstr "NOM"
@@ -1515,7 +1516,7 @@ msgstr "NOM"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 #, fuzzy
 msgid "ID"
 msgstr "PID"
@@ -1530,23 +1531,23 @@ msgstr "Pid : %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr "IPv4"
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr "IPv6"
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr "DATE D'ÉMISSION"
 
@@ -1630,49 +1631,54 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, fuzzy, c-format
+msgid "Instance name is: %s"
+msgstr "Le nom du conteneur est : %s"
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "Schème d'URL invalide \"%s\" in \"%s\""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr "Certificat invalide"
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, fuzzy, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "Clé de configuration invalide"
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Cible invalide %s"
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1688,7 +1694,7 @@ msgstr "nombre d'arguments incorrect pour la sous-comande"
 msgid "Invalid path %s"
 msgstr "Cible invalide %s"
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Cible invalide %s"
@@ -1703,7 +1709,7 @@ msgstr "Source invalide %s"
 msgid "Invalid target %s"
 msgstr "Cible invalide %s"
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr "IPs :"
 
@@ -1716,11 +1722,11 @@ msgstr "Créé : %s"
 msgid "Keep the image up to date after initial copy"
 msgstr "Garder l'image à jour après la copie initiale"
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr "DERNIÈRE UTILISATION À"
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1729,7 +1735,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1752,28 +1758,28 @@ msgstr "Architecture : %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias :"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1782,17 +1788,17 @@ msgstr ""
 msgid "List container devices"
 msgstr "Création du conteneur"
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 #, fuzzy
 msgid "List container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 #, fuzzy
 msgid "List containers"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 #, fuzzy
 msgid ""
 "List containers\n"
@@ -1919,11 +1925,11 @@ msgstr ""
 "    lxc list -c n,volatile.base_image:\\BASE IMAGE\\:0,s46,volatile.eth0."
 "hwaddr:MAC"
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1961,11 +1967,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1974,15 +1980,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Copie de l'image : %s"
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1995,11 +2001,11 @@ msgstr ""
 msgid "Log:"
 msgstr "Journal : "
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -2009,15 +2015,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Créé : %s"
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr "GÉRÉ"
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -2030,15 +2036,15 @@ msgstr "Rendre l'image publique"
 msgid "Make the image public"
 msgstr "Rendre l'image publique"
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -2051,7 +2057,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr "Création du conteneur"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 #, fuzzy
 msgid "Manage container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
@@ -2065,7 +2071,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr "Transfert de l'image : %s"
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 #, fuzzy
 msgid "Manage image aliases"
 msgstr "Rendre l'image publique"
@@ -2094,16 +2100,16 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 #, fuzzy
 msgid "Manage projects"
 msgstr "Rendre l'image publique"
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Copie de l'image : %s"
@@ -2121,11 +2127,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -2134,12 +2140,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, fuzzy, c-format
 msgid "Member %s removed"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, fuzzy, c-format
 msgid "Member %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2162,12 +2168,12 @@ msgstr "  Mémoire utilisée :"
 msgid "Memory:"
 msgstr "  Mémoire utilisée :"
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 #, fuzzy
 msgid "Migration API failure"
 msgstr "Échec lors de la migration vers l'hôte source: %s"
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2176,14 +2182,14 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 #, fuzzy
 msgid "Missing container name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 #, fuzzy
 msgid "Missing container.name name"
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
@@ -2195,16 +2201,16 @@ msgstr "Vous devez fournir le nom d'un conteneur pour : "
 msgid "Missing name"
 msgstr "Résumé manquant."
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 #, fuzzy
 msgid "Missing network name"
 msgstr "Nom du réseau"
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2216,18 +2222,18 @@ msgstr "Nom du réseau"
 msgid "Missing pool name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 #, fuzzy
 msgid "Missing project name"
 msgstr "Nom de l'ensemble de stockage"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2262,7 +2268,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 #, fuzzy
 msgid "More than one device matches, specify the device name"
@@ -2273,7 +2279,7 @@ msgid "More than one file to download, but target is not a directory"
 msgstr ""
 "Plusieurs fichiers à télécharger, mais la destination n'est pas un dossier"
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 #, fuzzy
 msgid "Move containers within or in between LXD instances"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2283,13 +2289,13 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Move storage volumes between pools"
 msgstr "Copie de l'image : %s"
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 #, fuzzy
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
@@ -2307,8 +2313,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr "Vous devez fournir le nom d'un conteneur pour : "
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr "NOM"
@@ -2321,8 +2327,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr "NON"
 
@@ -2344,7 +2350,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr "Nom : %s"
@@ -2354,31 +2360,31 @@ msgstr "Nom : %s"
 msgid "Name: %v"
 msgstr "Nom : %s"
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, fuzzy, c-format
 msgid "Network %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, fuzzy, c-format
 msgid "Network %s renamed to %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr "Nom du réseau"
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 #, fuzzy
 msgid "Network usage:"
 msgstr "  Réseau utilisé :"
@@ -2392,12 +2398,12 @@ msgstr "Nouvel alias à définir sur la cible"
 msgid "New aliases to add to the image"
 msgstr "Nouvel alias à définir sur la cible"
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 #, fuzzy
 msgid "New key/value to apply to a specific device"
 msgstr "Clé/valeur de configuration à appliquer au nouveau conteneur"
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr "Aucun périphérique existant pour ce réseau"
 
@@ -2436,7 +2442,7 @@ msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 "Seuls les volumes \"personnalisés\" peuvent être attachés aux conteneurs."
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr "Seules les URLs https sont supportées par simplestreams"
 
@@ -2445,12 +2451,12 @@ msgstr "Seules les URLs https sont supportées par simplestreams"
 msgid "Only https:// is supported for remote image import"
 msgstr "Seul https:// est supporté par l'import d'images distantes."
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 #, fuzzy
 msgid "Only managed networks can be modified"
 msgstr "Seuls les réseaux gérés par LXD peuvent être modifiés."
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, fuzzy, c-format
 msgid "Operation %s deleted"
 msgstr "Le réseau %s a été supprimé"
@@ -2469,31 +2475,31 @@ msgstr "Surcharger le mode terminal (auto, interactif ou non-interactif)"
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr "PROFILS"
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr "PROTOCOLE"
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr "PUBLIC"
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr "Paquets reçus"
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr "Paquets émis"
 
@@ -2530,13 +2536,13 @@ msgstr "État : %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr "Appuyer sur Entrée pour ouvrir à nouveau l'éditeur"
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr "Appuyer sur Entrée pour lancer à nouveau l'éditeur"
 
@@ -2548,7 +2554,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2571,46 +2577,46 @@ msgstr "l'analyse des alias a échoué %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr "Profil %s créé"
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, fuzzy, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "Profils %s appliqués à %s"
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "Profil %s supprimé de %s"
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, fuzzy, c-format
 msgid "Profile %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 #, fuzzy
 msgid "Profile to apply to the target container"
 msgstr "Profil à appliquer au nouveau conteneur"
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "Profils %s appliqués à %s"
@@ -2620,17 +2626,17 @@ msgstr "Profils %s appliqués à %s"
 msgid "Profiles: %s"
 msgstr "Profils : %s"
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, fuzzy, c-format
 msgid "Project %s created"
 msgstr "Profil %s créé"
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, fuzzy, c-format
 msgid "Project %s deleted"
 msgstr "Profil %s supprimé"
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, fuzzy, c-format
 msgid "Project %s renamed to %s"
 msgstr "Profil %s ajouté à %s"
@@ -2639,7 +2645,7 @@ msgstr "Profil %s ajouté à %s"
 msgid "Properties:"
 msgstr "Propriétés :"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr "Serveur d'images public"
 
@@ -2707,28 +2713,28 @@ msgstr "Ignorer l'état du conteneur (seulement pour start)"
 msgid "Refreshing the image: %s"
 msgstr "Récupération de l'image : %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "le serveur distant %s existe déjà"
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "le serveur distant %s n'existe pas"
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "le serveur distant %s existe en tant que <%s>"
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "le serveur distant %s est statique et ne peut être modifié"
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr "Mot de passe de l'administrateur distant"
 
@@ -2752,11 +2758,11 @@ msgstr "Serveur distant : %s"
 msgid "Remove %s (yes/no): "
 msgstr "Supprimer %s (oui/non) : "
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 #, fuzzy
 msgid "Remove aliases"
 msgstr "Mot de passe de l'administrateur distant"
@@ -2766,25 +2772,25 @@ msgstr "Mot de passe de l'administrateur distant"
 msgid "Remove container devices"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 #, fuzzy
 msgid "Remove profiles from containers"
 msgstr "Création du conteneur"
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2793,20 +2799,20 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Forcer le conteneur à s'arrêter"
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 #, fuzzy
 msgid "Rename projects"
 msgstr "Créé : %s"
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2873,7 +2879,7 @@ msgstr "Forcer le conteneur à s'arrêter"
 msgid "Retrieve the container's console log"
 msgstr "Forcer l'arrêt du conteneur (seulement pour stop)"
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "Récupération de l'image : %s"
@@ -2886,11 +2892,11 @@ msgstr ""
 msgid "SIZE"
 msgstr "TAILLE"
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr "INSTANTANÉS"
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr "SOURCE"
 
@@ -2898,42 +2904,42 @@ msgstr "SOURCE"
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr "ÉTAT"
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr "STATIQUE"
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 #, fuzzy
 msgid "STATUS"
 msgstr "ÉTAT"
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr "ENSEMBLE DE STOCKAGE"
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr "Certificat serveur rejeté par l'utilisateur"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 #, fuzzy
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 "Le serveur ne nous fait pas confiance après l'ajout de notre certificat"
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "Protocole du serveur (lxd ou simplestreams)"
 
@@ -2979,12 +2985,12 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 #, fuzzy
 msgid "Set network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2993,12 +2999,12 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 #, fuzzy
 msgid "Set profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -3007,12 +3013,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -3021,12 +3027,12 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 #, fuzzy
 msgid "Set storage pool configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -3049,7 +3055,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -3088,16 +3094,16 @@ msgstr "Afficher la configuration étendue"
 msgid "Show container or server information"
 msgstr "Afficher des informations supplémentaires"
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 #, fuzzy
 msgid "Show content of container file templates"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -3119,22 +3125,22 @@ msgstr "Afficher les commandes moins communes"
 msgid "Show local and remote versions"
 msgstr "Afficher la version du client"
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 #, fuzzy
 msgid "Show network configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 #, fuzzy
 msgid "Show profile configurations"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 #, fuzzy
 msgid "Show project options"
 msgstr "Afficher la configuration étendue"
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -3152,7 +3158,7 @@ msgstr "Afficher la configuration étendue"
 msgid "Show the container's last 100 log lines?"
 msgstr "Afficher les 100 dernières lignes du journal du conteneur ?"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 #, fuzzy
 msgid "Show the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -3165,11 +3171,11 @@ msgstr "Afficher la configuration étendue"
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -3177,7 +3183,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -3224,7 +3230,7 @@ msgstr "Création du conteneur"
 msgid "Starting %s"
 msgstr "Démarrage de %s"
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "État : %s"
@@ -3252,22 +3258,22 @@ msgstr "L'arrêt du conteneur a échoué !"
 msgid "Stopping the container failed: %s"
 msgstr "L'arrêt du conteneur a échoué !"
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, fuzzy, c-format
 msgid "Storage pool %s created"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, fuzzy, c-format
 msgid "Storage pool %s deleted"
 msgstr "Le réseau %s a été supprimé"
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, fuzzy, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "Le réseau %s a été créé"
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr "Nom de l'ensemble de stockage"
 
@@ -3314,38 +3320,38 @@ msgstr "Swap (courant)"
 msgid "Swap (peak)"
 msgstr "Swap (pointe)"
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 #, fuzzy
 msgid "Switch the current project"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 #, fuzzy
 msgid "Switch the default remote"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr "TYPE"
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3364,7 +3370,7 @@ msgstr ""
 "Le conteneur est en cours d'exécution. Utiliser --force pour qu'il soit "
 "arrêté et redémarré."
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 "Le conteneur que vous démarrez n'est attaché à aucune interface réseau."
@@ -3379,12 +3385,12 @@ msgstr "Le périphérique n'existe pas"
 msgid "The device doesn't exist"
 msgstr "Le périphérique n'existe pas"
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, fuzzy, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
@@ -3394,16 +3400,16 @@ msgstr "L'image locale '%s' n'a pas été trouvée, essayer '%s:' à la place."
 msgid "The profile device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr "Le périphérique indiqué n'existe pas"
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr "le périphérique indiqué ne correspond pas au réseau"
 
@@ -3435,11 +3441,11 @@ msgstr "Temps d'attente du conteneur avant de le tuer"
 msgid "Timestamps:"
 msgstr "Horodatage :"
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr "Pour attacher un réseau à un conteneur, utiliser : lxc network attach"
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr "Pour créer un réseau, utiliser : lxc network create"
 
@@ -3454,7 +3460,7 @@ msgstr ""
 "Pour démarrer votre premier conteneur, essayer : lxc launch ubuntu:16.04"
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3476,7 +3482,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3509,11 +3515,11 @@ msgstr "Type : éphémère"
 msgid "UPLOAD DATE"
 msgstr "DATE DE PUBLICATION"
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr "URL"
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr "UTILISÉ PAR"
@@ -3528,7 +3534,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3538,7 +3544,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "tous les profils de la source n'existent pas sur la cible"
@@ -3553,22 +3559,22 @@ msgstr "Clé de configuration invalide"
 msgid "Unset container or server configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 #, fuzzy
 msgid "Unset network configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 #, fuzzy
 msgid "Unset profile configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Clé de configuration invalide"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 #, fuzzy
 msgid "Unset storage pool configuration keys"
 msgstr "Clé de configuration invalide"
@@ -3597,7 +3603,7 @@ msgstr "Publié : %s"
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 #, fuzzy
 msgid "User aborted delete operation"
 msgstr "L'utilisateur a annulé l'opération de suppression."
@@ -3632,7 +3638,7 @@ msgstr "Créé : %s"
 msgid "WWN: %s"
 msgstr "Nom : %s"
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3660,8 +3666,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "Réaliser ou pas l'instantané de l'état de fonctionnement du conteneur"
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr "OUI"
 
@@ -3679,20 +3685,20 @@ msgstr "impossible de copier vers le même nom de conteneur"
 msgid "You must specify a destination container name when using --target"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 #, fuzzy
 msgid "You must specify a source container name"
 msgstr "vous devez spécifier un nom de conteneur source"
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3700,20 +3706,20 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 #, fuzzy
 msgid "alias"
 msgstr "Alias :"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3727,13 +3733,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3753,7 +3759,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3761,19 +3767,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3781,28 +3787,28 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 #, fuzzy
 msgid "current"
 msgstr "Swap (courant)"
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr "par défaut"
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3836,15 +3842,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3856,11 +3862,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 #, fuzzy
 msgid "delete [<remote>:]<project>"
 msgstr ""
@@ -3868,11 +3874,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3884,7 +3890,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3896,7 +3902,7 @@ msgstr ""
 msgid "disabled"
 msgstr "désactivé"
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3904,7 +3910,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3916,11 +3922,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3936,11 +3942,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3956,7 +3962,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -4000,11 +4006,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4020,11 +4026,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 #, fuzzy
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
@@ -4036,7 +4042,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 #, fuzzy
 msgid "get-default"
 msgstr "par défaut"
@@ -4055,7 +4061,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -4063,11 +4069,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -4075,7 +4081,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 #, fuzzy
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
@@ -4087,24 +4093,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -4116,23 +4122,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -4216,7 +4222,7 @@ msgstr ""
 "lxc info [<serveur distant>:]\n"
 "    Pour l'information du serveur LXD."
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -4232,7 +4238,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -4258,7 +4264,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 #, fuzzy
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
@@ -4284,13 +4290,13 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    Renomme un instantané."
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -4309,19 +4315,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -4342,7 +4348,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -4381,7 +4387,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
@@ -4395,11 +4401,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 #, fuzzy
 msgid "network"
 msgstr "Nom du réseau"
@@ -4408,11 +4414,11 @@ msgstr "Nom du réseau"
 msgid "no"
 msgstr "non"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr "ok (y/n) ?"
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 #, fuzzy
 msgid "operation"
 msgstr "Propriétés :"
@@ -4433,12 +4439,12 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 #, fuzzy
 msgid "profile"
 msgstr "Profils : %s"
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4477,7 +4483,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4489,24 +4495,24 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 #, fuzzy
 msgid "remote"
 msgstr "Serveur distant : %s"
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4514,19 +4520,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4542,11 +4548,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4564,11 +4570,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4604,7 +4610,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 #, fuzzy
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4612,7 +4618,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4624,7 +4630,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 #, fuzzy
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -4632,7 +4638,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4648,7 +4654,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4656,7 +4662,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4668,19 +4674,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4696,11 +4702,11 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4732,7 +4738,7 @@ msgstr ""
 "Détruit les conteneurs ou les instantanés ainsi que toute donnée associée "
 "(configuration, instantanés, …)."
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4760,16 +4766,16 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 #, fuzzy
 msgid "switch <remote>"
 msgstr "impossible de supprimer le serveur distant par défaut"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 #, fuzzy
 msgid "switch [<remote>:] <project>"
 msgstr "impossible de supprimer le serveur distant par défaut"
@@ -4779,15 +4785,15 @@ msgstr "impossible de supprimer le serveur distant par défaut"
 msgid "taken at %s"
 msgstr "pris à %s"
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4799,11 +4805,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4811,11 +4817,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
@@ -4827,7 +4833,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4840,14 +4846,17 @@ msgstr ""
 msgid "volume"
 msgstr "Colonnes"
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr "oui"
+
+#~ msgid "Container name is: %s"
+#~ msgstr "Le nom du conteneur est : %s"
 
 #~ msgid "PERSISTENT"
 #~ msgstr "PERSISTANT"

--- a/po/hi.po
+++ b/po/hi.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/id.po
+++ b/po/id.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/it.po
+++ b/po/it.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Luigi Operoso <brokenpip3@gmail.com>\n"
 "Language-Team: Italian <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
@@ -127,7 +127,7 @@ msgstr ""
 "### Un esempio è il seguente:\n"
 "###  description: My custom image"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -147,7 +147,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -168,7 +168,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -225,7 +225,7 @@ msgstr "%v (interrompi altre due volte per forzare)"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' non è un tipo di file supportato."
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(nessuno)"
 
@@ -248,7 +248,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -264,7 +264,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -276,19 +276,19 @@ msgstr "ALIAS"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARCHITETTURA"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Accetta certificato"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "Azione (default a GET)"
 
@@ -296,15 +296,15 @@ msgstr "Azione (default a GET)"
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr "Aggiungi nuovi alias"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr "Aggiungi un nuovo server remoto"
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -316,11 +316,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -329,22 +329,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Password amministratore per %s: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, fuzzy, c-format
 msgid "Alias %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, fuzzy, c-format
 msgid "Alias %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr "Nome dell'alias mancante"
 
@@ -362,19 +362,19 @@ msgstr "Architettura: %s"
 msgid "Architecture: %v"
 msgstr "Architettura: %s"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -398,7 +398,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -413,7 +413,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Aggiornamento automatico: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -421,13 +421,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -451,19 +451,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Bytes ricevuti"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Byte inviati"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr "NOME COMUNE"
 
@@ -485,12 +485,12 @@ msgstr "Utilizzo CPU:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 #, fuzzy
 msgid "CREATED"
 msgstr "CREATO IL"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "CREATO IL"
 
@@ -508,7 +508,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -520,16 +520,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr "Impossibile effettuare il pull di una directory senza --recursive"
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Impossible leggere da stdin: %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -537,7 +537,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -550,7 +550,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -564,12 +564,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificato del client salvato dal server: "
@@ -580,11 +580,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -593,11 +593,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Colonne"
 
@@ -613,21 +613,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -640,11 +640,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr "Il nome del container è: %s"
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -655,7 +650,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -683,7 +678,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -704,7 +699,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -731,15 +726,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Creazione del container in corso"
@@ -765,12 +760,12 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 #, fuzzy
 msgid "Create containers from images"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -778,24 +773,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -803,13 +802,14 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "Creazione di %s in corso"
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
 msgstr "Creazione del container in corso"
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -817,16 +817,16 @@ msgstr "Creazione del container in corso"
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr "DESCRIZIONE"
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -842,11 +842,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -858,7 +858,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -866,19 +866,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -887,46 +887,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -938,11 +938,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -969,7 +969,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr "La periferica esiste già: %s"
@@ -979,8 +979,8 @@ msgstr "La periferica esiste già: %s"
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1018,7 +1018,7 @@ msgstr "Utilizzo disco:"
 msgid "Disks:"
 msgstr "Utilizzo disco:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1031,11 +1031,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr "DATA DI SCADENZA"
 
@@ -1045,7 +1045,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1065,19 +1065,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1085,16 +1085,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1113,11 +1113,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1185,29 +1185,29 @@ msgstr "Creazione del container in corso"
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1217,11 +1217,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 #, fuzzy
 msgid "Filtering isn't supported yet"
 msgstr "'%s' non è un tipo di file supportato."
@@ -1235,7 +1235,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1251,7 +1251,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1275,10 +1275,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1310,11 +1310,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1326,19 +1326,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1350,7 +1350,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1358,7 +1358,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1372,23 +1372,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1466,49 +1466,54 @@ msgstr "Creazione del container in corso"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, fuzzy, c-format
+msgid "Instance name is: %s"
+msgstr "Il nome del container è: %s"
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, fuzzy, c-format
 msgid "Invalid format %q"
 msgstr "Proprietà errata: %s"
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1524,7 +1529,7 @@ msgstr "numero errato di argomenti del sottocomando"
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, fuzzy, c-format
 msgid "Invalid protocol: %s"
 msgstr "Proprietà errata: %s"
@@ -1539,7 +1544,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1552,11 +1557,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1565,7 +1570,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1588,28 +1593,28 @@ msgstr "Architettura: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 #, fuzzy
 msgid "List aliases"
 msgstr "Alias:"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1617,16 +1622,16 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 #, fuzzy
 msgid "List containers"
 msgstr "Creazione del container in corso"
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1693,11 +1698,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1735,11 +1740,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1747,15 +1752,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1768,11 +1773,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1782,15 +1787,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1803,15 +1808,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1824,7 +1829,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr "Creazione del container in corso"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1837,7 +1842,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr "Creazione del container in corso"
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1864,15 +1869,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1888,11 +1893,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1901,12 +1906,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1927,11 +1932,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1940,14 +1945,14 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 #, fuzzy
 msgid "Missing container name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1957,15 +1962,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1976,18 +1981,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 #, fuzzy
 msgid "Missing project name"
 msgstr "Il nome del container è: %s"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2020,7 +2025,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2029,7 +2034,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2037,12 +2042,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2059,8 +2064,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2073,8 +2078,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2096,7 +2101,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2106,31 +2111,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2142,11 +2147,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2180,7 +2185,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2188,11 +2193,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2210,31 +2215,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2270,13 +2275,13 @@ msgstr "Aggiornamento automatico: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2288,7 +2293,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2311,45 +2316,45 @@ msgstr "errore di processamento degli alias %s\n"
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2359,17 +2364,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2378,7 +2383,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2441,28 +2446,28 @@ msgstr "Creazione del container in corso"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, fuzzy, c-format
 msgid "Remote %s already exists"
 msgstr "il remote %s esiste già"
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, fuzzy, c-format
 msgid "Remote %s doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, fuzzy, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "il remote %s esiste come %s"
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, fuzzy, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "il remote %s è statico e non può essere modificato"
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2485,11 +2490,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2497,24 +2502,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2522,19 +2527,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2595,7 +2600,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2608,11 +2613,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2620,39 +2625,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2696,11 +2701,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2709,11 +2714,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2722,11 +2727,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2735,11 +2740,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2761,7 +2766,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2797,15 +2802,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2825,19 +2830,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2853,7 +2858,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2865,11 +2870,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2877,7 +2882,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2923,7 +2928,7 @@ msgstr "Creazione del container in corso"
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Aggiornamento automatico: %s"
@@ -2950,22 +2955,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -3010,36 +3015,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3053,7 +3058,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3066,12 +3071,12 @@ msgstr "La periferica esiste già"
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3081,16 +3086,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "il remote %s non esiste"
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3122,11 +3127,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3139,7 +3144,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3161,7 +3166,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3194,11 +3199,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3213,7 +3218,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3223,7 +3228,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 #, fuzzy
 msgid "Unset all profiles on the target container"
 msgstr "non tutti i profili dell'origine esistono nella destinazione"
@@ -3236,19 +3241,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3275,7 +3280,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3309,7 +3314,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3333,8 +3338,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3351,19 +3356,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr "Occorre specificare un nome di container come origine"
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3371,20 +3376,20 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 #, fuzzy
 msgid "alias"
 msgstr "Alias:"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3398,13 +3403,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3424,7 +3429,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3432,19 +3437,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3452,27 +3457,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3490,15 +3495,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3506,19 +3511,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3530,7 +3535,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3542,7 +3547,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3550,7 +3555,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3562,11 +3567,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3574,11 +3579,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3587,7 +3592,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "Creazione del container in corso"
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3627,11 +3632,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3639,11 +3644,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3651,7 +3656,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3669,7 +3674,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3677,11 +3682,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3689,7 +3694,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3697,24 +3702,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3726,23 +3731,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3816,7 +3821,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3832,7 +3837,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3858,7 +3863,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3872,13 +3877,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3897,19 +3902,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3930,7 +3935,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3969,17 +3974,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3987,11 +3992,11 @@ msgstr ""
 msgid "no"
 msgstr "no"
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -4007,11 +4012,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4033,7 +4038,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4041,23 +4046,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4065,19 +4070,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4085,11 +4090,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4099,11 +4104,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4123,11 +4128,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4135,11 +4140,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4148,7 +4153,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr "Creazione del container in corso"
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4156,7 +4161,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4168,19 +4173,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4188,11 +4193,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4209,7 +4214,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4229,15 +4234,15 @@ msgstr "senza stato"
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4246,15 +4251,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr "salvato alle %s"
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4266,11 +4271,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4278,11 +4283,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4290,7 +4295,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4303,14 +4308,17 @@ msgstr ""
 msgid "volume"
 msgstr "Colonne"
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr "si"
+
+#~ msgid "Container name is: %s"
+#~ msgstr "Il nome del container è: %s"
 
 #~ msgid "Commands:"
 #~ msgstr "Comandi:"

--- a/po/ja.po
+++ b/po/ja.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: LXD\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-20 11:43+0000\n"
 "Last-Translator: Hiroaki Nakamura <hnakamur@gmail.com>\n"
 "Language-Team: Japanese <https://hosted.weblate.org/projects/linux-"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -105,7 +105,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -125,7 +125,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' はサポートされないタイプのファイルです"
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -212,7 +212,7 @@ msgstr "- ポート %d (%s)"
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only はコピー元がスナップショットの場合は指定できません"
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr "--empty はイメージ名と同時に指定できません"
 
@@ -229,7 +229,7 @@ msgstr "--target はコンテナでは使えません"
 msgid "--target cannot be used with instances"
 msgstr "--target はコンテナでは使えません"
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -241,19 +241,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "証明書を受け入れます"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 
@@ -261,15 +261,15 @@ msgstr "使用するHTTPのメソッド (デフォルト: GET)"
 msgid "Add devices to containers or profiles"
 msgstr "コンテナもしくはプロファイルにデバイスを追加します"
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr "新たにエイリアスを追加します"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr "新たにリモートサーバを追加します"
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -288,11 +288,11 @@ msgstr ""
 "  lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --"
 "protocol=simplestreams\n"
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr "新たに信頼済みのクライアントを追加します"
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr "コンテナにプロファイルを追加します"
 
@@ -301,22 +301,22 @@ msgstr "コンテナにプロファイルを追加します"
 msgid "Address: %s"
 msgstr "アドレス: %s"
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "%s の管理者パスワード: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr "エイリアス %s は既に存在します"
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "エイリアス %s は存在しません"
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr "エイリアスを指定してください"
 
@@ -334,19 +334,19 @@ msgstr "アーキテクチャ: %s"
 msgid "Architecture: %v"
 msgstr "アーキテクチャ: %v"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr "コンテナにプロファイルを割り当てます"
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr "コンテナにネットワークインターフェースを追加します"
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr "プロファイルにネットワークインターフェースを追加します"
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr "新たなネットワークインターフェースをコンテナに追加します"
 
@@ -374,7 +374,7 @@ msgstr ""
 "このコマンドはコンテナのブートコンソールに接続できます。\n"
 "そしてそこから過去のログエントリを取り出すことができます。"
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "認証タイプ '%s' はサーバではサポートされていません"
@@ -389,7 +389,7 @@ msgstr "オートネゴシエーション: %v"
 msgid "Auto update: %s"
 msgstr "自動更新: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -397,13 +397,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr "バックアップのエクスポートが成功しました!"
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "不適切なキー/値のペア: %s"
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "不適切な キー=値 のペア: %s"
@@ -428,19 +428,19 @@ msgstr "--all とコンテナ名を両方同時に指定することはできま
 msgid "Brand: %v"
 msgstr "ブランド: %v"
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "受信バイト数"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "送信バイト数"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -462,11 +462,11 @@ msgstr "CPU使用量:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -484,7 +484,7 @@ msgstr "キャッシュ済: %s"
 msgid "Caches:"
 msgstr "キャッシュ:"
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr "ローカル上のリネームでは、設定やプロファイルの上書きはできません"
 
@@ -497,16 +497,16 @@ msgid "Can't pull a directory without --recursive"
 msgstr ""
 "ディレクトリを pull する場合は --recursive オプションを使用してください"
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "標準入力から読み込めません: %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr "デフォルトのリモートは削除できません"
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr "--fast と --columns は同時に指定できません"
 
@@ -514,7 +514,7 @@ msgstr "--fast と --columns は同時に指定できません"
 msgid "Can't specify a different remote for rename"
 msgstr "リネームの場合は異なるリモートを指定できません"
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr "クラスタでない場合はカラムとして L は指定できません"
 
@@ -527,7 +527,7 @@ msgstr "再帰 (recursive) モードでは uid/gid/mode を指定できません
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "キー '%s' が設定されていないので削除できません"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr "使用する Candid ドメイン"
 
@@ -541,12 +541,12 @@ msgstr "カード %d:"
 msgid "Card: %s (%s)"
 msgstr "カード: %s (%s)"
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "証明書のフィンガープリント: %s"
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "クライアント証明書がサーバに格納されました: "
@@ -557,11 +557,11 @@ msgid "Client version: %s\n"
 msgstr "クライアントバージョン: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -570,11 +570,11 @@ msgstr "クライアントバージョン: %s\n"
 msgid "Cluster member name"
 msgstr "クラスタメンバ名"
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr "クラスタリングが有効になりました"
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "カラムレイアウト"
 
@@ -594,21 +594,21 @@ msgstr ""
 "LXD の機能のすべてが、以下の色々なコマンドから操作できます。\n"
 "コマンドのヘルプは、--help をコマンドに付けて実行するだけです。"
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr "新しいコンテナに適用するキー/値の設定"
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr "新しいプロジェクトに適用するキー/値の設定"
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr "移動先のコンテナに適用するキー/値の設定"
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "設定の構文エラー: %s"
@@ -621,11 +621,6 @@ msgstr "コンソールログ:"
 msgid "Container name is mandatory"
 msgstr "コンテナ名を指定する必要があります"
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr "コンテナ名: %s"
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -636,7 +631,7 @@ msgstr "コンテナは以下のフィンガープリントで publish されま
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr "ステートフルなコンテナをステートレスにコピーします"
 
@@ -668,7 +663,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr "プロファイルに継承されたデバイスをコピーし、設定キーを上書きします"
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr "プロファイルをコピーします"
 
@@ -691,7 +686,7 @@ msgstr "コンテナをコピーします (スナップショットはコピー�
 msgid "Copy the volume without its snapshots"
 msgstr "ボリュームをコピーします (スナップショットはコピーしません)"
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr "コピー／移動元とは異なるプロジェクトにコピーします"
 
@@ -719,15 +714,15 @@ msgstr "コア %d"
 msgid "Cores:"
 msgstr "コア:"
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr "サーバ証明書格納用のディレクトリを作成できません"
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr "既存のイメージに対するエイリアスを作成します"
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr "空のコンテナを作成"
 
@@ -755,11 +750,11 @@ msgstr ""
 "--stateful を指定すると、LXD はコンテナの実行状態（プロセスのメモリ状態、TCP"
 "コネクション、など…を含む）を保存しようとします。"
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr "イメージからコンテナを作成します"
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr "新たにコンテナのファイルテンプレートを作成します"
 
@@ -767,38 +762,44 @@ msgstr "新たにコンテナのファイルテンプレートを作成します
 msgid "Create new custom storage volumes"
 msgstr "新たにカスタムストレージボリュームを作成します"
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr "新たにネットワークを作成します"
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr "プロファイルを作成します"
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr "プロジェクトを作成します"
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr "ストレージプールを作成します"
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
 msgstr "プロファイルを適用しないコンテナを作成します"
+
+#: lxc/init.go:57
+#, fuzzy
+msgid "Create virtual machine"
+msgstr "イメージのコピー中: %s"
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr "作成日時: %s"
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "%s を作成中"
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
 msgstr "コンテナを作成中"
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -806,16 +807,16 @@ msgstr "コンテナを作成中"
 msgid "Current number of VFs: %d"
 msgstr "現在の VF 数: %d"
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -832,11 +833,11 @@ msgstr "圧縮アルゴリズムを指定します: 圧縮アルゴリズム名 
 msgid "Define a compression algorithm: for image or none"
 msgstr "圧縮アルゴリズムを指定します: 圧縮アルゴリズム名 or none"
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr "バックグラウンドの操作を削除します（キャンセルを試みます）"
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr "コンテナのファイルテンプレートを削除します"
 
@@ -848,7 +849,7 @@ msgstr "コンテナとスナップショットを削除します"
 msgid "Delete files in containers"
 msgstr "コンテナ内のファイルを削除します"
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr "イメージのエイリアスを削除します"
 
@@ -856,19 +857,19 @@ msgstr "イメージのエイリアスを削除します"
 msgid "Delete images"
 msgstr "イメージを削除します"
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr "ネットワークを削除します"
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr "プロファイルを削除します"
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr "プロジェクトを削除します"
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr "ストレージプールを削除します"
 
@@ -877,46 +878,46 @@ msgid "Delete storage volumes"
 msgstr "ストレージボリュームを削除します"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -928,11 +929,11 @@ msgstr "ストレージボリュームを削除します"
 msgid "Description"
 msgstr "説明"
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr "コンテナからネットワークインターフェースを取り外します"
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr "プロファイルからネットワークインターフェースを取り外します"
 
@@ -959,7 +960,7 @@ msgstr "デバイス %s が %s で上書きされました"
 msgid "Device %s removed from %s"
 msgstr "デバイス %s が %s から削除されました"
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr "デバイスは既に存在します: %s"
@@ -969,8 +970,9 @@ msgstr "デバイスは既に存在します: %s"
 msgid "Device: %s"
 msgstr "デバイス: %s"
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+#, fuzzy
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 "サーバから変更されたイメージ、コンテナ、スナップショットを取得できませんでし"
 "た"
@@ -1009,7 +1011,7 @@ msgstr "ディスク:"
 msgid "Disks:"
 msgstr "ディスク:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr "--force を使う際にユーザーの確認を必要としない"
 
@@ -1022,11 +1024,11 @@ msgstr "進捗情報を表示しません"
 msgid "Driver: %v (%v)"
 msgstr "ドライバ: %v (%v)"
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1038,7 +1040,7 @@ msgstr ""
 "ファイル転送のサーバ側の初期処理はキャンセルできません（強制的に中断するには"
 "あと2回行ってください）"
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr "コンテナのファイルテンプレートを編集します"
 
@@ -1058,19 +1060,19 @@ msgstr "コンテナ内のファイルを編集します"
 msgid "Edit image properties"
 msgstr "イメージのプロパティを編集します"
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr "ネットワーク設定をYAMLで編集します"
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr "プロファイル設定をYAMLで編集します"
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr "プロジェクト設定をYAMLで編集します"
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr "ストレージプールの設定をYAMLで編集します"
 
@@ -1078,18 +1080,18 @@ msgstr "ストレージプールの設定をYAMLで編集します"
 msgid "Edit storage volume configurations as YAML"
 msgstr "ストレージボリュームの設定をYAMLで編集します"
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 "'%s' 中のカラムエントリが空です (カラムの指定に空文字列が指定されています)"
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 "クラスタリングで動作していないLXDインスタンス上でクラスタリングを有効にします"
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1117,11 +1119,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr "環境変数を設定します (例: HOME=/home/foo)"
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr "Ephemeral コンテナ"
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr "テンプレートファイル更新のエラー: %s"
@@ -1201,29 +1203,30 @@ msgstr "バックアップのエクスポート中: %s"
 msgid "Exporting the image: %s"
 msgstr "イメージのエクスポート中: %s"
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr "クラスタメンバへの接続に失敗しました"
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr "エイリアス %s の作成に失敗しました"
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+#, fuzzy
+msgid "Failed to get the new instance name"
 msgstr "新しいコンテナ名が取得できません"
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr "エイリアス %s の削除に失敗しました"
@@ -1233,11 +1236,11 @@ msgstr "エイリアス %s の削除に失敗しました"
 msgid "Failed to walk path for %s: %s"
 msgstr "パス %s にアクセスできませんでした: %s"
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr "Fast モード (--columns=nsacPt と同じ)"
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr "情報表示のフィルタリングはまだサポートされていません"
 
@@ -1250,7 +1253,7 @@ msgstr "証明書のフィンガープリント: %s"
 msgid "Force pseudo-terminal allocation"
 msgstr "強制的に擬似端末を割り当てます"
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr "degraded 状態であっても強制的にメンバを削除します"
 
@@ -1266,7 +1269,7 @@ msgstr "稼働中のコンテナを強制的に削除します"
 msgid "Force using the local unix socket"
 msgstr "強制的にローカルのUNIXソケットを使います"
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1305,10 +1308,10 @@ msgstr ""
 "\n"
 "本当に強制的に %s を削除してもよろしいですか? (yes/no):"
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr "フォーマット (csv|json|table|yaml)"
@@ -1340,11 +1343,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr "すべてのコマンドに対する man ページを作成します"
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr "クライアント証明書を生成します。1分ぐらいかかります..."
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr "ネットワークのランタイム情報を取得します"
 
@@ -1356,19 +1359,19 @@ msgstr "コンテナのデバイスの設定値を取得します"
 msgid "Get values for container or server configuration keys"
 msgstr "コンテナもしくはサーバの設定値を取得します"
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr "ネットワークの設定値を取得します"
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr "プロファイルの設定値を取得します"
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr "プロジェクトの設定値を取得します"
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr "ストレージプールの設定値を取得します"
 
@@ -1380,7 +1383,7 @@ msgstr "ストレージボリュームの設定値を取得します"
 msgid "Group ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のグループ ID (GID) (デフォルト 0)"
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1388,7 +1391,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr "ID"
 
@@ -1402,23 +1405,23 @@ msgstr "ID: %d"
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1499,52 +1502,57 @@ msgstr "コンテナのインポート中: %s"
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr "入力するデータ"
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, fuzzy, c-format
+msgid "Instance name is: %s"
+msgstr "コンテナ名: %s"
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr "インスタンスタイプ"
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr "不正な URL スキーム \"%s\" (\"%s\" 内)"
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr "不正な証明書です"
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr "'%s' は正しくない設定項目 (key) です (%s 中の)"
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 "不正な設定項目のカラムフォーマットです (フィールド数が多すぎます): '%s'"
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr "不正なフォーマット %q"
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 "'%s' は最大幅の値として不正です (-1 もしくは 0 もしくは正の整数でなくてはなり"
 "ません) ('%s' 中の)"
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr "'%s' は最大幅の値として不正です (整数でなくてはなりません) ('%s' 中の)"
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1560,7 +1568,7 @@ msgstr "引数の数が不正です"
 msgid "Invalid path %s"
 msgstr "不正なパス %s"
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr "不正なプロトコル: %s"
@@ -1575,7 +1583,7 @@ msgstr "不正なソース %s"
 msgid "Invalid target %s"
 msgstr "不正な送り先 %s"
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr "IPアドレス:"
 
@@ -1588,11 +1596,11 @@ msgstr "IsSM: %s (%s)"
 msgid "Keep the image up to date after initial copy"
 msgstr "最初にコピーした後も常にイメージを最新の状態に保つ"
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1601,7 +1609,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr "LXD - コマンドラインクライアント"
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr "LXD サーバはクラスタの一部ではありません"
 
@@ -1624,27 +1632,27 @@ msgstr "リンクを検出: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr "リンクスピード: %dMbit/s (%s duplex)"
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr "DHCP のリースを一覧表示します"
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr "エイリアスを一覧表示します"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr "クラスタのメンバをすべて一覧表示します"
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr "利用可能なネットワークを一覧表示します"
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr "利用可能なストレージプールを一覧表示します"
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr "バックグラウンド操作を一覧表示します"
 
@@ -1652,15 +1660,15 @@ msgstr "バックグラウンド操作を一覧表示します"
 msgid "List container devices"
 msgstr "コンテナのデバイスを一覧表示します"
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr "コンテナのファイルテンプレートを一覧表示します"
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr "コンテナを一覧表示します"
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 #, fuzzy
 msgid ""
 "List containers\n"
@@ -1788,11 +1796,11 @@ msgstr ""
 "MAXWIDTH: カラムの最大幅 (結果がこれより長い場合は切り詰められます)\n"
 "          デフォルトは -1 (制限なし)。0 はカラムのヘッダサイズに制限します。"
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr "イメージのエイリアスを一覧表示します"
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1858,11 +1866,11 @@ msgstr ""
 "    s - サイズ\n"
 "    u - アップロード日"
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr "プロファイルを一覧表示します"
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr "プロジェクトを一覧表示します"
 
@@ -1870,15 +1878,15 @@ msgstr "プロジェクトを一覧表示します"
 msgid "List storage volumes"
 msgstr "ストレージボリュームを一覧表示します"
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr "利用可能なリモートサーバを一覧表示します"
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr "信頼済みクライアントを一覧表示します"
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr "バックグラウンド操作の一覧表示、表示、削除を行います"
 
@@ -1891,11 +1899,11 @@ msgstr "ロケーション: %s"
 msgid "Log:"
 msgstr "ログ:"
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr "MAC アドレス: %s"
@@ -1905,15 +1913,15 @@ msgstr "MAC アドレス: %s"
 msgid "MAD: %s (%s)"
 msgstr "MAD: %s (%s)"
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1926,15 +1934,15 @@ msgstr "イメージを public にする"
 msgid "Make the image public"
 msgstr "イメージを public にする"
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr "ネットワークを管理し、コンテナをネットワークに接続します"
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr "クラスタのメンバを管理します"
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr "コマンドのエイリアスを管理します"
 
@@ -1946,7 +1954,7 @@ msgstr "コンテナやサーバの設定を管理します"
 msgid "Manage container devices"
 msgstr "コンテナのデバイスを管理します"
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr "コンテナのファイルテンプレートを管理します"
 
@@ -1958,7 +1966,7 @@ msgstr "コンテナのメタデータファイルを管理します"
 msgid "Manage files in containers"
 msgstr "コンテナ内のファイルを管理します"
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr "イメージのエイリアスを管理します"
 
@@ -1998,15 +2006,15 @@ msgstr ""
 "イメージは全ハッシュ文字列、一意に定まるハッシュの短縮表現、(設定され\n"
 "ている場合は) エイリアスで参照できます。"
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr "プロファイルを管理します"
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr "プロジェクトを管理します"
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr "ストレージプール、ストレージボリュームを管理します"
 
@@ -2026,11 +2034,11 @@ msgstr ""
 "プレフィックスで指定しない限りは、ボリュームに対する操作はすべて \"カスタム"
 "\" (ユーザが作成した) ボリュームに対して行われます。"
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr "リモートサーバのリストを管理します"
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr "信頼済みのクライアントを管理します"
 
@@ -2039,12 +2047,12 @@ msgstr "信頼済みのクライアントを管理します"
 msgid "Maximum number of VFs: %d"
 msgstr "VF の最大数: %d"
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr "メンバ %s が削除されました"
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr "メンバ名 %s を %s に変更しました"
@@ -2065,11 +2073,11 @@ msgstr "メモリ消費量:"
 msgid "Memory:"
 msgstr "メモリ:"
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr "マイグレーション API が失敗しました"
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr "マイグレーションが失敗しました"
 
@@ -2078,13 +2086,13 @@ msgid "Minimum level for log messages"
 msgstr "表示するログメッセージの最小レベル"
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr "コンテナ名を指定する必要があります"
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr "コンテナ名を指定する必要があります"
 
@@ -2094,15 +2102,15 @@ msgstr "コンテナ名を指定する必要があります"
 msgid "Missing name"
 msgstr "名前を指定する必要があります"
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr "ネットワーク名を指定する必要があります"
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2113,17 +2121,17 @@ msgstr "ネットワーク名を指定する必要があります"
 msgid "Missing pool name"
 msgstr "ストレージプール名を指定する必要があります"
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr "プロファイル名を指定する必要があります"
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr "プロジェクト名を指定する必要があります"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr "コピー元のプロファイル名を指定する必要があります"
 
@@ -2159,7 +2167,7 @@ msgstr ""
 "\n"
 "デフォルトではすべてのタイプのメッセージをモニタリングします。"
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr "複数のデバイスとマッチします。デバイス名を指定してください"
@@ -2170,7 +2178,7 @@ msgstr ""
 "ダウンロード対象のファイルが複数ありますが、コピー先がディレクトリではありま"
 "せん"
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr "LXD サーバ内もしくはサーバ間でコンテナを移動します"
 
@@ -2178,13 +2186,13 @@ msgstr "LXD サーバ内もしくはサーバ間でコンテナを移動しま�
 msgid "Move storage volumes between pools"
 msgstr "プール間でストレージボリュームを移動します"
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 #, fuzzy
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr "コンテナを移動します (スナップショットは移動しません)"
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 #, fuzzy
 msgid "Move the instance without its snapshots"
 msgstr "コンテナを移動します (スナップショットは移動しません)"
@@ -2202,8 +2210,8 @@ msgstr "ディレクトリからのインポートは root で実行する必要
 msgid "Must supply container name for: "
 msgstr "コンテナ名を指定する必要があります: "
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2216,8 +2224,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2239,7 +2247,7 @@ msgstr "NVIDIA 情報:"
 msgid "NVRM Version: %v"
 msgstr "NVRM バージョン: %v"
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr "名前: %s"
@@ -2249,31 +2257,31 @@ msgstr "名前: %s"
 msgid "Name: %v"
 msgstr "名前: %v"
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr "ネットワーク %s を作成しました"
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr "ネットワーク %s を削除しました"
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr "ネットワーク %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr "ネットワーク名 %s を %s に変更しました"
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr "ネットワーク名:"
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr "ネットワーク使用状況:"
 
@@ -2285,11 +2293,11 @@ msgstr "新しいエイリアスを定義する"
 msgid "New aliases to add to the image"
 msgstr "イメージに新しいエイリアスを追加します"
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr "指定するデバイスに適用する新しいキー/値"
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr "このネットワークに対するデバイスがありません"
 
@@ -2323,7 +2331,7 @@ msgstr "\"カスタム\" のボリュームのみがコンテナにアタッチ�
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr "\"カスタム\" のボリュームのみがスナップショットを取得できます"
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr "simplestreams は https の URL のみサポートします"
 
@@ -2331,11 +2339,11 @@ msgstr "simplestreams は https の URL のみサポートします"
 msgid "Only https:// is supported for remote image import"
 msgstr "リモートイメージのインポートは https:// のみをサポートします"
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr "管理対象のネットワークのみ変更できます"
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr "バックグラウンド操作 %s を削除しました"
@@ -2353,31 +2361,31 @@ msgstr "ターミナルモードを上書きします (auto, interactive, non-in
 msgid "PCI address: %v"
 msgstr "PCI アドレス: %v"
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr "PID"
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr "受信パケット"
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr "送信パケット"
 
@@ -2412,13 +2420,13 @@ msgstr "ポートタイプ: %s"
 msgid "Ports:"
 msgstr "ポート:"
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr "再度エディタを開くためには Enter キーを押します"
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr "再度エディタを起動するには Enter キーを押します"
 
@@ -2430,7 +2438,7 @@ msgstr "見やすい形 (pretty) で表示します"
 msgid "Print help"
 msgstr "ヘルプを表示します"
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr "レスポンスをそのまま表示します"
 
@@ -2453,45 +2461,45 @@ msgstr "エイリアスの処理が失敗しました: %s"
 msgid "Product: %v (%v)"
 msgstr "製品名: %v (%v)"
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr "プロファイル %s が %s に追加されました"
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr "プロファイル %s を作成しました"
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr "プロファイル %s を削除しました"
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr "プロファイル %s は %s に適用されていません"
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr "プロファイル %s が %s から削除されました"
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr "プロファイル名 %s を %s に変更しました"
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr "新しいコンテナに適用するプロファイル"
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr "移動先のコンテナに適用するプロファイル"
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr "プロファイル %s が %s に追加されました"
@@ -2501,17 +2509,17 @@ msgstr "プロファイル %s が %s に追加されました"
 msgid "Profiles: %s"
 msgstr "プロファイル: %s"
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr "プロジェクト %s を作成しました"
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr "プロジェクト %s を削除しました"
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr "プロジェクト名 %s を %s に変更しました"
@@ -2520,7 +2528,7 @@ msgstr "プロジェクト名 %s を %s に変更しました"
 msgid "Properties:"
 msgstr "プロパティ:"
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr "Public なイメージサーバとして設定します"
 
@@ -2583,28 +2591,28 @@ msgstr "コンテナの更新中: %s"
 msgid "Refreshing the image: %s"
 msgstr "イメージの更新中: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr "リモート %s は既に存在します"
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr "リモート %s は存在しません"
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr "リモート %s は <%s> として存在します"
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr "リモート %s は static ですので変更できません"
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr "リモートの管理者パスワード"
 
@@ -2627,11 +2635,11 @@ msgstr "リムーバブルディスク: %v"
 msgid "Remove %s (yes/no): "
 msgstr "%s を消去しますか (yes/no): "
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr "クラスタからメンバを削除します"
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr "エイリアスを削除します"
 
@@ -2639,24 +2647,24 @@ msgstr "エイリアスを削除します"
 msgid "Remove container devices"
 msgstr "コンテナのデバイスを削除します"
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr "コンテナからプロファイルを削除します"
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr "リモートサーバを削除します"
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr "信頼済みクライアントを削除します"
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr "クラスタメンバの名前を変更します"
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr "エイリアスの名前を変更します"
 
@@ -2664,19 +2672,19 @@ msgstr "エイリアスの名前を変更します"
 msgid "Rename containers and snapshots"
 msgstr "コンテナまたはコンテナのスナップショットの名前を変更します"
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr "ネットワーク名を変更します"
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr "プロファイル名を変更します"
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr "プロジェクト名を変更します"
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr "リモートサーバ名を変更します"
 
@@ -2743,7 +2751,7 @@ msgstr "スナップショットからストレージボリュームをリスト
 msgid "Retrieve the container's console log"
 msgstr "コンテナのコンソールログを取得します"
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr "イメージの取得中: %s"
@@ -2756,11 +2764,11 @@ msgstr "すべてのコンテナに対してコマンドを実行します"
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2768,39 +2776,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr "SR-IOV 情報:"
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr "直接リクエスト (raw query) を LXD に送ります"
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr "サーバの認証タイプ (tls もしくは candid)"
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr "ユーザによりサーバ証明書が拒否されました"
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr "認証後、サーバが我々を信用していません"
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr "サーバのプロトコル (lxd or simplestreams)"
 
@@ -2860,11 +2868,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc config set [<remote>:][<container>] <key> <value>"
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr "ネットワークの設定項目を設定します"
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2877,11 +2885,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc network set [<remote>:]<network> <key> <value>"
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr "プロファイルの設定項目を設定します"
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2894,11 +2902,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr "プロジェクトの設定項目を設定します"
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2911,11 +2919,11 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc project set [<remote>:]<project> <key> <value>"
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr "ストレージプールの設定項目を設定します"
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2945,7 +2953,7 @@ msgstr ""
 "後方互換性のため、単一の設定を行う場合は次の形式でも設定できます:\n"
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr "リモートの URL を設定します"
 
@@ -2981,15 +2989,15 @@ msgstr "コンテナもしくはサーバの設定を表示します"
 msgid "Show container or server information"
 msgstr "コンテナもしくはサーバの情報を表示します"
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr "コンテナのファイルテンプレートの内容を表示します"
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr "クラスタメンバの詳細を表示します"
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr "バックグラウンド操作の詳細を表示します"
 
@@ -3009,19 +3017,19 @@ msgstr "全てのコマンドを表示します (主なコマンドだけでは�
 msgid "Show local and remote versions"
 msgstr "ローカルとリモートのバージョンを表示します"
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr "ネットワークの設定を表示します"
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr "プロファイルの設定を表示します"
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr "プロジェクトの設定を表示します"
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr "ストレージプールの設定とリソースを表示します"
 
@@ -3037,7 +3045,7 @@ msgstr "ストレージボリュームの設定を表示する"
 msgid "Show the container's last 100 log lines?"
 msgstr "コンテナログの最後の 100 行を表示しますか?"
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr "デフォルトのリモートを表示します"
 
@@ -3049,11 +3057,11 @@ msgstr "拡張した設定を表示する"
 msgid "Show the resources available to the server"
 msgstr "サーバで使用可能なリソースを表示します"
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr "ストレージプールで利用可能なリソースを表示します"
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr "使用量と空き容量を byte で表示します"
 
@@ -3061,7 +3069,7 @@ msgstr "使用量と空き容量を byte で表示します"
 msgid "Show useful information about images"
 msgstr "イメージについての情報を表示します"
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr "ストレージプールの情報を表示します"
 
@@ -3106,7 +3114,7 @@ msgstr "コンテナを起動します"
 msgid "Starting %s"
 msgstr "%s を起動中"
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr "状態: %s"
@@ -3133,22 +3141,22 @@ msgstr "コンテナの停止に失敗しました！"
 msgid "Stopping the container failed: %s"
 msgstr "コンテナの停止に失敗しました: %s"
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr "ストレージプール %s を作成しました"
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr "ストレージプール %s を削除しました"
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr "ストレージプール %s はメンバ %s 上でペンディング状態です"
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr "ストレージプール名"
 
@@ -3192,37 +3200,37 @@ msgstr "Swap (現在値)"
 msgid "Swap (peak)"
 msgstr "Swap (ピーク)"
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr "現在のプロジェクトを切り替えます"
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr "デフォルトのリモートを切り替えます"
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr "--container-only と --target は同時に指定できません"
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 #, fuzzy
 msgid "The --instance-only flag can't be used with --target"
 msgstr "--container-only と --target は同時に指定できません"
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr "--mode と --target は同時に指定できません"
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr "--stateless と --target は同時に指定できません"
 
@@ -3238,7 +3246,7 @@ msgstr ""
 "コンテナは現在実行中です。停止して、再起動するために --force を使用してくださ"
 "い"
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr "起動しようとしたコンテナに接続されているネットワークがありません。"
 
@@ -3251,14 +3259,14 @@ msgstr "デバイスはすでに存在します"
 msgid "The device doesn't exist"
 msgstr "デバイスが存在しません"
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 "ローカルイメージ '%s' が見つかりません。代わりに '%s:%s' を試してみてくださ"
 "い。"
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3268,16 +3276,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr "プロファイルのデバイスが存在しません"
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr "移動元の LXD インスタンスはクラスタに属していません"
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr "指定したデバイスが存在しません"
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr "指定したデバイスはネットワークとマッチしません"
 
@@ -3320,12 +3328,12 @@ msgstr "コンテナを強制停止するまでの時間"
 msgid "Timestamps:"
 msgstr "タイムスタンプ:"
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 "コンテナにネットワークを接続するには、lxc network attach を使用してください"
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 "新しいネットワークを作成するには、lxc network create を使用してください"
@@ -3341,7 +3349,7 @@ msgstr ""
 "さい"
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 "--target オプションは、コピー先のリモートサーバがクラスタに属していなければな"
@@ -3365,7 +3373,7 @@ msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpu
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)"
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr "転送モード。pull, push, relay のいずれか(デフォルトはpull)。"
 
@@ -3398,11 +3406,11 @@ msgstr "タイプ: ephemeral"
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3417,7 +3425,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr "テンポラリファイルを作成できません: %v"
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
@@ -3427,7 +3435,7 @@ msgstr "未知のカラム名の短縮形です '%c' ('%s' 中)"
 msgid "Unknown file type '%s'"
 msgstr "未知のファイルタイプ '%s'"
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr "移動先のコンテナのすべてのプロファイルを削除します"
 
@@ -3439,19 +3447,19 @@ msgstr "コンテナデバイスの設定を削除します"
 msgid "Unset container or server configuration keys"
 msgstr "コンテナもしくはサーバの設定を削除します"
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr "ネットワークの設定を削除します"
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr "プロファイルの設定を削除します"
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr "プロジェクトの設定を削除します"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr "ストレージプールの設定を削除します"
 
@@ -3480,7 +3488,7 @@ msgstr "使用済: %v"
 msgid "User ID to run the command as (default 0)"
 msgstr "コマンドを実行する際のユーザ ID (UID) (デフォルト 0)"
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr "ユーザが削除操作を中断しました"
 
@@ -3516,7 +3524,7 @@ msgstr "Verb: %s (%s)"
 msgid "WWN: %s"
 msgstr "WWN: %s"
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr "処理が完全に終わるまで待ちます"
 
@@ -3543,8 +3551,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr "コンテナの稼動状態のスナップショットを取得するかどうか"
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3560,19 +3568,19 @@ msgstr "--mode と同時に -t または -T は指定できません"
 msgid "You must specify a destination container name when using --target"
 msgstr "--target オプションを使うときはコピー先のコンテナ名を指定してください"
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr "コピー元のコンテナ名を指定してください"
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3580,19 +3588,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr "alias"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3606,13 +3614,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3632,7 +3640,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3640,19 +3648,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3660,27 +3668,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr "create [<remote>:]<project>"
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr "現在値"
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3701,15 +3709,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "delete [<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3717,19 +3725,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr "delete [<remote>:]<project>"
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr "説明"
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3741,7 +3749,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3753,7 +3761,7 @@ msgstr ""
 msgid "disabled"
 msgstr "無効"
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr "ドライバ"
 
@@ -3761,7 +3769,7 @@ msgstr "ドライバ"
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3773,11 +3781,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3785,11 +3793,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3797,7 +3805,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr "edit [<remote>:][<container>[/<snapshot>]]"
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3839,11 +3847,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3851,11 +3859,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr "get [<remote>:]<project> <key>"
 
@@ -3863,7 +3871,7 @@ msgstr "get [<remote>:]<project> <key>"
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3881,7 +3889,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr "ストレージ情報"
 
@@ -3889,11 +3897,11 @@ msgstr "ストレージ情報"
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3901,7 +3909,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 
@@ -3909,24 +3917,24 @@ msgstr "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3938,11 +3946,11 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
@@ -3950,7 +3958,7 @@ msgstr ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    \"list\" コマンドを \"list -c ns46S\" で上書きします。"
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
@@ -3958,7 +3966,7 @@ msgstr ""
 "lxc alias remove my-list\n"
 "    \"my-list\" というエイリアスを削除します。"
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -4067,7 +4075,7 @@ msgstr ""
 "lxc info [<remote>:] [--resources]\n"
 "    LXD サーバの情報を表示します。"
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -4091,7 +4099,7 @@ msgstr ""
 "lxc launch ubuntu:16.04 u1 < config.yaml\n"
 "    config.yaml の設定を使ってコンテナを作成し、起動します"
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 #, fuzzy
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
@@ -4134,7 +4142,7 @@ msgstr ""
 "lxc monitor --type=lifecycle\n"
 "    lifecycle イベントのみを表示します。"
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -4158,7 +4166,7 @@ msgstr ""
 "lxc move <container>/<old snapshot name> <container>/<new snapshot name>\n"
 "    スナップショットをリネームします。"
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
@@ -4166,7 +4174,7 @@ msgstr ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    上記のオペレーション UUID の詳細を表示します"
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -4198,7 +4206,7 @@ msgstr ""
 "c1 path=opt\n"
 "    ホストの /share/c1 をコンテナ内の /opt にマウントします。"
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
@@ -4206,7 +4214,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
@@ -4214,7 +4222,7 @@ msgstr ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    profile.yaml の内容でプロファイルを更新します"
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -4244,7 +4252,7 @@ msgstr ""
 "lxc restore u1 snap0\n"
 "    スナップショットからリストアします。"
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -4294,7 +4302,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
@@ -4302,11 +4310,11 @@ msgstr ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr "名前"
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr "network"
 
@@ -4314,11 +4322,11 @@ msgstr "network"
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr "ok (y/n)?"
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr "operation"
 
@@ -4334,11 +4342,11 @@ msgstr "pause [<remote>:]<container> [[<remote>:]<container>...]"
 msgid "please use `lxc profile`"
 msgstr "`lxc profile` コマンドを使ってください"
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr "profile"
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4366,7 +4374,7 @@ msgstr ""
 "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/"
 "<path>...]"
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4374,23 +4382,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr "remote"
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr "remove <alias>"
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4398,19 +4406,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4418,11 +4426,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4434,11 +4442,11 @@ msgstr ""
 "rename [<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new "
 "snapshot name>]"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr "rename [<remote>:]<project> <new-name>"
 
@@ -4458,11 +4466,11 @@ msgstr "restore [<remote>:]<pool> <volume> <snapshot>"
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr "set [<remote>:]<container|profile> <device> <key>=<value>..."
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr "set [<remote>:]<network> <key>=<value>..."
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4470,11 +4478,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr "set [<remote>:]<pool> <volume> <key>=<value>..."
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr "set [<remote>:]<profile> <key><value>..."
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr "set [<remote>:]<project> <key>=<value>..."
 
@@ -4482,7 +4490,7 @@ msgstr "set [<remote>:]<project> <key>=<value>..."
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr "set [<remote>:][<container>] <key>=<value>..."
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4490,7 +4498,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4502,19 +4510,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4522,11 +4530,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr "show [<remote>:]<pool> <volume>[/<snapshot>]"
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4542,7 +4550,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr "使用量"
 
@@ -4562,15 +4570,15 @@ msgstr "ステートレス"
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr "stop [<remote>:]<container> [[<remote>:]<container>...]"
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr "switch <remote>"
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr "switch [<remote>:] <project>"
 
@@ -4579,15 +4587,15 @@ msgstr "switch [<remote>:] <project>"
 msgid "taken at %s"
 msgstr "%s に取得しました"
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr "総容量"
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4599,11 +4607,11 @@ msgstr "サーバに接続できません"
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4611,11 +4619,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr "unset [<remote>:]<project> <key>"
 
@@ -4623,7 +4631,7 @@ msgstr "unset [<remote>:]<project> <key>"
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr "ストレージを使用中の"
 
@@ -4635,14 +4643,17 @@ msgstr ""
 msgid "volume"
 msgstr "volume"
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""
+
+#~ msgid "Container name is: %s"
+#~ msgstr "コンテナ名: %s"
 
 #~ msgid "Type: persistent"
 #~ msgstr "タイプ: persistent"

--- a/po/ko.po
+++ b/po/ko.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/lxd.pot
+++ b/po/lxd.pot
@@ -7,7 +7,7 @@
 msgid   ""
 msgstr  "Project-Id-Version: lxd\n"
         "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-        "POT-Creation-Date: 2019-10-24 10:21-0400\n"
+        "POT-Creation-Date: 2019-11-07 16:26+0000\n"
         "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
         "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
         "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,7 +16,7 @@ msgstr  "Project-Id-Version: lxd\n"
         "Content-Type: text/plain; charset=CHARSET\n"
         "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid   "### This is a yaml representation of a storage pool.\n"
         "### Any line starting with a '#' will be ignored.\n"
         "###\n"
@@ -97,7 +97,7 @@ msgid   "### This is a yaml representation of the image properties.\n"
         "###  description: My custom image"
 msgstr  ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid   "### This is a yaml representation of the network.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -116,7 +116,7 @@ msgid   "### This is a yaml representation of the network.\n"
         "### Note that only the configuration can be changed."
 msgstr  ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid   "### This is a yaml representation of the profile.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -136,7 +136,7 @@ msgid   "### This is a yaml representation of the profile.\n"
         "### Note that the name is shown but cannot be changed"
 msgstr  ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid   "### This is a yaml representation of the project.\n"
         "### Any line starting with a '# will be ignored.\n"
         "###\n"
@@ -177,7 +177,7 @@ msgstr  ""
 msgid   "'%s' isn't a supported file type"
 msgstr  ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid   "(none)"
 msgstr  ""
 
@@ -200,7 +200,7 @@ msgstr  ""
 msgid   "--container-only can't be passed when the source is a snapshot"
 msgstr  ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid   "--empty cannot be combined with an image name"
 msgstr  ""
 
@@ -216,7 +216,7 @@ msgstr  ""
 msgid   "--target cannot be used with instances"
 msgstr  ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid   "ALIAS"
 msgstr  ""
 
@@ -228,19 +228,19 @@ msgstr  ""
 msgid   "ARCH"
 msgstr  ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid   "ARCHITECTURE"
 msgstr  ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid   "AUTH TYPE"
 msgstr  ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid   "Accept certificate"
 msgstr  ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid   "Action (defaults to GET)"
 msgstr  ""
 
@@ -248,15 +248,15 @@ msgstr  ""
 msgid   "Add devices to containers or profiles"
 msgstr  ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid   "Add new aliases"
 msgstr  ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid   "Add new remote servers"
 msgstr  ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid   "Add new remote servers\n"
         "\n"
         "URL for remote resources must be HTTPS (https://).\n"
@@ -265,11 +265,11 @@ msgid   "Add new remote servers\n"
         "  lxc remote add some-name https://LOGIN:PASSWORD@example.com/some/path --protocol=simplestreams\n"
 msgstr  ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid   "Add new trusted clients"
 msgstr  ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid   "Add profiles to containers"
 msgstr  ""
 
@@ -278,22 +278,22 @@ msgstr  ""
 msgid   "Address: %s"
 msgstr  ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid   "Admin password for %s:"
 msgstr  ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid   "Alias %s already exists"
 msgstr  ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid   "Alias %s doesn't exist"
 msgstr  ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid   "Alias name missing"
 msgstr  ""
 
@@ -311,19 +311,19 @@ msgstr  ""
 msgid   "Architecture: %v"
 msgstr  ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid   "Assign sets of profiles to containers"
 msgstr  ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid   "Attach network interfaces to containers"
 msgstr  ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid   "Attach network interfaces to profiles"
 msgstr  ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid   "Attach new network interfaces to containers"
 msgstr  ""
 
@@ -346,7 +346,7 @@ msgid   "Attach to container consoles\n"
         "as well as retrieve past log entries from it."
 msgstr  ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid   "Authentication type '%s' not supported by server"
 msgstr  ""
@@ -361,7 +361,7 @@ msgstr  ""
 msgid   "Auto update: %s"
 msgstr  ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid   "BASE IMAGE"
 msgstr  ""
 
@@ -369,12 +369,12 @@ msgstr  ""
 msgid   "Backup exported successfully!"
 msgstr  ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid   "Bad key/value pair: %s"
 msgstr  ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176 lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176 lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid   "Bad key=value pair: %s"
 msgstr  ""
@@ -398,19 +398,19 @@ msgstr  ""
 msgid   "Brand: %v"
 msgstr  ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid   "Bytes received"
 msgstr  ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid   "Bytes sent"
 msgstr  ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid   "CANCELABLE"
 msgstr  ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid   "COMMON NAME"
 msgstr  ""
 
@@ -432,11 +432,11 @@ msgstr  ""
 msgid   "CPUs (%s):"
 msgstr  ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid   "CREATED"
 msgstr  ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid   "CREATED AT"
 msgstr  ""
 
@@ -454,7 +454,7 @@ msgstr  ""
 msgid   "Caches:"
 msgstr  ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid   "Can't override configuration or profiles in local rename"
 msgstr  ""
 
@@ -466,16 +466,16 @@ msgstr  ""
 msgid   "Can't pull a directory without --recursive"
 msgstr  ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid   "Can't read from stdin: %s"
 msgstr  ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid   "Can't remove the default remote"
 msgstr  ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid   "Can't specify --fast with --columns"
 msgstr  ""
 
@@ -483,7 +483,7 @@ msgstr  ""
 msgid   "Can't specify a different remote for rename"
 msgstr  ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid   "Can't specify column L when not clustered"
 msgstr  ""
 
@@ -496,7 +496,7 @@ msgstr  ""
 msgid   "Can't unset key '%s', it's not currently set"
 msgstr  ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid   "Candid domain to use"
 msgstr  ""
 
@@ -510,12 +510,12 @@ msgstr  ""
 msgid   "Card: %s (%s)"
 msgstr  ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid   "Certificate fingerprint: %s"
 msgstr  ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid   "Client certificate stored at server:"
 msgstr  ""
 
@@ -524,15 +524,15 @@ msgstr  ""
 msgid   "Client version: %s\n"
 msgstr  ""
 
-#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53 lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729 lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145 lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587 lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1292 lxc/storage_volume.go:1371 lxc/storage_volume.go:1464
+#: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584 lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54 lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730 lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146 lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588 lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305 lxc/storage_volume.go:465 lxc/storage_volume.go:542 lxc/storage_volume.go:784 lxc/storage_volume.go:981 lxc/storage_volume.go:1146 lxc/storage_volume.go:1176 lxc/storage_volume.go:1292 lxc/storage_volume.go:1371 lxc/storage_volume.go:1464
 msgid   "Cluster member name"
 msgstr  ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid   "Clustering enabled"
 msgstr  ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid   "Columns"
 msgstr  ""
 
@@ -547,19 +547,19 @@ msgid   "Command line client for LXD\n"
         "For help with any of those, simply call them with --help."
 msgstr  ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid   "Config key/value to apply to the new container"
 msgstr  ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid   "Config key/value to apply to the new project"
 msgstr  ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid   "Config key/value to apply to the target container"
 msgstr  ""
 
-#: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143 lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303 lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143 lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid   "Config parsing error: %s"
 msgstr  ""
@@ -572,11 +572,6 @@ msgstr  ""
 msgid   "Container name is mandatory"
 msgstr  ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid   "Container name is: %s"
-msgstr  ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid   "Container published with fingerprint: %s"
@@ -587,7 +582,7 @@ msgstr  ""
 msgid   "Control: %s (%s)"
 msgstr  ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid   "Copy a stateful container stateless"
 msgstr  ""
 
@@ -614,7 +609,7 @@ msgstr  ""
 msgid   "Copy profile inherited devices and override configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid   "Copy profiles"
 msgstr  ""
 
@@ -634,7 +629,7 @@ msgstr  ""
 msgid   "Copy the volume without its snapshots"
 msgstr  ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid   "Copy to a project different from the source"
 msgstr  ""
 
@@ -661,15 +656,15 @@ msgstr  ""
 msgid   "Cores:"
 msgstr  ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid   "Could not create server cert dir"
 msgstr  ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid   "Create aliases for existing images"
 msgstr  ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid   "Create an empty container"
 msgstr  ""
 
@@ -692,11 +687,11 @@ msgid   "Create container snapshots\n"
         "running state, including process memory state, TCP connections, ..."
 msgstr  ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid   "Create containers from images"
 msgstr  ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid   "Create new container file templates"
 msgstr  ""
 
@@ -704,24 +699,28 @@ msgstr  ""
 msgid   "Create new custom storage volumes"
 msgstr  ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid   "Create new networks"
 msgstr  ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid   "Create profiles"
 msgstr  ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid   "Create projects"
 msgstr  ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid   "Create storage pools"
 msgstr  ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid   "Create the container with no profiles applied"
+msgstr  ""
+
+#: lxc/init.go:57
+msgid   "Create virtual machine"
 msgstr  ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -729,13 +728,13 @@ msgstr  ""
 msgid   "Created: %s"
 msgstr  ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid   "Creating %s"
 msgstr  ""
 
-#: lxc/init.go:153
-msgid   "Creating the container"
+#: lxc/init.go:155
+msgid   "Creating the instance"
 msgstr  ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -743,15 +742,15 @@ msgstr  ""
 msgid   "Current number of VFs: %d"
 msgstr  ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid   "DATABASE"
 msgstr  ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869 lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870 lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid   "DESCRIPTION"
 msgstr  ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid   "DRIVER"
 msgstr  ""
 
@@ -767,11 +766,11 @@ msgstr  ""
 msgid   "Define a compression algorithm: for image or none"
 msgstr  ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid   "Delete a background operation (will attempt to cancel)"
 msgstr  ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid   "Delete container file templates"
 msgstr  ""
 
@@ -783,7 +782,7 @@ msgstr  ""
 msgid   "Delete files in containers"
 msgstr  ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid   "Delete image aliases"
 msgstr  ""
 
@@ -791,19 +790,19 @@ msgstr  ""
 msgid   "Delete images"
 msgstr  ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid   "Delete networks"
 msgstr  ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid   "Delete profiles"
 msgstr  ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid   "Delete projects"
 msgstr  ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid   "Delete storage pools"
 msgstr  ""
 
@@ -811,15 +810,15 @@ msgstr  ""
 msgid   "Delete storage volumes"
 msgstr  ""
 
-#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143 lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145 lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327 lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513 lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:28 lxc/config_template.go:65 lxc/config_template.go:108 lxc/config_template.go:150 lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28 lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193 lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311 lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104 lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28 lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31 lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325 lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668 lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960 lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142 lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101 lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163 lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403 lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711 lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28 lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333 lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583 lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30 lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454 lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32 lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332 lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650 lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1286 lxc/storage_volume.go:1362 lxc/storage_volume.go:1461 lxc/storage_volume.go:1492 lxc/storage_volume.go:1563 lxc/version.go:22
+#: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91 lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144 lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146 lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31 lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580 lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76 lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327 lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513 lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28 lxc/config_metadata.go:53 lxc/config_metadata.go:175 lxc/config_template.go:29 lxc/config_template.go:66 lxc/config_template.go:109 lxc/config_template.go:151 lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29 lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194 lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41 lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154 lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128 lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592 lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311 lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105 lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28 lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50 lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32 lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326 lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669 lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961 lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143 lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102 lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164 lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404 lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712 lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29 lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334 lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584 lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31 lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455 lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685 lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33 lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333 lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651 lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139 lxc/storage_volume.go:218 lxc/storage_volume.go:301 lxc/storage_volume.go:462 lxc/storage_volume.go:539 lxc/storage_volume.go:615 lxc/storage_volume.go:697 lxc/storage_volume.go:778 lxc/storage_volume.go:978 lxc/storage_volume.go:1069 lxc/storage_volume.go:1142 lxc/storage_volume.go:1173 lxc/storage_volume.go:1286 lxc/storage_volume.go:1362 lxc/storage_volume.go:1461 lxc/storage_volume.go:1492 lxc/storage_volume.go:1563 lxc/version.go:22
 msgid   "Description"
 msgstr  ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid   "Detach network interfaces from containers"
 msgstr  ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid   "Detach network interfaces from profiles"
 msgstr  ""
 
@@ -846,7 +845,7 @@ msgstr  ""
 msgid   "Device %s removed from %s"
 msgstr  ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid   "Device already exists: %s"
 msgstr  ""
@@ -856,8 +855,8 @@ msgstr  ""
 msgid   "Device: %s"
 msgstr  ""
 
-#: lxc/init.go:313
-msgid   "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid   "Didn't get any affected image, instance or snapshot from server"
 msgstr  ""
 
 #: lxc/image.go:607
@@ -893,7 +892,7 @@ msgstr  ""
 msgid   "Disks:"
 msgstr  ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid   "Don't require user confirmation for using --force"
 msgstr  ""
 
@@ -906,11 +905,11 @@ msgstr  ""
 msgid   "Driver: %v (%v)"
 msgstr  ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid   "EPHEMERAL"
 msgstr  ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid   "EXPIRY DATE"
 msgstr  ""
 
@@ -918,7 +917,7 @@ msgstr  ""
 msgid   "Early server side processing of file tranfer requests cannot be canceled (interrupt two more times to force)"
 msgstr  ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid   "Edit container file templates"
 msgstr  ""
 
@@ -938,19 +937,19 @@ msgstr  ""
 msgid   "Edit image properties"
 msgstr  ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid   "Edit network configurations as YAML"
 msgstr  ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid   "Edit profile configurations as YAML"
 msgstr  ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid   "Edit project configurations as YAML"
 msgstr  ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid   "Edit storage pool configurations as YAML"
 msgstr  ""
 
@@ -958,16 +957,16 @@ msgstr  ""
 msgid   "Edit storage volume configurations as YAML"
 msgstr  ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid   "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr  ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid   "Enable clustering on a single non-clustered LXD instance"
 msgstr  ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid   "Enable clustering on a single non-clustered LXD instance\n"
         "\n"
         "  This command turns a non-clustered LXD instance into the first member of a new\n"
@@ -982,11 +981,11 @@ msgstr  ""
 msgid   "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr  ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid   "Ephemeral container"
 msgstr  ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid   "Error updating template file: %s"
 msgstr  ""
@@ -1049,28 +1048,28 @@ msgstr  ""
 msgid   "Exporting the image: %s"
 msgstr  ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid   "FILENAME"
 msgstr  ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971 lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971 lxc/image_alias.go:232
 msgid   "FINGERPRINT"
 msgstr  ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid   "Failed to connect to cluster member"
 msgstr  ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid   "Failed to create alias %s"
 msgstr  ""
 
-#: lxc/copy.go:417
-msgid   "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid   "Failed to get the new instance name"
 msgstr  ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid   "Failed to remove alias %s"
 msgstr  ""
@@ -1080,11 +1079,11 @@ msgstr  ""
 msgid   "Failed to walk path for %s: %s"
 msgstr  ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid   "Fast mode (same as --columns=nsacPt)"
 msgstr  ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid   "Filtering isn't supported yet"
 msgstr  ""
 
@@ -1097,7 +1096,7 @@ msgstr  ""
 msgid   "Force pseudo-terminal allocation"
 msgstr  ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid   "Force removing a member, even if degraded"
 msgstr  ""
 
@@ -1113,7 +1112,7 @@ msgstr  ""
 msgid   "Force using the local unix socket"
 msgstr  ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid   "Forcefully removing a server from the cluster should only be done as a last\n"
         "resort.\n"
@@ -1132,7 +1131,7 @@ msgid   "Forcefully removing a server from the cluster should only be done as a 
         "Are you really sure you want to force removing %s? (yes/no): "
 msgstr  ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238 lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154 lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103 lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509 lxc/storage_volume.go:1071
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239 lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155 lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104 lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510 lxc/storage_volume.go:1071
 msgid   "Format (csv|json|table|yaml)"
 msgstr  ""
 
@@ -1163,11 +1162,11 @@ msgstr  ""
 msgid   "Generate manpages for all commands"
 msgstr  ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid   "Generating a client certificate. This may take a minute..."
 msgstr  ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid   "Get runtime information on networks"
 msgstr  ""
 
@@ -1179,19 +1178,19 @@ msgstr  ""
 msgid   "Get values for container or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid   "Get values for network configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid   "Get values for profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid   "Get values for project configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid   "Get values for storage pool configuration keys"
 msgstr  ""
 
@@ -1203,7 +1202,7 @@ msgstr  ""
 msgid   "Group ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid   "HOSTNAME"
 msgstr  ""
 
@@ -1211,7 +1210,7 @@ msgstr  ""
 msgid   "Hugepages:\n"
 msgstr  ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid   "ID"
 msgstr  ""
 
@@ -1225,23 +1224,23 @@ msgstr  ""
 msgid   "ID: %s"
 msgstr  ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid   "IMAGES"
 msgstr  ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid   "IP ADDRESS"
 msgstr  ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid   "IPV4"
 msgstr  ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid   "IPV6"
 msgstr  ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid   "ISSUE DATE"
 msgstr  ""
 
@@ -1314,49 +1313,54 @@ msgstr  ""
 msgid   "Infiniband:"
 msgstr  ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid   "Input data"
 msgstr  ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid   "Instance name is: %s"
+msgstr  ""
+
+#: lxc/init.go:53
 msgid   "Instance type"
 msgstr  ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid   "Invalid URL scheme \"%s\" in \"%s\""
 msgstr  ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid   "Invalid certificate"
 msgstr  ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid   "Invalid config key '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid   "Invalid config key column format (too many fields): '%s'"
 msgstr  ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid   "Invalid format %q"
 msgstr  ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid   "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid   "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr  ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid   "Invalid name in '%s', empty string is only allowed when defining maxWidth"
 msgstr  ""
@@ -1370,7 +1374,7 @@ msgstr  ""
 msgid   "Invalid path %s"
 msgstr  ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid   "Invalid protocol: %s"
 msgstr  ""
@@ -1385,7 +1389,7 @@ msgstr  ""
 msgid   "Invalid target %s"
 msgstr  ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid   "Ips:"
 msgstr  ""
 
@@ -1398,11 +1402,11 @@ msgstr  ""
 msgid   "Keep the image up to date after initial copy"
 msgstr  ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid   "LAST USED AT"
 msgstr  ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164 lxc/storage_volume.go:1123
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165 lxc/storage_volume.go:1123
 msgid   "LOCATION"
 msgstr  ""
 
@@ -1410,7 +1414,7 @@ msgstr  ""
 msgid   "LXD - Command line client"
 msgstr  ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid   "LXD server isn't part of a cluster"
 msgstr  ""
 
@@ -1433,27 +1437,27 @@ msgstr  ""
 msgid   "Link speed: %dMbit/s (%s duplex)"
 msgstr  ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid   "List DHCP leases"
 msgstr  ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid   "List aliases"
 msgstr  ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid   "List all the cluster members"
 msgstr  ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid   "List available networks"
 msgstr  ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid   "List available storage pools"
 msgstr  ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid   "List background operations"
 msgstr  ""
 
@@ -1461,15 +1465,15 @@ msgstr  ""
 msgid   "List container devices"
 msgstr  ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid   "List container file templates"
 msgstr  ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid   "List containers"
 msgstr  ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid   "List containers\n"
         "\n"
         "Default column layout: ns46tS\n"
@@ -1530,11 +1534,11 @@ msgid   "List containers\n"
         "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr  ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid   "List image aliases"
 msgstr  ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid   "List image aliases\n"
         "\n"
         "Filters may be part of the image hash or part of the image alias name.\n"
@@ -1570,11 +1574,11 @@ msgid   "List images\n"
         "    t - Type"
 msgstr  ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid   "List profiles"
 msgstr  ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid   "List projects"
 msgstr  ""
 
@@ -1582,15 +1586,15 @@ msgstr  ""
 msgid   "List storage volumes"
 msgstr  ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid   "List the available remotes"
 msgstr  ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid   "List trusted clients"
 msgstr  ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid   "List, show and delete background operations"
 msgstr  ""
 
@@ -1603,11 +1607,11 @@ msgstr  ""
 msgid   "Log:"
 msgstr  ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid   "MAC ADDRESS"
 msgstr  ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid   "MAC address: %s"
 msgstr  ""
@@ -1617,15 +1621,15 @@ msgstr  ""
 msgid   "MAD: %s (%s)"
 msgstr  ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid   "MANAGED"
 msgstr  ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid   "MESSAGE"
 msgstr  ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid   "MTU: %d"
 msgstr  ""
@@ -1638,15 +1642,15 @@ msgstr  ""
 msgid   "Make the image public"
 msgstr  ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid   "Manage and attach containers to networks"
 msgstr  ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid   "Manage cluster members"
 msgstr  ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid   "Manage command aliases"
 msgstr  ""
 
@@ -1658,7 +1662,7 @@ msgstr  ""
 msgid   "Manage container devices"
 msgstr  ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid   "Manage container file templates"
 msgstr  ""
 
@@ -1670,7 +1674,7 @@ msgstr  ""
 msgid   "Manage files in containers"
 msgstr  ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid   "Manage image aliases"
 msgstr  ""
 
@@ -1696,15 +1700,15 @@ msgid   "Manage images\n"
         "hash or alias name (if one is set)."
 msgstr  ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid   "Manage profiles"
 msgstr  ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid   "Manage projects"
 msgstr  ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid   "Manage storage pools and volumes"
 msgstr  ""
 
@@ -1718,11 +1722,11 @@ msgid   "Manage storage volumes\n"
         "Unless specified through a prefix, all volume operations affect \"custom\" (user created) volumes."
 msgstr  ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid   "Manage the list of remote servers"
 msgstr  ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid   "Manage trusted clients"
 msgstr  ""
 
@@ -1731,12 +1735,12 @@ msgstr  ""
 msgid   "Maximum number of VFs: %d"
 msgstr  ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid   "Member %s removed"
 msgstr  ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid   "Member %s renamed to %s"
 msgstr  ""
@@ -1757,11 +1761,11 @@ msgstr  ""
 msgid   "Memory:"
 msgstr  ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid   "Migration API failure"
 msgstr  ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid   "Migration operation failure"
 msgstr  ""
 
@@ -1769,11 +1773,11 @@ msgstr  ""
 msgid   "Minimum level for log messages"
 msgstr  ""
 
-#: lxc/config_metadata.go:101 lxc/config_metadata.go:199 lxc/config_template.go:89 lxc/config_template.go:132 lxc/config_template.go:174 lxc/config_template.go:261 lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_metadata.go:101 lxc/config_metadata.go:199 lxc/config_template.go:90 lxc/config_template.go:133 lxc/config_template.go:175 lxc/config_template.go:262 lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid   "Missing container name"
 msgstr  ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid   "Missing container.name name"
 msgstr  ""
 
@@ -1781,23 +1785,23 @@ msgstr  ""
 msgid   "Missing name"
 msgstr  ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399 lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752 lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039 lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400 lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753 lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040 lxc/network.go:1107
 msgid   "Missing network name"
 msgstr  ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413 lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163 lxc/storage_volume.go:242 lxc/storage_volume.go:487 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:820 lxc/storage_volume.go:1003 lxc/storage_volume.go:1094 lxc/storage_volume.go:1198 lxc/storage_volume.go:1313 lxc/storage_volume.go:1393 lxc/storage_volume.go:1515 lxc/storage_volume.go:1586
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414 lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163 lxc/storage_volume.go:242 lxc/storage_volume.go:487 lxc/storage_volume.go:563 lxc/storage_volume.go:639 lxc/storage_volume.go:721 lxc/storage_volume.go:820 lxc/storage_volume.go:1003 lxc/storage_volume.go:1094 lxc/storage_volume.go:1198 lxc/storage_volume.go:1313 lxc/storage_volume.go:1393 lxc/storage_volume.go:1515 lxc/storage_volume.go:1586
 msgid   "Missing pool name"
 msgstr  ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551 lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552 lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid   "Missing profile name"
 msgstr  ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357 lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358 lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid   "Missing project name"
 msgstr  ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid   "Missing source profile name"
 msgstr  ""
 
@@ -1829,7 +1833,7 @@ msgid   "Monitor a local or remote LXD server\n"
         "By default the monitor will listen to all message types."
 msgstr  ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659 lxc/storage_volume.go:740
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659 lxc/storage_volume.go:740
 msgid   "More than one device matches, specify the device name"
 msgstr  ""
 
@@ -1837,7 +1841,7 @@ msgstr  ""
 msgid   "More than one file to download, but target is not a directory"
 msgstr  ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid   "Move containers within or in between LXD instances"
 msgstr  ""
 
@@ -1845,11 +1849,11 @@ msgstr  ""
 msgid   "Move storage volumes between pools"
 msgstr  ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid   "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr  ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid   "Move the instance without its snapshots"
 msgstr  ""
 
@@ -1866,7 +1870,7 @@ msgstr  ""
 msgid   "Must supply container name for: "
 msgstr  ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619 lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557 lxc/storage_volume.go:1118
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620 lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558 lxc/storage_volume.go:1118
 msgid   "NAME"
 msgstr  ""
 
@@ -1878,7 +1882,7 @@ msgstr  ""
 msgid   "NICs:"
 msgstr  ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427 lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428 lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid   "NO"
 msgstr  ""
 
@@ -1900,7 +1904,7 @@ msgstr  ""
 msgid   "NVRM Version: %v"
 msgstr  ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid   "Name: %s"
 msgstr  ""
@@ -1910,31 +1914,31 @@ msgstr  ""
 msgid   "Name: %v"
 msgstr  ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid   "Network %s created"
 msgstr  ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid   "Network %s deleted"
 msgstr  ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid   "Network %s pending on member %s"
 msgstr  ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid   "Network %s renamed to %s"
 msgstr  ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid   "Network name"
 msgstr  ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid   "Network usage:"
 msgstr  ""
 
@@ -1946,11 +1950,11 @@ msgstr  ""
 msgid   "New aliases to add to the image"
 msgstr  ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid   "New key/value to apply to a specific device"
 msgstr  ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid   "No device found for this network"
 msgstr  ""
 
@@ -1984,7 +1988,7 @@ msgstr  ""
 msgid   "Only \"custom\" volumes can be snapshotted"
 msgstr  ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid   "Only https URLs are supported for simplestreams"
 msgstr  ""
 
@@ -1992,11 +1996,11 @@ msgstr  ""
 msgid   "Only https:// is supported for remote image import"
 msgstr  ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid   "Only managed networks can be modified"
 msgstr  ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid   "Operation %s deleted"
 msgstr  ""
@@ -2014,31 +2018,31 @@ msgstr  ""
 msgid   "PCI address: %v"
 msgstr  ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid   "PID"
 msgstr  ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid   "PROCESSES"
 msgstr  ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid   "PROFILES"
 msgstr  ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid   "PROTOCOL"
 msgstr  ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid   "PUBLIC"
 msgstr  ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid   "Packets received"
 msgstr  ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid   "Packets sent"
 msgstr  ""
 
@@ -2073,11 +2077,11 @@ msgstr  ""
 msgid   "Ports:"
 msgstr  ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303 lxc/storage_volume.go:918 lxc/storage_volume.go:948
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304 lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid   "Press enter to open the editor again"
 msgstr  ""
 
-#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144 lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144 lxc/config_template.go:204 lxc/image.go:415
 msgid   "Press enter to start the editor again"
 msgstr  ""
 
@@ -2089,7 +2093,7 @@ msgstr  ""
 msgid   "Print help"
 msgstr  ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid   "Print the raw response"
 msgstr  ""
 
@@ -2112,45 +2116,45 @@ msgstr  ""
 msgid   "Product: %v (%v)"
 msgstr  ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid   "Profile %s added to %s"
 msgstr  ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid   "Profile %s created"
 msgstr  ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid   "Profile %s deleted"
 msgstr  ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid   "Profile %s isn't currently applied to %s"
 msgstr  ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid   "Profile %s removed from %s"
 msgstr  ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid   "Profile %s renamed to %s"
 msgstr  ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid   "Profile to apply to the new container"
 msgstr  ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid   "Profile to apply to the target container"
 msgstr  ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid   "Profiles %s applied to %s"
 msgstr  ""
@@ -2160,17 +2164,17 @@ msgstr  ""
 msgid   "Profiles: %s"
 msgstr  ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid   "Project %s created"
 msgstr  ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid   "Project %s deleted"
 msgstr  ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid   "Project %s renamed to %s"
 msgstr  ""
@@ -2179,7 +2183,7 @@ msgstr  ""
 msgid   "Properties:"
 msgstr  ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid   "Public image server"
 msgstr  ""
 
@@ -2242,27 +2246,27 @@ msgstr  ""
 msgid   "Refreshing the image: %s"
 msgstr  ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid   "Remote %s already exists"
 msgstr  ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666 lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667 lxc/remote.go:705
 #, c-format
 msgid   "Remote %s doesn't exist"
 msgstr  ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid   "Remote %s exists as <%s>"
 msgstr  ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid   "Remote %s is static and cannot be modified"
 msgstr  ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid   "Remote admin password"
 msgstr  ""
 
@@ -2285,11 +2289,11 @@ msgstr  ""
 msgid   "Remove %s (yes/no): "
 msgstr  ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid   "Remove a member from the cluster"
 msgstr  ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid   "Remove aliases"
 msgstr  ""
 
@@ -2297,23 +2301,23 @@ msgstr  ""
 msgid   "Remove container devices"
 msgstr  ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid   "Remove profiles from containers"
 msgstr  ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid   "Remove remotes"
 msgstr  ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid   "Remove trusted clients"
 msgstr  ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid   "Rename a cluster member"
 msgstr  ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250 lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251 lxc/image_alias.go:252
 msgid   "Rename aliases"
 msgstr  ""
 
@@ -2321,19 +2325,19 @@ msgstr  ""
 msgid   "Rename containers and snapshots"
 msgstr  ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid   "Rename networks"
 msgstr  ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid   "Rename profiles"
 msgstr  ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid   "Rename projects"
 msgstr  ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid   "Rename remotes"
 msgstr  ""
 
@@ -2391,7 +2395,7 @@ msgstr  ""
 msgid   "Retrieve the container's console log"
 msgstr  ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid   "Retrieving image: %s"
 msgstr  ""
@@ -2404,11 +2408,11 @@ msgstr  ""
 msgid   "SIZE"
 msgstr  ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid   "SNAPSHOTS"
 msgstr  ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid   "SOURCE"
 msgstr  ""
 
@@ -2416,39 +2420,39 @@ msgstr  ""
 msgid   "SR-IOV information:"
 msgstr  ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid   "STATE"
 msgstr  ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid   "STATIC"
 msgstr  ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid   "STATUS"
 msgstr  ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid   "STORAGE POOL"
 msgstr  ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid   "Send a raw query to LXD"
 msgstr  ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid   "Server authentication type (tls or candid)"
 msgstr  ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid   "Server certificate NACKed by user"
 msgstr  ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid   "Server doesn't trust us after authentication"
 msgstr  ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid   "Server protocol (lxd or simplestreams)"
 msgstr  ""
 
@@ -2486,44 +2490,44 @@ msgid   "Set container or server configuration keys\n"
         "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr  ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid   "Set network configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid   "Set network configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr  ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid   "Set profile configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid   "Set profile configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr  ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid   "Set project configuration keys"
 msgstr  ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid   "Set project configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
         "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr  ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid   "Set storage pool configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid   "Set storage pool configuration keys\n"
         "\n"
         "For backward compatibility, a single configuration key may still be set with:\n"
@@ -2541,7 +2545,7 @@ msgid   "Set storage volume configuration keys\n"
         "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr  ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid   "Set the URL for the remote"
 msgstr  ""
 
@@ -2577,15 +2581,15 @@ msgstr  ""
 msgid   "Show container or server information"
 msgstr  ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid   "Show content of container file templates"
 msgstr  ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid   "Show details of a cluster member"
 msgstr  ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid   "Show details on a background operation"
 msgstr  ""
 
@@ -2605,19 +2609,19 @@ msgstr  ""
 msgid   "Show local and remote versions"
 msgstr  ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid   "Show network configurations"
 msgstr  ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid   "Show profile configurations"
 msgstr  ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid   "Show project options"
 msgstr  ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid   "Show storage pool configurations and resources"
 msgstr  ""
 
@@ -2633,7 +2637,7 @@ msgstr  ""
 msgid   "Show the container's last 100 log lines?"
 msgstr  ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid   "Show the default remote"
 msgstr  ""
 
@@ -2645,11 +2649,11 @@ msgstr  ""
 msgid   "Show the resources available to the server"
 msgstr  ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid   "Show the resources available to the storage pool"
 msgstr  ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid   "Show the used and free space in bytes"
 msgstr  ""
 
@@ -2657,7 +2661,7 @@ msgstr  ""
 msgid   "Show useful information about images"
 msgstr  ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid   "Show useful information about storage pools"
 msgstr  ""
 
@@ -2702,7 +2706,7 @@ msgstr  ""
 msgid   "Starting %s"
 msgstr  ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid   "State: %s"
 msgstr  ""
@@ -2729,22 +2733,22 @@ msgstr  ""
 msgid   "Stopping the container failed: %s"
 msgstr  ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid   "Storage pool %s created"
 msgstr  ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid   "Storage pool %s deleted"
 msgstr  ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid   "Storage pool %s pending on member %s"
 msgstr  ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid   "Storage pool name"
 msgstr  ""
 
@@ -2788,35 +2792,35 @@ msgstr  ""
 msgid   "Swap (peak)"
 msgstr  ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid   "Switch the current project"
 msgstr  ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid   "Switch the default remote"
 msgstr  ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid   "TARGET"
 msgstr  ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867 lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868 lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid   "TYPE"
 msgstr  ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid   "The --container-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid   "The --instance-only flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid   "The --mode flag can't be used with --target"
 msgstr  ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid   "The --stateless flag can't be used with --target"
 msgstr  ""
 
@@ -2828,7 +2832,7 @@ msgstr  ""
 msgid   "The container is currently running. Use --force to have it stopped and restarted"
 msgstr  ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid   "The container you are starting doesn't have any network attached to it."
 msgstr  ""
 
@@ -2840,12 +2844,12 @@ msgstr  ""
 msgid   "The device doesn't exist"
 msgstr  ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr  ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid   "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr  ""
@@ -2854,15 +2858,15 @@ msgstr  ""
 msgid   "The profile device doesn't exist"
 msgstr  ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid   "The source LXD instance is not clustered"
 msgstr  ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673 lxc/storage_volume.go:754
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673 lxc/storage_volume.go:754
 msgid   "The specified device doesn't exist"
 msgstr  ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid   "The specified device doesn't match the network"
 msgstr  ""
 
@@ -2890,11 +2894,11 @@ msgstr  ""
 msgid   "Timestamps:"
 msgstr  ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid   "To attach a network to a container, use: lxc network attach"
 msgstr  ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid   "To create a new network, use: lxc network create"
 msgstr  ""
 
@@ -2906,7 +2910,7 @@ msgstr  ""
 msgid   "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr  ""
 
-#: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617 lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617 lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid   "To use --target, the destination remote must be a cluster"
 msgstr  ""
 
@@ -2928,7 +2932,7 @@ msgstr  ""
 msgid   "Transfer mode. One of pull (default), push or relay"
 msgstr  ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid   "Transfer mode. One of pull (default), push or relay."
 msgstr  ""
 
@@ -2961,11 +2965,11 @@ msgstr  ""
 msgid   "UPLOAD DATE"
 msgstr  ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid   "URL"
 msgstr  ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566 lxc/storage_volume.go:1120
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567 lxc/storage_volume.go:1120
 msgid   "USED BY"
 msgstr  ""
 
@@ -2979,7 +2983,7 @@ msgstr  ""
 msgid   "Unable to create a temporary file: %v"
 msgstr  ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid   "Unknown column shorthand char '%c' in '%s'"
 msgstr  ""
@@ -2989,7 +2993,7 @@ msgstr  ""
 msgid   "Unknown file type '%s'"
 msgstr  ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid   "Unset all profiles on the target container"
 msgstr  ""
 
@@ -3001,19 +3005,19 @@ msgstr  ""
 msgid   "Unset container or server configuration keys"
 msgstr  ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid   "Unset network configuration keys"
 msgstr  ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid   "Unset profile configuration keys"
 msgstr  ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid   "Unset project configuration keys"
 msgstr  ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid   "Unset storage pool configuration keys"
 msgstr  ""
 
@@ -3039,7 +3043,7 @@ msgstr  ""
 msgid   "User ID to run the command as (default 0)"
 msgstr  ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid   "User aborted delete operation"
 msgstr  ""
 
@@ -3072,7 +3076,7 @@ msgstr  ""
 msgid   "WWN: %s"
 msgstr  ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid   "Wait for the operation to complete"
 msgstr  ""
 
@@ -3092,7 +3096,7 @@ msgstr  ""
 msgid   "Whether or not to snapshot the container's running state"
 msgstr  ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429 lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430 lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid   "YES"
 msgstr  ""
 
@@ -3108,19 +3112,19 @@ msgstr  ""
 msgid   "You must specify a destination container name when using --target"
 msgstr  ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid   "You must specify a source container name"
 msgstr  ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid   "add <alias> <target>"
 msgstr  ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid   "add [<remote>:] <cert>"
 msgstr  ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid   "add [<remote>:]<container> <profile>"
 msgstr  ""
 
@@ -3128,19 +3132,19 @@ msgstr  ""
 msgid   "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr  ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid   "add [<remote>] <IP|FQDN|URL>"
 msgstr  ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid   "alias"
 msgstr  ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid   "assign [<remote>:]<container> <profiles>"
 msgstr  ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid   "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr  ""
 
@@ -3152,11 +3156,11 @@ msgstr  ""
 msgid   "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr  ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid   "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface name>]"
 msgstr  ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid   "cluster"
 msgstr  ""
 
@@ -3176,7 +3180,7 @@ msgstr  ""
 msgid   "copy [<remote>:]<image> <remote>:"
 msgstr  ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid   "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr  ""
 
@@ -3184,19 +3188,19 @@ msgstr  ""
 msgid   "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr  ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid   "create [<remote>:]<alias> <fingerprint>"
 msgstr  ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid   "create [<remote>:]<container> <template>"
 msgstr  ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid   "create [<remote>:]<network> [key=value...]"
 msgstr  ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid   "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr  ""
 
@@ -3204,27 +3208,27 @@ msgstr  ""
 msgid   "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr  ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid   "create [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid   "create [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid   "current"
 msgstr  ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid   "default"
 msgstr  ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid   "delete [<remote>:]<alias>"
 msgstr  ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid   "delete [<remote>:]<container> <template>"
 msgstr  ""
 
@@ -3240,15 +3244,15 @@ msgstr  ""
 msgid   "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid   "delete [<remote>:]<network>"
 msgstr  ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid   "delete [<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid   "delete [<remote>:]<pool>"
 msgstr  ""
 
@@ -3256,19 +3260,19 @@ msgstr  ""
 msgid   "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid   "delete [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid   "delete [<remote>:]<project>"
 msgstr  ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid   "description"
 msgstr  ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid   "detach [<remote>:]<network> <container> [<device name>]"
 msgstr  ""
 
@@ -3280,7 +3284,7 @@ msgstr  ""
 msgid   "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr  ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid   "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr  ""
 
@@ -3292,7 +3296,7 @@ msgstr  ""
 msgid   "disabled"
 msgstr  ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid   "driver"
 msgstr  ""
 
@@ -3300,7 +3304,7 @@ msgstr  ""
 msgid   "edit [<remote>:]<container>"
 msgstr  ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid   "edit [<remote>:]<container> <template>"
 msgstr  ""
 
@@ -3312,11 +3316,11 @@ msgstr  ""
 msgid   "edit [<remote>:]<image>"
 msgstr  ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid   "edit [<remote>:]<network>"
 msgstr  ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid   "edit [<remote>:]<pool>"
 msgstr  ""
 
@@ -3324,11 +3328,11 @@ msgstr  ""
 msgid   "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid   "edit [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid   "edit [<remote>:]<project>"
 msgstr  ""
 
@@ -3336,7 +3340,7 @@ msgstr  ""
 msgid   "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid   "enable [<remote>:] <name>"
 msgstr  ""
 
@@ -3374,11 +3378,11 @@ msgstr  ""
 msgid   "get [<remote>:]<container|profile> <device> <key>"
 msgstr  ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid   "get [<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid   "get [<remote>:]<pool> <key>"
 msgstr  ""
 
@@ -3386,11 +3390,11 @@ msgstr  ""
 msgid   "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr  ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid   "get [<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid   "get [<remote>:]<project> <key>"
 msgstr  ""
 
@@ -3398,7 +3402,7 @@ msgstr  ""
 msgid   "get [<remote>:][<container>] <key>"
 msgstr  ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid   "get-default"
 msgstr  ""
 
@@ -3414,7 +3418,7 @@ msgstr  ""
 msgid   "import [<remote>:] <backup file>"
 msgstr  ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid   "info"
 msgstr  ""
 
@@ -3422,11 +3426,11 @@ msgstr  ""
 msgid   "info [<remote>:]<image>"
 msgstr  ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid   "info [<remote>:]<network>"
 msgstr  ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid   "info [<remote>:]<pool>"
 msgstr  ""
 
@@ -3434,7 +3438,7 @@ msgstr  ""
 msgid   "info [<remote>:][<container>]"
 msgstr  ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid   "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr  ""
 
@@ -3442,23 +3446,23 @@ msgstr  ""
 msgid   "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr  ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid   "list"
 msgstr  ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803 lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804 lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid   "list [<remote>:]"
 msgstr  ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid   "list [<remote>:] [<filter>...]"
 msgstr  ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid   "list [<remote>:] [<filters>...]"
 msgstr  ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid   "list [<remote>:]<container>"
 msgstr  ""
 
@@ -3470,21 +3474,21 @@ msgstr  ""
 msgid   "list [<remote>:]<pool>"
 msgstr  ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid   "list-leases [<remote>:]<network>"
 msgstr  ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid   "lxc alias add list \"list -c ns46S\"\n"
         "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr  ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid   "lxc alias remove my-list\n"
         "    Remove the \"my-list\" alias."
 msgstr  ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid   "lxc alias rename list my-list\n"
         "    Rename existing alias \"list\" to \"my-list\"."
 msgstr  ""
@@ -3546,7 +3550,7 @@ msgid   "lxc info [<remote>:]<container> [--show-log]\n"
         "    For LXD server information."
 msgstr  ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid   "lxc init ubuntu:16.04 u1\n"
         "\n"
         "lxc init ubuntu:16.04 u1 < config.yaml\n"
@@ -3560,7 +3564,7 @@ msgid   "lxc launch ubuntu:16.04 u1\n"
         "    Create and start the container with configuration from config.yaml"
 msgstr  ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid   "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0.parent:ETHP\n"
         "  Show containers using the \"NAME\", \"BASE IMAGE\", \"STATE\", \"IPV4\", \"IPV6\" and \"MAC\" columns.\n"
         "  \"BASE IMAGE\", \"MAC\" and \"IMAGE OS\" are custom columns generated from container configuration keys.\n"
@@ -3581,7 +3585,7 @@ msgid   "lxc monitor --type=logging\n"
         "    Only show lifecycle events."
 msgstr  ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid   "lxc move [<remote>:]<source container> [<remote>:][<destination container>] [--container-only]\n"
         "    Move a container between two hosts, renaming it if destination name differs.\n"
         "\n"
@@ -3592,12 +3596,12 @@ msgid   "lxc move [<remote>:]<source container> [<remote>:][<destination contain
         "    Rename a snapshot."
 msgstr  ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid   "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
         "    Show details on that operation UUID"
 msgstr  ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid   "lxc profile assign foo default,bar\n"
         "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
         "\n"
@@ -3613,17 +3617,17 @@ msgid   "lxc profile device add [<remote>:]profile1 <device-name> disk source=/s
         "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr  ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid   "lxc profile edit <profile> < profile.yaml\n"
         "    Update a profile using the content of profile.yaml"
 msgstr  ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid   "lxc project edit <project> < project.yaml\n"
         "    Update a project using the content of project.yaml"
 msgstr  ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid   "lxc query -X DELETE --wait /1.0/containers/c1\n"
         "    Delete local container \"c1\"."
 msgstr  ""
@@ -3641,7 +3645,7 @@ msgid   "lxc snapshot u1 snap0\n"
         "    Restore the snapshot."
 msgstr  ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid   "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
         "    Update a storage pool using the content of pool.yaml."
 msgstr  ""
@@ -3675,15 +3679,15 @@ msgstr  ""
 msgid   "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr  ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid   "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/<snapshot>]]"
 msgstr  ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid   "name"
 msgstr  ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid   "network"
 msgstr  ""
 
@@ -3691,11 +3695,11 @@ msgstr  ""
 msgid   "no"
 msgstr  ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid   "ok (y/n)?"
 msgstr  ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid   "operation"
 msgstr  ""
 
@@ -3711,11 +3715,11 @@ msgstr  ""
 msgid   "please use `lxc profile`"
 msgstr  ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid   "profile"
 msgstr  ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid   "project"
 msgstr  ""
 
@@ -3731,7 +3735,7 @@ msgstr  ""
 msgid   "push <source path> [<remote>:]<container>/<path> [[<remote>:]<container>/<path>...]"
 msgstr  ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid   "query [<remote>:]<API path>"
 msgstr  ""
 
@@ -3739,23 +3743,23 @@ msgstr  ""
 msgid   "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr  ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid   "remote"
 msgstr  ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid   "remove <alias>"
 msgstr  ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid   "remove <remote>"
 msgstr  ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid   "remove [<remote>:] <hostname|fingerprint>"
 msgstr  ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid   "remove [<remote>:]<container> <profile>"
 msgstr  ""
 
@@ -3763,19 +3767,19 @@ msgstr  ""
 msgid   "remove [<remote>:]<container|profile> <name>..."
 msgstr  ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid   "remove [<remote>:]<member>"
 msgstr  ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid   "rename <old alias> <new alias>"
 msgstr  ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid   "rename <remote> <new-name>"
 msgstr  ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid   "rename [<remote>:]<alias> <new-name>"
 msgstr  ""
 
@@ -3783,11 +3787,11 @@ msgstr  ""
 msgid   "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid   "rename [<remote>:]<member> <new-name>"
 msgstr  ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid   "rename [<remote>:]<network> <new-name>"
 msgstr  ""
 
@@ -3795,11 +3799,11 @@ msgstr  ""
 msgid   "rename [<remote>:]<pool> <old name>[/<old snapshot name>] <new name>[/<new snapshot name>]"
 msgstr  ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid   "rename [<remote>:]<profile> <new-name>"
 msgstr  ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid   "rename [<remote>:]<project> <new-name>"
 msgstr  ""
 
@@ -3819,11 +3823,11 @@ msgstr  ""
 msgid   "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr  ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid   "set [<remote>:]<network> <key>=<value>..."
 msgstr  ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid   "set [<remote>:]<pool> <key> <value>"
 msgstr  ""
 
@@ -3831,11 +3835,11 @@ msgstr  ""
 msgid   "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr  ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid   "set [<remote>:]<profile> <key><value>..."
 msgstr  ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid   "set [<remote>:]<project> <key>=<value>..."
 msgstr  ""
 
@@ -3843,7 +3847,7 @@ msgstr  ""
 msgid   "set [<remote>:][<container>] <key>=<value>..."
 msgstr  ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid   "set-url <remote> <URL>"
 msgstr  ""
 
@@ -3851,7 +3855,7 @@ msgstr  ""
 msgid   "show [<remote>:]<container>"
 msgstr  ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid   "show [<remote>:]<container> <template>"
 msgstr  ""
 
@@ -3863,19 +3867,19 @@ msgstr  ""
 msgid   "show [<remote>:]<image>"
 msgstr  ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid   "show [<remote>:]<member>"
 msgstr  ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid   "show [<remote>:]<network>"
 msgstr  ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid   "show [<remote>:]<operation>"
 msgstr  ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid   "show [<remote>:]<pool>"
 msgstr  ""
 
@@ -3883,11 +3887,11 @@ msgstr  ""
 msgid   "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr  ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid   "show [<remote>:]<profile>"
 msgstr  ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid   "show [<remote>:]<project>"
 msgstr  ""
 
@@ -3903,7 +3907,7 @@ msgstr  ""
 msgid   "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr  ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid   "space used"
 msgstr  ""
 
@@ -3923,15 +3927,15 @@ msgstr  ""
 msgid   "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr  ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid   "storage"
 msgstr  ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid   "switch <remote>"
 msgstr  ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid   "switch [<remote>:] <project>"
 msgstr  ""
 
@@ -3940,15 +3944,15 @@ msgstr  ""
 msgid   "taken at %s"
 msgstr  ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid   "template"
 msgstr  ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid   "total space"
 msgstr  ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid   "trust"
 msgstr  ""
 
@@ -3960,11 +3964,11 @@ msgstr  ""
 msgid   "unset [<remote>:]<container|profile> <device> <key>"
 msgstr  ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid   "unset [<remote>:]<network> <key>"
 msgstr  ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid   "unset [<remote>:]<pool> <key>"
 msgstr  ""
 
@@ -3972,11 +3976,11 @@ msgstr  ""
 msgid   "unset [<remote>:]<pool> <volume> <key>"
 msgstr  ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid   "unset [<remote>:]<profile> <key>"
 msgstr  ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid   "unset [<remote>:]<project> <key>"
 msgstr  ""
 
@@ -3984,7 +3988,7 @@ msgstr  ""
 msgid   "unset [<remote>:][<container>] <key>"
 msgstr  ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid   "used by"
 msgstr  ""
 
@@ -3996,11 +4000,11 @@ msgstr  ""
 msgid   "volume"
 msgstr  ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid   "y"
 msgstr  ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854 lxc/image.go:1028
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854 lxc/image.go:1028
 msgid   "yes"
 msgstr  ""
 

--- a/po/nb_NO.po
+++ b/po/nb_NO.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/nl.po
+++ b/po/nl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Dutch <https://hosted.weblate.org/projects/linux-containers/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -151,7 +151,7 @@ msgstr ""
 "### Bijvoorbeeld:\n"
 "###  description: Mijn eigen image"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -171,7 +171,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -192,7 +192,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(geen)"
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -285,19 +285,19 @@ msgstr ""
 msgid "ARCH"
 msgstr "ARCHITECTUUR"
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARCHITECTUUR"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -305,15 +305,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -325,11 +325,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -338,22 +338,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -371,19 +371,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -430,13 +430,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -460,19 +460,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -494,11 +494,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -528,16 +528,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -572,12 +572,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -587,11 +587,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -600,11 +600,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -620,21 +620,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -647,11 +647,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -690,7 +685,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -711,7 +706,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -738,15 +733,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -770,11 +765,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -782,24 +777,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -807,13 +806,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -821,16 +820,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -846,11 +845,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -862,7 +861,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -870,19 +869,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -891,46 +890,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -942,11 +941,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -973,7 +972,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -983,8 +982,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1020,7 +1019,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1033,11 +1032,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1047,7 +1046,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1067,19 +1066,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1087,16 +1086,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1115,11 +1114,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1185,29 +1184,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1217,11 +1216,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1234,7 +1233,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1250,7 +1249,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1274,10 +1273,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1309,11 +1308,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1325,19 +1324,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1349,7 +1348,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1357,7 +1356,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1371,23 +1370,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1463,49 +1462,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1520,7 +1524,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1535,7 +1539,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1548,11 +1552,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1561,7 +1565,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1584,27 +1588,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1612,15 +1616,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1687,11 +1691,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1729,11 +1733,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1741,15 +1745,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1762,11 +1766,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1776,15 +1780,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1797,15 +1801,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1817,7 +1821,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1829,7 +1833,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1856,15 +1860,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1880,11 +1884,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1893,12 +1897,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1919,11 +1923,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1932,13 +1936,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1948,15 +1952,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1967,17 +1971,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2010,7 +2014,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2019,7 +2023,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2027,12 +2031,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2049,8 +2053,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2063,8 +2067,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2086,7 +2090,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2096,31 +2100,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2132,11 +2136,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2170,7 +2174,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2178,11 +2182,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2200,31 +2204,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2259,13 +2263,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2277,7 +2281,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2300,45 +2304,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2348,17 +2352,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2367,7 +2371,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2430,28 +2434,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2474,11 +2478,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2486,24 +2490,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2511,19 +2515,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2583,7 +2587,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2596,11 +2600,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2608,39 +2612,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2684,11 +2688,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2697,11 +2701,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2710,11 +2714,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2723,11 +2727,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2749,7 +2753,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2785,15 +2789,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2813,19 +2817,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2841,7 +2845,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2853,11 +2857,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2910,7 +2914,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2937,22 +2941,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2996,36 +3000,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3039,7 +3043,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3052,12 +3056,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3066,16 +3070,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3107,11 +3111,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3124,7 +3128,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3146,7 +3150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3179,11 +3183,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3198,7 +3202,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3208,7 +3212,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3220,19 +3224,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3259,7 +3263,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3293,7 +3297,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3317,8 +3321,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3334,19 +3338,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3354,19 +3358,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3380,13 +3384,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3406,7 +3410,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3414,19 +3418,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3434,27 +3438,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3472,15 +3476,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3488,19 +3492,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3512,7 +3516,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3524,7 +3528,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3532,7 +3536,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3544,11 +3548,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3556,11 +3560,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3568,7 +3572,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3608,11 +3612,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3620,11 +3624,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3632,7 +3636,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3650,7 +3654,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3658,11 +3662,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3670,7 +3674,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3678,24 +3682,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3707,23 +3711,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3797,7 +3801,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3813,7 +3817,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3839,7 +3843,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,13 +3857,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3878,19 +3882,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3911,7 +3915,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3950,17 +3954,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3968,11 +3972,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3988,11 +3992,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4014,7 +4018,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4022,23 +4026,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4046,19 +4050,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4066,11 +4070,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4080,11 +4084,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4104,11 +4108,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4116,11 +4120,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4128,7 +4132,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4136,7 +4140,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4148,19 +4152,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4168,11 +4172,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4188,7 +4192,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4208,15 +4212,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4225,15 +4229,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4245,11 +4249,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4257,11 +4261,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4269,7 +4273,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4281,11 +4285,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/pa.po
+++ b/po/pa.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/pl.po
+++ b/po/pl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2018-09-08 19:22+0000\n"
 "Last-Translator: m4sk1n <me@m4sk.in>\n"
 "Language-Team: Polish <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "|| n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.2-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -133,7 +133,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -153,7 +153,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -174,7 +174,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -234,7 +234,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -257,7 +257,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -273,7 +273,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -285,19 +285,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -305,15 +305,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -325,11 +325,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -338,22 +338,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -371,19 +371,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -407,7 +407,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -422,7 +422,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -430,13 +430,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -460,19 +460,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -494,11 +494,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -516,7 +516,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -528,16 +528,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -545,7 +545,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -558,7 +558,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -572,12 +572,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -587,11 +587,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -600,11 +600,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -620,21 +620,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -647,11 +647,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -690,7 +685,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -711,7 +706,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -738,15 +733,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -770,11 +765,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -782,24 +777,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -807,13 +806,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -821,16 +820,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -846,11 +845,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -862,7 +861,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -870,19 +869,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -891,46 +890,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -942,11 +941,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -973,7 +972,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -983,8 +982,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1020,7 +1019,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1033,11 +1032,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1047,7 +1046,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1067,19 +1066,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1087,16 +1086,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1115,11 +1114,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1185,29 +1184,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1217,11 +1216,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1234,7 +1233,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1250,7 +1249,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1274,10 +1273,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1309,11 +1308,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1325,19 +1324,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1349,7 +1348,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1357,7 +1356,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1371,23 +1370,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1463,49 +1462,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1520,7 +1524,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1535,7 +1539,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1548,11 +1552,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1561,7 +1565,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1584,27 +1588,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1612,15 +1616,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1687,11 +1691,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1729,11 +1733,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1741,15 +1745,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1762,11 +1766,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1776,15 +1780,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1797,15 +1801,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1817,7 +1821,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1829,7 +1833,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1856,15 +1860,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1880,11 +1884,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1893,12 +1897,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1919,11 +1923,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1932,13 +1936,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1948,15 +1952,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1967,17 +1971,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2010,7 +2014,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2019,7 +2023,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2027,12 +2031,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2049,8 +2053,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2063,8 +2067,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2086,7 +2090,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2096,31 +2100,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2132,11 +2136,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2170,7 +2174,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2178,11 +2182,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2200,31 +2204,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2259,13 +2263,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2277,7 +2281,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2300,45 +2304,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2348,17 +2352,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2367,7 +2371,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2430,28 +2434,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2474,11 +2478,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2486,24 +2490,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2511,19 +2515,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2583,7 +2587,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2596,11 +2600,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2608,39 +2612,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2684,11 +2688,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2697,11 +2701,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2710,11 +2714,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2723,11 +2727,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2749,7 +2753,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2785,15 +2789,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2813,19 +2817,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2841,7 +2845,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2853,11 +2857,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2865,7 +2869,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2910,7 +2914,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2937,22 +2941,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2996,36 +3000,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3039,7 +3043,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3052,12 +3056,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3066,16 +3070,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3107,11 +3111,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3124,7 +3128,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3146,7 +3150,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3179,11 +3183,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3198,7 +3202,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3208,7 +3212,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3220,19 +3224,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3259,7 +3263,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3293,7 +3297,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3317,8 +3321,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3334,19 +3338,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3354,19 +3358,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3380,13 +3384,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3406,7 +3410,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3414,19 +3418,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3434,27 +3438,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3472,15 +3476,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3488,19 +3492,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3512,7 +3516,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3524,7 +3528,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3532,7 +3536,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3544,11 +3548,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3556,11 +3560,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3568,7 +3572,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3608,11 +3612,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3620,11 +3624,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3632,7 +3636,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3650,7 +3654,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3658,11 +3662,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3670,7 +3674,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3678,24 +3682,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3707,23 +3711,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3797,7 +3801,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3813,7 +3817,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3839,7 +3843,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3853,13 +3857,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3878,19 +3882,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3911,7 +3915,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3950,17 +3954,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3968,11 +3972,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3988,11 +3992,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4014,7 +4018,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4022,23 +4026,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4046,19 +4050,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4066,11 +4070,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4080,11 +4084,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4104,11 +4108,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4116,11 +4120,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4128,7 +4132,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4136,7 +4140,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4148,19 +4152,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4168,11 +4172,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4188,7 +4192,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4208,15 +4212,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4225,15 +4229,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4245,11 +4249,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4257,11 +4261,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4269,7 +4273,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4281,11 +4285,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2019-09-06 07:09+0000\n"
 "Last-Translator: Stéphane Graber <stgraber@stgraber.org>\n"
 "Language-Team: Portuguese (Brazil) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 3.9-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -173,7 +173,7 @@ msgstr ""
 "# # # um exemplo seria:\n"
 "# # # Descrição: Minha imagem personalizada"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -209,7 +209,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado."
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -247,7 +247,7 @@ msgstr ""
 "###\n"
 "### Note que o nome é exibido, porém não pode ser alterado"
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -304,7 +304,7 @@ msgstr "%v (interrompa mais duas vezes para forçar)"
 msgid "'%s' isn't a supported file type"
 msgstr "'%s' não é um tipo de arquivo suportado"
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(nenhum)"
 
@@ -327,7 +327,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr "--container-only não pode ser passado quando a fonte é um snapshot"
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 #, fuzzy
 msgid "--empty cannot be combined with an image name"
 msgstr "--refresh só pode ser usado com containers"
@@ -346,7 +346,7 @@ msgstr "--refresh só pode ser usado com containers"
 msgid "--target cannot be used with instances"
 msgstr "--refresh só pode ser usado com containers"
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ALIAS"
 
@@ -358,19 +358,19 @@ msgstr "ALIASES"
 msgid "ARCH"
 msgstr "ARQUITETURA"
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "ARQUITETURA"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr "TIPO DE AUTENTICAÇÃO"
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Aceitar certificado"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr "Ação (padrão para o GET)"
 
@@ -378,15 +378,15 @@ msgstr "Ação (padrão para o GET)"
 msgid "Add devices to containers or profiles"
 msgstr "Adicionar dispositivos aos containers ou perfis"
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr "Adicionar novo aliases"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr "Adicionar novos servidores remoto"
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -398,11 +398,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr "Adicionar novos clientes confiáveis"
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr "Adicionar perfis aos containers"
 
@@ -411,22 +411,22 @@ msgstr "Adicionar perfis aos containers"
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Senha de administrador para %s: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr "Alias %s já existe"
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr "Alias %s não existe"
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr "Nome do alias ausente"
 
@@ -444,19 +444,19 @@ msgstr "Arquitetura: %s"
 msgid "Architecture: %v"
 msgstr "Arquitetura: %v"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr "Atribuir conjuntos de perfis aos containers"
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr "Anexar interfaces de rede aos containers"
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr "Anexar interfaces de rede aos perfis"
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr "Anexar uma nova interface de rede aos containers"
 
@@ -480,7 +480,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr "Tipo de autenticação '%s' não suportada pelo servidor"
@@ -495,7 +495,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Atualização automática: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr "IMAGEM BASE"
 
@@ -503,13 +503,13 @@ msgstr "IMAGEM BASE"
 msgid "Backup exported successfully!"
 msgstr "Backup exportado com sucesso!"
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr "par de chave/valor inválido %s"
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr "par de chave=valor inválido %s"
@@ -533,19 +533,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr "Marca: %v"
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Bytes recebido"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Bytes enviado"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr "CANCELÁVEL"
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr "NOME COMUM"
 
@@ -567,11 +567,11 @@ msgstr "Utilização do CPU:"
 msgid "CPUs (%s):"
 msgstr "CPUs:"
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr "CRIADO"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "CRIADO EM"
 
@@ -590,7 +590,7 @@ msgstr "Em cache: %s"
 msgid "Caches:"
 msgstr "Em cache: %s"
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -602,16 +602,16 @@ msgstr "Não pode fornecer um nome para a imagem de destino"
 msgid "Can't pull a directory without --recursive"
 msgstr "Não pode pegar um diretório sem --recursive"
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Não é possível ler stdin: %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr "Não é possível remover o default remoto"
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr "Não é possível especificar --fast com --columns"
 
@@ -619,7 +619,7 @@ msgstr "Não é possível especificar --fast com --columns"
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr "Não pode especificar a coluna L, quando não em cluster"
 
@@ -632,7 +632,7 @@ msgstr "Não é possível fornecer o uid/gid/modo no modo recursivo"
 msgid "Can't unset key '%s', it's not currently set"
 msgstr "Não é possível remover chave '%s', não está atualmente definido"
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -646,12 +646,12 @@ msgstr "Cartão %d:"
 msgid "Card: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr "Certificado fingerprint: %s"
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Certificado do cliente armazenado no servidor: "
@@ -662,11 +662,11 @@ msgid "Client version: %s\n"
 msgstr "Versão do cliente: %s\n"
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -675,11 +675,11 @@ msgstr "Versão do cliente: %s\n"
 msgid "Cluster member name"
 msgstr "Nome de membro do cluster"
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr "Clustering ativado"
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Colunas"
 
@@ -700,21 +700,21 @@ msgstr ""
 "abaixo.\n"
 "Para obter ajuda com qualquer um desses, simplesmente use-os com --help."
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr "Configuração chave/valor para aplicar ao novo contêiner"
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr "Erro de análise de configuração: %s"
@@ -727,11 +727,6 @@ msgstr "Log de Console:"
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -742,7 +737,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -770,7 +765,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr "Copiar perfis"
 
@@ -791,7 +786,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -819,15 +814,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr "Impossível criar diretório para certificado do servidor"
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -855,11 +850,11 @@ msgstr ""
 "Quando --stateful é usado, o LXD tenta criar um checkpoint do estado atual \n"
 "do container, incluindo estado de memória dos processos, conexões TCP, ..."
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -867,55 +862,61 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr "Criar novas redes"
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr "Criar perfis"
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr "Criar projetos"
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
 msgstr ""
+
+#: lxc/init.go:57
+#, fuzzy
+msgid "Create virtual machine"
+msgstr "Copiar a imagem: %s"
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr "Criado: %s"
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr "Criando %s"
 
-#: lxc/init.go:153
-msgid "Creating the container"
-msgstr ""
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
+msgstr "Criando %s"
 
 #: lxc/info.go:134 lxc/info.go:219
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr "DRIVER"
 
@@ -932,11 +933,11 @@ msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 msgid "Define a compression algorithm: for image or none"
 msgstr "Definir um algoritmo de compressão: para imagem ou nenhum"
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -948,7 +949,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr "Apagar nomes alternativos da imagem"
 
@@ -956,19 +957,19 @@ msgstr "Apagar nomes alternativos da imagem"
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr "Apagar projetos"
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -977,46 +978,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -1028,11 +1029,11 @@ msgstr ""
 msgid "Description"
 msgstr "Descrição"
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr "Desconectar interfaces de rede dos containers"
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr "Desconectar interfaces de rede dos perfis"
 
@@ -1059,7 +1060,7 @@ msgstr "Dispositivo %s sobreposto em %s"
 msgid "Device %s removed from %s"
 msgstr "Dispositivo %s removido de %s"
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr "O dispositivo já existe: %s"
@@ -1069,8 +1070,8 @@ msgstr "O dispositivo já existe: %s"
 msgid "Device: %s"
 msgstr "Em cache: %s"
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1108,7 +1109,7 @@ msgstr "Uso de disco:"
 msgid "Disks:"
 msgstr "Uso de disco:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1121,11 +1122,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr "EFÊMERO"
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr "DATA DE VALIDADE"
 
@@ -1135,7 +1136,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr "Editar templates de arquivo do container"
 
@@ -1155,20 +1156,20 @@ msgstr "Editar arquivos no container"
 msgid "Edit image properties"
 msgstr "Editar propriedades da imagem"
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr "Editar configurações de rede como YAML"
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 #, fuzzy
 msgid "Edit project configurations as YAML"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1176,16 +1177,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1204,11 +1205,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1274,29 +1275,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1306,11 +1307,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1323,7 +1324,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr "Forçar alocação de pseudo-terminal"
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1339,7 +1340,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1363,10 +1364,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1398,11 +1399,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1414,20 +1415,20 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 #, fuzzy
 msgid "Get values for project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1439,7 +1440,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr "HOSTNAME"
 
@@ -1447,7 +1448,7 @@ msgstr "HOSTNAME"
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr "ID"
 
@@ -1461,23 +1462,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr "IPV4"
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr "IPV6"
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1553,49 +1554,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1610,7 +1616,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1625,7 +1631,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1638,11 +1644,11 @@ msgstr "Em cache: %s"
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1651,7 +1657,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1674,27 +1680,27 @@ msgstr "Arquitetura: %v"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1702,15 +1708,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1777,11 +1783,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1819,11 +1825,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1831,15 +1837,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1852,11 +1858,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1866,15 +1872,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr "Em cache: %s"
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1887,15 +1893,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1907,7 +1913,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1919,7 +1925,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1946,15 +1952,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1970,11 +1976,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1983,12 +1989,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2009,11 +2015,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2022,13 +2028,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -2038,15 +2044,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2057,17 +2063,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2100,7 +2106,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2109,7 +2115,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2117,12 +2123,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2139,8 +2145,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2153,8 +2159,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2176,7 +2182,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2186,31 +2192,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2222,11 +2228,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2260,7 +2266,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2268,11 +2274,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2290,31 +2296,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2349,13 +2355,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2367,7 +2373,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2390,45 +2396,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2438,17 +2444,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2457,7 +2463,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2520,28 +2526,28 @@ msgstr "Editar arquivos no container"
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2564,11 +2570,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2576,24 +2582,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2601,19 +2607,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2673,7 +2679,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2686,11 +2692,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2698,39 +2704,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2774,11 +2780,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2787,11 +2793,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2800,12 +2806,12 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 #, fuzzy
 msgid "Set project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2814,11 +2820,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2840,7 +2846,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2876,15 +2882,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2904,19 +2910,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2932,7 +2938,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2944,11 +2950,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2956,7 +2962,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -3001,7 +3007,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -3028,22 +3034,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -3087,36 +3093,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3130,7 +3136,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3143,12 +3149,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3157,16 +3163,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3198,11 +3204,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3215,7 +3221,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3237,7 +3243,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3270,11 +3276,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3289,7 +3295,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3299,7 +3305,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3311,20 +3317,20 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 #, fuzzy
 msgid "Unset project configuration keys"
 msgstr "Editar configurações de perfil como YAML"
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3351,7 +3357,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3385,7 +3391,7 @@ msgstr "Em cache: %s"
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3409,8 +3415,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3426,19 +3432,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3446,19 +3452,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3472,13 +3478,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3498,7 +3504,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3506,19 +3512,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3526,27 +3532,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3564,15 +3570,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3580,19 +3586,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3604,7 +3610,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3616,7 +3622,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3624,7 +3630,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3636,11 +3642,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3648,11 +3654,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3660,7 +3666,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3700,11 +3706,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3712,11 +3718,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3724,7 +3730,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3742,7 +3748,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3750,11 +3756,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3762,7 +3768,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3770,24 +3776,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3799,23 +3805,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3889,7 +3895,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3905,7 +3911,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3931,7 +3937,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3945,13 +3951,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3970,19 +3976,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -4003,7 +4009,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -4042,17 +4048,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -4060,11 +4066,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -4080,11 +4086,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4106,7 +4112,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4114,23 +4120,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4138,19 +4144,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4158,11 +4164,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4172,11 +4178,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4196,11 +4202,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4208,11 +4214,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4220,7 +4226,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4228,7 +4234,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4240,19 +4246,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4260,11 +4266,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4280,7 +4286,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4300,15 +4306,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4317,15 +4323,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4337,11 +4343,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4349,11 +4355,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4361,7 +4367,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4373,11 +4379,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr "sim"

--- a/po/ru.po
+++ b/po/ru.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2018-06-22 15:57+0000\n"
 "Last-Translator: Александр Киль <shorrey@gmail.com>\n"
 "Language-Team: Russian <https://hosted.weblate.org/projects/linux-containers/"
@@ -20,7 +20,7 @@ msgstr ""
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Generator: Weblate 3.1-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 #, fuzzy
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
@@ -161,7 +161,7 @@ msgstr ""
 "### Например:\n"
 "###  description: My custom image"
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -197,7 +197,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что только конфигурация может быть изменена."
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -235,7 +235,7 @@ msgstr ""
 "###\n"
 "### Обратите внимание, что имя отображается, но не может быть изменено"
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 #, fuzzy
 msgid ""
 "### This is a yaml representation of the project.\n"
@@ -295,7 +295,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr "(пусто)"
 
@@ -318,7 +318,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -334,7 +334,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr "ПСЕВДОНИМ"
 
@@ -347,19 +347,19 @@ msgstr "ПСЕВДОНИМ"
 msgid "ARCH"
 msgstr "ARCH"
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr "АРХИТЕКТУРА"
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr "Принять сертификат"
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -367,16 +367,16 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 #, fuzzy
 msgid "Add new aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -388,11 +388,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -401,22 +401,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, fuzzy, c-format
 msgid "Admin password for %s:"
 msgstr "Пароль администратора для %s: "
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -434,19 +434,19 @@ msgstr "Архитектура: %s"
 msgid "Architecture: %v"
 msgstr "Архитектура: %s"
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -485,7 +485,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr "Авто-обновление: %s"
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -493,13 +493,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -523,19 +523,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr "Получено байтов"
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr "Отправлено байтов"
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr "ОБЩЕЕ ИМЯ"
 
@@ -558,12 +558,12 @@ msgstr " Использование ЦП:"
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 #, fuzzy
 msgid "CREATED"
 msgstr "СОЗДАН"
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr "СОЗДАН"
 
@@ -581,7 +581,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -593,16 +593,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr "Невозможно прочитать из стандартного ввода: %s"
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -610,7 +610,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -623,7 +623,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -637,12 +637,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 #, fuzzy
 msgid "Client certificate stored at server:"
 msgstr "Сертификат клиента хранится на сервере: "
@@ -653,11 +653,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -666,11 +666,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr "Столбцы"
 
@@ -686,21 +686,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -713,11 +713,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr "Имя контейнера является обязательным"
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr "Имя контейнера: %s"
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -728,7 +723,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -756,7 +751,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -778,7 +773,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -806,15 +801,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr "Не удалось создать каталог сертификата сервера"
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 #, fuzzy
 msgid "Create an empty container"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -840,11 +835,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 #, fuzzy
 msgid "Create new container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -854,57 +849,63 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Create new custom storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 #, fuzzy
 msgid "Create storage pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 #, fuzzy
 msgid "Create the container with no profiles applied"
 msgstr "Невозможно добавить имя контейнера в список"
+
+#: lxc/init.go:57
+#, fuzzy
+msgid "Create virtual machine"
+msgstr "Копирование образа: %s"
 
 #: lxc/image.go:876 lxc/info.go:448
 #, c-format
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
-msgstr ""
+#: lxc/init.go:155
+#, fuzzy
+msgid "Creating the instance"
+msgstr "Невозможно добавить имя контейнера в список"
 
 #: lxc/info.go:134 lxc/info.go:219
 #, c-format
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -920,11 +921,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 #, fuzzy
 msgid "Delete container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -938,7 +939,7 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -946,19 +947,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -968,46 +969,46 @@ msgid "Delete storage volumes"
 msgstr "Копирование образа: %s"
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -1019,11 +1020,11 @@ msgstr "Копирование образа: %s"
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -1050,7 +1051,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -1060,8 +1061,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -1100,7 +1101,7 @@ msgstr " Использование диска:"
 msgid "Disks:"
 msgstr " Использование диска:"
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -1113,11 +1114,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1127,7 +1128,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 #, fuzzy
 msgid "Edit container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1148,19 +1149,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1168,16 +1169,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1196,11 +1197,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, fuzzy, c-format
 msgid "Error updating template file: %s"
 msgstr "Копирование образа: %s"
@@ -1269,29 +1270,29 @@ msgstr "Копирование образа: %s"
 msgid "Exporting the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1301,11 +1302,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1318,7 +1319,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1334,7 +1335,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1358,10 +1359,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1393,11 +1394,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1409,19 +1410,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1433,7 +1434,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1441,7 +1442,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1455,23 +1456,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1550,49 +1551,54 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, fuzzy, c-format
+msgid "Instance name is: %s"
+msgstr "Имя контейнера: %s"
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1607,7 +1613,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1622,7 +1628,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1635,11 +1641,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1648,7 +1654,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1671,28 +1677,28 @@ msgstr "Архитектура: %s"
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 #, fuzzy
 msgid "List aliases"
 msgstr "Псевдонимы:"
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1700,16 +1706,16 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 #, fuzzy
 msgid "List container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1776,11 +1782,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1818,11 +1824,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1831,15 +1837,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1852,11 +1858,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1866,15 +1872,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1887,15 +1893,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1907,7 +1913,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 #, fuzzy
 msgid "Manage container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
@@ -1920,7 +1926,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1947,15 +1953,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 #, fuzzy
 msgid "Manage storage pools and volumes"
 msgstr "Копирование образа: %s"
@@ -1973,11 +1979,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1986,12 +1992,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -2014,11 +2020,11 @@ msgstr " Использование памяти:"
 msgid "Memory:"
 msgstr " Использование памяти:"
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -2027,14 +2033,14 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 #, fuzzy
 msgid "Missing container name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -2044,15 +2050,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -2063,18 +2069,18 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 #, fuzzy
 msgid "Missing project name"
 msgstr "Имя контейнера: %s"
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -2108,7 +2114,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -2117,7 +2123,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -2126,12 +2132,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr "Копирование образа: %s"
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2148,8 +2154,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2162,8 +2168,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2185,7 +2191,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2195,31 +2201,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 #, fuzzy
 msgid "Network usage:"
 msgstr " Использование сети:"
@@ -2232,11 +2238,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2271,7 +2277,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2279,11 +2285,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2301,31 +2307,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2360,13 +2366,13 @@ msgstr "Авто-обновление: %s"
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2378,7 +2384,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2401,45 +2407,45 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2449,17 +2455,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2468,7 +2474,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2532,28 +2538,28 @@ msgstr "Невозможно добавить имя контейнера в с�
 msgid "Refreshing the image: %s"
 msgstr "Копирование образа: %s"
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2576,11 +2582,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2589,24 +2595,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2615,19 +2621,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2690,7 +2696,7 @@ msgstr "Копирование образа: %s"
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2703,11 +2709,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2715,39 +2721,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2791,11 +2797,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2804,11 +2810,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2817,11 +2823,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2830,11 +2836,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2856,7 +2862,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2893,16 +2899,16 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 #, fuzzy
 msgid "Show content of container file templates"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2922,19 +2928,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2950,7 +2956,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2962,11 +2968,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2974,7 +2980,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -3020,7 +3026,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, fuzzy, c-format
 msgid "State: %s"
 msgstr "Авто-обновление: %s"
@@ -3048,22 +3054,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr "Невозможно добавить имя контейнера в список"
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -3108,36 +3114,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -3151,7 +3157,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3164,12 +3170,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3178,16 +3184,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3219,11 +3225,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3236,7 +3242,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3258,7 +3264,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3291,11 +3297,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3310,7 +3316,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3320,7 +3326,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3332,19 +3338,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3371,7 +3377,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3405,7 +3411,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3429,8 +3435,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3446,19 +3452,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3466,20 +3472,20 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 #, fuzzy
 msgid "alias"
 msgstr "Псевдонимы:"
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3493,13 +3499,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3519,7 +3525,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3527,19 +3533,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3547,27 +3553,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3597,15 +3603,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3617,11 +3623,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 #, fuzzy
 msgid "delete [<remote>:]<project>"
 msgstr ""
@@ -3629,11 +3635,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3645,7 +3651,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3657,7 +3663,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3665,7 +3671,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3677,11 +3683,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3693,11 +3699,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3709,7 +3715,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3753,11 +3759,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3769,11 +3775,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 #, fuzzy
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
@@ -3785,7 +3791,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3803,7 +3809,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3811,11 +3817,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3823,7 +3829,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 #, fuzzy
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
@@ -3835,24 +3841,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3864,23 +3870,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3954,7 +3960,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3970,7 +3976,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3996,7 +4002,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -4010,13 +4016,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -4035,19 +4041,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -4068,7 +4074,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -4107,7 +4113,7 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 #, fuzzy
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
@@ -4117,11 +4123,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -4129,11 +4135,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -4153,11 +4159,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -4187,7 +4193,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -4199,23 +4205,23 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4223,19 +4229,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4247,11 +4253,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4265,11 +4271,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4301,7 +4307,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 #, fuzzy
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
@@ -4309,7 +4315,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4321,7 +4327,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 #, fuzzy
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
@@ -4329,7 +4335,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 #, fuzzy
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
@@ -4345,7 +4351,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4353,7 +4359,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4365,19 +4371,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4389,11 +4395,11 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4417,7 +4423,7 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4445,15 +4451,15 @@ msgstr ""
 "\n"
 "lxc %s [<remote>:]<container> [[<remote>:]<container>...]%s"
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4462,15 +4468,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4482,11 +4488,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4494,11 +4500,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 #, fuzzy
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
@@ -4510,7 +4516,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4523,14 +4529,17 @@ msgstr ""
 msgid "volume"
 msgstr "Столбцы"
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr "да"
+
+#~ msgid "Container name is: %s"
+#~ msgstr "Имя контейнера: %s"
 
 #~ msgid "Connection refused; is LXD running?"
 #~ msgstr "В соединении отказано; LXD запущен?"

--- a/po/sl.po
+++ b/po/sl.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/sr.po
+++ b/po/sr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/sv.po
+++ b/po/sv.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/te.po
+++ b/po/te.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/tr.po
+++ b/po/tr.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/uk.po
+++ b/po/uk.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Automatically generated\n"
 "Language-Team: none\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -102,7 +102,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -122,7 +122,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -143,7 +143,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -208,7 +208,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -224,7 +224,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -236,19 +236,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -256,15 +256,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -276,11 +276,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -289,22 +289,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -322,19 +322,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -358,7 +358,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -373,7 +373,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -381,13 +381,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -411,19 +411,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -445,11 +445,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -467,7 +467,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -479,16 +479,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -496,7 +496,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -523,12 +523,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -538,11 +538,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -551,11 +551,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -571,21 +571,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -598,11 +598,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -613,7 +608,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -641,7 +636,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -662,7 +657,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -689,15 +684,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -721,11 +716,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -733,24 +728,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -758,13 +757,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -772,16 +771,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -797,11 +796,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -813,7 +812,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -821,19 +820,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -842,46 +841,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -893,11 +892,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -924,7 +923,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -934,8 +933,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -971,7 +970,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -984,11 +983,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -998,7 +997,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1018,19 +1017,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1038,16 +1037,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1066,11 +1065,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1136,29 +1135,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1168,11 +1167,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1185,7 +1184,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1201,7 +1200,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1225,10 +1224,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1260,11 +1259,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1276,19 +1275,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1300,7 +1299,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1308,7 +1307,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1322,23 +1321,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1414,49 +1413,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1471,7 +1475,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1486,7 +1490,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1499,11 +1503,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1512,7 +1516,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1535,27 +1539,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1563,15 +1567,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1638,11 +1642,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1680,11 +1684,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1692,15 +1696,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1713,11 +1717,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1727,15 +1731,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1748,15 +1752,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1768,7 +1772,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1780,7 +1784,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1807,15 +1811,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1831,11 +1835,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1844,12 +1848,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1870,11 +1874,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1883,13 +1887,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1899,15 +1903,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1918,17 +1922,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1961,7 +1965,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1970,7 +1974,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1978,12 +1982,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2000,8 +2004,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2014,8 +2018,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2037,7 +2041,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2047,31 +2051,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2083,11 +2087,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2121,7 +2125,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2129,11 +2133,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2151,31 +2155,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2210,13 +2214,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2228,7 +2232,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2251,45 +2255,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2299,17 +2303,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2318,7 +2322,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2381,28 +2385,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2425,11 +2429,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2437,24 +2441,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2462,19 +2466,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2534,7 +2538,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2547,11 +2551,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2559,39 +2563,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2635,11 +2639,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2648,11 +2652,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2661,11 +2665,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2674,11 +2678,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2700,7 +2704,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2736,15 +2740,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2764,19 +2768,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2792,7 +2796,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2804,11 +2808,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2816,7 +2820,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2861,7 +2865,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2888,22 +2892,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2947,36 +2951,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2990,7 +2994,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3003,12 +3007,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3017,16 +3021,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3058,11 +3062,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3075,7 +3079,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3097,7 +3101,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3130,11 +3134,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3149,7 +3153,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3159,7 +3163,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3171,19 +3175,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3210,7 +3214,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3244,7 +3248,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3268,8 +3272,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3285,19 +3289,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3305,19 +3309,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3331,13 +3335,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3357,7 +3361,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3365,19 +3369,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3385,27 +3389,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3423,15 +3427,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3439,19 +3443,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3463,7 +3467,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3475,7 +3479,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3483,7 +3487,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3495,11 +3499,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3507,11 +3511,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3519,7 +3523,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3559,11 +3563,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3571,11 +3575,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3583,7 +3587,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3601,7 +3605,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3609,11 +3613,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3621,7 +3625,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3629,24 +3633,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3658,23 +3662,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3748,7 +3752,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3764,7 +3768,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3790,7 +3794,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3804,13 +3808,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3829,19 +3833,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3862,7 +3866,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3901,17 +3905,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3919,11 +3923,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3939,11 +3943,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3965,7 +3969,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3973,23 +3977,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3997,19 +4001,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4017,11 +4021,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4031,11 +4035,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4055,11 +4059,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4067,11 +4071,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4079,7 +4083,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4087,7 +4091,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4099,19 +4103,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4119,11 +4123,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4139,7 +4143,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4159,15 +4163,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4176,15 +4180,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4196,11 +4200,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4208,11 +4212,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4220,7 +4224,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4232,11 +4236,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/po/zh_Hans.po
+++ b/po/zh_Hans.po
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: lxd\n"
 "Report-Msgid-Bugs-To: lxc-devel@lists.linuxcontainers.org\n"
-"POT-Creation-Date: 2019-10-24 10:21-0400\n"
+"POT-Creation-Date: 2019-11-07 16:23+0000\n"
 "PO-Revision-Date: 2018-09-11 19:15+0000\n"
 "Last-Translator: 0x0916 <w@laoqinren.net>\n"
 "Language-Team: Chinese (Simplified) <https://hosted.weblate.org/projects/"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Weblate 3.2-dev\n"
 
-#: lxc/storage.go:224
+#: lxc/storage.go:225
 msgid ""
 "### This is a yaml representation of a storage pool.\n"
 "### Any line starting with a '#' will be ignored.\n"
@@ -105,7 +105,7 @@ msgid ""
 "###  description: My custom image"
 msgstr ""
 
-#: lxc/network.go:554
+#: lxc/network.go:555
 msgid ""
 "### This is a yaml representation of the network.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -125,7 +125,7 @@ msgid ""
 "### Note that only the configuration can be changed."
 msgstr ""
 
-#: lxc/profile.go:415
+#: lxc/profile.go:416
 msgid ""
 "### This is a yaml representation of the profile.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -146,7 +146,7 @@ msgid ""
 "### Note that the name is shown but cannot be changed"
 msgstr ""
 
-#: lxc/project.go:225
+#: lxc/project.go:226
 msgid ""
 "### This is a yaml representation of the project.\n"
 "### Any line starting with a '# will be ignored.\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "'%s' isn't a supported file type"
 msgstr ""
 
-#: lxc/profile.go:222
+#: lxc/profile.go:223
 msgid "(none)"
 msgstr ""
 
@@ -211,7 +211,7 @@ msgstr ""
 msgid "--container-only can't be passed when the source is a snapshot"
 msgstr ""
 
-#: lxc/init.go:120
+#: lxc/init.go:122
 msgid "--empty cannot be combined with an image name"
 msgstr ""
 
@@ -227,7 +227,7 @@ msgstr ""
 msgid "--target cannot be used with instances"
 msgstr ""
 
-#: lxc/alias.go:125 lxc/image.go:968 lxc/image_alias.go:230
+#: lxc/alias.go:126 lxc/image.go:968 lxc/image_alias.go:231
 msgid "ALIAS"
 msgstr ""
 
@@ -239,19 +239,19 @@ msgstr ""
 msgid "ARCH"
 msgstr ""
 
-#: lxc/list.go:422
+#: lxc/list.go:423
 msgid "ARCHITECTURE"
 msgstr ""
 
-#: lxc/remote.go:515
+#: lxc/remote.go:516
 msgid "AUTH TYPE"
 msgstr ""
 
-#: lxc/remote.go:94
+#: lxc/remote.go:95
 msgid "Accept certificate"
 msgstr ""
 
-#: lxc/query.go:40
+#: lxc/query.go:41
 msgid "Action (defaults to GET)"
 msgstr ""
 
@@ -259,15 +259,15 @@ msgstr ""
 msgid "Add devices to containers or profiles"
 msgstr ""
 
-#: lxc/alias.go:52 lxc/alias.go:53
+#: lxc/alias.go:53 lxc/alias.go:54
 msgid "Add new aliases"
 msgstr ""
 
-#: lxc/remote.go:83
+#: lxc/remote.go:84
 msgid "Add new remote servers"
 msgstr ""
 
-#: lxc/remote.go:84
+#: lxc/remote.go:85
 msgid ""
 "Add new remote servers\n"
 "\n"
@@ -279,11 +279,11 @@ msgid ""
 "protocol=simplestreams\n"
 msgstr ""
 
-#: lxc/config_trust.go:56 lxc/config_trust.go:57
+#: lxc/config_trust.go:57 lxc/config_trust.go:58
 msgid "Add new trusted clients"
 msgstr ""
 
-#: lxc/profile.go:99 lxc/profile.go:100
+#: lxc/profile.go:100 lxc/profile.go:101
 msgid "Add profiles to containers"
 msgstr ""
 
@@ -292,22 +292,22 @@ msgstr ""
 msgid "Address: %s"
 msgstr ""
 
-#: lxc/remote.go:363
+#: lxc/remote.go:364
 #, c-format
 msgid "Admin password for %s:"
 msgstr ""
 
-#: lxc/alias.go:76 lxc/alias.go:172
+#: lxc/alias.go:77 lxc/alias.go:173
 #, c-format
 msgid "Alias %s already exists"
 msgstr ""
 
-#: lxc/alias.go:166 lxc/alias.go:217
+#: lxc/alias.go:167 lxc/alias.go:218
 #, c-format
 msgid "Alias %s doesn't exist"
 msgstr ""
 
-#: lxc/image_alias.go:81 lxc/image_alias.go:128 lxc/image_alias.go:275
+#: lxc/image_alias.go:82 lxc/image_alias.go:129 lxc/image_alias.go:276
 msgid "Alias name missing"
 msgstr ""
 
@@ -325,19 +325,19 @@ msgstr ""
 msgid "Architecture: %v"
 msgstr ""
 
-#: lxc/profile.go:162 lxc/profile.go:163
+#: lxc/profile.go:163 lxc/profile.go:164
 msgid "Assign sets of profiles to containers"
 msgstr ""
 
-#: lxc/network.go:106
+#: lxc/network.go:107
 msgid "Attach network interfaces to containers"
 msgstr ""
 
-#: lxc/network.go:179 lxc/network.go:180
+#: lxc/network.go:180 lxc/network.go:181
 msgid "Attach network interfaces to profiles"
 msgstr ""
 
-#: lxc/network.go:107
+#: lxc/network.go:108
 msgid "Attach new network interfaces to containers"
 msgstr ""
 
@@ -361,7 +361,7 @@ msgid ""
 "as well as retrieve past log entries from it."
 msgstr ""
 
-#: lxc/remote.go:346
+#: lxc/remote.go:347
 #, c-format
 msgid "Authentication type '%s' not supported by server"
 msgstr ""
@@ -376,7 +376,7 @@ msgstr ""
 msgid "Auto update: %s"
 msgstr ""
 
-#: lxc/list.go:434 lxc/list.go:435
+#: lxc/list.go:435 lxc/list.go:436
 msgid "BASE IMAGE"
 msgstr ""
 
@@ -384,13 +384,13 @@ msgstr ""
 msgid "Backup exported successfully!"
 msgstr ""
 
-#: lxc/network.go:286
+#: lxc/network.go:287
 #, c-format
 msgid "Bad key/value pair: %s"
 msgstr ""
 
-#: lxc/copy.go:125 lxc/init.go:185 lxc/project.go:120 lxc/publish.go:176
-#: lxc/storage.go:122 lxc/storage_volume.go:504
+#: lxc/copy.go:125 lxc/init.go:187 lxc/project.go:121 lxc/publish.go:176
+#: lxc/storage.go:123 lxc/storage_volume.go:504
 #, c-format
 msgid "Bad key=value pair: %s"
 msgstr ""
@@ -414,19 +414,19 @@ msgstr ""
 msgid "Brand: %v"
 msgstr ""
 
-#: lxc/info.go:545 lxc/network.go:785
+#: lxc/info.go:545 lxc/network.go:786
 msgid "Bytes received"
 msgstr ""
 
-#: lxc/info.go:546 lxc/network.go:786
+#: lxc/info.go:546 lxc/network.go:787
 msgid "Bytes sent"
 msgstr ""
 
-#: lxc/operation.go:161
+#: lxc/operation.go:162
 msgid "CANCELABLE"
 msgstr ""
 
-#: lxc/config_trust.go:173
+#: lxc/config_trust.go:174
 msgid "COMMON NAME"
 msgstr ""
 
@@ -448,11 +448,11 @@ msgstr ""
 msgid "CPUs (%s):"
 msgstr ""
 
-#: lxc/operation.go:162
+#: lxc/operation.go:163
 msgid "CREATED"
 msgstr ""
 
-#: lxc/list.go:423
+#: lxc/list.go:424
 msgid "CREATED AT"
 msgstr ""
 
@@ -470,7 +470,7 @@ msgstr ""
 msgid "Caches:"
 msgstr ""
 
-#: lxc/move.go:110
+#: lxc/move.go:109
 msgid "Can't override configuration or profiles in local rename"
 msgstr ""
 
@@ -482,16 +482,16 @@ msgstr ""
 msgid "Can't pull a directory without --recursive"
 msgstr ""
 
-#: lxc/utils.go:236 lxc/utils.go:256
+#: lxc/utils.go:224 lxc/utils.go:244
 #, c-format
 msgid "Can't read from stdin: %s"
 msgstr ""
 
-#: lxc/remote.go:624
+#: lxc/remote.go:625
 msgid "Can't remove the default remote"
 msgstr ""
 
-#: lxc/list.go:441
+#: lxc/list.go:442
 msgid "Can't specify --fast with --columns"
 msgstr ""
 
@@ -499,7 +499,7 @@ msgstr ""
 msgid "Can't specify a different remote for rename"
 msgstr ""
 
-#: lxc/list.go:453
+#: lxc/list.go:454
 msgid "Can't specify column L when not clustered"
 msgstr ""
 
@@ -512,7 +512,7 @@ msgstr ""
 msgid "Can't unset key '%s', it's not currently set"
 msgstr ""
 
-#: lxc/remote.go:99
+#: lxc/remote.go:100
 msgid "Candid domain to use"
 msgstr ""
 
@@ -526,12 +526,12 @@ msgstr ""
 msgid "Card: %s (%s)"
 msgstr ""
 
-#: lxc/remote.go:258
+#: lxc/remote.go:259
 #, c-format
 msgid "Certificate fingerprint: %s"
 msgstr ""
 
-#: lxc/remote.go:402
+#: lxc/remote.go:403
 msgid "Client certificate stored at server:"
 msgstr ""
 
@@ -541,11 +541,11 @@ msgid "Client version: %s\n"
 msgstr ""
 
 #: lxc/config.go:96 lxc/config.go:376 lxc/config.go:469 lxc/config.go:584
-#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:53
-#: lxc/move.go:60 lxc/network.go:256 lxc/network.go:671 lxc/network.go:729
-#: lxc/network.go:1016 lxc/network.go:1083 lxc/network.go:1145
-#: lxc/storage.go:91 lxc/storage.go:335 lxc/storage.go:391 lxc/storage.go:587
-#: lxc/storage.go:654 lxc/storage.go:737 lxc/storage_volume.go:305
+#: lxc/config.go:702 lxc/copy.go:54 lxc/info.go:44 lxc/init.go:54
+#: lxc/move.go:59 lxc/network.go:257 lxc/network.go:672 lxc/network.go:730
+#: lxc/network.go:1017 lxc/network.go:1084 lxc/network.go:1146
+#: lxc/storage.go:92 lxc/storage.go:336 lxc/storage.go:392 lxc/storage.go:588
+#: lxc/storage.go:655 lxc/storage.go:738 lxc/storage_volume.go:305
 #: lxc/storage_volume.go:465 lxc/storage_volume.go:542
 #: lxc/storage_volume.go:784 lxc/storage_volume.go:981
 #: lxc/storage_volume.go:1146 lxc/storage_volume.go:1176
@@ -554,11 +554,11 @@ msgstr ""
 msgid "Cluster member name"
 msgstr ""
 
-#: lxc/cluster.go:401
+#: lxc/cluster.go:402
 msgid "Clustering enabled"
 msgstr ""
 
-#: lxc/image.go:959 lxc/list.go:113
+#: lxc/image.go:959 lxc/list.go:114
 msgid "Columns"
 msgstr ""
 
@@ -574,21 +574,21 @@ msgid ""
 "For help with any of those, simply call them with --help."
 msgstr ""
 
-#: lxc/copy.go:45 lxc/init.go:47
+#: lxc/copy.go:45 lxc/init.go:48
 msgid "Config key/value to apply to the new container"
 msgstr ""
 
-#: lxc/project.go:87
+#: lxc/project.go:88
 msgid "Config key/value to apply to the new project"
 msgstr ""
 
-#: lxc/move.go:51
+#: lxc/move.go:50
 msgid "Config key/value to apply to the target container"
 msgstr ""
 
 #: lxc/config.go:270 lxc/config.go:343 lxc/config_metadata.go:143
-#: lxc/image.go:414 lxc/network.go:639 lxc/profile.go:497 lxc/project.go:303
-#: lxc/storage.go:302 lxc/storage_volume.go:917 lxc/storage_volume.go:947
+#: lxc/image.go:414 lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304
+#: lxc/storage.go:303 lxc/storage_volume.go:917 lxc/storage_volume.go:947
 #, c-format
 msgid "Config parsing error: %s"
 msgstr ""
@@ -601,11 +601,6 @@ msgstr ""
 msgid "Container name is mandatory"
 msgstr ""
 
-#: lxc/copy.go:422 lxc/init.go:319
-#, c-format
-msgid "Container name is: %s"
-msgstr ""
-
 #: lxc/publish.go:276
 #, c-format
 msgid "Container published with fingerprint: %s"
@@ -616,7 +611,7 @@ msgstr ""
 msgid "Control: %s (%s)"
 msgstr ""
 
-#: lxc/copy.go:52 lxc/move.go:58
+#: lxc/copy.go:52 lxc/move.go:57
 msgid "Copy a stateful container stateless"
 msgstr ""
 
@@ -644,7 +639,7 @@ msgstr ""
 msgid "Copy profile inherited devices and override configuration keys"
 msgstr ""
 
-#: lxc/profile.go:242 lxc/profile.go:243
+#: lxc/profile.go:243 lxc/profile.go:244
 msgid "Copy profiles"
 msgstr ""
 
@@ -665,7 +660,7 @@ msgstr ""
 msgid "Copy the volume without its snapshots"
 msgstr ""
 
-#: lxc/copy.go:55 lxc/move.go:61
+#: lxc/copy.go:55 lxc/move.go:60
 msgid "Copy to a project different from the source"
 msgstr ""
 
@@ -692,15 +687,15 @@ msgstr ""
 msgid "Cores:"
 msgstr ""
 
-#: lxc/remote.go:273
+#: lxc/remote.go:274
 msgid "Could not create server cert dir"
 msgstr ""
 
-#: lxc/image_alias.go:56 lxc/image_alias.go:57
+#: lxc/image_alias.go:57 lxc/image_alias.go:58
 msgid "Create aliases for existing images"
 msgstr ""
 
-#: lxc/init.go:55
+#: lxc/init.go:56
 msgid "Create an empty container"
 msgstr ""
 
@@ -724,11 +719,11 @@ msgid ""
 "running state, including process memory state, TCP connections, ..."
 msgstr ""
 
-#: lxc/init.go:38 lxc/init.go:39
+#: lxc/init.go:39 lxc/init.go:40
 msgid "Create containers from images"
 msgstr ""
 
-#: lxc/config_template.go:64 lxc/config_template.go:65
+#: lxc/config_template.go:65 lxc/config_template.go:66
 msgid "Create new container file templates"
 msgstr ""
 
@@ -736,24 +731,28 @@ msgstr ""
 msgid "Create new custom storage volumes"
 msgstr ""
 
-#: lxc/network.go:252 lxc/network.go:253
+#: lxc/network.go:253 lxc/network.go:254
 msgid "Create new networks"
 msgstr ""
 
-#: lxc/profile.go:298 lxc/profile.go:299
+#: lxc/profile.go:299 lxc/profile.go:300
 msgid "Create profiles"
 msgstr ""
 
-#: lxc/project.go:84 lxc/project.go:85
+#: lxc/project.go:85 lxc/project.go:86
 msgid "Create projects"
 msgstr ""
 
-#: lxc/storage.go:87 lxc/storage.go:88
+#: lxc/storage.go:88 lxc/storage.go:89
 msgid "Create storage pools"
 msgstr ""
 
-#: lxc/copy.go:56 lxc/init.go:54
+#: lxc/copy.go:56 lxc/init.go:55
 msgid "Create the container with no profiles applied"
+msgstr ""
+
+#: lxc/init.go:57
+msgid "Create virtual machine"
 msgstr ""
 
 #: lxc/image.go:876 lxc/info.go:448
@@ -761,13 +760,13 @@ msgstr ""
 msgid "Created: %s"
 msgstr ""
 
-#: lxc/init.go:155
+#: lxc/init.go:157
 #, c-format
 msgid "Creating %s"
 msgstr ""
 
-#: lxc/init.go:153
-msgid "Creating the container"
+#: lxc/init.go:155
+msgid "Creating the instance"
 msgstr ""
 
 #: lxc/info.go:134 lxc/info.go:219
@@ -775,16 +774,16 @@ msgstr ""
 msgid "Current number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:127
+#: lxc/cluster.go:128
 msgid "DATABASE"
 msgstr ""
 
-#: lxc/image.go:973 lxc/image_alias.go:233 lxc/list.go:424 lxc/network.go:869
-#: lxc/operation.go:159 lxc/storage.go:558 lxc/storage_volume.go:1119
+#: lxc/image.go:973 lxc/image_alias.go:234 lxc/list.go:425 lxc/network.go:870
+#: lxc/operation.go:160 lxc/storage.go:559 lxc/storage_volume.go:1119
 msgid "DESCRIPTION"
 msgstr ""
 
-#: lxc/storage.go:559
+#: lxc/storage.go:560
 msgid "DRIVER"
 msgstr ""
 
@@ -800,11 +799,11 @@ msgstr ""
 msgid "Define a compression algorithm: for image or none"
 msgstr ""
 
-#: lxc/operation.go:51 lxc/operation.go:52
+#: lxc/operation.go:52 lxc/operation.go:53
 msgid "Delete a background operation (will attempt to cancel)"
 msgstr ""
 
-#: lxc/config_template.go:107 lxc/config_template.go:108
+#: lxc/config_template.go:108 lxc/config_template.go:109
 msgid "Delete container file templates"
 msgstr ""
 
@@ -816,7 +815,7 @@ msgstr ""
 msgid "Delete files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:103 lxc/image_alias.go:104
+#: lxc/image_alias.go:104 lxc/image_alias.go:105
 msgid "Delete image aliases"
 msgstr ""
 
@@ -824,19 +823,19 @@ msgstr ""
 msgid "Delete images"
 msgstr ""
 
-#: lxc/network.go:324 lxc/network.go:325
+#: lxc/network.go:325 lxc/network.go:326
 msgid "Delete networks"
 msgstr ""
 
-#: lxc/profile.go:352 lxc/profile.go:353
+#: lxc/profile.go:353 lxc/profile.go:354
 msgid "Delete profiles"
 msgstr ""
 
-#: lxc/project.go:149 lxc/project.go:150
+#: lxc/project.go:150 lxc/project.go:151
 msgid "Delete projects"
 msgstr ""
 
-#: lxc/storage.go:161 lxc/storage.go:162
+#: lxc/storage.go:162 lxc/storage.go:163
 msgid "Delete storage pools"
 msgstr ""
 
@@ -845,46 +844,46 @@ msgid "Delete storage volumes"
 msgstr ""
 
 #: lxc/action.go:31 lxc/action.go:50 lxc/action.go:70 lxc/action.go:91
-#: lxc/alias.go:21 lxc/alias.go:53 lxc/alias.go:99 lxc/alias.go:143
-#: lxc/alias.go:194 lxc/cluster.go:28 lxc/cluster.go:67 lxc/cluster.go:145
-#: lxc/cluster.go:195 lxc/cluster.go:245 lxc/cluster.go:330 lxc/config.go:31
+#: lxc/alias.go:22 lxc/alias.go:54 lxc/alias.go:100 lxc/alias.go:144
+#: lxc/alias.go:195 lxc/cluster.go:29 lxc/cluster.go:68 lxc/cluster.go:146
+#: lxc/cluster.go:196 lxc/cluster.go:246 lxc/cluster.go:331 lxc/config.go:31
 #: lxc/config.go:90 lxc/config.go:373 lxc/config.go:454 lxc/config.go:580
 #: lxc/config.go:699 lxc/config_device.go:24 lxc/config_device.go:76
 #: lxc/config_device.go:188 lxc/config_device.go:261 lxc/config_device.go:327
 #: lxc/config_device.go:416 lxc/config_device.go:507 lxc/config_device.go:513
 #: lxc/config_device.go:613 lxc/config_device.go:681 lxc/config_metadata.go:28
 #: lxc/config_metadata.go:53 lxc/config_metadata.go:175
-#: lxc/config_template.go:28 lxc/config_template.go:65
-#: lxc/config_template.go:108 lxc/config_template.go:150
-#: lxc/config_template.go:236 lxc/config_template.go:295 lxc/config_trust.go:28
-#: lxc/config_trust.go:57 lxc/config_trust.go:115 lxc/config_trust.go:193
+#: lxc/config_template.go:29 lxc/config_template.go:66
+#: lxc/config_template.go:109 lxc/config_template.go:151
+#: lxc/config_template.go:237 lxc/config_template.go:296 lxc/config_trust.go:29
+#: lxc/config_trust.go:58 lxc/config_trust.go:116 lxc/config_trust.go:194
 #: lxc/console.go:32 lxc/copy.go:41 lxc/delete.go:30 lxc/exec.go:41
 #: lxc/export.go:33 lxc/file.go:72 lxc/file.go:105 lxc/file.go:154
 #: lxc/file.go:217 lxc/file.go:407 lxc/image.go:38 lxc/image.go:128
 #: lxc/image.go:270 lxc/image.go:321 lxc/image.go:446 lxc/image.go:592
 #: lxc/image.go:808 lxc/image.go:934 lxc/image.go:1232 lxc/image.go:1311
-#: lxc/image_alias.go:24 lxc/image_alias.go:57 lxc/image_alias.go:104
-#: lxc/image_alias.go:149 lxc/image_alias.go:251 lxc/import.go:28
-#: lxc/info.go:32 lxc/init.go:39 lxc/launch.go:23 lxc/list.go:43 lxc/main.go:50
-#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:38 lxc/network.go:31
-#: lxc/network.go:107 lxc/network.go:180 lxc/network.go:253 lxc/network.go:325
-#: lxc/network.go:375 lxc/network.go:460 lxc/network.go:545 lxc/network.go:668
-#: lxc/network.go:726 lxc/network.go:806 lxc/network.go:891 lxc/network.go:960
-#: lxc/network.go:1010 lxc/network.go:1080 lxc/network.go:1142
-#: lxc/operation.go:23 lxc/operation.go:52 lxc/operation.go:101
-#: lxc/operation.go:180 lxc/profile.go:28 lxc/profile.go:100 lxc/profile.go:163
-#: lxc/profile.go:243 lxc/profile.go:299 lxc/profile.go:353 lxc/profile.go:403
-#: lxc/profile.go:527 lxc/profile.go:576 lxc/profile.go:635 lxc/profile.go:711
-#: lxc/profile.go:761 lxc/profile.go:820 lxc/profile.go:874 lxc/project.go:28
-#: lxc/project.go:85 lxc/project.go:150 lxc/project.go:213 lxc/project.go:333
-#: lxc/project.go:383 lxc/project.go:468 lxc/project.go:523 lxc/project.go:583
-#: lxc/project.go:612 lxc/project.go:665 lxc/publish.go:35 lxc/query.go:30
-#: lxc/remote.go:33 lxc/remote.go:84 lxc/remote.go:418 lxc/remote.go:454
-#: lxc/remote.go:534 lxc/remote.go:596 lxc/remote.go:646 lxc/remote.go:684
-#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:32
-#: lxc/storage.go:88 lxc/storage.go:162 lxc/storage.go:212 lxc/storage.go:332
-#: lxc/storage.go:387 lxc/storage.go:507 lxc/storage.go:581 lxc/storage.go:650
-#: lxc/storage.go:734 lxc/storage_volume.go:32 lxc/storage_volume.go:139
+#: lxc/image_alias.go:25 lxc/image_alias.go:58 lxc/image_alias.go:105
+#: lxc/image_alias.go:150 lxc/image_alias.go:252 lxc/import.go:28
+#: lxc/info.go:32 lxc/init.go:40 lxc/launch.go:23 lxc/list.go:44 lxc/main.go:50
+#: lxc/manpage.go:19 lxc/monitor.go:30 lxc/move.go:37 lxc/network.go:32
+#: lxc/network.go:108 lxc/network.go:181 lxc/network.go:254 lxc/network.go:326
+#: lxc/network.go:376 lxc/network.go:461 lxc/network.go:546 lxc/network.go:669
+#: lxc/network.go:727 lxc/network.go:807 lxc/network.go:892 lxc/network.go:961
+#: lxc/network.go:1011 lxc/network.go:1081 lxc/network.go:1143
+#: lxc/operation.go:24 lxc/operation.go:53 lxc/operation.go:102
+#: lxc/operation.go:181 lxc/profile.go:29 lxc/profile.go:101 lxc/profile.go:164
+#: lxc/profile.go:244 lxc/profile.go:300 lxc/profile.go:354 lxc/profile.go:404
+#: lxc/profile.go:528 lxc/profile.go:577 lxc/profile.go:636 lxc/profile.go:712
+#: lxc/profile.go:762 lxc/profile.go:821 lxc/profile.go:875 lxc/project.go:29
+#: lxc/project.go:86 lxc/project.go:151 lxc/project.go:214 lxc/project.go:334
+#: lxc/project.go:384 lxc/project.go:469 lxc/project.go:524 lxc/project.go:584
+#: lxc/project.go:613 lxc/project.go:666 lxc/publish.go:35 lxc/query.go:31
+#: lxc/remote.go:34 lxc/remote.go:85 lxc/remote.go:419 lxc/remote.go:455
+#: lxc/remote.go:535 lxc/remote.go:597 lxc/remote.go:647 lxc/remote.go:685
+#: lxc/rename.go:21 lxc/restore.go:24 lxc/snapshot.go:24 lxc/storage.go:33
+#: lxc/storage.go:89 lxc/storage.go:163 lxc/storage.go:213 lxc/storage.go:333
+#: lxc/storage.go:388 lxc/storage.go:508 lxc/storage.go:582 lxc/storage.go:651
+#: lxc/storage.go:735 lxc/storage_volume.go:32 lxc/storage_volume.go:139
 #: lxc/storage_volume.go:218 lxc/storage_volume.go:301
 #: lxc/storage_volume.go:462 lxc/storage_volume.go:539
 #: lxc/storage_volume.go:615 lxc/storage_volume.go:697
@@ -896,11 +895,11 @@ msgstr ""
 msgid "Description"
 msgstr ""
 
-#: lxc/network.go:374 lxc/network.go:375
+#: lxc/network.go:375 lxc/network.go:376
 msgid "Detach network interfaces from containers"
 msgstr ""
 
-#: lxc/network.go:459 lxc/network.go:460
+#: lxc/network.go:460 lxc/network.go:461
 msgid "Detach network interfaces from profiles"
 msgstr ""
 
@@ -927,7 +926,7 @@ msgstr ""
 msgid "Device %s removed from %s"
 msgstr ""
 
-#: lxc/utils.go:143 lxc/utils.go:167
+#: lxc/utils.go:131 lxc/utils.go:155
 #, c-format
 msgid "Device already exists: %s"
 msgstr ""
@@ -937,8 +936,8 @@ msgstr ""
 msgid "Device: %s"
 msgstr ""
 
-#: lxc/init.go:313
-msgid "Didn't get any affected image, container or snapshot from server"
+#: lxc/init.go:330
+msgid "Didn't get any affected image, instance or snapshot from server"
 msgstr ""
 
 #: lxc/image.go:607
@@ -974,7 +973,7 @@ msgstr ""
 msgid "Disks:"
 msgstr ""
 
-#: lxc/cluster.go:250
+#: lxc/cluster.go:251
 msgid "Don't require user confirmation for using --force"
 msgstr ""
 
@@ -987,11 +986,11 @@ msgstr ""
 msgid "Driver: %v (%v)"
 msgstr ""
 
-#: lxc/list.go:658
+#: lxc/list.go:659
 msgid "EPHEMERAL"
 msgstr ""
 
-#: lxc/config_trust.go:175
+#: lxc/config_trust.go:176
 msgid "EXPIRY DATE"
 msgstr ""
 
@@ -1001,7 +1000,7 @@ msgid ""
 "(interrupt two more times to force)"
 msgstr ""
 
-#: lxc/config_template.go:149 lxc/config_template.go:150
+#: lxc/config_template.go:150 lxc/config_template.go:151
 msgid "Edit container file templates"
 msgstr ""
 
@@ -1021,19 +1020,19 @@ msgstr ""
 msgid "Edit image properties"
 msgstr ""
 
-#: lxc/network.go:544 lxc/network.go:545
+#: lxc/network.go:545 lxc/network.go:546
 msgid "Edit network configurations as YAML"
 msgstr ""
 
-#: lxc/profile.go:402 lxc/profile.go:403
+#: lxc/profile.go:403 lxc/profile.go:404
 msgid "Edit profile configurations as YAML"
 msgstr ""
 
-#: lxc/project.go:212 lxc/project.go:213
+#: lxc/project.go:213 lxc/project.go:214
 msgid "Edit project configurations as YAML"
 msgstr ""
 
-#: lxc/storage.go:211 lxc/storage.go:212
+#: lxc/storage.go:212 lxc/storage.go:213
 msgid "Edit storage pool configurations as YAML"
 msgstr ""
 
@@ -1041,16 +1040,16 @@ msgstr ""
 msgid "Edit storage volume configurations as YAML"
 msgstr ""
 
-#: lxc/image.go:985 lxc/list.go:465
+#: lxc/image.go:985 lxc/list.go:466
 #, c-format
 msgid "Empty column entry (redundant, leading or trailing command) in '%s'"
 msgstr ""
 
-#: lxc/cluster.go:329
+#: lxc/cluster.go:330
 msgid "Enable clustering on a single non-clustered LXD instance"
 msgstr ""
 
-#: lxc/cluster.go:330
+#: lxc/cluster.go:331
 msgid ""
 "Enable clustering on a single non-clustered LXD instance\n"
 "\n"
@@ -1069,11 +1068,11 @@ msgstr ""
 msgid "Environment variable to set (e.g. HOME=/home/foo)"
 msgstr ""
 
-#: lxc/copy.go:48 lxc/init.go:49
+#: lxc/copy.go:48 lxc/init.go:50
 msgid "Ephemeral container"
 msgstr ""
 
-#: lxc/config_template.go:202
+#: lxc/config_template.go:203
 #, c-format
 msgid "Error updating template file: %s"
 msgstr ""
@@ -1139,29 +1138,29 @@ msgstr ""
 msgid "Exporting the image: %s"
 msgstr ""
 
-#: lxc/config_template.go:278
+#: lxc/config_template.go:279
 msgid "FILENAME"
 msgstr ""
 
-#: lxc/config_trust.go:172 lxc/image.go:970 lxc/image.go:971
-#: lxc/image_alias.go:231
+#: lxc/config_trust.go:173 lxc/image.go:970 lxc/image.go:971
+#: lxc/image_alias.go:232
 msgid "FINGERPRINT"
 msgstr ""
 
-#: lxc/move.go:224
+#: lxc/move.go:231
 msgid "Failed to connect to cluster member"
 msgstr ""
 
-#: lxc/utils.go:212
+#: lxc/utils.go:200
 #, c-format
 msgid "Failed to create alias %s"
 msgstr ""
 
-#: lxc/copy.go:417
-msgid "Failed to get the new container name"
+#: lxc/copy.go:420
+msgid "Failed to get the new instance name"
 msgstr ""
 
-#: lxc/utils.go:202
+#: lxc/utils.go:190
 #, c-format
 msgid "Failed to remove alias %s"
 msgstr ""
@@ -1171,11 +1170,11 @@ msgstr ""
 msgid "Failed to walk path for %s: %s"
 msgstr ""
 
-#: lxc/list.go:115
+#: lxc/list.go:116
 msgid "Fast mode (same as --columns=nsacPt)"
 msgstr ""
 
-#: lxc/network.go:837 lxc/operation.go:130
+#: lxc/network.go:838 lxc/operation.go:131
 msgid "Filtering isn't supported yet"
 msgstr ""
 
@@ -1188,7 +1187,7 @@ msgstr ""
 msgid "Force pseudo-terminal allocation"
 msgstr ""
 
-#: lxc/cluster.go:249
+#: lxc/cluster.go:250
 msgid "Force removing a member, even if degraded"
 msgstr ""
 
@@ -1204,7 +1203,7 @@ msgstr ""
 msgid "Force using the local unix socket"
 msgstr ""
 
-#: lxc/cluster.go:257
+#: lxc/cluster.go:258
 #, c-format
 msgid ""
 "Forcefully removing a server from the cluster should only be done as a last\n"
@@ -1228,10 +1227,10 @@ msgid ""
 "Are you really sure you want to force removing %s? (yes/no): "
 msgstr ""
 
-#: lxc/alias.go:101 lxc/cluster.go:69 lxc/config_template.go:238
-#: lxc/config_trust.go:117 lxc/image.go:960 lxc/image_alias.go:154
-#: lxc/list.go:114 lxc/network.go:810 lxc/network.go:893 lxc/operation.go:103
-#: lxc/profile.go:580 lxc/project.go:385 lxc/remote.go:458 lxc/storage.go:509
+#: lxc/alias.go:102 lxc/cluster.go:70 lxc/config_template.go:239
+#: lxc/config_trust.go:118 lxc/image.go:960 lxc/image_alias.go:155
+#: lxc/list.go:115 lxc/network.go:811 lxc/network.go:894 lxc/operation.go:104
+#: lxc/profile.go:581 lxc/project.go:386 lxc/remote.go:459 lxc/storage.go:510
 #: lxc/storage_volume.go:1071
 msgid "Format (csv|json|table|yaml)"
 msgstr ""
@@ -1263,11 +1262,11 @@ msgstr ""
 msgid "Generate manpages for all commands"
 msgstr ""
 
-#: lxc/remote.go:214
+#: lxc/remote.go:215
 msgid "Generating a client certificate. This may take a minute..."
 msgstr ""
 
-#: lxc/network.go:725 lxc/network.go:726
+#: lxc/network.go:726 lxc/network.go:727
 msgid "Get runtime information on networks"
 msgstr ""
 
@@ -1279,19 +1278,19 @@ msgstr ""
 msgid "Get values for container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:667 lxc/network.go:668
+#: lxc/network.go:668 lxc/network.go:669
 msgid "Get values for network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:526 lxc/profile.go:527
+#: lxc/profile.go:527 lxc/profile.go:528
 msgid "Get values for profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:332 lxc/project.go:333
+#: lxc/project.go:333 lxc/project.go:334
 msgid "Get values for project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:331 lxc/storage.go:332
+#: lxc/storage.go:332 lxc/storage.go:333
 msgid "Get values for storage pool configuration keys"
 msgstr ""
 
@@ -1303,7 +1302,7 @@ msgstr ""
 msgid "Group ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/network.go:937
+#: lxc/network.go:938
 msgid "HOSTNAME"
 msgstr ""
 
@@ -1311,7 +1310,7 @@ msgstr ""
 msgid "Hugepages:\n"
 msgstr ""
 
-#: lxc/operation.go:157
+#: lxc/operation.go:158
 msgid "ID"
 msgstr ""
 
@@ -1325,23 +1324,23 @@ msgstr ""
 msgid "ID: %s"
 msgstr ""
 
-#: lxc/project.go:449
+#: lxc/project.go:450
 msgid "IMAGES"
 msgstr ""
 
-#: lxc/network.go:939
+#: lxc/network.go:940
 msgid "IP ADDRESS"
 msgstr ""
 
-#: lxc/list.go:420
+#: lxc/list.go:421
 msgid "IPV4"
 msgstr ""
 
-#: lxc/list.go:421
+#: lxc/list.go:422
 msgid "IPV6"
 msgstr ""
 
-#: lxc/config_trust.go:174
+#: lxc/config_trust.go:175
 msgid "ISSUE DATE"
 msgstr ""
 
@@ -1417,49 +1416,54 @@ msgstr ""
 msgid "Infiniband:"
 msgstr ""
 
-#: lxc/query.go:41
+#: lxc/query.go:42
 msgid "Input data"
 msgstr ""
 
-#: lxc/init.go:52
+#: lxc/copy.go:426 lxc/init.go:337
+#, c-format
+msgid "Instance name is: %s"
+msgstr ""
+
+#: lxc/init.go:53
 msgid "Instance type"
 msgstr ""
 
-#: lxc/remote.go:166
+#: lxc/remote.go:167
 #, c-format
 msgid "Invalid URL scheme \"%s\" in \"%s\""
 msgstr ""
 
-#: lxc/config_trust.go:156
+#: lxc/config_trust.go:157
 msgid "Invalid certificate"
 msgstr ""
 
-#: lxc/list.go:497
+#: lxc/list.go:498
 #, c-format
 msgid "Invalid config key '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:491
+#: lxc/list.go:492
 #, c-format
 msgid "Invalid config key column format (too many fields): '%s'"
 msgstr ""
 
-#: lxc/utils.go:301
+#: lxc/utils/table.go:56
 #, c-format
 msgid "Invalid format %q"
 msgstr ""
 
-#: lxc/list.go:516
+#: lxc/list.go:517
 #, c-format
 msgid "Invalid max width (must -1, 0 or a positive integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:513
+#: lxc/list.go:514
 #, c-format
 msgid "Invalid max width (must be an integer) '%s' in '%s'"
 msgstr ""
 
-#: lxc/list.go:504
+#: lxc/list.go:505
 #, c-format
 msgid ""
 "Invalid name in '%s', empty string is only allowed when defining maxWidth"
@@ -1474,7 +1478,7 @@ msgstr ""
 msgid "Invalid path %s"
 msgstr ""
 
-#: lxc/remote.go:155
+#: lxc/remote.go:156
 #, c-format
 msgid "Invalid protocol: %s"
 msgstr ""
@@ -1489,7 +1493,7 @@ msgstr ""
 msgid "Invalid target %s"
 msgstr ""
 
-#: lxc/info.go:483 lxc/network.go:777
+#: lxc/info.go:483 lxc/network.go:778
 msgid "Ips:"
 msgstr ""
 
@@ -1502,11 +1506,11 @@ msgstr ""
 msgid "Keep the image up to date after initial copy"
 msgstr ""
 
-#: lxc/list.go:425
+#: lxc/list.go:426
 msgid "LAST USED AT"
 msgstr ""
 
-#: lxc/list.go:449 lxc/network.go:943 lxc/operation.go:164
+#: lxc/list.go:450 lxc/network.go:944 lxc/operation.go:165
 #: lxc/storage_volume.go:1123
 msgid "LOCATION"
 msgstr ""
@@ -1515,7 +1519,7 @@ msgstr ""
 msgid "LXD - Command line client"
 msgstr ""
 
-#: lxc/cluster.go:103
+#: lxc/cluster.go:104
 msgid "LXD server isn't part of a cluster"
 msgstr ""
 
@@ -1538,27 +1542,27 @@ msgstr ""
 msgid "Link speed: %dMbit/s (%s duplex)"
 msgstr ""
 
-#: lxc/network.go:890 lxc/network.go:891
+#: lxc/network.go:891 lxc/network.go:892
 msgid "List DHCP leases"
 msgstr ""
 
-#: lxc/alias.go:98 lxc/alias.go:99
+#: lxc/alias.go:99 lxc/alias.go:100
 msgid "List aliases"
 msgstr ""
 
-#: lxc/cluster.go:66 lxc/cluster.go:67
+#: lxc/cluster.go:67 lxc/cluster.go:68
 msgid "List all the cluster members"
 msgstr ""
 
-#: lxc/network.go:805 lxc/network.go:806
+#: lxc/network.go:806 lxc/network.go:807
 msgid "List available networks"
 msgstr ""
 
-#: lxc/storage.go:506 lxc/storage.go:507
+#: lxc/storage.go:507 lxc/storage.go:508
 msgid "List available storage pools"
 msgstr ""
 
-#: lxc/operation.go:100 lxc/operation.go:101
+#: lxc/operation.go:101 lxc/operation.go:102
 msgid "List background operations"
 msgstr ""
 
@@ -1566,15 +1570,15 @@ msgstr ""
 msgid "List container devices"
 msgstr ""
 
-#: lxc/config_template.go:235 lxc/config_template.go:236
+#: lxc/config_template.go:236 lxc/config_template.go:237
 msgid "List container file templates"
 msgstr ""
 
-#: lxc/list.go:42
+#: lxc/list.go:43
 msgid "List containers"
 msgstr ""
 
-#: lxc/list.go:43
+#: lxc/list.go:44
 msgid ""
 "List containers\n"
 "\n"
@@ -1641,11 +1645,11 @@ msgid ""
 "  Defaults to -1 (unlimited). Use 0 to limit to the column header size."
 msgstr ""
 
-#: lxc/image_alias.go:148
+#: lxc/image_alias.go:149
 msgid "List image aliases"
 msgstr ""
 
-#: lxc/image_alias.go:149
+#: lxc/image_alias.go:150
 msgid ""
 "List image aliases\n"
 "\n"
@@ -1683,11 +1687,11 @@ msgid ""
 "    t - Type"
 msgstr ""
 
-#: lxc/profile.go:575 lxc/profile.go:576
+#: lxc/profile.go:576 lxc/profile.go:577
 msgid "List profiles"
 msgstr ""
 
-#: lxc/project.go:382 lxc/project.go:383
+#: lxc/project.go:383 lxc/project.go:384
 msgid "List projects"
 msgstr ""
 
@@ -1695,15 +1699,15 @@ msgstr ""
 msgid "List storage volumes"
 msgstr ""
 
-#: lxc/remote.go:453 lxc/remote.go:454
+#: lxc/remote.go:454 lxc/remote.go:455
 msgid "List the available remotes"
 msgstr ""
 
-#: lxc/config_trust.go:114 lxc/config_trust.go:115
+#: lxc/config_trust.go:115 lxc/config_trust.go:116
 msgid "List trusted clients"
 msgstr ""
 
-#: lxc/operation.go:22 lxc/operation.go:23
+#: lxc/operation.go:23 lxc/operation.go:24
 msgid "List, show and delete background operations"
 msgstr ""
 
@@ -1716,11 +1720,11 @@ msgstr ""
 msgid "Log:"
 msgstr ""
 
-#: lxc/network.go:938
+#: lxc/network.go:939
 msgid "MAC ADDRESS"
 msgstr ""
 
-#: lxc/network.go:771
+#: lxc/network.go:772
 #, c-format
 msgid "MAC address: %s"
 msgstr ""
@@ -1730,15 +1734,15 @@ msgstr ""
 msgid "MAD: %s (%s)"
 msgstr ""
 
-#: lxc/network.go:868
+#: lxc/network.go:869
 msgid "MANAGED"
 msgstr ""
 
-#: lxc/cluster.go:129
+#: lxc/cluster.go:130
 msgid "MESSAGE"
 msgstr ""
 
-#: lxc/network.go:772
+#: lxc/network.go:773
 #, c-format
 msgid "MTU: %d"
 msgstr ""
@@ -1751,15 +1755,15 @@ msgstr ""
 msgid "Make the image public"
 msgstr ""
 
-#: lxc/network.go:30 lxc/network.go:31
+#: lxc/network.go:31 lxc/network.go:32
 msgid "Manage and attach containers to networks"
 msgstr ""
 
-#: lxc/cluster.go:27 lxc/cluster.go:28
+#: lxc/cluster.go:28 lxc/cluster.go:29
 msgid "Manage cluster members"
 msgstr ""
 
-#: lxc/alias.go:20 lxc/alias.go:21
+#: lxc/alias.go:21 lxc/alias.go:22
 msgid "Manage command aliases"
 msgstr ""
 
@@ -1771,7 +1775,7 @@ msgstr ""
 msgid "Manage container devices"
 msgstr ""
 
-#: lxc/config_template.go:27 lxc/config_template.go:28
+#: lxc/config_template.go:28 lxc/config_template.go:29
 msgid "Manage container file templates"
 msgstr ""
 
@@ -1783,7 +1787,7 @@ msgstr ""
 msgid "Manage files in containers"
 msgstr ""
 
-#: lxc/image_alias.go:23 lxc/image_alias.go:24
+#: lxc/image_alias.go:24 lxc/image_alias.go:25
 msgid "Manage image aliases"
 msgstr ""
 
@@ -1810,15 +1814,15 @@ msgid ""
 "hash or alias name (if one is set)."
 msgstr ""
 
-#: lxc/profile.go:27 lxc/profile.go:28
+#: lxc/profile.go:28 lxc/profile.go:29
 msgid "Manage profiles"
 msgstr ""
 
-#: lxc/project.go:27 lxc/project.go:28
+#: lxc/project.go:28 lxc/project.go:29
 msgid "Manage projects"
 msgstr ""
 
-#: lxc/storage.go:31 lxc/storage.go:32
+#: lxc/storage.go:32 lxc/storage.go:33
 msgid "Manage storage pools and volumes"
 msgstr ""
 
@@ -1834,11 +1838,11 @@ msgid ""
 "\" (user created) volumes."
 msgstr ""
 
-#: lxc/remote.go:32 lxc/remote.go:33
+#: lxc/remote.go:33 lxc/remote.go:34
 msgid "Manage the list of remote servers"
 msgstr ""
 
-#: lxc/config_trust.go:27 lxc/config_trust.go:28
+#: lxc/config_trust.go:28 lxc/config_trust.go:29
 msgid "Manage trusted clients"
 msgstr ""
 
@@ -1847,12 +1851,12 @@ msgstr ""
 msgid "Maximum number of VFs: %d"
 msgstr ""
 
-#: lxc/cluster.go:312
+#: lxc/cluster.go:313
 #, c-format
 msgid "Member %s removed"
 msgstr ""
 
-#: lxc/cluster.go:225
+#: lxc/cluster.go:226
 #, c-format
 msgid "Member %s renamed to %s"
 msgstr ""
@@ -1873,11 +1877,11 @@ msgstr ""
 msgid "Memory:"
 msgstr ""
 
-#: lxc/move.go:237
+#: lxc/move.go:244
 msgid "Migration API failure"
 msgstr ""
 
-#: lxc/move.go:242
+#: lxc/move.go:249
 msgid "Migration operation failure"
 msgstr ""
 
@@ -1886,13 +1890,13 @@ msgid "Minimum level for log messages"
 msgstr ""
 
 #: lxc/config_metadata.go:101 lxc/config_metadata.go:199
-#: lxc/config_template.go:89 lxc/config_template.go:132
-#: lxc/config_template.go:174 lxc/config_template.go:261
-#: lxc/config_template.go:319 lxc/profile.go:197 lxc/profile.go:659
+#: lxc/config_template.go:90 lxc/config_template.go:133
+#: lxc/config_template.go:175 lxc/config_template.go:262
+#: lxc/config_template.go:320 lxc/profile.go:198 lxc/profile.go:660
 msgid "Missing container name"
 msgstr ""
 
-#: lxc/profile.go:124
+#: lxc/profile.go:125
 msgid "Missing container.name name"
 msgstr ""
 
@@ -1902,15 +1906,15 @@ msgstr ""
 msgid "Missing name"
 msgstr ""
 
-#: lxc/network.go:131 lxc/network.go:204 lxc/network.go:349 lxc/network.go:399
-#: lxc/network.go:484 lxc/network.go:589 lxc/network.go:694 lxc/network.go:752
-#: lxc/network.go:916 lxc/network.go:984 lxc/network.go:1039
-#: lxc/network.go:1106
+#: lxc/network.go:132 lxc/network.go:205 lxc/network.go:350 lxc/network.go:400
+#: lxc/network.go:485 lxc/network.go:590 lxc/network.go:695 lxc/network.go:753
+#: lxc/network.go:917 lxc/network.go:985 lxc/network.go:1040
+#: lxc/network.go:1107
 msgid "Missing network name"
 msgstr ""
 
-#: lxc/storage.go:186 lxc/storage.go:256 lxc/storage.go:357 lxc/storage.go:413
-#: lxc/storage.go:610 lxc/storage.go:682 lxc/storage_volume.go:163
+#: lxc/storage.go:187 lxc/storage.go:257 lxc/storage.go:358 lxc/storage.go:414
+#: lxc/storage.go:611 lxc/storage.go:683 lxc/storage_volume.go:163
 #: lxc/storage_volume.go:242 lxc/storage_volume.go:487
 #: lxc/storage_volume.go:563 lxc/storage_volume.go:639
 #: lxc/storage_volume.go:721 lxc/storage_volume.go:820
@@ -1921,17 +1925,17 @@ msgstr ""
 msgid "Missing pool name"
 msgstr ""
 
-#: lxc/profile.go:323 lxc/profile.go:377 lxc/profile.go:451 lxc/profile.go:551
-#: lxc/profile.go:735 lxc/profile.go:788 lxc/profile.go:844
+#: lxc/profile.go:324 lxc/profile.go:378 lxc/profile.go:452 lxc/profile.go:552
+#: lxc/profile.go:736 lxc/profile.go:789 lxc/profile.go:845
 msgid "Missing profile name"
 msgstr ""
 
-#: lxc/project.go:110 lxc/project.go:179 lxc/project.go:257 lxc/project.go:357
-#: lxc/project.go:492 lxc/project.go:550 lxc/project.go:636
+#: lxc/project.go:111 lxc/project.go:180 lxc/project.go:258 lxc/project.go:358
+#: lxc/project.go:493 lxc/project.go:551 lxc/project.go:637
 msgid "Missing project name"
 msgstr ""
 
-#: lxc/profile.go:268
+#: lxc/profile.go:269
 msgid "Missing source profile name"
 msgstr ""
 
@@ -1964,7 +1968,7 @@ msgid ""
 "By default the monitor will listen to all message types."
 msgstr ""
 
-#: lxc/network.go:419 lxc/network.go:504 lxc/storage_volume.go:659
+#: lxc/network.go:420 lxc/network.go:505 lxc/storage_volume.go:659
 #: lxc/storage_volume.go:740
 msgid "More than one device matches, specify the device name"
 msgstr ""
@@ -1973,7 +1977,7 @@ msgstr ""
 msgid "More than one file to download, but target is not a directory"
 msgstr ""
 
-#: lxc/move.go:37 lxc/move.go:38
+#: lxc/move.go:36 lxc/move.go:37
 msgid "Move containers within or in between LXD instances"
 msgstr ""
 
@@ -1981,12 +1985,12 @@ msgstr ""
 msgid "Move storage volumes between pools"
 msgstr ""
 
-#: lxc/move.go:55
+#: lxc/move.go:54
 msgid ""
 "Move the container without its snapshots (deprecated, use instance-only)"
 msgstr ""
 
-#: lxc/move.go:56
+#: lxc/move.go:55
 msgid "Move the instance without its snapshots"
 msgstr ""
 
@@ -2003,8 +2007,8 @@ msgstr ""
 msgid "Must supply container name for: "
 msgstr ""
 
-#: lxc/cluster.go:125 lxc/list.go:426 lxc/network.go:866 lxc/profile.go:619
-#: lxc/project.go:448 lxc/remote.go:512 lxc/storage.go:557
+#: lxc/cluster.go:126 lxc/list.go:427 lxc/network.go:867 lxc/profile.go:620
+#: lxc/project.go:449 lxc/remote.go:513 lxc/storage.go:558
 #: lxc/storage_volume.go:1118
 msgid "NAME"
 msgstr ""
@@ -2017,8 +2021,8 @@ msgstr ""
 msgid "NICs:"
 msgstr ""
 
-#: lxc/network.go:851 lxc/operation.go:142 lxc/project.go:427
-#: lxc/project.go:432 lxc/remote.go:475 lxc/remote.go:480
+#: lxc/network.go:852 lxc/operation.go:143 lxc/project.go:428
+#: lxc/project.go:433 lxc/remote.go:476 lxc/remote.go:481
 msgid "NO"
 msgstr ""
 
@@ -2040,7 +2044,7 @@ msgstr ""
 msgid "NVRM Version: %v"
 msgstr ""
 
-#: lxc/info.go:438 lxc/network.go:770
+#: lxc/info.go:438 lxc/network.go:771
 #, c-format
 msgid "Name: %s"
 msgstr ""
@@ -2050,31 +2054,31 @@ msgstr ""
 msgid "Name: %v"
 msgstr ""
 
-#: lxc/network.go:307
+#: lxc/network.go:308
 #, c-format
 msgid "Network %s created"
 msgstr ""
 
-#: lxc/network.go:359
+#: lxc/network.go:360
 #, c-format
 msgid "Network %s deleted"
 msgstr ""
 
-#: lxc/network.go:305
+#: lxc/network.go:306
 #, c-format
 msgid "Network %s pending on member %s"
 msgstr ""
 
-#: lxc/network.go:994
+#: lxc/network.go:995
 #, c-format
 msgid "Network %s renamed to %s"
 msgstr ""
 
-#: lxc/init.go:50
+#: lxc/init.go:51
 msgid "Network name"
 msgstr ""
 
-#: lxc/info.go:553 lxc/network.go:784
+#: lxc/info.go:553 lxc/network.go:785
 msgid "Network usage:"
 msgstr ""
 
@@ -2086,11 +2090,11 @@ msgstr ""
 msgid "New aliases to add to the image"
 msgstr ""
 
-#: lxc/copy.go:46 lxc/move.go:52
+#: lxc/copy.go:46 lxc/move.go:51
 msgid "New key/value to apply to a specific device"
 msgstr ""
 
-#: lxc/network.go:428 lxc/network.go:513
+#: lxc/network.go:429 lxc/network.go:514
 msgid "No device found for this network"
 msgstr ""
 
@@ -2124,7 +2128,7 @@ msgstr ""
 msgid "Only \"custom\" volumes can be snapshotted"
 msgstr ""
 
-#: lxc/remote.go:149
+#: lxc/remote.go:150
 msgid "Only https URLs are supported for simplestreams"
 msgstr ""
 
@@ -2132,11 +2136,11 @@ msgstr ""
 msgid "Only https:// is supported for remote image import"
 msgstr ""
 
-#: lxc/network.go:615 lxc/network.go:1054
+#: lxc/network.go:616 lxc/network.go:1055
 msgid "Only managed networks can be modified"
 msgstr ""
 
-#: lxc/operation.go:82
+#: lxc/operation.go:83
 #, c-format
 msgid "Operation %s deleted"
 msgstr ""
@@ -2154,31 +2158,31 @@ msgstr ""
 msgid "PCI address: %v"
 msgstr ""
 
-#: lxc/list.go:428
+#: lxc/list.go:429
 msgid "PID"
 msgstr ""
 
-#: lxc/list.go:427
+#: lxc/list.go:428
 msgid "PROCESSES"
 msgstr ""
 
-#: lxc/list.go:429 lxc/project.go:450
+#: lxc/list.go:430 lxc/project.go:451
 msgid "PROFILES"
 msgstr ""
 
-#: lxc/remote.go:514
+#: lxc/remote.go:515
 msgid "PROTOCOL"
 msgstr ""
 
-#: lxc/image.go:972 lxc/remote.go:516
+#: lxc/image.go:972 lxc/remote.go:517
 msgid "PUBLIC"
 msgstr ""
 
-#: lxc/info.go:547 lxc/network.go:787
+#: lxc/info.go:547 lxc/network.go:788
 msgid "Packets received"
 msgstr ""
 
-#: lxc/info.go:548 lxc/network.go:788
+#: lxc/info.go:548 lxc/network.go:789
 msgid "Packets sent"
 msgstr ""
 
@@ -2213,13 +2217,13 @@ msgstr ""
 msgid "Ports:"
 msgstr ""
 
-#: lxc/network.go:640 lxc/profile.go:498 lxc/project.go:304 lxc/storage.go:303
+#: lxc/network.go:641 lxc/profile.go:499 lxc/project.go:305 lxc/storage.go:304
 #: lxc/storage_volume.go:918 lxc/storage_volume.go:948
 msgid "Press enter to open the editor again"
 msgstr ""
 
 #: lxc/config.go:271 lxc/config.go:344 lxc/config_metadata.go:144
-#: lxc/config_template.go:203 lxc/image.go:415
+#: lxc/config_template.go:204 lxc/image.go:415
 msgid "Press enter to start the editor again"
 msgstr ""
 
@@ -2231,7 +2235,7 @@ msgstr ""
 msgid "Print help"
 msgstr ""
 
-#: lxc/query.go:39
+#: lxc/query.go:40
 msgid "Print the raw response"
 msgstr ""
 
@@ -2254,45 +2258,45 @@ msgstr ""
 msgid "Product: %v (%v)"
 msgstr ""
 
-#: lxc/profile.go:146
+#: lxc/profile.go:147
 #, c-format
 msgid "Profile %s added to %s"
 msgstr ""
 
-#: lxc/profile.go:336
+#: lxc/profile.go:337
 #, c-format
 msgid "Profile %s created"
 msgstr ""
 
-#: lxc/profile.go:387
+#: lxc/profile.go:388
 #, c-format
 msgid "Profile %s deleted"
 msgstr ""
 
-#: lxc/profile.go:669
+#: lxc/profile.go:670
 #, c-format
 msgid "Profile %s isn't currently applied to %s"
 msgstr ""
 
-#: lxc/profile.go:694
+#: lxc/profile.go:695
 #, c-format
 msgid "Profile %s removed from %s"
 msgstr ""
 
-#: lxc/profile.go:745
+#: lxc/profile.go:746
 #, c-format
 msgid "Profile %s renamed to %s"
 msgstr ""
 
-#: lxc/copy.go:47 lxc/init.go:48
+#: lxc/copy.go:47 lxc/init.go:49
 msgid "Profile to apply to the new container"
 msgstr ""
 
-#: lxc/move.go:53
+#: lxc/move.go:52
 msgid "Profile to apply to the target container"
 msgstr ""
 
-#: lxc/profile.go:226
+#: lxc/profile.go:227
 #, c-format
 msgid "Profiles %s applied to %s"
 msgstr ""
@@ -2302,17 +2306,17 @@ msgstr ""
 msgid "Profiles: %s"
 msgstr ""
 
-#: lxc/project.go:133
+#: lxc/project.go:134
 #, c-format
 msgid "Project %s created"
 msgstr ""
 
-#: lxc/project.go:189
+#: lxc/project.go:190
 #, c-format
 msgid "Project %s deleted"
 msgstr ""
 
-#: lxc/project.go:507
+#: lxc/project.go:508
 #, c-format
 msgid "Project %s renamed to %s"
 msgstr ""
@@ -2321,7 +2325,7 @@ msgstr ""
 msgid "Properties:"
 msgstr ""
 
-#: lxc/remote.go:98
+#: lxc/remote.go:99
 msgid "Public image server"
 msgstr ""
 
@@ -2384,28 +2388,28 @@ msgstr ""
 msgid "Refreshing the image: %s"
 msgstr ""
 
-#: lxc/remote.go:562
+#: lxc/remote.go:563
 #, c-format
 msgid "Remote %s already exists"
 msgstr ""
 
-#: lxc/project.go:692 lxc/remote.go:554 lxc/remote.go:616 lxc/remote.go:666
-#: lxc/remote.go:704
+#: lxc/project.go:693 lxc/remote.go:555 lxc/remote.go:617 lxc/remote.go:667
+#: lxc/remote.go:705
 #, c-format
 msgid "Remote %s doesn't exist"
 msgstr ""
 
-#: lxc/remote.go:123
+#: lxc/remote.go:124
 #, c-format
 msgid "Remote %s exists as <%s>"
 msgstr ""
 
-#: lxc/remote.go:558 lxc/remote.go:620 lxc/remote.go:708
+#: lxc/remote.go:559 lxc/remote.go:621 lxc/remote.go:709
 #, c-format
 msgid "Remote %s is static and cannot be modified"
 msgstr ""
 
-#: lxc/remote.go:95
+#: lxc/remote.go:96
 msgid "Remote admin password"
 msgstr ""
 
@@ -2428,11 +2432,11 @@ msgstr ""
 msgid "Remove %s (yes/no): "
 msgstr ""
 
-#: lxc/cluster.go:244 lxc/cluster.go:245
+#: lxc/cluster.go:245 lxc/cluster.go:246
 msgid "Remove a member from the cluster"
 msgstr ""
 
-#: lxc/alias.go:193 lxc/alias.go:194
+#: lxc/alias.go:194 lxc/alias.go:195
 msgid "Remove aliases"
 msgstr ""
 
@@ -2440,24 +2444,24 @@ msgstr ""
 msgid "Remove container devices"
 msgstr ""
 
-#: lxc/profile.go:634 lxc/profile.go:635
+#: lxc/profile.go:635 lxc/profile.go:636
 msgid "Remove profiles from containers"
 msgstr ""
 
-#: lxc/remote.go:595 lxc/remote.go:596
+#: lxc/remote.go:596 lxc/remote.go:597
 msgid "Remove remotes"
 msgstr ""
 
-#: lxc/config_trust.go:192 lxc/config_trust.go:193
+#: lxc/config_trust.go:193 lxc/config_trust.go:194
 msgid "Remove trusted clients"
 msgstr ""
 
-#: lxc/cluster.go:194 lxc/cluster.go:195
+#: lxc/cluster.go:195 lxc/cluster.go:196
 msgid "Rename a cluster member"
 msgstr ""
 
-#: lxc/alias.go:142 lxc/alias.go:143 lxc/image_alias.go:250
-#: lxc/image_alias.go:251
+#: lxc/alias.go:143 lxc/alias.go:144 lxc/image_alias.go:251
+#: lxc/image_alias.go:252
 msgid "Rename aliases"
 msgstr ""
 
@@ -2465,19 +2469,19 @@ msgstr ""
 msgid "Rename containers and snapshots"
 msgstr ""
 
-#: lxc/network.go:959 lxc/network.go:960
+#: lxc/network.go:960 lxc/network.go:961
 msgid "Rename networks"
 msgstr ""
 
-#: lxc/profile.go:710 lxc/profile.go:711
+#: lxc/profile.go:711 lxc/profile.go:712
 msgid "Rename profiles"
 msgstr ""
 
-#: lxc/project.go:467 lxc/project.go:468
+#: lxc/project.go:468 lxc/project.go:469
 msgid "Rename projects"
 msgstr ""
 
-#: lxc/remote.go:533 lxc/remote.go:534
+#: lxc/remote.go:534 lxc/remote.go:535
 msgid "Rename remotes"
 msgstr ""
 
@@ -2537,7 +2541,7 @@ msgstr ""
 msgid "Retrieve the container's console log"
 msgstr ""
 
-#: lxc/init.go:276
+#: lxc/init.go:285
 #, c-format
 msgid "Retrieving image: %s"
 msgstr ""
@@ -2550,11 +2554,11 @@ msgstr ""
 msgid "SIZE"
 msgstr ""
 
-#: lxc/list.go:430
+#: lxc/list.go:431
 msgid "SNAPSHOTS"
 msgstr ""
 
-#: lxc/storage.go:564
+#: lxc/storage.go:565
 msgid "SOURCE"
 msgstr ""
 
@@ -2562,39 +2566,39 @@ msgstr ""
 msgid "SR-IOV information:"
 msgstr ""
 
-#: lxc/cluster.go:128 lxc/list.go:431 lxc/network.go:873 lxc/storage.go:562
+#: lxc/cluster.go:129 lxc/list.go:432 lxc/network.go:874 lxc/storage.go:563
 msgid "STATE"
 msgstr ""
 
-#: lxc/remote.go:517
+#: lxc/remote.go:518
 msgid "STATIC"
 msgstr ""
 
-#: lxc/operation.go:160
+#: lxc/operation.go:161
 msgid "STATUS"
 msgstr ""
 
-#: lxc/list.go:433
+#: lxc/list.go:434
 msgid "STORAGE POOL"
 msgstr ""
 
-#: lxc/query.go:29 lxc/query.go:30
+#: lxc/query.go:30 lxc/query.go:31
 msgid "Send a raw query to LXD"
 msgstr ""
 
-#: lxc/remote.go:97
+#: lxc/remote.go:98
 msgid "Server authentication type (tls or candid)"
 msgstr ""
 
-#: lxc/remote.go:266
+#: lxc/remote.go:267
 msgid "Server certificate NACKed by user"
 msgstr ""
 
-#: lxc/remote.go:398
+#: lxc/remote.go:399
 msgid "Server doesn't trust us after authentication"
 msgstr ""
 
-#: lxc/remote.go:96
+#: lxc/remote.go:97
 msgid "Server protocol (lxd or simplestreams)"
 msgstr ""
 
@@ -2638,11 +2642,11 @@ msgid ""
 "    lxc config set [<remote>:][<container>] <key> <value>"
 msgstr ""
 
-#: lxc/network.go:1009
+#: lxc/network.go:1010
 msgid "Set network configuration keys"
 msgstr ""
 
-#: lxc/network.go:1010
+#: lxc/network.go:1011
 msgid ""
 "Set network configuration keys\n"
 "\n"
@@ -2651,11 +2655,11 @@ msgid ""
 "    lxc network set [<remote>:]<network> <key> <value>"
 msgstr ""
 
-#: lxc/profile.go:760
+#: lxc/profile.go:761
 msgid "Set profile configuration keys"
 msgstr ""
 
-#: lxc/profile.go:761
+#: lxc/profile.go:762
 msgid ""
 "Set profile configuration keys\n"
 "\n"
@@ -2664,11 +2668,11 @@ msgid ""
 "    lxc profile set [<remote>:]<profile> <key> <value>"
 msgstr ""
 
-#: lxc/project.go:522
+#: lxc/project.go:523
 msgid "Set project configuration keys"
 msgstr ""
 
-#: lxc/project.go:523
+#: lxc/project.go:524
 msgid ""
 "Set project configuration keys\n"
 "\n"
@@ -2677,11 +2681,11 @@ msgid ""
 "    lxc project set [<remote>:]<project> <key> <value>"
 msgstr ""
 
-#: lxc/storage.go:580
+#: lxc/storage.go:581
 msgid "Set storage pool configuration keys"
 msgstr ""
 
-#: lxc/storage.go:581
+#: lxc/storage.go:582
 msgid ""
 "Set storage pool configuration keys\n"
 "\n"
@@ -2703,7 +2707,7 @@ msgid ""
 "    lxc storage volume set [<remote>:]<pool> <volume> <key> <value>"
 msgstr ""
 
-#: lxc/remote.go:683 lxc/remote.go:684
+#: lxc/remote.go:684 lxc/remote.go:685
 msgid "Set the URL for the remote"
 msgstr ""
 
@@ -2739,15 +2743,15 @@ msgstr ""
 msgid "Show container or server information"
 msgstr ""
 
-#: lxc/config_template.go:294 lxc/config_template.go:295
+#: lxc/config_template.go:295 lxc/config_template.go:296
 msgid "Show content of container file templates"
 msgstr ""
 
-#: lxc/cluster.go:144 lxc/cluster.go:145
+#: lxc/cluster.go:145 lxc/cluster.go:146
 msgid "Show details of a cluster member"
 msgstr ""
 
-#: lxc/operation.go:179 lxc/operation.go:180
+#: lxc/operation.go:180 lxc/operation.go:181
 msgid "Show details on a background operation"
 msgstr ""
 
@@ -2767,19 +2771,19 @@ msgstr ""
 msgid "Show local and remote versions"
 msgstr ""
 
-#: lxc/network.go:1079 lxc/network.go:1080
+#: lxc/network.go:1080 lxc/network.go:1081
 msgid "Show network configurations"
 msgstr ""
 
-#: lxc/profile.go:819 lxc/profile.go:820
+#: lxc/profile.go:820 lxc/profile.go:821
 msgid "Show profile configurations"
 msgstr ""
 
-#: lxc/project.go:611 lxc/project.go:612
+#: lxc/project.go:612 lxc/project.go:613
 msgid "Show project options"
 msgstr ""
 
-#: lxc/storage.go:649 lxc/storage.go:650
+#: lxc/storage.go:650 lxc/storage.go:651
 msgid "Show storage pool configurations and resources"
 msgstr ""
 
@@ -2795,7 +2799,7 @@ msgstr ""
 msgid "Show the container's last 100 log lines?"
 msgstr ""
 
-#: lxc/remote.go:417 lxc/remote.go:418
+#: lxc/remote.go:418 lxc/remote.go:419
 msgid "Show the default remote"
 msgstr ""
 
@@ -2807,11 +2811,11 @@ msgstr ""
 msgid "Show the resources available to the server"
 msgstr ""
 
-#: lxc/storage.go:653
+#: lxc/storage.go:654
 msgid "Show the resources available to the storage pool"
 msgstr ""
 
-#: lxc/storage.go:390
+#: lxc/storage.go:391
 msgid "Show the used and free space in bytes"
 msgstr ""
 
@@ -2819,7 +2823,7 @@ msgstr ""
 msgid "Show useful information about images"
 msgstr ""
 
-#: lxc/storage.go:386 lxc/storage.go:387
+#: lxc/storage.go:387 lxc/storage.go:388
 msgid "Show useful information about storage pools"
 msgstr ""
 
@@ -2864,7 +2868,7 @@ msgstr ""
 msgid "Starting %s"
 msgstr ""
 
-#: lxc/network.go:773
+#: lxc/network.go:774
 #, c-format
 msgid "State: %s"
 msgstr ""
@@ -2891,22 +2895,22 @@ msgstr ""
 msgid "Stopping the container failed: %s"
 msgstr ""
 
-#: lxc/storage.go:144
+#: lxc/storage.go:145
 #, c-format
 msgid "Storage pool %s created"
 msgstr ""
 
-#: lxc/storage.go:196
+#: lxc/storage.go:197
 #, c-format
 msgid "Storage pool %s deleted"
 msgstr ""
 
-#: lxc/storage.go:142
+#: lxc/storage.go:143
 #, c-format
 msgid "Storage pool %s pending on member %s"
 msgstr ""
 
-#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:51 lxc/move.go:59
+#: lxc/copy.go:53 lxc/import.go:35 lxc/init.go:52 lxc/move.go:58
 msgid "Storage pool name"
 msgstr ""
 
@@ -2950,36 +2954,36 @@ msgstr ""
 msgid "Swap (peak)"
 msgstr ""
 
-#: lxc/project.go:664 lxc/project.go:665
+#: lxc/project.go:665 lxc/project.go:666
 msgid "Switch the current project"
 msgstr ""
 
-#: lxc/remote.go:645 lxc/remote.go:646
+#: lxc/remote.go:646 lxc/remote.go:647
 msgid "Switch the default remote"
 msgstr ""
 
-#: lxc/alias.go:126
+#: lxc/alias.go:127
 msgid "TARGET"
 msgstr ""
 
-#: lxc/image.go:977 lxc/image_alias.go:232 lxc/list.go:432 lxc/network.go:867
-#: lxc/network.go:940 lxc/operation.go:158 lxc/storage_volume.go:1117
+#: lxc/image.go:977 lxc/image_alias.go:233 lxc/list.go:433 lxc/network.go:868
+#: lxc/network.go:941 lxc/operation.go:159 lxc/storage_volume.go:1117
 msgid "TYPE"
 msgstr ""
 
-#: lxc/move.go:154
+#: lxc/move.go:161
 msgid "The --container-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:158
+#: lxc/move.go:165
 msgid "The --instance-only flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:162
+#: lxc/move.go:169
 msgid "The --mode flag can't be used with --target"
 msgstr ""
 
-#: lxc/move.go:150
+#: lxc/move.go:157
 msgid "The --stateless flag can't be used with --target"
 msgstr ""
 
@@ -2993,7 +2997,7 @@ msgid ""
 "restarted"
 msgstr ""
 
-#: lxc/init.go:370
+#: lxc/init.go:388
 msgid "The container you are starting doesn't have any network attached to it."
 msgstr ""
 
@@ -3006,12 +3010,12 @@ msgstr ""
 msgid "The device doesn't exist"
 msgstr ""
 
-#: lxc/init.go:354
+#: lxc/init.go:372
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:%s' instead."
 msgstr ""
 
-#: lxc/init.go:350
+#: lxc/init.go:368
 #, c-format
 msgid "The local image '%s' couldn't be found, trying '%s:' instead."
 msgstr ""
@@ -3020,16 +3024,16 @@ msgstr ""
 msgid "The profile device doesn't exist"
 msgstr ""
 
-#: lxc/move.go:229
+#: lxc/move.go:236
 msgid "The source LXD instance is not clustered"
 msgstr ""
 
-#: lxc/network.go:433 lxc/network.go:518 lxc/storage_volume.go:673
+#: lxc/network.go:434 lxc/network.go:519 lxc/storage_volume.go:673
 #: lxc/storage_volume.go:754
 msgid "The specified device doesn't exist"
 msgstr ""
 
-#: lxc/network.go:437 lxc/network.go:522
+#: lxc/network.go:438 lxc/network.go:523
 msgid "The specified device doesn't match the network"
 msgstr ""
 
@@ -3061,11 +3065,11 @@ msgstr ""
 msgid "Timestamps:"
 msgstr ""
 
-#: lxc/init.go:372
+#: lxc/init.go:390
 msgid "To attach a network to a container, use: lxc network attach"
 msgstr ""
 
-#: lxc/init.go:371
+#: lxc/init.go:389
 msgid "To create a new network, use: lxc network create"
 msgstr ""
 
@@ -3078,7 +3082,7 @@ msgid "To start your first container, try: lxc launch ubuntu:18.04"
 msgstr ""
 
 #: lxc/config.go:293 lxc/config.go:418 lxc/config.go:536 lxc/config.go:617
-#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:758 lxc/storage.go:419
+#: lxc/copy.go:118 lxc/info.go:309 lxc/network.go:759 lxc/storage.go:420
 msgid "To use --target, the destination remote must be a cluster"
 msgstr ""
 
@@ -3100,7 +3104,7 @@ msgstr ""
 msgid "Transfer mode. One of pull (default), push or relay"
 msgstr ""
 
-#: lxc/move.go:57 lxc/storage_volume.go:304
+#: lxc/move.go:56 lxc/storage_volume.go:304
 msgid "Transfer mode. One of pull (default), push or relay."
 msgstr ""
 
@@ -3133,11 +3137,11 @@ msgstr ""
 msgid "UPLOAD DATE"
 msgstr ""
 
-#: lxc/cluster.go:126 lxc/remote.go:513
+#: lxc/cluster.go:127 lxc/remote.go:514
 msgid "URL"
 msgstr ""
 
-#: lxc/network.go:870 lxc/profile.go:620 lxc/project.go:451 lxc/storage.go:566
+#: lxc/network.go:871 lxc/profile.go:621 lxc/project.go:452 lxc/storage.go:567
 #: lxc/storage_volume.go:1120
 msgid "USED BY"
 msgstr ""
@@ -3152,7 +3156,7 @@ msgstr ""
 msgid "Unable to create a temporary file: %v"
 msgstr ""
 
-#: lxc/image.go:992 lxc/list.go:479
+#: lxc/image.go:992 lxc/list.go:480
 #, c-format
 msgid "Unknown column shorthand char '%c' in '%s'"
 msgstr ""
@@ -3162,7 +3166,7 @@ msgstr ""
 msgid "Unknown file type '%s'"
 msgstr ""
 
-#: lxc/move.go:54
+#: lxc/move.go:53
 msgid "Unset all profiles on the target container"
 msgstr ""
 
@@ -3174,19 +3178,19 @@ msgstr ""
 msgid "Unset container or server configuration keys"
 msgstr ""
 
-#: lxc/network.go:1141 lxc/network.go:1142
+#: lxc/network.go:1142 lxc/network.go:1143
 msgid "Unset network configuration keys"
 msgstr ""
 
-#: lxc/profile.go:873 lxc/profile.go:874
+#: lxc/profile.go:874 lxc/profile.go:875
 msgid "Unset profile configuration keys"
 msgstr ""
 
-#: lxc/project.go:582 lxc/project.go:583
+#: lxc/project.go:583 lxc/project.go:584
 msgid "Unset project configuration keys"
 msgstr ""
 
-#: lxc/storage.go:733 lxc/storage.go:734
+#: lxc/storage.go:734 lxc/storage.go:735
 msgid "Unset storage pool configuration keys"
 msgstr ""
 
@@ -3213,7 +3217,7 @@ msgstr ""
 msgid "User ID to run the command as (default 0)"
 msgstr ""
 
-#: lxc/cluster.go:276 lxc/delete.go:47
+#: lxc/cluster.go:277 lxc/delete.go:47
 msgid "User aborted delete operation"
 msgstr ""
 
@@ -3247,7 +3251,7 @@ msgstr ""
 msgid "WWN: %s"
 msgstr ""
 
-#: lxc/query.go:38
+#: lxc/query.go:39
 msgid "Wait for the operation to complete"
 msgstr ""
 
@@ -3271,8 +3275,8 @@ msgstr ""
 msgid "Whether or not to snapshot the container's running state"
 msgstr ""
 
-#: lxc/network.go:853 lxc/operation.go:144 lxc/project.go:429
-#: lxc/project.go:434 lxc/remote.go:477 lxc/remote.go:482
+#: lxc/network.go:854 lxc/operation.go:145 lxc/project.go:430
+#: lxc/project.go:435 lxc/remote.go:478 lxc/remote.go:483
 msgid "YES"
 msgstr ""
 
@@ -3288,19 +3292,19 @@ msgstr ""
 msgid "You must specify a destination container name when using --target"
 msgstr ""
 
-#: lxc/copy.go:79 lxc/move.go:213
+#: lxc/copy.go:79 lxc/move.go:220
 msgid "You must specify a source container name"
 msgstr ""
 
-#: lxc/alias.go:51
+#: lxc/alias.go:52
 msgid "add <alias> <target>"
 msgstr ""
 
-#: lxc/config_trust.go:55
+#: lxc/config_trust.go:56
 msgid "add [<remote>:] <cert>"
 msgstr ""
 
-#: lxc/profile.go:98
+#: lxc/profile.go:99
 msgid "add [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -3308,19 +3312,19 @@ msgstr ""
 msgid "add [<remote>:]<container|profile> <device> <type> [key=value...]"
 msgstr ""
 
-#: lxc/remote.go:82
+#: lxc/remote.go:83
 msgid "add [<remote>] <IP|FQDN|URL>"
 msgstr ""
 
-#: lxc/alias.go:19 lxc/image_alias.go:22
+#: lxc/alias.go:20 lxc/image_alias.go:23
 msgid "alias"
 msgstr ""
 
-#: lxc/profile.go:160
+#: lxc/profile.go:161
 msgid "assign [<remote>:]<container> <profiles>"
 msgstr ""
 
-#: lxc/network.go:105
+#: lxc/network.go:106
 msgid ""
 "attach [<remote>:]<network> <container> [<device name>] [<interface name>]"
 msgstr ""
@@ -3334,13 +3338,13 @@ msgid ""
 "attach-profile [<remote:>]<pool> <volume> <profile> [<device name>] <path>"
 msgstr ""
 
-#: lxc/network.go:178
+#: lxc/network.go:179
 msgid ""
 "attach-profile [<remote>:]<network> <profile> [<device name>] [<interface "
 "name>]"
 msgstr ""
 
-#: lxc/cluster.go:26
+#: lxc/cluster.go:27
 msgid "cluster"
 msgstr ""
 
@@ -3360,7 +3364,7 @@ msgstr ""
 msgid "copy [<remote>:]<image> <remote>:"
 msgstr ""
 
-#: lxc/profile.go:240
+#: lxc/profile.go:241
 msgid "copy [<remote>:]<profile> [<remote>:]<profile>"
 msgstr ""
 
@@ -3368,19 +3372,19 @@ msgstr ""
 msgid "copy [<remote>:]<source>[/<snapshot>] [[<remote>:]<destination>]"
 msgstr ""
 
-#: lxc/image_alias.go:55
+#: lxc/image_alias.go:56
 msgid "create [<remote>:]<alias> <fingerprint>"
 msgstr ""
 
-#: lxc/config_template.go:63
+#: lxc/config_template.go:64
 msgid "create [<remote>:]<container> <template>"
 msgstr ""
 
-#: lxc/network.go:251
+#: lxc/network.go:252
 msgid "create [<remote>:]<network> [key=value...]"
 msgstr ""
 
-#: lxc/storage.go:86
+#: lxc/storage.go:87
 msgid "create [<remote>:]<pool> <driver> [key=value...]"
 msgstr ""
 
@@ -3388,27 +3392,27 @@ msgstr ""
 msgid "create [<remote>:]<pool> <volume> [key=value...]"
 msgstr ""
 
-#: lxc/profile.go:297
+#: lxc/profile.go:298
 msgid "create [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:83
+#: lxc/project.go:84
 msgid "create [<remote>:]<project>"
 msgstr ""
 
-#: lxc/project.go:439
+#: lxc/project.go:440
 msgid "current"
 msgstr ""
 
-#: lxc/remote.go:505
+#: lxc/remote.go:506
 msgid "default"
 msgstr ""
 
-#: lxc/image_alias.go:101
+#: lxc/image_alias.go:102
 msgid "delete [<remote>:]<alias>"
 msgstr ""
 
-#: lxc/config_template.go:105
+#: lxc/config_template.go:106
 msgid "delete [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3426,15 +3430,15 @@ msgstr ""
 msgid "delete [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/network.go:322
+#: lxc/network.go:323
 msgid "delete [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:49
+#: lxc/operation.go:50
 msgid "delete [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:159
+#: lxc/storage.go:160
 msgid "delete [<remote>:]<pool>"
 msgstr ""
 
@@ -3442,19 +3446,19 @@ msgstr ""
 msgid "delete [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:350
+#: lxc/profile.go:351
 msgid "delete [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:147
+#: lxc/project.go:148
 msgid "delete [<remote>:]<project>"
 msgstr ""
 
-#: lxc/storage.go:445
+#: lxc/storage.go:446
 msgid "description"
 msgstr ""
 
-#: lxc/network.go:373
+#: lxc/network.go:374
 msgid "detach [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3466,7 +3470,7 @@ msgstr ""
 msgid "detach-profile [<remote:>]<pool> <volume> <profile> [<device name>]"
 msgstr ""
 
-#: lxc/network.go:458
+#: lxc/network.go:459
 msgid "detach-profile [<remote>:]<network> <container> [<device name>]"
 msgstr ""
 
@@ -3478,7 +3482,7 @@ msgstr ""
 msgid "disabled"
 msgstr ""
 
-#: lxc/storage.go:444
+#: lxc/storage.go:445
 msgid "driver"
 msgstr ""
 
@@ -3486,7 +3490,7 @@ msgstr ""
 msgid "edit [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:148
+#: lxc/config_template.go:149
 msgid "edit [<remote>:]<container> <template>"
 msgstr ""
 
@@ -3498,11 +3502,11 @@ msgstr ""
 msgid "edit [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:543
+#: lxc/network.go:544
 msgid "edit [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:210
+#: lxc/storage.go:211
 msgid "edit [<remote>:]<pool>"
 msgstr ""
 
@@ -3510,11 +3514,11 @@ msgstr ""
 msgid "edit [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:401
+#: lxc/profile.go:402
 msgid "edit [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:211
+#: lxc/project.go:212
 msgid "edit [<remote>:]<project>"
 msgstr ""
 
@@ -3522,7 +3526,7 @@ msgstr ""
 msgid "edit [<remote>:][<container>[/<snapshot>]]"
 msgstr ""
 
-#: lxc/cluster.go:328
+#: lxc/cluster.go:329
 msgid "enable [<remote>:] <name>"
 msgstr ""
 
@@ -3562,11 +3566,11 @@ msgstr ""
 msgid "get [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:666
+#: lxc/network.go:667
 msgid "get [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:330
+#: lxc/storage.go:331
 msgid "get [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -3574,11 +3578,11 @@ msgstr ""
 msgid "get [<remote>:]<pool> <volume>[/<snapshot>] <key>"
 msgstr ""
 
-#: lxc/profile.go:525
+#: lxc/profile.go:526
 msgid "get [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:331
+#: lxc/project.go:332
 msgid "get [<remote>:]<project> <key>"
 msgstr ""
 
@@ -3586,7 +3590,7 @@ msgstr ""
 msgid "get [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/remote.go:416
+#: lxc/remote.go:417
 msgid "get-default"
 msgstr ""
 
@@ -3604,7 +3608,7 @@ msgstr ""
 msgid "import [<remote>:] <backup file>"
 msgstr ""
 
-#: lxc/storage.go:442
+#: lxc/storage.go:443
 msgid "info"
 msgstr ""
 
@@ -3612,11 +3616,11 @@ msgstr ""
 msgid "info [<remote>:]<image>"
 msgstr ""
 
-#: lxc/network.go:724
+#: lxc/network.go:725
 msgid "info [<remote>:]<network>"
 msgstr ""
 
-#: lxc/storage.go:385
+#: lxc/storage.go:386
 msgid "info [<remote>:]<pool>"
 msgstr ""
 
@@ -3624,7 +3628,7 @@ msgstr ""
 msgid "info [<remote>:][<container>]"
 msgstr ""
 
-#: lxc/init.go:37
+#: lxc/init.go:38
 msgid "init [[<remote>:]<image>] [<remote>:][<name>] [< config"
 msgstr ""
 
@@ -3632,24 +3636,24 @@ msgstr ""
 msgid "launch [<remote>:]<image> [<remote>:][<name>]"
 msgstr ""
 
-#: lxc/alias.go:96 lxc/remote.go:451
+#: lxc/alias.go:97 lxc/remote.go:452
 msgid "list"
 msgstr ""
 
-#: lxc/cluster.go:64 lxc/config_trust.go:112 lxc/network.go:803
-#: lxc/operation.go:98 lxc/profile.go:573 lxc/project.go:380 lxc/storage.go:504
+#: lxc/cluster.go:65 lxc/config_trust.go:113 lxc/network.go:804
+#: lxc/operation.go:99 lxc/profile.go:574 lxc/project.go:381 lxc/storage.go:505
 msgid "list [<remote>:]"
 msgstr ""
 
-#: lxc/image.go:931 lxc/list.go:40
+#: lxc/image.go:931 lxc/list.go:41
 msgid "list [<remote>:] [<filter>...]"
 msgstr ""
 
-#: lxc/image_alias.go:146
+#: lxc/image_alias.go:147
 msgid "list [<remote>:] [<filters>...]"
 msgstr ""
 
-#: lxc/config_template.go:234
+#: lxc/config_template.go:235
 msgid "list [<remote>:]<container>"
 msgstr ""
 
@@ -3661,23 +3665,23 @@ msgstr ""
 msgid "list [<remote>:]<pool>"
 msgstr ""
 
-#: lxc/network.go:889
+#: lxc/network.go:890
 msgid "list-leases [<remote>:]<network>"
 msgstr ""
 
-#: lxc/alias.go:55
+#: lxc/alias.go:56
 msgid ""
 "lxc alias add list \"list -c ns46S\"\n"
 "    Overwrite the \"list\" command to pass -c ns46S."
 msgstr ""
 
-#: lxc/alias.go:196
+#: lxc/alias.go:197
 msgid ""
 "lxc alias remove my-list\n"
 "    Remove the \"my-list\" alias."
 msgstr ""
 
-#: lxc/alias.go:145
+#: lxc/alias.go:146
 msgid ""
 "lxc alias rename list my-list\n"
 "    Rename existing alias \"list\" to \"my-list\"."
@@ -3751,7 +3755,7 @@ msgid ""
 "    For LXD server information."
 msgstr ""
 
-#: lxc/init.go:40
+#: lxc/init.go:41
 msgid ""
 "lxc init ubuntu:16.04 u1\n"
 "\n"
@@ -3767,7 +3771,7 @@ msgid ""
 "    Create and start the container with configuration from config.yaml"
 msgstr ""
 
-#: lxc/list.go:103
+#: lxc/list.go:104
 msgid ""
 "lxc list -c nFs46,volatile.eth0.hwaddr:MAC,config:image.os,devices:eth0."
 "parent:ETHP\n"
@@ -3793,7 +3797,7 @@ msgid ""
 "    Only show lifecycle events."
 msgstr ""
 
-#: lxc/move.go:40
+#: lxc/move.go:39
 msgid ""
 "lxc move [<remote>:]<source container> [<remote>:][<destination container>] "
 "[--container-only]\n"
@@ -3807,13 +3811,13 @@ msgid ""
 "    Rename a snapshot."
 msgstr ""
 
-#: lxc/operation.go:182
+#: lxc/operation.go:183
 msgid ""
 "lxc operation show 344a79e4-d88a-45bf-9c39-c72c26f6ab8a\n"
 "    Show details on that operation UUID"
 msgstr ""
 
-#: lxc/profile.go:165
+#: lxc/profile.go:166
 msgid ""
 "lxc profile assign foo default,bar\n"
 "    Set the profiles for \"foo\" to \"default\" and \"bar\".\n"
@@ -3832,19 +3836,19 @@ msgid ""
 "    Will mount the host's /share/c1 onto /opt in the container."
 msgstr ""
 
-#: lxc/profile.go:405
+#: lxc/profile.go:406
 msgid ""
 "lxc profile edit <profile> < profile.yaml\n"
 "    Update a profile using the content of profile.yaml"
 msgstr ""
 
-#: lxc/project.go:215
+#: lxc/project.go:216
 msgid ""
 "lxc project edit <project> < project.yaml\n"
 "    Update a project using the content of project.yaml"
 msgstr ""
 
-#: lxc/query.go:32
+#: lxc/query.go:33
 msgid ""
 "lxc query -X DELETE --wait /1.0/containers/c1\n"
 "    Delete local container \"c1\"."
@@ -3865,7 +3869,7 @@ msgid ""
 "    Restore the snapshot."
 msgstr ""
 
-#: lxc/storage.go:214
+#: lxc/storage.go:215
 msgid ""
 "lxc storage edit [<remote>:]<pool> < pool.yaml\n"
 "    Update a storage pool using the content of pool.yaml."
@@ -3904,17 +3908,17 @@ msgstr ""
 msgid "move [<pool>/]<volume> [<pool>/]<volume>"
 msgstr ""
 
-#: lxc/move.go:35
+#: lxc/move.go:34
 msgid ""
 "move [<remote>:]<container>[/<snapshot>] [<remote>:][<container>[/"
 "<snapshot>]]"
 msgstr ""
 
-#: lxc/storage.go:443
+#: lxc/storage.go:444
 msgid "name"
 msgstr ""
 
-#: lxc/network.go:29
+#: lxc/network.go:30
 msgid "network"
 msgstr ""
 
@@ -3922,11 +3926,11 @@ msgstr ""
 msgid "no"
 msgstr ""
 
-#: lxc/remote.go:259
+#: lxc/remote.go:260
 msgid "ok (y/n)?"
 msgstr ""
 
-#: lxc/operation.go:21
+#: lxc/operation.go:22
 msgid "operation"
 msgstr ""
 
@@ -3942,11 +3946,11 @@ msgstr ""
 msgid "please use `lxc profile`"
 msgstr ""
 
-#: lxc/profile.go:26
+#: lxc/profile.go:27
 msgid "profile"
 msgstr ""
 
-#: lxc/project.go:26
+#: lxc/project.go:27
 msgid "project"
 msgstr ""
 
@@ -3968,7 +3972,7 @@ msgid ""
 "<path>...]"
 msgstr ""
 
-#: lxc/query.go:28
+#: lxc/query.go:29
 msgid "query [<remote>:]<API path>"
 msgstr ""
 
@@ -3976,23 +3980,23 @@ msgstr ""
 msgid "refresh [<remote>:]<image> [[<remote>:]<image>...]"
 msgstr ""
 
-#: lxc/remote.go:31
+#: lxc/remote.go:32
 msgid "remote"
 msgstr ""
 
-#: lxc/alias.go:191
+#: lxc/alias.go:192
 msgid "remove <alias>"
 msgstr ""
 
-#: lxc/remote.go:593
+#: lxc/remote.go:594
 msgid "remove <remote>"
 msgstr ""
 
-#: lxc/config_trust.go:190
+#: lxc/config_trust.go:191
 msgid "remove [<remote>:] <hostname|fingerprint>"
 msgstr ""
 
-#: lxc/profile.go:633
+#: lxc/profile.go:634
 msgid "remove [<remote>:]<container> <profile>"
 msgstr ""
 
@@ -4000,19 +4004,19 @@ msgstr ""
 msgid "remove [<remote>:]<container|profile> <name>..."
 msgstr ""
 
-#: lxc/cluster.go:242
+#: lxc/cluster.go:243
 msgid "remove [<remote>:]<member>"
 msgstr ""
 
-#: lxc/alias.go:140
+#: lxc/alias.go:141
 msgid "rename <old alias> <new alias>"
 msgstr ""
 
-#: lxc/remote.go:531
+#: lxc/remote.go:532
 msgid "rename <remote> <new-name>"
 msgstr ""
 
-#: lxc/image_alias.go:248
+#: lxc/image_alias.go:249
 msgid "rename [<remote>:]<alias> <new-name>"
 msgstr ""
 
@@ -4020,11 +4024,11 @@ msgstr ""
 msgid "rename [<remote>:]<container>[/<snapshot>] <container>[/<snapshot>]"
 msgstr ""
 
-#: lxc/cluster.go:192
+#: lxc/cluster.go:193
 msgid "rename [<remote>:]<member> <new-name>"
 msgstr ""
 
-#: lxc/network.go:957
+#: lxc/network.go:958
 msgid "rename [<remote>:]<network> <new-name>"
 msgstr ""
 
@@ -4034,11 +4038,11 @@ msgid ""
 "snapshot name>]"
 msgstr ""
 
-#: lxc/profile.go:708
+#: lxc/profile.go:709
 msgid "rename [<remote>:]<profile> <new-name>"
 msgstr ""
 
-#: lxc/project.go:465
+#: lxc/project.go:466
 msgid "rename [<remote>:]<project> <new-name>"
 msgstr ""
 
@@ -4058,11 +4062,11 @@ msgstr ""
 msgid "set [<remote>:]<container|profile> <device> <key>=<value>..."
 msgstr ""
 
-#: lxc/network.go:1008
+#: lxc/network.go:1009
 msgid "set [<remote>:]<network> <key>=<value>..."
 msgstr ""
 
-#: lxc/storage.go:579
+#: lxc/storage.go:580
 msgid "set [<remote>:]<pool> <key> <value>"
 msgstr ""
 
@@ -4070,11 +4074,11 @@ msgstr ""
 msgid "set [<remote>:]<pool> <volume> <key>=<value>..."
 msgstr ""
 
-#: lxc/profile.go:759
+#: lxc/profile.go:760
 msgid "set [<remote>:]<profile> <key><value>..."
 msgstr ""
 
-#: lxc/project.go:521
+#: lxc/project.go:522
 msgid "set [<remote>:]<project> <key>=<value>..."
 msgstr ""
 
@@ -4082,7 +4086,7 @@ msgstr ""
 msgid "set [<remote>:][<container>] <key>=<value>..."
 msgstr ""
 
-#: lxc/remote.go:682
+#: lxc/remote.go:683
 msgid "set-url <remote> <URL>"
 msgstr ""
 
@@ -4090,7 +4094,7 @@ msgstr ""
 msgid "show [<remote>:]<container>"
 msgstr ""
 
-#: lxc/config_template.go:293
+#: lxc/config_template.go:294
 msgid "show [<remote>:]<container> <template>"
 msgstr ""
 
@@ -4102,19 +4106,19 @@ msgstr ""
 msgid "show [<remote>:]<image>"
 msgstr ""
 
-#: lxc/cluster.go:143
+#: lxc/cluster.go:144
 msgid "show [<remote>:]<member>"
 msgstr ""
 
-#: lxc/network.go:1078
+#: lxc/network.go:1079
 msgid "show [<remote>:]<network>"
 msgstr ""
 
-#: lxc/operation.go:178
+#: lxc/operation.go:179
 msgid "show [<remote>:]<operation>"
 msgstr ""
 
-#: lxc/storage.go:648
+#: lxc/storage.go:649
 msgid "show [<remote>:]<pool>"
 msgstr ""
 
@@ -4122,11 +4126,11 @@ msgstr ""
 msgid "show [<remote>:]<pool> <volume>[/<snapshot>]"
 msgstr ""
 
-#: lxc/profile.go:818
+#: lxc/profile.go:819
 msgid "show [<remote>:]<profile>"
 msgstr ""
 
-#: lxc/project.go:610
+#: lxc/project.go:611
 msgid "show [<remote>:]<project>"
 msgstr ""
 
@@ -4142,7 +4146,7 @@ msgstr ""
 msgid "snapshot [<remote>:]<pool> <volume> [<snapshot>]"
 msgstr ""
 
-#: lxc/storage.go:447
+#: lxc/storage.go:448
 msgid "space used"
 msgstr ""
 
@@ -4162,15 +4166,15 @@ msgstr ""
 msgid "stop [<remote>:]<container> [[<remote>:]<container>...]"
 msgstr ""
 
-#: lxc/storage.go:30
+#: lxc/storage.go:31
 msgid "storage"
 msgstr ""
 
-#: lxc/remote.go:644
+#: lxc/remote.go:645
 msgid "switch <remote>"
 msgstr ""
 
-#: lxc/project.go:663
+#: lxc/project.go:664
 msgid "switch [<remote>:] <project>"
 msgstr ""
 
@@ -4179,15 +4183,15 @@ msgstr ""
 msgid "taken at %s"
 msgstr ""
 
-#: lxc/config_template.go:26
+#: lxc/config_template.go:27
 msgid "template"
 msgstr ""
 
-#: lxc/storage.go:446
+#: lxc/storage.go:447
 msgid "total space"
 msgstr ""
 
-#: lxc/config_trust.go:26
+#: lxc/config_trust.go:27
 msgid "trust"
 msgstr ""
 
@@ -4199,11 +4203,11 @@ msgstr ""
 msgid "unset [<remote>:]<container|profile> <device> <key>"
 msgstr ""
 
-#: lxc/network.go:1140
+#: lxc/network.go:1141
 msgid "unset [<remote>:]<network> <key>"
 msgstr ""
 
-#: lxc/storage.go:732
+#: lxc/storage.go:733
 msgid "unset [<remote>:]<pool> <key>"
 msgstr ""
 
@@ -4211,11 +4215,11 @@ msgstr ""
 msgid "unset [<remote>:]<pool> <volume> <key>"
 msgstr ""
 
-#: lxc/profile.go:872
+#: lxc/profile.go:873
 msgid "unset [<remote>:]<profile> <key>"
 msgstr ""
 
-#: lxc/project.go:581
+#: lxc/project.go:582
 msgid "unset [<remote>:]<project> <key>"
 msgstr ""
 
@@ -4223,7 +4227,7 @@ msgstr ""
 msgid "unset [<remote>:][<container>] <key>"
 msgstr ""
 
-#: lxc/storage.go:441
+#: lxc/storage.go:442
 msgid "used by"
 msgstr ""
 
@@ -4235,11 +4239,11 @@ msgstr ""
 msgid "volume"
 msgstr ""
 
-#: lxc/remote.go:265
+#: lxc/remote.go:266
 msgid "y"
 msgstr ""
 
-#: lxc/cluster.go:275 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
+#: lxc/cluster.go:276 lxc/delete.go:46 lxc/image.go:849 lxc/image.go:854
 #: lxc/image.go:1028
 msgid "yes"
 msgstr ""

--- a/shared/cert.go
+++ b/shared/cert.go
@@ -210,6 +210,8 @@ func mynames() ([]string, error) {
 	return ret, nil
 }
 
+// FindOrGenCert generates a keypair if needed.
+// The type argument is false for server, true for client.
 func FindOrGenCert(certf string, keyf string, certtype bool) error {
 	if PathExists(certf) && PathExists(keyf) {
 		return nil

--- a/shared/container.go
+++ b/shared/container.go
@@ -391,6 +391,10 @@ func ConfigKeyChecker(key string) (func(value string) error, error) {
 		if strings.HasSuffix(key, ".apply_quota") {
 			return IsAny, nil
 		}
+
+		if strings.HasSuffix(key, "vm.uuid") {
+			return IsAny, nil
+		}
 	}
 
 	if strings.HasPrefix(key, "environment.") {


### PR DESCRIPTION
This PR adds basic VM support.

You can download a VM image and create a VM instance on a `dir` pool by doing:

```
lxc init ubuntu:18.04 c1 --vm -s mydirpool -p vmdefault
```

Or launch an empty one for PXE boot:

```
lxc init c1 --vm -s mydirpool -p vmdefault --empty
```

The vmdefault profile needs to have cloud init config to create a login user and password.