### PR TITLE
Mount options for disk device mounts #6225

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -869,3 +869,6 @@ elevated permissions.
 
 ## compression_squashfs
 Adds support for importing/exporting of images/backups using SquashFS file system format.
+
+## container\_raw\_mount
+This adds support for passing in raw mount options for disk devices. 

--- a/doc/containers.md
+++ b/doc/containers.md
@@ -481,20 +481,21 @@ if the source is a block device, a regular mount.
 
 The following properties exist:
 
-Key             | Type      | Default           | Required  | Description
-:--             | :--       | :--               | :--       | :--
-limits.read     | string    | -                 | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
-limits.write    | string    | -                 | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
-limits.max      | string    | -                 | no        | Same as modifying both limits.read and limits.write
-path            | string    | -                 | yes       | Path inside the container where the disk will be mounted
-source          | string    | -                 | yes       | Path on the host, either to a file/directory or to a block device
-required        | boolean   | true              | no        | Controls whether to fail if the source doesn't exist
-readonly        | boolean   | false             | no        | Controls whether to make the mount read-only
-size            | string    | -                 | no        | Disk size in bytes (various suffixes supported, see below). This is only supported for the rootfs (/).
-recursive       | boolean   | false             | no        | Whether or not to recursively mount the source path
-pool            | string    | -                 | no        | The storage pool the disk device belongs to. This is only applicable for storage volumes managed by LXD.
-propagation     | string    | -                 | no        | Controls how a bind-mount is shared between the container and the host. (Can be one of `private`, the default, or `shared`, `slave`, `unbindable`,  `rshared`, `rslave`, `runbindable`,  `rprivate`. Please see the Linux Kernel [shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) documentation for a full explanation)
-shift           | boolean   | false             | no        | Setup a shifting overlay to translate the source uid/gid to match the container
+Key              | Type      | Default           | Required  | Description
+:--              | :--       | :--               | :--       | :--
+limits.read      | string    | -                 | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
+limits.write     | string    | -                 | no        | I/O limit in byte/s (various suffixes supported, see below) or in iops (must be suffixed with "iops")
+limits.max       | string    | -                 | no        | Same as modifying both limits.read and limits.write
+path             | string    | -                 | yes       | Path inside the container where the disk will be mounted
+source           | string    | -                 | yes       | Path on the host, either to a file/directory or to a block device
+required         | boolean   | true              | no        | Controls whether to fail if the source doesn't exist
+readonly         | boolean   | false             | no        | Controls whether to make the mount read-only
+size             | string    | -                 | no        | Disk size in bytes (various suffixes supported, see below). This is only supported for the rootfs (/).
+recursive        | boolean   | false             | no        | Whether or not to recursively mount the source path
+pool             | string    | -                 | no        | The storage pool the disk device belongs to. This is only applicable for storage volumes managed by LXD.
+propagation      | string    | -                 | no        | Controls how a bind-mount is shared between the container and the host. (Can be one of `private`, the default, or `shared`, `slave`, `unbindable`,  `rshared`, `rslave`, `runbindable`,  `rprivate`. Please see the Linux Kernel [shared subtree](https://www.kernel.org/doc/Documentation/filesystems/sharedsubtree.txt) documentation for a full explanation)
+shift            | boolean   | false             | no        | Setup a shifting overlay to translate the source uid/gid to match the container
+raw.mount.options| string    | -                 | no        | Filesystem specific mount options 
 
 If multiple disks, backed by the same block device, have I/O limits set,
 the average of the limits will be used.

--- a/lxd/device/device_utils_disk.go
+++ b/lxd/device/device_utils_disk.go
@@ -48,7 +48,7 @@ func IsBlockdev(path string) bool {
 }
 
 // DiskMount mounts a disk device.
-func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, propagation string) error {
+func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, propagation string, rawMountOptions string) error {
 	var err error
 
 	// Prepare the mount flags
@@ -95,7 +95,7 @@ func DiskMount(srcPath string, dstPath string, readonly bool, recursive bool, pr
 	}
 
 	// Mount the filesystem
-	err = unix.Mount(srcPath, dstPath, fstype, uintptr(flags), "")
+	err = unix.Mount(srcPath, dstPath, fstype, uintptr(flags), rawMountOptions)
 	if err != nil {
 		return fmt.Errorf("Unable to mount %s at %s: %s", srcPath, dstPath, err)
 	}

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -273,7 +273,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 		}
 		f.Close()
 
-		err = DiskMount(srcPath, devPath, false, false, "")
+		err = DiskMount(srcPath, devPath, false, false, "", "")
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -62,19 +62,20 @@ func (d *disk) validateConfig() error {
 	}
 
 	rules := map[string]func(string) error{
-		"path":         shared.IsNotEmpty,
-		"required":     shared.IsBool,
-		"optional":     shared.IsBool, // "optional" is deprecated, replaced by "required".
-		"readonly":     shared.IsBool,
-		"recursive":    shared.IsBool,
-		"shift":        shared.IsBool,
-		"source":       shared.IsAny,
-		"limits.read":  shared.IsAny,
-		"limits.write": shared.IsAny,
-		"limits.max":   shared.IsAny,
-		"size":         shared.IsAny,
-		"pool":         shared.IsAny,
-		"propagation":  validatePropagation,
+		"path":              shared.IsNotEmpty,
+		"required":          shared.IsBool,
+		"optional":          shared.IsBool, // "optional" is deprecated, replaced by "required".
+		"readonly":          shared.IsBool,
+		"recursive":         shared.IsBool,
+		"shift":             shared.IsBool,
+		"source":            shared.IsAny,
+		"limits.read":       shared.IsAny,
+		"limits.write":      shared.IsAny,
+		"limits.max":        shared.IsAny,
+		"size":              shared.IsAny,
+		"pool":              shared.IsAny,
+		"propagation":       validatePropagation,
+		"raw.mount.options": shared.IsAny,
 	}
 
 	err := d.config.Validate(rules)
@@ -606,7 +607,7 @@ func (d *disk) createDevice() (string, error) {
 	}
 
 	// Mount the fs.
-	err := DiskMount(srcPath, devPath, isReadOnly, isRecursive, d.config["propagation"])
+	err := DiskMount(srcPath, devPath, isReadOnly, isRecursive, d.config["propagation"], d.config["raw.mount.options"])
 	if err != nil {
 		return "", err
 	}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -174,6 +174,7 @@ var APIExtensions = []string{
 	"ceph_data_pool_name",
 	"container_syscall_intercept_mount",
 	"compression_squashfs",
+	"container_raw_mount",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This PR adds support for passing in raw mount option string for disk device mounts, e.g: 

lxc config device add first vfat1 disk source=/dev/loop9 path=/mnt/test raw.mount.options=gid=123,uid=456