### PR TITLE
lxd/device/nic/routed: Adds veth routed NIC device

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -871,4 +871,7 @@ elevated permissions.
 Adds support for importing/exporting of images/backups using SquashFS file system format.
 
 ## container\_raw\_mount
-This adds support for passing in raw mount options for disk devices. 
+This adds support for passing in raw mount options for disk devices.
+
+## container\_nic\_routed
+This introduces the `routed` "nic" device type.

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -635,6 +635,7 @@ func (d *Daemon) init() error {
 		"network_l2proxy",
 		"network_gateway_device_route",
 		"network_phys_macvlan_mtu",
+		"network_veth_router",
 	}
 	for _, extension := range lxcExtensions {
 		d.os.LXCFeatures[extension] = lxc.HasApiExtension(extension)

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -11,6 +11,7 @@ var nicTypes = map[string]func() device{
 	"ipvlan":   func() device { return &nicIPVLAN{} },
 	"p2p":      func() device { return &nicP2P{} },
 	"bridged":  func() device { return &nicBridged{} },
+	"routed":   func() device { return &nicRouted{} },
 	"macvlan":  func() device { return &nicMACVLAN{} },
 	"sriov":    func() device { return &nicSRIOV{} },
 }

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -27,7 +27,6 @@ func (d *nicIPVLAN) validateConfig() error {
 		"name",
 		"mtu",
 		"hwaddr",
-		"host_name",
 		"vlan",
 	}
 

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -1,0 +1,296 @@
+package device
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/lxc/lxd/lxd/instance/instancetype"
+	"github.com/lxc/lxd/shared"
+)
+
+const nicRoutedIPv4GW = "169.254.0.1"
+const nicRoutedIPv6GW = "fe80::1"
+
+type nicRouted struct {
+	deviceCommon
+}
+
+func (d *nicRouted) CanHotPlug() (bool, []string) {
+	return false, []string{}
+}
+
+// validateConfig checks the supplied config for correctness.
+func (d *nicRouted) validateConfig() error {
+	if d.instance.Type() != instancetype.Container {
+		return ErrUnsupportedDevType
+	}
+
+	requiredFields := []string{}
+	optionalFields := []string{
+		"name",
+		"parent",
+		"mtu",
+		"hwaddr",
+		"host_name",
+		"vlan",
+	}
+
+	rules := nicValidationRules(requiredFields, optionalFields)
+	rules["ipv4.address"] = func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		return NetworkValidAddressV4List(value)
+	}
+	rules["ipv6.address"] = func(value string) error {
+		if value == "" {
+			return nil
+		}
+
+		return NetworkValidAddressV6List(value)
+	}
+
+	err := d.config.Validate(rules)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateEnvironment checks the runtime environment for correctness.
+func (d *nicRouted) validateEnvironment() error {
+	if d.config["name"] == "" {
+		return fmt.Errorf("Requires name property to start")
+	}
+
+	if d.config["parent"] != "" && !shared.PathExists(fmt.Sprintf("/sys/class/net/%s", d.config["parent"])) {
+		return fmt.Errorf("Parent device '%s' doesn't exist", d.config["parent"])
+	}
+
+	if d.config["parent"] == "" && d.config["vlan"] != "" {
+		return fmt.Errorf("The vlan setting can only be used when combined with a parent interface")
+	}
+
+	extensions := d.state.OS.LXCFeatures
+	if !extensions["network_veth_router"] || !extensions["network_l2proxy"] {
+		return fmt.Errorf("Requires liblxc has following API extensions: network_veth_router, network_l2proxy")
+	}
+
+	// Check necessary sysctls are configured for use with l2proxy parent for routed mode.
+	if d.config["parent"] != "" && d.config["ipv4.address"] != "" {
+		ipv4FwdPath := fmt.Sprintf("ipv4/conf/%s/forwarding", d.config["parent"])
+		sysctlVal, err := NetworkSysctlGet(ipv4FwdPath)
+		if err != nil || sysctlVal != "1\n" {
+			return fmt.Errorf("Error reading net sysctl %s: %v", ipv4FwdPath, err)
+		}
+		if sysctlVal != "1\n" {
+			return fmt.Errorf("Routed mode requires sysctl net.ipv4.conf.%s.forwarding=1", d.config["parent"])
+		}
+	}
+
+	// Check necessary sysctls are configured for use with l2proxy parent for routed mode.
+	if d.config["parent"] != "" && d.config["ipv6.address"] != "" {
+		ipv6FwdPath := fmt.Sprintf("ipv6/conf/%s/forwarding", d.config["parent"])
+		sysctlVal, err := NetworkSysctlGet(ipv6FwdPath)
+		if err != nil {
+			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
+		}
+		if sysctlVal != "1\n" {
+			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.forwarding=1", d.config["parent"])
+		}
+
+		ipv6ProxyNdpPath := fmt.Sprintf("ipv6/conf/%s/proxy_ndp", d.config["parent"])
+		sysctlVal, err = NetworkSysctlGet(ipv6ProxyNdpPath)
+		if err != nil {
+			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
+		}
+		if sysctlVal != "1\n" {
+			return fmt.Errorf("Routed mode requires sysctl net.ipv6.conf.%s.proxy_ndp=1", d.config["parent"])
+		}
+	}
+
+	return nil
+}
+
+// Start is run when the instance is starting up (Routed mode doesn't support hot plugging).
+func (d *nicRouted) Start() (*RunConfig, error) {
+	err := d.validateEnvironment()
+	if err != nil {
+		return nil, err
+	}
+
+	// Lock to avoid issues with containers starting in parallel.
+	networkCreateSharedDeviceLock.Lock()
+	defer networkCreateSharedDeviceLock.Unlock()
+
+	saveData := make(map[string]string)
+
+	// Decide which parent we should use based on VLAN setting.
+	parentName := ""
+	if d.config["parent"] != "" {
+		parentName = NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
+
+		statusDev, err := NetworkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], parentName, d.config["vlan"])
+		if err != nil {
+			return nil, err
+		}
+
+		// Record whether we created this device or not so it can be removed on stop.
+		saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
+
+		// If we created a VLAN interface, we need to setup the sysctls on that interface.
+		if statusDev == "created" {
+			err := d.setupParentSysctls(parentName)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	hostName := d.config["host_name"]
+	if hostName == "" {
+		hostName = NetworkRandomDevName("veth")
+	}
+	saveData["host_name"] = hostName
+
+	err = d.volatileSet(saveData)
+	if err != nil {
+		return nil, err
+	}
+
+	runConf := RunConfig{}
+	nic := []RunConfigItem{
+		{Key: "name", Value: d.config["name"]},
+		{Key: "type", Value: "veth"},
+		{Key: "flags", Value: "up"},
+		{Key: "veth.mode", Value: "router"},
+		{Key: "veth.pair", Value: saveData["host_name"]},
+	}
+
+	// If there is a designated parent interface, activate the layer2 proxy mode to advertise
+	// the instance's IPs over that interface using proxy APR/NDP.
+	if parentName != "" {
+		nic = append(nic,
+			RunConfigItem{Key: "l2proxy", Value: "1"},
+			RunConfigItem{Key: "link", Value: parentName},
+		)
+	}
+
+	if d.config["mtu"] != "" {
+		nic = append(nic, RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
+	}
+
+	if d.config["ipv4.address"] != "" {
+		for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
+			addr = strings.TrimSpace(addr)
+			nic = append(nic, RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
+		}
+
+		// Use a fixed link-local address as the next-hop default gateway.
+		nic = append(nic, RunConfigItem{Key: "ipv4.gateway", Value: nicRoutedIPv4GW})
+	}
+
+	if d.config["ipv6.address"] != "" {
+		for _, addr := range strings.Split(d.config["ipv6.address"], ",") {
+			addr = strings.TrimSpace(addr)
+			nic = append(nic, RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
+		}
+
+		// Use a fixed link-local address as the next-hop default gateway.
+		nic = append(nic, RunConfigItem{Key: "ipv6.gateway", Value: nicRoutedIPv6GW})
+	}
+
+	runConf.NetworkInterface = nic
+	runConf.PostHooks = append(runConf.PostHooks, d.postStart)
+	return &runConf, nil
+}
+
+// setupParentSysctls configures the required sysctls on the parent to allow l2proxy to work.
+// Because of our policy not to modify sysctls on existing interfaces, this should only be called
+// if we created the parent interface.
+func (d *nicRouted) setupParentSysctls(parentName string) error {
+	if d.config["ipv4.address"] != "" {
+		// Set necessary sysctls for use with l2proxy parent in routed mode.
+		ipv4FwdPath := fmt.Sprintf("ipv4/conf/%s/forwarding", parentName)
+		err := NetworkSysctlSet(ipv4FwdPath, "1")
+		if err != nil {
+			return fmt.Errorf("Error setting net sysctl %s: %v", ipv4FwdPath, err)
+		}
+	}
+
+	if d.config["ipv6.address"] != "" {
+		// Set necessary sysctls use with l2proxy parent in routed mode.
+		ipv6FwdPath := fmt.Sprintf("ipv6/conf/%s/forwarding", parentName)
+		err := NetworkSysctlSet(ipv6FwdPath, "1")
+		if err != nil {
+			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6FwdPath, err)
+		}
+
+		ipv6ProxyNdpPath := fmt.Sprintf("ipv6/conf/%s/proxy_ndp", parentName)
+		err = NetworkSysctlSet(ipv6ProxyNdpPath, "1")
+		if err != nil {
+			return fmt.Errorf("Error reading net sysctl %s: %v", ipv6ProxyNdpPath, err)
+		}
+	}
+
+	return nil
+}
+
+// postStart is run after the instance is started.
+func (d *nicRouted) postStart() error {
+	v := d.volatileGet()
+
+	// If host_name is defined (and it should be), then we add the dummy link-local gateway IPs
+	// to the host end of the veth pair. This ensures that liveness detection of the gateways
+	// inside the instance work and ensure that traffic doesn't periodically halt whilst ARP/NDP
+	// is re-detected.
+	if v["host_name"] != "" {
+		if d.config["ipv4.address"] != "" {
+			_, err := shared.RunCommand("ip", "-4", "addr", "add", fmt.Sprintf("%s/32", nicRoutedIPv4GW), "dev", v["host_name"])
+			if err != nil {
+				return err
+			}
+		}
+
+		if d.config["ipv6.address"] != "" {
+			_, err := shared.RunCommand("ip", "-6", "addr", "add", fmt.Sprintf("%s/128", nicRoutedIPv6GW), "dev", v["host_name"])
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// Stop is run when the device is removed from the instance.
+func (d *nicRouted) Stop() (*RunConfig, error) {
+	runConf := RunConfig{
+		PostHooks: []func() error{d.postStop},
+	}
+
+	return &runConf, nil
+}
+
+// postStop is run after the device is removed from the instance.
+func (d *nicRouted) postStop() error {
+	defer d.volatileSet(map[string]string{
+		"last_state.created": "",
+		"host_name":          "",
+	})
+
+	v := d.volatileGet()
+
+	// This will delete the parent interface if we created it for VLAN parent.
+	if shared.IsTrue(v["last_state.created"]) {
+		parentName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
+		err := NetworkRemoveInterfaceIfNeeded(d.state, parentName, d.instance, d.config["parent"], d.config["vlan"])
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -175,6 +175,7 @@ var APIExtensions = []string{
 	"container_syscall_intercept_mount",
 	"compression_squashfs",
 	"container_raw_mount",
+	"container_nic_routed",
 }
 
 // APIExtensionsCount returns the number of available API extensions.

--- a/test/main.sh
+++ b/test/main.sh
@@ -197,6 +197,7 @@ run_test test_container_devices_nic_physical "container devices - nic - physical
 run_test test_container_devices_nic_macvlan "container devices - nic - macvlan"
 run_test test_container_devices_nic_ipvlan "container devices - nic - ipvlan"
 run_test test_container_devices_nic_sriov "container devices - nic - sriov"
+run_test test_container_devices_nic_routed "container devices - nic - routed"
 run_test test_container_devices_infiniband_physical "container devices - infiniband - physical"
 run_test test_container_devices_infiniband_sriov "container devices - infiniband - sriov"
 run_test test_container_devices_proxy "container devices - proxy"

--- a/test/suites/container_devices_nic_routed.sh
+++ b/test/suites/container_devices_nic_routed.sh
@@ -1,0 +1,168 @@
+test_container_devices_nic_routed() {
+  ensure_import_testimage
+  ensure_has_localhost_remote "${LXD_ADDR}"
+
+  if ! lxc info | grep 'network_veth_router: "true"' ; then
+    echo "==> SKIP: No veth router support"
+    return
+  fi
+
+  ctName="nt$$"
+  ipRand=$(shuf -i 0-9 -n 1)
+
+  sysctl net.ipv6.conf.all.forwarding=1
+
+  # Test routed support to offline container (hot plugging not supported).
+  ip link add "${ctName}" type dummy
+  sysctl net.ipv6.conf."${ctName}".proxy_ndp=1
+  sysctl net.ipv6.conf."${ctName}".forwarding=1
+  sysctl net.ipv4.conf."${ctName}".forwarding=1
+  sysctl net.ipv6.conf."${ctName}".accept_dad=0
+
+  # Add IP addresses to parent interface (this is needed for automatic gateway detection in container).
+  ip link set "${ctName}" up
+  ip addr add 192.0.2.1/32 dev "${ctName}"
+  ip addr add 2001:db8::1/128 dev "${ctName}"
+
+  # Wait for IPv6 DAD to complete.
+  while true
+  do
+    if ! ip -6 a show dev "${ctName}" | grep "tentative" ; then
+      break
+    fi
+    sleep 2
+  done
+
+  # Create dummy vlan parent.
+  # Use slash notation when setting sysctls on vlan interface (that has period in interface name).
+  ip link add link "${ctName}" name "${ctName}.1234" type vlan id 1234
+  sysctl net/ipv6/conf/"${ctName}.1234"/proxy_ndp=1
+  sysctl net/ipv6/conf/"${ctName}.1234"/forwarding=1
+  sysctl net/ipv4/conf/"${ctName}.1234"/forwarding=1
+  sysctl net/ipv6/conf/"${ctName}.1234"/accept_dad=0
+
+  # Add IP addresses to parent interface (this is needed for automatic gateway detection in container).
+  ip link set "${ctName}.1234" up
+  ip addr add 192.0.3.254/32 dev "${ctName}.1234"
+  ip addr add 2001:db8:2::1/128 dev "${ctName}.1234"
+
+  # Record how many nics we started with.
+  startNicCount=$(find /sys/class/net | wc -l)
+
+  # Check that starting routed container.
+  lxc init testimage "${ctName}"
+  lxc config device add "${ctName}" eth0 nic \
+    name=eth0 \
+    nictype=routed \
+    parent=${ctName} \
+    ipv4.address="192.0.2.1${ipRand}" \
+    ipv6.address="2001:db8::1${ipRand}" \
+    mtu=1600
+  lxc start "${ctName}"
+
+  # Check custom MTU is applied.
+  if ! lxc exec "${ctName}" -- ip link show eth0 | grep "mtu 1600" ; then
+    echo "mtu invalid"
+    false
+  fi
+
+  lxc stop "${ctName}"
+
+  # Check that MTU is inherited from parent device when not specified on device.
+  ip link set "${ctName}" mtu 1605
+  lxc config device unset "${ctName}" eth0 mtu
+  lxc start "${ctName}"
+  lxc exec "${ctName}" -- sysctl net.ipv6.conf.eth0.accept_dad=0
+
+  if ! lxc exec "${ctName}" -- grep "1605" /sys/class/net/eth0/mtu ; then
+    echo "mtu not inherited from parent"
+    false
+  fi
+
+  #Spin up another container with multiple IPs.
+  lxc init testimage "${ctName}2"
+  lxc config device add "${ctName}2" eth0 nic \
+    name=eth0 \
+    nictype=routed \
+    parent=${ctName} \
+    ipv4.address="192.0.2.2${ipRand}, 192.0.2.3${ipRand}" \
+    ipv6.address="2001:db8::2${ipRand}, 2001:db8::3${ipRand}"
+  lxc start "${ctName}2"
+  lxc exec "${ctName}2" -- sysctl net.ipv6.conf.eth0.accept_dad=0
+
+  # Wait for IPv6 DAD to complete.
+  while true
+  do
+    if ! lxc exec "${ctName}" -- ip -6 a show dev eth0 | grep "tentative" ; then
+      break
+    fi
+    sleep 2
+  done
+
+  while true
+  do
+    if ! lxc exec "${ctName}2" -- ip -6 a show dev eth0 | grep "tentative" ; then
+      break
+    fi
+    sleep 2
+  done
+
+  # Check comms between containers.
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.1"
+  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::1"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.1"
+  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::1"
+
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1"
+  lxc exec "${ctName}2" -- ping6 -c3 -W5 "2001:db8::1"
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1"
+  lxc exec "${ctName}2" -- ping6 -c3 -W5 "2001:db8::1"
+
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.2${ipRand}"
+  lxc exec "${ctName}" -- ping -c2 -W5 "192.0.2.3${ipRand}"
+
+  lxc exec "${ctName}" -- ping6 -c3 -W5 "2001:db8::3${ipRand}"
+  lxc exec "${ctName}" -- ping6 -c2 -W5 "2001:db8::2${ipRand}"
+
+  lxc exec "${ctName}2" -- ping -c2 -W5 "192.0.2.1${ipRand}"
+  lxc exec "${ctName}2" -- ping6 -c2 -W5 "2001:db8::1${ipRand}"
+
+  lxc stop -f "${ctName}2"
+  lxc stop -f "${ctName}"
+
+  # Check routed ontop of VLAN parent.
+  lxc config device set "${ctName}" eth0 vlan 1234
+  lxc start "${ctName}"
+
+  # Check VLAN interface created
+  if ! grep "1" "/sys/class/net/${ctName}.1234/carrier" ; then
+    echo "vlan interface not created"
+    false
+  fi
+
+  # Check volatile cleanup on stop.
+  lxc stop -f "${ctName}"
+  if lxc config show "${ctName}" | grep volatile.eth0 | grep -v volatile.eth0.hwaddr | grep -v volatile.eth0.name ; then
+    echo "unexpected volatile key remains"
+    false
+  fi
+
+  # Check parent device is still up.
+  if ! grep "1" "/sys/class/net/${ctName}/carrier" ; then
+    echo "parent is down"
+    false
+  fi
+
+  # Check we haven't left any NICS lying around.
+  endNicCount=$(find /sys/class/net | wc -l)
+  if [ "$startNicCount" != "$endNicCount" ]; then
+    echo "leftover NICS detected"
+    false
+  fi
+
+  # Cleanup routed checks
+  lxc delete "${ctName}" -f
+  lxc delete "${ctName}2" -f
+  ip link delete "${ctName}.1234"
+  ip link delete "${ctName}"
+}


### PR DESCRIPTION
Adds `routed` NIC type:

Example usage 1: Routed mode with parent for layer 2 proxy:
This is useful when you want the container to "join" the parent's layer 2 network.
    
     lxc config device add c1 eth0 nic nictype=routed parent=eth0 ipv4.address=192.168.1.200 ipv6.address=2a02:xxx:xxx:3::200/128
    
Example usage 2: Routed mode without parent (layer 2 proxy disabled):
This is useful in a fully routed or multihoned environment where layer2 ARP/NDP proxying isn't required.
    
     lxc config device add c1 eth0 nic nictype=routed ipv4.address=192.168.1.200 ipv6.address=2a02:xxx:xxx:3::200/128
    
In both examples the container will see the following default gateways added:
    
     169.254.0.1
     fe80::1
    
These are static link-local addresses that are added to each veth pair on the host-side, and provides a consistent next-hop address.
    
Closes #6175
    
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>

