### PR TITLE
VM cloud-init config drive

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -876,7 +876,7 @@ func instanceCreateInternal(s *state.State, args db.InstanceArgs) (Instance, err
 	}
 
 	// Validate container devices with the supplied container name and devices.
-	err = containerValidDevices(s, s.Cluster, args.Name, args.Devices, false)
+	err = instanceValidDevices(s, s.Cluster, args.Type, args.Name, args.Devices, false)
 	if err != nil {
 		return nil, errors.Wrap(err, "Invalid devices")
 	}

--- a/lxd/container.go
+++ b/lxd/container.go
@@ -195,28 +195,49 @@ func containerValidConfig(sysOS *sys.OS, config map[string]string, profile bool,
 	return nil
 }
 
-// containerValidDevices validate container device configs.
-func containerValidDevices(state *state.State, cluster *db.Cluster, instanceName string, devices deviceConfig.Devices, expanded bool) error {
+// instanceValidDevices validate instance device configs.
+func instanceValidDevices(state *state.State, cluster *db.Cluster, instanceType instancetype.Type, instanceName string, devices deviceConfig.Devices, expanded bool) error {
 	// Empty device list
 	if devices == nil {
 		return nil
 	}
 
-	// Create a temporary containerLXC struct to use as an Instance in device validation.
+	// Create a temporary Instance for use in device validation.
 	// Populate it's name, localDevices and expandedDevices properties based on the mode of
 	// validation occurring. In non-expanded validation expensive checks should be avoided.
-	instance := &containerLXC{
-		name:         instanceName,
-		localDevices: devices.Clone(), // Prevent devices from modifying their config.
-	}
+	var inst Instance
 
-	if expanded {
-		instance.expandedDevices = instance.localDevices // Avoid another clone.
+	if instanceType == instancetype.Container {
+		c := &containerLXC{
+			dbType:       instancetype.Container,
+			name:         instanceName,
+			localDevices: devices.Clone(), // Prevent devices from modifying their config.
+		}
+
+		if expanded {
+			c.expandedDevices = c.localDevices // Avoid another clone.
+		}
+
+		inst = c
+	} else if instanceType == instancetype.VM {
+		vm := &vmQemu{
+			dbType:       instancetype.VM,
+			name:         instanceName,
+			localDevices: devices.Clone(), // Prevent devices from modifying their config.
+		}
+
+		if expanded {
+			vm.expandedDevices = vm.localDevices // Avoid another clone.
+		}
+
+		inst = vm
+	} else {
+		return fmt.Errorf("Invalid instance type")
 	}
 
 	// Check each device individually using the device package.
 	for name, config := range devices {
-		_, err := device.New(instance, state, name, config, nil, nil)
+		_, err := device.New(inst, state, name, config, nil, nil)
 		if err != nil {
 			return err
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -295,7 +295,7 @@ func containerLXCCreate(s *state.State, args db.InstanceArgs) (container, error)
 		return nil, err
 	}
 
-	err = containerValidDevices(s, s.Cluster, c.Name(), c.expandedDevices, true)
+	err = instanceValidDevices(s, s.Cluster, c.Type(), c.Name(), c.expandedDevices, true)
 	if err != nil {
 		c.Delete()
 		logger.Error("Failed creating container", ctxMap)
@@ -4130,7 +4130,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Validate the new devices without using expanded devices validation (expensive checks disabled).
-	err = containerValidDevices(c.state, c.state.Cluster, c.Name(), args.Devices, false)
+	err = instanceValidDevices(c.state, c.state.Cluster, c.Type(), c.Name(), args.Devices, false)
 	if err != nil {
 		return errors.Wrap(err, "Invalid devices")
 	}
@@ -4321,7 +4321,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Do full expanded validation of the devices diff.
-	err = containerValidDevices(c.state, c.state.Cluster, c.Name(), c.expandedDevices, true)
+	err = instanceValidDevices(c.state, c.state.Cluster, c.Type(), c.Name(), c.expandedDevices, true)
 	if err != nil {
 		return errors.Wrap(err, "Invalid expanded devices")
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -6485,6 +6485,7 @@ func (c *containerLXC) removeUnixDevices() error {
 // fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
 // generated name and hwaddr properties if these are missing from the device.
 func (c *containerLXC) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
+	var err error
 	newDevice := m.Clone()
 
 	// Function to try and guess an available name
@@ -6578,7 +6579,7 @@ func (c *containerLXC) fillNetworkDevice(name string, m deviceConfig.Device) (de
 		volatileHwaddr := c.localConfig[configKey]
 		if volatileHwaddr == "" {
 			// Generate a new MAC address
-			volatileHwaddr, err := deviceNextInterfaceHWAddr()
+			volatileHwaddr, err = deviceNextInterfaceHWAddr()
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/device/device_instance.go
+++ b/lxd/device/device_instance.go
@@ -12,6 +12,7 @@ type Instance interface {
 	Name() string
 	Type() instancetype.Type
 	Project() string
+	Path() string
 	DevicesPath() string
 	RootfsPath() string
 	LogPath() string

--- a/lxd/device/device_utils_generic.go
+++ b/lxd/device/device_utils_generic.go
@@ -1,0 +1,24 @@
+package device
+
+import (
+	"strings"
+)
+
+// deviceNameEncode encodes a string to be used as part of a file name in the LXD devices path.
+// The encoding scheme replaces "-" with "--" and then "/" with "-".
+func deviceNameEncode(text string) string {
+	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
+}
+
+// deviceNameDecode decodes a string used in the LXD devices path back to its original form.
+// The decoding scheme converts "-" back to "/" and "--" back to "-".
+func deviceNameDecode(text string) string {
+	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
+	// converted back to "/" before making a final pass to convert "\0" back to original "-".
+	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
+}
+
+// deviceJoinPath joins together prefix and text delimited by a "." for device path generation.
+func deviceJoinPath(parts ...string) string {
+	return strings.Join(parts, ".")
+}

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -237,7 +237,7 @@ func UnixDeviceCreate(s *state.State, idmapSet *idmap.IdmapSet, devicesPath stri
 
 	destPath := unixDeviceDestPath(m)
 	relativeDestPath := strings.TrimPrefix(destPath, "/")
-	devName := unixDeviceEncode(unixDeviceJoinPath(prefix, relativeDestPath))
+	devName := deviceNameEncode(deviceJoinPath(prefix, relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	// Create the new entry.
@@ -296,7 +296,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 
 	// Convert the requested dest path inside the instance to an encoded relative one.
 	ourDestPath := unixDeviceDestPath(m)
-	ourEncRelDestFile := unixDeviceEncode(strings.TrimPrefix(ourDestPath, "/"))
+	ourEncRelDestFile := deviceNameEncode(strings.TrimPrefix(ourDestPath, "/"))
 
 	// Load all existing host devices.
 	dents, err := ioutil.ReadDir(devicesPath)
@@ -328,7 +328,7 @@ func unixDeviceSetup(s *state.State, devicesPath string, typePrefix string, devi
 	}
 
 	// Create the device on the host.
-	ourPrefix := unixDeviceJoinPath(typePrefix, deviceName)
+	ourPrefix := deviceJoinPath(typePrefix, deviceName)
 	d, err := UnixDeviceCreate(s, nil, devicesPath, ourPrefix, m, defaultMode)
 	if err != nil {
 		return err
@@ -425,9 +425,9 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = unixDeviceEncode(unixDeviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = unixDeviceEncode(unixDeviceJoinPath(typePrefix, deviceName))
+		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	ourDevs := []string{}
@@ -489,7 +489,7 @@ func unixDeviceRemove(devicesPath string, typePrefix string, deviceName string, 
 
 		// Append this device to the mount rules (these will be unmounted).
 		runConf.Mounts = append(runConf.Mounts, MountEntryItem{
-			TargetPath: unixDeviceDecode(ourEncRelDestFile),
+			TargetPath: deviceNameDecode(ourEncRelDestFile),
 		})
 
 		absDevPath := filepath.Join(devicesPath, ourDev)
@@ -515,9 +515,9 @@ func unixDeviceDeleteFiles(s *state.State, devicesPath string, typePrefix string
 	var ourPrefix string
 	// If a prefix override has been supplied, use that for filtering the devices to remove.
 	if optPrefix != "" {
-		ourPrefix = unixDeviceEncode(unixDeviceJoinPath(typePrefix, deviceName, optPrefix))
+		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName, optPrefix))
 	} else {
-		ourPrefix = unixDeviceEncode(unixDeviceJoinPath(typePrefix, deviceName))
+		ourPrefix = deviceNameEncode(deviceJoinPath(typePrefix, deviceName))
 	}
 
 	// Load all devices.

--- a/lxd/device/device_utils_unix.go
+++ b/lxd/device/device_utils_unix.go
@@ -381,29 +381,10 @@ func unixDeviceSetupCharNum(s *state.State, devicesPath string, typePrefix strin
 // UnixDeviceExists checks if the unix device already exists in devices path.
 func UnixDeviceExists(devicesPath string, prefix string, path string) bool {
 	relativeDestPath := strings.TrimPrefix(path, "/")
-	devName := fmt.Sprintf("%s.%s", unixDeviceEncode(prefix), unixDeviceEncode(relativeDestPath))
+	devName := fmt.Sprintf("%s.%s", deviceNameEncode(prefix), deviceNameEncode(relativeDestPath))
 	devPath := filepath.Join(devicesPath, devName)
 
 	return shared.PathExists(devPath)
-}
-
-// unixDeviceEncode encodes a string to be used as part of a file name in the LXD devices path.
-// The encoding scheme replaces "-" with "--" and then "/" with "-".
-func unixDeviceEncode(text string) string {
-	return strings.Replace(strings.Replace(text, "-", "--", -1), "/", "-", -1)
-}
-
-// unixDeviceDecode decodes a string used in the LXD devices path back to its original form.
-// The decoding scheme converts "-" back to "/" and "--" back to "-".
-func unixDeviceDecode(text string) string {
-	// This converts "--" to the null character "\0" first, to allow remaining "-" chars to be
-	// converted back to "/" before making a final pass to convert "\0" back to original "-".
-	return strings.Replace(strings.Replace(strings.Replace(text, "--", "\000", -1), "-", "/", -1), "\000", "-", -1)
-}
-
-// unixDeviceJoinPath joins together prefix and text delimited by a "." for device path generation.
-func unixDeviceJoinPath(parts ...string) string {
-	return strings.Join(parts, ".")
 }
 
 // unixRemoveDevice identifies all files related to the supplied typePrefix and deviceName and then

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -172,7 +172,7 @@ func (d *disk) validateConfig() error {
 // getDevicePath returns the absolute path on the host for this instance and supplied device config.
 func (d *disk) getDevicePath(devName string, devConfig deviceConfig.Device) string {
 	relativeDestPath := strings.TrimPrefix(devConfig["path"], "/")
-	devPath := fmt.Sprintf("disk.%s.%s", strings.Replace(devName, "/", "-", -1), strings.Replace(relativeDestPath, "/", "-", -1))
+	devPath := deviceNameEncode(deviceJoinPath("disk", devName, relativeDestPath))
 	return filepath.Join(d.instance.DevicesPath(), devPath)
 }
 
@@ -1051,7 +1051,7 @@ func (d *disk) getParentBlocks(path string) ([]string, error) {
 // generateVMConfigDrive generates an ISO containing the cloud init config for a VM.
 // Returns the path to the ISO.
 func (d *disk) generateVMConfigDrive() (string, error) {
-	scratchDir := filepath.Join(d.instance.DevicesPath(), strings.Replace(d.name, "/", "-", -1))
+	scratchDir := filepath.Join(d.instance.DevicesPath(), deviceNameEncode(d.name))
 
 	// Create config drive dir.
 	err := os.MkdirAll(scratchDir, 0100)

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -163,7 +163,7 @@ func (d *gpu) Start() (*RunConfig, error) {
 			}
 
 			for _, dev := range nvidiaDevices {
-				prefix := unixDeviceJoinPath("unix", d.name)
+				prefix := deviceJoinPath("unix", d.name)
 				if UnixDeviceExists(d.instance.DevicesPath(), prefix, dev.path) {
 					continue
 				}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -177,6 +177,12 @@ func (d *nicBridged) Start() (*RunConfig, error) {
 		{Key: "link", Value: peerName},
 	}
 
+	if d.instance.Type() == instancetype.VM {
+		runConf.NetworkInterface = append(runConf.NetworkInterface,
+			RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
+		)
+	}
+
 	return &runConf, nil
 }
 

--- a/lxd/device/unix_common.go
+++ b/lxd/device/unix_common.go
@@ -88,9 +88,9 @@ func (d *unixCommon) Register() error {
 		}
 
 		// Derive the host side path for the instance device file.
-		ourPrefix := unixDeviceJoinPath("unix", deviceName)
+		ourPrefix := deviceJoinPath("unix", deviceName)
 		relativeDestPath := strings.TrimPrefix(unixDeviceDestPath(deviceConfig), "/")
-		devName := unixDeviceEncode(unixDeviceJoinPath(ourPrefix, relativeDestPath))
+		devName := deviceNameEncode(deviceJoinPath(ourPrefix, relativeDestPath))
 		devPath := filepath.Join(devicesPath, devName)
 
 		runConf := RunConfig{}

--- a/lxd/profiles.go
+++ b/lxd/profiles.go
@@ -15,6 +15,7 @@ import (
 	"github.com/lxc/lxd/lxd/cluster"
 	"github.com/lxc/lxd/lxd/db"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
@@ -107,8 +108,9 @@ func profilesPost(d *Daemon, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Validate container devices with an empty instanceName to indicate profile validation.
-	err = containerValidDevices(d.State(), d.cluster, "", deviceConfig.NewDevices(req.Devices), false)
+	// Validate instance devices with an empty instanceName to indicate profile validation.
+	// At this point we don't know the instance type, so just use Container type for validation.
+	err = instanceValidDevices(d.State(), d.cluster, instancetype.Container, "", deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return response.BadRequest(err)
 	}

--- a/lxd/profiles_utils.go
+++ b/lxd/profiles_utils.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/db/query"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/pkg/errors"
@@ -19,8 +20,9 @@ func doProfileUpdate(d *Daemon, project, name string, id int64, profile *api.Pro
 		return err
 	}
 
-	// Validate container devices with an empty instanceName to indicate profile validation.
-	err = containerValidDevices(d.State(), d.cluster, "", deviceConfig.NewDevices(req.Devices), false)
+	// Validate instance devices with an empty instanceName to indicate profile validation.
+	// At this point we don't know the instance type, so just use Container type for validation.
+	err = instanceValidDevices(d.State(), d.cluster, instancetype.Container, "", deviceConfig.NewDevices(req.Devices), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -2512,6 +2512,8 @@ func (vm *vmQemu) DaemonState() *state.State {
 // fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
 // generated name and hwaddr properties if these are missing from the device.
 func (vm *vmQemu) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
+	var err error
+
 	newDevice := m.Clone()
 	updateKey := func(key string, value string) error {
 		tx, err := vm.state.Cluster.Begin()
@@ -2539,7 +2541,7 @@ func (vm *vmQemu) fillNetworkDevice(name string, m deviceConfig.Device) (deviceC
 		volatileHwaddr := vm.localConfig[configKey]
 		if volatileHwaddr == "" {
 			// Generate a new MAC address
-			volatileHwaddr, err := deviceNextInterfaceHWAddr()
+			volatileHwaddr, err = deviceNextInterfaceHWAddr()
 			if err != nil {
 				return nil, err
 			}

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -665,6 +665,7 @@ func (vm *vmQemu) generateConfigShare() error {
 		os.Remove(filepath.Join(configDrivePath, "cloud-init", "network-config"))
 	}
 
+	// Append any user.meta-data to our predefined meta-data config.
 	err = ioutil.WriteFile(filepath.Join(configDrivePath, "cloud-init", "meta-data"), []byte(fmt.Sprintf("instance-id: %s\nlocal-hostname: %s\n%s\n", vm.Name(), vm.Name(), vm.ExpandedConfig()["user.meta-data"])), 0400)
 	if err != nil {
 		return err

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -172,7 +172,7 @@ func vmQemuCreate(s *state.State, args db.InstanceArgs) (Instance, error) {
 		return nil, err
 	}
 
-	err = containerValidDevices(s, s.Cluster, vm.Name(), vm.expandedDevices, true)
+	err = instanceValidDevices(s, s.Cluster, vm.Type(), vm.Name(), vm.expandedDevices, true)
 	if err != nil {
 		logger.Error("Failed creating instance", ctxMap)
 		return nil, errors.Wrap(err, "Invalid devices")
@@ -1296,7 +1296,7 @@ func (vm *vmQemu) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Validate the new devices without using expanded devices validation (expensive checks disabled).
-	err = containerValidDevices(vm.state, vm.state.Cluster, vm.Name(), args.Devices, false)
+	err = instanceValidDevices(vm.state, vm.state.Cluster, vm.Type(), vm.Name(), args.Devices, false)
 	if err != nil {
 		return errors.Wrap(err, "Invalid devices")
 	}
@@ -1480,7 +1480,7 @@ func (vm *vmQemu) Update(args db.InstanceArgs, userRequested bool) error {
 	}
 
 	// Do full expanded validation of the devices diff.
-	err = containerValidDevices(vm.state, vm.state.Cluster, vm.Name(), vm.expandedDevices, true)
+	err = instanceValidDevices(vm.state, vm.state.Cluster, vm.Type(), vm.Name(), vm.expandedDevices, true)
 	if err != nil {
 		return errors.Wrap(err, "Invalid expanded devices")
 	}

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -1072,8 +1072,8 @@ func (vm *vmQemu) addRootDriveConfig(sb *strings.Builder) error {
 	sb.WriteString(fmt.Sprintf(`
 # Root drive ("root" device)
 [drive "lxd_root"]
-file = "raw"
-format = "%s"
+file = "%s"
+format = "raw"
 if = "none"
 cache = "none"
 aio = "native"

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -2214,15 +2214,17 @@ func (vm *vmQemu) RenderState() (*api.InstanceState, error) {
 	statusCode := vm.statusCode()
 	pid, _ := vm.pid()
 
-	status, err := vm.agentGetState()
-	if err != nil {
-		logger.Warn("Could not get VM state from agent", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
-	} else {
-		status.Pid = int64(pid)
-		status.Status = statusCode.String()
-		status.StatusCode = statusCode
+	if statusCode == api.Running {
+		status, err := vm.agentGetState()
+		if err != nil {
+			logger.Warn("Could not get VM state from agent", log.Ctx{"project": vm.Project(), "instance": vm.Name(), "err": err})
+		} else {
+			status.Pid = int64(pid)
+			status.Status = statusCode.String()
+			status.StatusCode = statusCode
 
-		return status, nil
+			return status, nil
+		}
 	}
 
 	// At least return the Status and StatusCode if we couldn't get any

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -427,11 +427,12 @@ func (vm *vmQemu) Start(stateful bool) error {
 		vm.VolatileSet(map[string]string{"volatile.vm.uuid": vmUUID})
 	}
 
-	// Copy OVMF firmware to nvram file.
+	// Copy OVMF settings firmware to nvram file.
+	// This firmware file can be modified by the VM so it must be copied from the defaults.
 	if !shared.PathExists(vm.getNvramPath()) {
 		srcOvmfFile := "/usr/share/OVMF/OVMF_VARS.ms.fd"
 		if !shared.PathExists(srcOvmfFile) {
-			return fmt.Errorf("Required secure boot EFI firmware file missing: %s", srcOvmfFile)
+			return fmt.Errorf("Required secure boot EFI firmware settings file missing: %s", srcOvmfFile)
 		}
 
 		err = shared.FileCopy(srcOvmfFile, vm.getNvramPath())
@@ -440,7 +441,7 @@ func (vm *vmQemu) Start(stateful bool) error {
 		}
 	}
 
-	tapDev := map[string]string{}
+	devConfs := make([]*device.RunConfig, 0, len(vm.expandedDevices))
 
 	// Setup devices in sorted order, this ensures that device mounts are added in path order.
 	for _, dev := range vm.expandedDevices.Sorted() {
@@ -454,18 +455,10 @@ func (vm *vmQemu) Start(stateful bool) error {
 			continue
 		}
 
-		if len(runConf.NetworkInterface) > 0 {
-			for _, nicItem := range runConf.NetworkInterface {
-				if nicItem.Key == "link" {
-					tapDev["tap"] = nicItem.Value
-					tapDev["hwaddr"] = vm.localConfig[fmt.Sprintf("volatile.%s.hwaddr", dev.Name)]
-				}
-			}
-
-		}
+		devConfs = append(devConfs, runConf)
 	}
 
-	confFile, err := vm.generateQemuConfigFile(tapDev)
+	confFile, err := vm.generateQemuConfigFile(devConfs)
 	if err != nil {
 		return err
 	}
@@ -796,7 +789,7 @@ systemctl start run-lxd_config.mount lxd-agent.service
 }
 
 // generateQemuConfigFile writes the qemu config file and returns its location.
-func (vm *vmQemu) generateQemuConfigFile(tapDev map[string]string) (string, error) {
+func (vm *vmQemu) generateQemuConfigFile(devConfs []*device.RunConfig) (string, error) {
 	var sb *strings.Builder = &strings.Builder{}
 
 	// Base config. This is common for all VMs and has no variables in it.
@@ -886,11 +879,6 @@ backend = "pty"
 		return "", err
 	}
 
-	err = vm.addRootDriveConfig(sb)
-	if err != nil {
-		return "", err
-	}
-
 	err = vm.addCPUConfig(sb)
 	if err != nil {
 		return "", err
@@ -900,13 +888,39 @@ backend = "pty"
 	vm.addVsockConfig(sb)
 	vm.addMonitorConfig(sb)
 	vm.addConfDriveConfig(sb)
-	vm.addNetConfig(sb, tapDev)
+
+	for _, runConf := range devConfs {
+		// Add root drive device.
+		if runConf.RootFS.Path != "" {
+			err = vm.addRootDriveConfig(sb)
+			if err != nil {
+				return "", err
+			}
+		}
+
+		// Add drive devices.
+		if len(runConf.Mounts) > 0 {
+			driveIndex := 0
+			for _, drive := range runConf.Mounts {
+				// Increment so index starts at 1, as root drive uses index 0.
+				driveIndex++
+
+				vm.addDriveConfig(sb, driveIndex, drive)
+			}
+		}
+
+		// Add network device.
+		if len(runConf.NetworkInterface) > 0 {
+			vm.addNetDevConfig(sb, runConf.NetworkInterface)
+		}
+	}
 
 	// Write the config file to disk.
 	configPath := filepath.Join(vm.LogPath(), "qemu.conf")
 	return configPath, ioutil.WriteFile(configPath, []byte(sb.String()), 0640)
 }
 
+// addMemoryConfig adds the qemu config required for setting the size of the VM's memory.
 func (vm *vmQemu) addMemoryConfig(sb *strings.Builder) error {
 	// Configure memory limit.
 	memSize := vm.expandedConfig["limits.memory"]
@@ -930,6 +944,7 @@ size = "%dK"
 	return nil
 }
 
+// addVsockConfig adds the qemu config required for setting up the host->VM vsock socket.
 func (vm *vmQemu) addVsockConfig(sb *strings.Builder) {
 	vsockID := vm.vsockID()
 
@@ -952,6 +967,7 @@ addr = "0x0"
 	return
 }
 
+// addCPUConfig adds the qemu config required for setting the number of virtualised CPUs.
 func (vm *vmQemu) addCPUConfig(sb *strings.Builder) error {
 	// Configure CPU limit. TODO add control of sockets, cores and threads.
 	cpus := vm.expandedConfig["limits.cpu"]
@@ -976,6 +992,7 @@ cpus = "%d"
 	return nil
 }
 
+// addMonitorConfig adds the qemu config required for setting up the host side VM monitor device.
 func (vm *vmQemu) addMonitorConfig(sb *strings.Builder) {
 	monitorPath := vm.getMonitorPath()
 
@@ -995,11 +1012,12 @@ mode = "control"
 	return
 }
 
+// addFirmwareConfig adds the qemu config required for adding a secure boot compatible EFI firmware.
 func (vm *vmQemu) addFirmwareConfig(sb *strings.Builder) {
 	nvramPath := vm.getNvramPath()
 
 	sb.WriteString(fmt.Sprintf(`
-# Firmware
+# Firmware (read only)
 [drive]
 file = "/usr/share/OVMF/OVMF_CODE.fd"
 if = "pflash"
@@ -1007,6 +1025,7 @@ format = "raw"
 unit = "0"
 readonly = "on"
 
+# Firmware settings (writable)
 [drive]
 file = "%s"
 if = "pflash"
@@ -1017,6 +1036,27 @@ unit = "1"
 	return
 }
 
+// addConfDriveConfig adds the qemu config required for adding the config drive.
+func (vm *vmQemu) addConfDriveConfig(sb *strings.Builder) {
+	// Devices use "qemu_" prefix indicating that this is a internally named device.
+	sb.WriteString(fmt.Sprintf(`
+# Config drive
+[fsdev "qemu_config"]
+fsdriver = "local"
+security_model = "none"
+readonly = "on"
+path = "%s"
+
+[device "dev-qemu_config"]
+driver = "virtio-9p-pci"
+fsdev = "qemu_config"
+mount_tag = "config"
+`, filepath.Join(vm.Path(), "config")))
+
+	return
+}
+
+// addRootDriveConfig adds the qemu config required for adding the root drive.
 func (vm *vmQemu) addRootDriveConfig(sb *strings.Builder) error {
 	pool, err := storagePools.GetPoolByInstance(vm.state, vm)
 	if err != nil {
@@ -1028,6 +1068,7 @@ func (vm *vmQemu) addRootDriveConfig(sb *strings.Builder) error {
 		return err
 	}
 
+	// Devices use "lxd_" prefix indicating that this is a user named device.
 	sb.WriteString(fmt.Sprintf(`
 # Root drive ("root" device)
 [drive "lxd_root"]
@@ -1050,28 +1091,49 @@ bootindex = "1"
 	return nil
 }
 
-func (vm *vmQemu) addConfDriveConfig(sb *strings.Builder) {
-	sb.WriteString(fmt.Sprintf(`
-# Config drive
-[fsdev "qemu_config"]
-fsdriver = "local"
-security_model = "none"
-readonly = "on"
-path = "%s"
+// addDriveConfig adds the qemu config required for adding a supplementary drive.
+func (vm *vmQemu) addDriveConfig(sb *strings.Builder, driveIndex int, driveConf device.MountEntryItem) {
+	driveName := fmt.Sprintf(driveConf.TargetPath)
 
-[device "dev-qemu_config"]
-driver = "virtio-9p-pci"
-fsdev = "qemu_config"
-mount_tag = "config"
-`, filepath.Join(vm.Path(), "config")))
+	// Devices use "lxd_" prefix indicating that this is a user named device.
+	sb.WriteString(fmt.Sprintf(`
+# %s drive
+[drive "lxd_%s"]
+file = "%s"
+format = "raw"
+if = "none"
+cache = "none"
+aio = "native"
+
+[device "dev-lxd_%s"]
+driver = "scsi-hd"
+bus = "qemu_scsi.0"
+channel = "0"
+scsi-id = "%d"
+lun = "1"
+drive = "lxd_%s"
+`, driveName, driveName, driveConf.DevPath, driveName, driveIndex, driveName))
 
 	return
 }
 
-func (vm *vmQemu) addNetConfig(sb *strings.Builder, tapDev map[string]string) {
+// addNetDevConfig adds the qemu config required for adding a network device.
+func (vm *vmQemu) addNetDevConfig(sb *strings.Builder, nicConfig []device.RunConfigItem) {
+	var devName, devTap, devHwaddr string
+	for _, nicItem := range nicConfig {
+		if nicItem.Key == "name" {
+			devName = nicItem.Value
+		} else if nicItem.Key == "link" {
+			devTap = nicItem.Value
+		} else if nicItem.Key == "hwaddr" {
+			devHwaddr = nicItem.Value
+		}
+	}
+
+	// Devices use "lxd_" prefix indicating that this is a user named device.
 	sb.WriteString(fmt.Sprintf(`
-# Network card ("eth0" device)
-[netdev "lxd_eth0"]
+# Network card ("%s" device)
+[netdev "lxd_%s"]
 type = "tap"
 ifname = "%s"
 script = "no"
@@ -1091,15 +1153,17 @@ mac = "%s"
 bus = "qemu_pcie5"
 addr = "0x0"
 bootindex = "2""
-`, tapDev["tap"], tapDev["hwaddr"]))
+`, devName, devName, devTap, devHwaddr))
 
 	return
 }
 
+// pidFilePath returns the path where the qemu process should write its PID.
 func (vm *vmQemu) pidFilePath() string {
 	return filepath.Join(vm.LogPath(), "qemu.pid")
 }
 
+// pid gets the PID of the running qemu process.
 func (vm *vmQemu) pid() (int, error) {
 	pidStr, err := ioutil.ReadFile(vm.pidFilePath())
 	if os.IsNotExist(err) {
@@ -1118,6 +1182,7 @@ func (vm *vmQemu) pid() (int, error) {
 	return pid, nil
 }
 
+// Stop stops the VM.
 func (vm *vmQemu) Stop(stateful bool) error {
 	if stateful {
 		return fmt.Errorf("Stateful stop isn't supported for VMs at this time")


### PR DESCRIPTION
Adds the ability to attach a cloud-init config drive to a VM:

E.g.

```
lxc config device add v1 config disk source=cloud-init:config
```

This will generate and attach an ISO file containing the VM's cloud-init config variables in such a way that cloud-init inside the VM will detect it and action them.