### PR TITLE
lxd/include: Fix SECCOMP_GET_ACTION_AVAIL define

### DIFF
--- a/lxd/include/lxd_seccomp.h
+++ b/lxd/include/lxd_seccomp.h
@@ -8,7 +8,7 @@
 #include <linux/filter.h>
 #include <linux/types.h>
 
-#ifdef SECCOMP_GET_ACTION_AVAIL
+#ifndef SECCOMP_GET_ACTION_AVAIL
 #define SECCOMP_GET_ACTION_AVAIL 2
 #endif
 


### PR DESCRIPTION
There was a typo in the code, resulting with compilation error on system
where SECCOMP_GET_ACTION_AVAIL is not defined by the standard headers.

Signed-off-by: Louis Solofrizzo <lsolofrizzo@online.net>