### PR TITLE
Storage createFromCopy instance rename

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -820,6 +820,7 @@ func containerCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInsta
 	return c, nil
 }
 
+// instanceCreateInternal creates an instance record and storage volume record in the database.
 func instanceCreateInternal(s *state.State, args db.InstanceArgs) (Instance, error) {
 	// Set default values.
 	if args.Project == "" {

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -612,7 +612,8 @@ func createFromCopy(d *Daemon, project string, req *api.InstancesPost) response.
 	}
 
 	resources := map[string][]string{}
-	resources["containers"] = []string{req.Name, req.Source.Source}
+	resources["instances"] = []string{req.Name, req.Source.Source}
+	resources["containers"] = resources["instances"] // Populate old field name.
 
 	op, err := operations.OperationCreate(d.State(), targetProject, operations.OperationClassTask, db.OperationContainerCreate, resources, nil, run, nil, nil)
 	if err != nil {

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -604,7 +604,7 @@ func createFromCopy(d *Daemon, project string, req *api.InstancesPost) response.
 
 	run := func(op *operations.Operation) error {
 		instanceOnly := req.Source.InstanceOnly || req.Source.ContainerOnly
-		_, err := containerCreateAsCopy(d.State(), args, source, instanceOnly, req.Source.Refresh)
+		_, err := instanceCreateAsCopy(d.State(), args, source, instanceOnly, req.Source.Refresh)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This lays the ground work for linking createFromCopy to the new storage layer's CreateInstanceFromCopy function.

- Renames container references to instance
- Adds proper revert function
- Improves comments