### PR TITLE
Use the node ID from the nodes ID table, not the raft one

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -650,7 +650,7 @@ func Promote(state *state.State, gateway *Gateway, nodes []db.RaftNode) error {
 
 	// Unlock regular access to our cluster database and add the database role.
 	err = state.Cluster.ExitExclusive(func(tx *db.ClusterTx) error {
-		err = tx.NodeAddRole(id, db.ClusterRoleDatabase)
+		err = tx.NodeAddRole(state.Cluster.GetNodeID(), db.ClusterRoleDatabase)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to add database role for the node")
 		}

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -375,6 +375,30 @@ func (c *ClusterTx) NodeAddRole(id int64, role ClusterRole) error {
 	return nil
 }
 
+// NodeRemoveRole removes a role from the node.
+func (c *ClusterTx) NodeRemoveRole(id int64, role ClusterRole) error {
+	// Translate role names to ids
+	roleID := -1
+	for k, v := range ClusterRoles {
+		if v == role {
+			roleID = k
+			break
+		}
+	}
+
+	if roleID < 0 {
+		return fmt.Errorf("Invalid role: %v", role)
+	}
+
+	// Update the database record
+	_, err := c.tx.Exec("DELETE FROM nodes_roles WHERE node_id=? AND role=?", id, roleID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // NodeRemove removes the node with the given id.
 func (c *ClusterTx) NodeRemove(id int64) error {
 	result, err := c.tx.Exec("DELETE FROM nodes WHERE id=?", id)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -74,6 +74,7 @@ var patches = []patch{
 	{name: "storage_api_rename_container_snapshots_links_again", run: patchStorageApiUpdateContainerSnapshots},
 	{name: "storage_api_rename_container_snapshots_dir_again_again", run: patchStorageApiRenameContainerSnapshotsDir},
 	{name: "clustering_add_roles", run: patchClusteringAddRoles},
+	{name: "clustering_add_roles_again", run: patchClusteringAddRoles},
 }
 
 type patch struct {
@@ -3369,6 +3370,11 @@ func patchClusteringAddRoles(name string, d *Daemon) error {
 
 			if shared.StringInSlice(node.Address, addresses) && !shared.StringInSlice(string(db.ClusterRoleDatabase), node.Roles) {
 				err = tx.NodeAddRole(node.ID, db.ClusterRoleDatabase)
+				if err != nil {
+					return err
+				}
+			} else if shared.StringInSlice(string(db.ClusterRoleDatabase), node.Roles) {
+				err = tx.NodeRemoveRole(node.ID, db.ClusterRoleDatabase)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>