### PR TITLE
lxd/storage/cephfs: Properly handle root path

### DIFF
--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -264,7 +264,7 @@ func (d *cephfs) Mount() (bool, error) {
 	// Parse the namespace / path.
 	fields := strings.SplitN(d.config["cephfs.path"], "/", 2)
 	fsName := fields[0]
-	fsPath := "/"
+	fsPath := ""
 	if len(fields) > 1 {
 		fsPath = fields[1]
 	}


### PR DESCRIPTION
Closes #6477

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>