### PR TITLE
Device: Moves RunConfig to device/config package

### DIFF
--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -1,4 +1,4 @@
-package device
+package config
 
 // MountOwnerShiftNone do not use owner shifting.
 const MountOwnerShiftNone = ""

--- a/lxd/device/device.go
+++ b/lxd/device/device.go
@@ -43,7 +43,7 @@ type Device interface {
 	// Start peforms any host-side configuration required to start the device for the instance.
 	// This can be when a device is plugged into a running instance or the instance is starting.
 	// Returns run-time configuration needed for configuring the instance with the new device.
-	Start() (*RunConfig, error)
+	Start() (*deviceConfig.RunConfig, error)
 
 	// Register provides the ability for a device to subcribe to events that LXD can generate.
 	// It is called after a device is started (after Start()) or when LXD starts.
@@ -58,7 +58,7 @@ type Device interface {
 	// Stop performs any host-side cleanup required when a device is removed from an instance,
 	// either due to unplugging it from a running instance or instance is being shutdown.
 	// Returns run-time configuration needed for detaching the device from the instance.
-	Stop() (*RunConfig, error)
+	Stop() (*deviceConfig.RunConfig, error)
 
 	// Remove performs any host-side cleanup when an instance is removed from an instance.
 	Remove() error

--- a/lxd/device/device_instance.go
+++ b/lxd/device/device_instance.go
@@ -19,5 +19,5 @@ type Instance interface {
 	ExpandedConfig() map[string]string
 	LocalDevices() deviceConfig.Devices
 	ExpandedDevices() deviceConfig.Devices
-	DeviceEventHandler(*RunConfig) error
+	DeviceEventHandler(*deviceConfig.RunConfig) error
 }

--- a/lxd/device/device_utils_infiniband.go
+++ b/lxd/device/device_utils_infiniband.go
@@ -70,7 +70,7 @@ func infinibandDevices(nics *api.ResourcesNetwork, parent string) map[string]*ap
 
 // infinibandAddDevices creates the UNIX devices for the provided IBF device and then configures the
 // supplied runConfig with the Cgroup rules and mount instructions to pass the device into instance.
-func infinibandAddDevices(s *state.State, devicesPath string, deviceName string, ibDev *api.ResourcesNetworkCardPort, runConf *RunConfig) error {
+func infinibandAddDevices(s *state.State, devicesPath string, deviceName string, ibDev *api.ResourcesNetworkCardPort, runConf *deviceConfig.RunConfig) error {
 	if ibDev.Infiniband == nil {
 		return fmt.Errorf("No infiniband devices supplied")
 	}

--- a/lxd/device/device_utils_unix_events.go
+++ b/lxd/device/device_utils_unix_events.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
@@ -20,8 +21,8 @@ type UnixEvent struct {
 
 // UnixSubscription used to subcribe to specific events.
 type UnixSubscription struct {
-	Path    string                              // The absolute source path on the host.
-	Handler func(UnixEvent) (*RunConfig, error) // The function to run when an event occurs.
+	Path    string                                           // The absolute source path on the host.
+	Handler func(UnixEvent) (*deviceConfig.RunConfig, error) // The function to run when an event occurs.
 }
 
 // unixHandlers stores the event handler callbacks for Unix events.
@@ -31,7 +32,7 @@ var unixHandlers = map[string]UnixSubscription{}
 var unixMutex sync.Mutex
 
 // unixRegisterHandler registers a handler function to be called whenever a Unix device event occurs.
-func unixRegisterHandler(s *state.State, instance Instance, deviceName, path string, handler func(UnixEvent) (*RunConfig, error)) error {
+func unixRegisterHandler(s *state.State, instance Instance, deviceName, path string, handler func(UnixEvent) (*deviceConfig.RunConfig, error)) error {
 	if path == "" || handler == nil {
 		return fmt.Errorf("Invalid subscription")
 	}

--- a/lxd/device/device_utils_usb_events.go
+++ b/lxd/device/device_utils_usb_events.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/state"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
@@ -27,13 +28,13 @@ type USBEvent struct {
 }
 
 // usbHandlers stores the event handler callbacks for USB events.
-var usbHandlers = map[string]func(USBEvent) (*RunConfig, error){}
+var usbHandlers = map[string]func(USBEvent) (*deviceConfig.RunConfig, error){}
 
 // usbMutex controls access to the usbHandlers map.
 var usbMutex sync.Mutex
 
 // usbRegisterHandler registers a handler function to be called whenever a USB device event occurs.
-func usbRegisterHandler(instance Instance, deviceName string, handler func(USBEvent) (*RunConfig, error)) {
+func usbRegisterHandler(instance Instance, deviceName string, handler func(USBEvent) (*deviceConfig.RunConfig, error)) {
 	usbMutex.Lock()
 	defer usbMutex.Unlock()
 

--- a/lxd/device/gpu.go
+++ b/lxd/device/gpu.go
@@ -11,6 +11,7 @@ import (
 
 	"golang.org/x/sys/unix"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
@@ -71,13 +72,13 @@ func (d *gpu) validateEnvironment() error {
 }
 
 // Start is run when the device is added to the container.
-func (d *gpu) Start() (*RunConfig, error) {
+func (d *gpu) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
+	runConf := deviceConfig.RunConfig{}
 	gpus, err := resources.GetGPU()
 	if err != nil {
 		return nil, err
@@ -184,8 +185,8 @@ func (d *gpu) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *gpu) Stop() (*RunConfig, error) {
-	runConf := RunConfig{
+func (d *gpu) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
@@ -56,7 +57,7 @@ func (d *infinibandPhysical) validateEnvironment() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *infinibandPhysical) Start() (*RunConfig, error) {
+func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -101,7 +102,7 @@ func (d *infinibandPhysical) Start() (*RunConfig, error) {
 		}
 	}
 
-	runConf := RunConfig{}
+	runConf := deviceConfig.RunConfig{}
 
 	// Configure runConf with infiniband setup instructions.
 	err = infinibandAddDevices(d.state, d.instance.DevicesPath(), d.name, ibDev, &runConf)
@@ -114,7 +115,7 @@ func (d *infinibandPhysical) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -125,11 +126,11 @@ func (d *infinibandPhysical) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *infinibandPhysical) Stop() (*RunConfig, error) {
+func (d *infinibandPhysical) Stop() (*deviceConfig.RunConfig, error) {
 	v := d.volatileGet()
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
-		NetworkInterface: []RunConfigItem{
+		NetworkInterface: []deviceConfig.RunConfigItem{
 			{Key: "link", Value: v["host_name"]},
 		},
 	}

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/resources"
 	"github.com/lxc/lxd/shared"
@@ -57,7 +58,7 @@ func (d *infinibandSRIOV) validateEnvironment() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *infinibandSRIOV) Start() (*RunConfig, error) {
+func (d *infinibandSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -123,7 +124,7 @@ func (d *infinibandSRIOV) Start() (*RunConfig, error) {
 		}
 	}
 
-	runConf := RunConfig{}
+	runConf := deviceConfig.RunConfig{}
 
 	// Configure runConf with infiniband setup instructions.
 	err = infinibandAddDevices(d.state, d.instance.DevicesPath(), d.name, vfDev, &runConf)
@@ -136,7 +137,7 @@ func (d *infinibandSRIOV) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -147,11 +148,11 @@ func (d *infinibandSRIOV) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *infinibandSRIOV) Stop() (*RunConfig, error) {
+func (d *infinibandSRIOV) Stop() (*deviceConfig.RunConfig, error) {
 	v := d.volatileGet()
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks:        []func() error{d.postStop},
-		NetworkInterface: []RunConfigItem{{Key: "link", Value: v["host_name"]}},
+		NetworkInterface: []deviceConfig.RunConfigItem{{Key: "link", Value: v["host_name"]}},
 	}
 
 	err := unixDeviceRemove(d.instance.DevicesPath(), IBDevPrefix, d.name, "", &runConf)

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -110,7 +110,7 @@ func (d *nicBridged) Add() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *nicBridged) Start() (*RunConfig, error) {
+func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -169,8 +169,8 @@ func (d *nicBridged) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -179,7 +179,7 @@ func (d *nicBridged) Start() (*RunConfig, error) {
 
 	if d.instance.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
-			RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
+			deviceConfig.RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
 		)
 	}
 
@@ -247,8 +247,8 @@ func (d *nicBridged) Update(oldDevices deviceConfig.Devices, isRunning bool) err
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicBridged) Stop() (*RunConfig, error) {
-	runConf := RunConfig{
+func (d *nicBridged) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -106,7 +107,7 @@ func (d *nicIPVLAN) validateEnvironment() error {
 }
 
 // Start is run when the instance is starting up (IPVLAN doesn't support hot plugging).
-func (d *nicIPVLAN) Start() (*RunConfig, error) {
+func (d *nicIPVLAN) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -142,8 +143,8 @@ func (d *nicIPVLAN) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	nic := []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	nic := []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "ipvlan"},
 		{Key: "flags", Value: "up"},
@@ -154,25 +155,25 @@ func (d *nicIPVLAN) Start() (*RunConfig, error) {
 	}
 
 	if d.config["mtu"] != "" {
-		nic = append(nic, RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
 	}
 
 	if d.config["ipv4.address"] != "" {
 		for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
 			addr = strings.TrimSpace(addr)
-			nic = append(nic, RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
 		}
 
-		nic = append(nic, RunConfigItem{Key: "ipv4.gateway", Value: "dev"})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.gateway", Value: "dev"})
 	}
 
 	if d.config["ipv6.address"] != "" {
 		for _, addr := range strings.Split(d.config["ipv6.address"], ",") {
 			addr = strings.TrimSpace(addr)
-			nic = append(nic, RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
 		}
 
-		nic = append(nic, RunConfigItem{Key: "ipv6.gateway", Value: "dev"})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.gateway", Value: "dev"})
 	}
 
 	runConf.NetworkInterface = nic
@@ -211,8 +212,8 @@ func (d *nicIPVLAN) setupParentSysctls(parentName string) error {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicIPVLAN) Stop() (*RunConfig, error) {
-	runConf := RunConfig{
+func (d *nicIPVLAN) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -41,7 +42,7 @@ func (d *nicMACVLAN) validateEnvironment() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *nicMACVLAN) Start() (*RunConfig, error) {
+func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -103,8 +104,8 @@ func (d *nicMACVLAN) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -115,11 +116,11 @@ func (d *nicMACVLAN) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicMACVLAN) Stop() (*RunConfig, error) {
+func (d *nicMACVLAN) Stop() (*deviceConfig.RunConfig, error) {
 	v := d.volatileGet()
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
-		NetworkInterface: []RunConfigItem{
+		NetworkInterface: []deviceConfig.RunConfigItem{
 			{Key: "link", Value: v["host_name"]},
 		},
 	}

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -53,7 +53,7 @@ func (d *nicP2P) CanHotPlug() (bool, []string) {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *nicP2P) Start() (*RunConfig, error) {
+func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -83,8 +83,8 @@ func (d *nicP2P) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -119,8 +119,8 @@ func (d *nicP2P) Update(oldDevices deviceConfig.Devices, isRunning bool) error {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicP2P) Stop() (*RunConfig, error) {
-	runConf := RunConfig{
+func (d *nicP2P) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -3,6 +3,7 @@ package device
 import (
 	"fmt"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -48,7 +49,7 @@ func (d *nicPhysical) validateEnvironment() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *nicPhysical) Start() (*RunConfig, error) {
+func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -107,8 +108,8 @@ func (d *nicPhysical) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -119,11 +120,11 @@ func (d *nicPhysical) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicPhysical) Stop() (*RunConfig, error) {
+func (d *nicPhysical) Stop() (*deviceConfig.RunConfig, error) {
 	v := d.volatileGet()
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
-		NetworkInterface: []RunConfigItem{
+		NetworkInterface: []deviceConfig.RunConfigItem{
 			{Key: "link", Value: v["host_name"]},
 		},
 	}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -115,7 +116,7 @@ func (d *nicRouted) validateEnvironment() error {
 }
 
 // Start is run when the instance is starting up (Routed mode doesn't support hot plugging).
-func (d *nicRouted) Start() (*RunConfig, error) {
+func (d *nicRouted) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -160,8 +161,8 @@ func (d *nicRouted) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	nic := []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	nic := []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "veth"},
 		{Key: "flags", Value: "up"},
@@ -173,33 +174,33 @@ func (d *nicRouted) Start() (*RunConfig, error) {
 	// the instance's IPs over that interface using proxy APR/NDP.
 	if parentName != "" {
 		nic = append(nic,
-			RunConfigItem{Key: "l2proxy", Value: "1"},
-			RunConfigItem{Key: "link", Value: parentName},
+			deviceConfig.RunConfigItem{Key: "l2proxy", Value: "1"},
+			deviceConfig.RunConfigItem{Key: "link", Value: parentName},
 		)
 	}
 
 	if d.config["mtu"] != "" {
-		nic = append(nic, RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "mtu", Value: d.config["mtu"]})
 	}
 
 	if d.config["ipv4.address"] != "" {
 		for _, addr := range strings.Split(d.config["ipv4.address"], ",") {
 			addr = strings.TrimSpace(addr)
-			nic = append(nic, RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.address", Value: fmt.Sprintf("%s/32", addr)})
 		}
 
 		// Use a fixed link-local address as the next-hop default gateway.
-		nic = append(nic, RunConfigItem{Key: "ipv4.gateway", Value: nicRoutedIPv4GW})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv4.gateway", Value: nicRoutedIPv4GW})
 	}
 
 	if d.config["ipv6.address"] != "" {
 		for _, addr := range strings.Split(d.config["ipv6.address"], ",") {
 			addr = strings.TrimSpace(addr)
-			nic = append(nic, RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
+			nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.address", Value: fmt.Sprintf("%s/128", addr)})
 		}
 
 		// Use a fixed link-local address as the next-hop default gateway.
-		nic = append(nic, RunConfigItem{Key: "ipv6.gateway", Value: nicRoutedIPv6GW})
+		nic = append(nic, deviceConfig.RunConfigItem{Key: "ipv6.gateway", Value: nicRoutedIPv6GW})
 	}
 
 	runConf.NetworkInterface = nic
@@ -266,8 +267,8 @@ func (d *nicRouted) postStart() error {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicRouted) Stop() (*RunConfig, error) {
-	runConf := RunConfig{
+func (d *nicRouted) Stop() (*deviceConfig.RunConfig, error) {
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/shared"
 )
@@ -59,7 +60,7 @@ func (d *nicSRIOV) validateEnvironment() error {
 }
 
 // Start is run when the device is added to a running instance or instance is starting up.
-func (d *nicSRIOV) Start() (*RunConfig, error) {
+func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
@@ -109,8 +110,8 @@ func (d *nicSRIOV) Start() (*RunConfig, error) {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
-	runConf.NetworkInterface = []RunConfigItem{
+	runConf := deviceConfig.RunConfig{}
+	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -121,11 +122,11 @@ func (d *nicSRIOV) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *nicSRIOV) Stop() (*RunConfig, error) {
+func (d *nicSRIOV) Stop() (*deviceConfig.RunConfig, error) {
 	v := d.volatileGet()
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
-		NetworkInterface: []RunConfigItem{
+		NetworkInterface: []deviceConfig.RunConfigItem{
 			{Key: "link", Value: v["host_name"]},
 		},
 	}

--- a/lxd/device/none.go
+++ b/lxd/device/none.go
@@ -1,5 +1,9 @@
 package device
 
+import (
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+)
+
 type none struct {
 	deviceCommon
 }
@@ -16,11 +20,11 @@ func (d *none) validateConfig() error {
 }
 
 // Start is run when the device is added to the container.
-func (d *none) Start() (*RunConfig, error) {
+func (d *none) Start() (*deviceConfig.RunConfig, error) {
 	return nil, nil
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *none) Stop() (*RunConfig, error) {
+func (d *none) Stop() (*deviceConfig.RunConfig, error) {
 	return nil, nil
 }

--- a/lxd/device/proxy.go
+++ b/lxd/device/proxy.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 	"gopkg.in/lxc/go-lxc.v2"
 
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/iptables"
 	"github.com/lxc/lxd/lxd/project"
@@ -127,14 +128,14 @@ func (d *proxy) validateEnvironment() error {
 }
 
 // Start is run when the device is added to the container.
-func (d *proxy) Start() (*RunConfig, error) {
+func (d *proxy) Start() (*deviceConfig.RunConfig, error) {
 	err := d.validateEnvironment()
 	if err != nil {
 		return nil, err
 	}
 
 	// Proxy devices have to be setup once the container is running.
-	runConf := RunConfig{}
+	runConf := deviceConfig.RunConfig{}
 	runConf.PostHooks = []func() error{
 		func() error {
 			if shared.IsTrue(d.config["nat"]) {
@@ -224,7 +225,7 @@ func (d *proxy) checkProcStarted(logPath string) (bool, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *proxy) Stop() (*RunConfig, error) {
+func (d *proxy) Stop() (*deviceConfig.RunConfig, error) {
 	// Remove possible iptables entries
 	iptables.ContainerClear("ipv4", fmt.Sprintf("%s (%s)", d.instance.Name(), d.name), "nat")
 	iptables.ContainerClear("ipv6", fmt.Sprintf("%s (%s)", d.instance.Name(), d.name), "nat")

--- a/lxd/device/usb.go
+++ b/lxd/device/usb.go
@@ -69,20 +69,20 @@ func (d *usb) Register() error {
 	// Extract variables needed to run the event hook so that the reference to this device
 	// struct is not needed to be kept in memory.
 	devicesPath := d.instance.DevicesPath()
-	deviceConfig := d.config
+	devConfig := d.config
 	deviceName := d.name
 	state := d.state
 
 	// Handler for when a USB event occurs.
-	f := func(e USBEvent) (*RunConfig, error) {
-		if !usbIsOurDevice(deviceConfig, &e) {
+	f := func(e USBEvent) (*deviceConfig.RunConfig, error) {
+		if !usbIsOurDevice(devConfig, &e) {
 			return nil, nil
 		}
 
-		runConf := RunConfig{}
+		runConf := deviceConfig.RunConfig{}
 
 		if e.Action == "add" {
-			err := unixDeviceSetupCharNum(state, devicesPath, "unix", deviceName, deviceConfig, e.Major, e.Minor, e.Path, false, &runConf)
+			err := unixDeviceSetupCharNum(state, devicesPath, "unix", deviceName, devConfig, e.Major, e.Minor, e.Path, false, &runConf)
 			if err != nil {
 				return nil, err
 			}
@@ -115,13 +115,13 @@ func (d *usb) Register() error {
 }
 
 // Start is run when the device is added to the instance.
-func (d *usb) Start() (*RunConfig, error) {
+func (d *usb) Start() (*deviceConfig.RunConfig, error) {
 	usbs, err := d.loadUsb()
 	if err != nil {
 		return nil, err
 	}
 
-	runConf := RunConfig{}
+	runConf := deviceConfig.RunConfig{}
 	runConf.PostHooks = []func() error{d.Register}
 
 	for _, usb := range usbs {
@@ -143,11 +143,11 @@ func (d *usb) Start() (*RunConfig, error) {
 }
 
 // Stop is run when the device is removed from the instance.
-func (d *usb) Stop() (*RunConfig, error) {
+func (d *usb) Stop() (*deviceConfig.RunConfig, error) {
 	// Unregister any USB event handlers for this device.
 	usbUnregisterHandler(d.instance, d.name)
 
-	runConf := RunConfig{
+	runConf := deviceConfig.RunConfig{
 		PostHooks: []func() error{d.postStop},
 	}
 

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/lxc/lxd/lxd/backup"
 	"github.com/lxc/lxd/lxd/db"
-	"github.com/lxc/lxd/lxd/device"
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/operations"
@@ -66,7 +65,7 @@ type Instance interface {
 	IsStateful() bool
 
 	// Hooks
-	DeviceEventHandler(*device.RunConfig) error
+	DeviceEventHandler(*deviceConfig.RunConfig) error
 
 	// Properties
 	ID() int

--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -454,7 +454,7 @@ func (vm *vmQemu) Start(stateful bool) error {
 		}
 	}
 
-	devConfs := make([]*device.RunConfig, 0, len(vm.expandedDevices))
+	devConfs := make([]*deviceConfig.RunConfig, 0, len(vm.expandedDevices))
 
 	// Setup devices in sorted order, this ensures that device mounts are added in path order.
 	for _, dev := range vm.expandedDevices.Sorted() {
@@ -543,7 +543,7 @@ func (vm *vmQemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (
 // deviceStart loads a new device and calls its Start() function. After processing the runtime
 // config returned from Start(), it also runs the device's Register() function irrespective of
 // whether the instance is running or not.
-func (vm *vmQemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*device.RunConfig, error) {
+func (vm *vmQemu) deviceStart(deviceName string, rawConfig deviceConfig.Device, isRunning bool) (*deviceConfig.RunConfig, error) {
 	d, _, err := vm.deviceLoad(deviceName, rawConfig)
 	if err != nil {
 		return nil, err
@@ -804,7 +804,7 @@ echo "To start it now, unmount this filesystem and run: systemctl start lxd-agen
 }
 
 // generateQemuConfigFile writes the qemu config file and returns its location.
-func (vm *vmQemu) generateQemuConfigFile(devConfs []*device.RunConfig) (string, error) {
+func (vm *vmQemu) generateQemuConfigFile(devConfs []*deviceConfig.RunConfig) (string, error) {
 	var sb *strings.Builder = &strings.Builder{}
 
 	// Base config. This is common for all VMs and has no variables in it.
@@ -1107,7 +1107,7 @@ bootindex = "1"
 }
 
 // addDriveConfig adds the qemu config required for adding a supplementary drive.
-func (vm *vmQemu) addDriveConfig(sb *strings.Builder, driveIndex int, driveConf device.MountEntryItem) {
+func (vm *vmQemu) addDriveConfig(sb *strings.Builder, driveIndex int, driveConf deviceConfig.MountEntryItem) {
 	driveName := fmt.Sprintf(driveConf.TargetPath)
 
 	// Devices use "lxd_" prefix indicating that this is a user named device.
@@ -1133,7 +1133,7 @@ drive = "lxd_%s"
 }
 
 // addNetDevConfig adds the qemu config required for adding a network device.
-func (vm *vmQemu) addNetDevConfig(sb *strings.Builder, nicConfig []device.RunConfigItem) {
+func (vm *vmQemu) addNetDevConfig(sb *strings.Builder, nicConfig []deviceConfig.RunConfigItem) {
 	var devName, devTap, devHwaddr string
 	for _, nicItem := range nicConfig {
 		if nicItem.Key == "name" {
@@ -2487,7 +2487,7 @@ func (vm *vmQemu) IsStateful() bool {
 	return vm.stateful
 }
 
-func (vm *vmQemu) DeviceEventHandler(runConf *device.RunConfig) error {
+func (vm *vmQemu) DeviceEventHandler(runConf *deviceConfig.RunConfig) error {
 	return fmt.Errorf("DeviceEventHandler Not implemented")
 }
 


### PR DESCRIPTION
This is required to avoid the `instance` package needing to import the `device` package which causes circular imports when using `instance` in the `storage` package.

This is because the `device` package uses constants from the `storage` package and so requires an import.

This move makes sense though as it moves a Config struct into the config package.