### PR TITLE
lxd/device/disk: Prevents error logs about unsupported disk drive on VM stop

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -736,7 +736,8 @@ func (d *disk) createDevice() (string, error) {
 // Stop is run when the device is removed from the instance.
 func (d *disk) Stop() (*deviceConfig.RunConfig, error) {
 	if d.instance.Type() == instancetype.VM {
-		if shared.IsRootDiskDevice(d.config) {
+		// Only root disks and cloud-init:config drives supported on VMs.
+		if shared.IsRootDiskDevice(d.config) || d.config["source"] == diskSourceCloudInit {
 			return &deviceConfig.RunConfig{}, nil
 		}
 


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>