### PR TITLE
Storage backup import cleanup

### DIFF
--- a/lxd/images.go
+++ b/lxd/images.go
@@ -122,14 +122,13 @@ func compressFile(compress string, infile io.Reader, outfile io.Writer) error {
 		defer os.Remove(tempfile.Name())
 
 		// Prepare 'tar2sqfs' arguments
-		args := []string{"tar2sqfs", "--no-skip", "--force",
-			"--compressor", "xz", tempfile.Name()}
+		args := []string{"tar2sqfs", "--no-skip", "--force", "--compressor", "xz", tempfile.Name()}
 		cmd = exec.Command(args[0], args[1:]...)
 		cmd.Stdin = infile
 
-		err = cmd.Run()
+		output, err := cmd.CombinedOutput()
 		if err != nil {
-			return err
+			return fmt.Errorf("tar2sqfs: %v (%v)", err, strings.TrimSpace(string(output)))
 		}
 		// Replay the result to outfile
 		tempfile.Seek(0, 0)

--- a/shared/archive_linux.go
+++ b/shared/archive_linux.go
@@ -23,6 +23,9 @@ func DetectCompression(fname string) ([]string, string, []string, error) {
 	return DetectCompressionFile(f)
 }
 
+// DetectCompressionFile detects the compression type of a file and returns the tar arguments needed
+// to unpack the file, compression type (in the form of a file extension), and the command needed
+// to decompress the file to an uncompressed tarball.
 func DetectCompressionFile(f io.ReadSeeker) ([]string, string, []string, error) {
 	// read header parts to detect compression method
 	// bz2 - 2 bytes, 'BZ' signature/magic number
@@ -50,8 +53,7 @@ func DetectCompressionFile(f io.ReadSeeker) ([]string, string, []string, error) 
 	case bytes.Equal(header[257:262], []byte{'u', 's', 't', 'a', 'r'}):
 		return []string{"-xf"}, ".tar", []string{}, nil
 	case bytes.Equal(header[0:4], []byte{'h', 's', 'q', 's'}):
-		return []string{"-xf"}, ".squashfs",
-			[]string{"sqfs2tar", "--no-skip"}, nil
+		return []string{"-xf"}, ".squashfs", []string{"sqfs2tar", "--no-skip"}, nil
 	default:
 		return nil, "", nil, fmt.Errorf("Unsupported compression")
 	}


### PR DESCRIPTION
This PR lays the groundwork needed to link backup restoration to new storage layer.

- Renames containerCreateFromBackup to instanceCreateFromBackup.
- Modifies instanceCreateFromBackup to return a revert function rather than the old storage pool (used to delete the unpacked backup files on error).
- Restructures instanceCreateFromBackup to only use the storage pool in a single place (which will then be replaced with the new storage pkg where possible).
 