### PR TITLE
Database changes for multi arch cluster

### DIFF
--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -18,6 +18,7 @@ import (
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/pkg/errors"
 )
@@ -172,8 +173,15 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 			return err
 		}
 
+		// TODO: when fixing #6380 this should be replaced with the
+		// actual architecture of the foreign node.
+		arch, err := osarch.ArchitectureGetLocalID()
+		if err != nil {
+			return err
+		}
+
 		// Add the new node
-		id, err := tx.NodeAdd(name, address)
+		id, err := tx.NodeAddWithArch(name, address, arch)
 		if err != nil {
 			return errors.Wrap(err, "Failed to insert new node into the database")
 		}

--- a/lxd/db/cluster/open.go
+++ b/lxd/db/cluster/open.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/pkg/errors"
 )
@@ -165,11 +166,15 @@ func EnsureSchema(db *sql.DB, address string, dir string) (bool, error) {
 	// 1. This is needed for referential integrity with other tables. Also,
 	// create a default profile.
 	if initial == 0 {
+		arch, err := osarch.ArchitectureGetLocalID()
+		if err != nil {
+			return false, err
+		}
 		err = query.Transaction(db, func(tx *sql.Tx) error {
 			stmt := `
-INSERT INTO nodes(id, name, address, schema, api_extensions) VALUES(1, 'none', '0.0.0.0', ?, ?)
+INSERT INTO nodes(id, name, address, schema, api_extensions, arch) VALUES(1, 'none', '0.0.0.0', ?, ?, ?)
 `
-			_, err = tx.Exec(stmt, SchemaVersion, apiExtensions)
+			_, err = tx.Exec(stmt, SchemaVersion, apiExtensions, arch)
 			if err != nil {
 				return err
 			}

--- a/lxd/db/cluster/open_test.go
+++ b/lxd/db/cluster/open_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/db/cluster"
 	"github.com/lxc/lxd/lxd/db/query"
+	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/mpvl/subtest"
 	"github.com/stretchr/testify/assert"
@@ -165,10 +166,10 @@ CREATE TABLE schema (
 func addNode(t *testing.T, db *sql.DB, address string, schema int, apiExtensions int) {
 	err := query.Transaction(db, func(tx *sql.Tx) error {
 		stmt := `
-INSERT INTO nodes(name, address, schema, api_extensions) VALUES (?, ?, ?, ?)
+INSERT INTO nodes(name, address, schema, api_extensions, arch) VALUES (?, ?, ?, ?, ?)
 `
 		name := fmt.Sprintf("node at %s", address)
-		_, err := tx.Exec(stmt, name, address, schema, apiExtensions)
+		_, err := tx.Exec(stmt, name, address, schema, apiExtensions, osarch.ARCH_64BIT_INTEL_X86)
 		return err
 	})
 	require.NoError(t, err)

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -303,6 +303,7 @@ CREATE TABLE nodes (
     api_extensions INTEGER NOT NULL,
     heartbeat DATETIME DEFAULT CURRENT_TIMESTAMP,
     pending INTEGER NOT NULL DEFAULT 0,
+    arch INTEGER NOT NULL DEFAULT 0 CHECK (arch > 0),
     UNIQUE (name),
     UNIQUE (address)
 );
@@ -487,5 +488,5 @@ CREATE TABLE storage_volumes_config (
     FOREIGN KEY (storage_volume_id) REFERENCES storage_volumes (id) ON DELETE CASCADE
 );
 
-INSERT INTO schema (version, updated_at) VALUES (19, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (20, strftime("%s"))
 `

--- a/shared/osarch/architectures.go
+++ b/shared/osarch/architectures.go
@@ -105,3 +105,16 @@ func ArchitecturePersonalities(arch int) ([]int, error) {
 
 	return []int{}, fmt.Errorf("Architecture isn't supported: %d", arch)
 }
+
+// ArchitectureGetLocalID returns the local hardware architecture ID
+func ArchitectureGetLocalID() (int, error) {
+	name, err := ArchitectureGetLocal()
+	if err != nil {
+		return -1, err
+	}
+	id, err := ArchitectureId(name)
+	if err != nil {
+		return -1, err
+	}
+	return id, nil
+}


### PR DESCRIPTION
This adds a new "arch" column to the "nodes" table, in preparation for putting in place multi-arch cluster support, see #6380.