### PR TITLE
Don't block RBAC on startup

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -1253,11 +1253,18 @@ func (d *Daemon) setupRBACServer(rbacURL string, rbacKey string, rbacExpiry int6
 		return result, err
 	}
 
-	// Perform full sync
-	err = server.SyncProjects()
-	if err != nil {
-		return err
-	}
+	// Perform full sync when online
+	go func() {
+		for {
+			err = server.SyncProjects()
+			if err != nil {
+				time.Sleep(time.Minute)
+				continue
+			}
+
+			break
+		}
+	}()
 
 	server.StartStatusCheck()
 

--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -1216,7 +1216,7 @@ var mountFlagsToOptMap = map[C.ulong]string{
 }
 
 func mountFlagsToOpts(flags C.ulong) string {
-	var currentBit C.ulong = 0
+	var currentBit C.ulong
 	opts := ""
 	var msRec C.ulong = (flags & C.MS_REC)
 


### PR DESCRIPTION
This fixes handling of an RBAC server not being online during startup, especially hits when running RBAC in a LXD container.