### PR TITLE
Block cluster connections on working event forwarding

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -612,6 +612,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		if err != nil {
 			return err
 		}
+
 		err = clusterRebalance(client)
 		if err != nil {
 			return err
@@ -922,10 +923,12 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(err)
 		}
+
 		networks, err := d.cluster.Networks()
 		if err != nil {
 			return response.SmartError(err)
 		}
+
 		for _, name := range networks {
 			err := client.DeleteNetwork(name)
 			if err != nil {
@@ -938,6 +941,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		if err != nil && err != db.ErrNoSuchObject {
 			return response.SmartError(err)
 		}
+
 		for _, name := range pools {
 			err := client.DeleteStoragePool(name)
 			if err != nil {
@@ -965,6 +969,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(err)
 		}
+
 		put := api.ClusterPut{}
 		put.Enabled = false
 		_, err = client.UpdateCluster(put, "")
@@ -982,17 +987,19 @@ func tryClusterRebalance(d *Daemon) error {
 	leader, err := d.gateway.LeaderAddress()
 	if err != nil {
 		// This is not a fatal error, so let's just log it.
-		return errors.Wrap(err, "failed to get current leader member")
+		return errors.Wrap(err, "Failed to get current leader member")
 	}
 	cert := d.endpoints.NetworkCert()
 	client, err := cluster.Connect(leader, cert, true)
 	if err != nil {
-		return errors.Wrap(err, "failed to connect to leader member")
+		return errors.Wrap(err, "Failed to connect to leader member")
 	}
+
 	_, _, err = client.RawQuery("POST", "/internal/cluster/rebalance", nil, "")
 	if err != nil {
-		return errors.Wrap(err, "request to rebalance cluster failed")
+		return errors.Wrap(err, "Request to rebalance cluster failed")
 	}
+
 	return nil
 }
 
@@ -1159,6 +1166,7 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 	if err != nil {
 		return response.SmartError(err)
 	}
+
 	_, _, err = client.RawQuery("POST", "/internal/cluster/promote", post, "")
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -608,7 +608,7 @@ func clusterPutJoin(d *Daemon, req api.ClusterPut) response.Response {
 		// Add the cluster flag from the agent
 		version.UserAgentFeatures([]string{"cluster"})
 
-		client, err = cluster.Connect(req.ClusterAddress, d.endpoints.NetworkCert(), false)
+		client, err = cluster.Connect(req.ClusterAddress, d.endpoints.NetworkCert(), true)
 		if err != nil {
 			return err
 		}
@@ -965,7 +965,7 @@ func clusterNodeDelete(d *Daemon, r *http.Request) response.Response {
 	if force != 1 {
 		// Try to gracefully reset the database on the node.
 		cert := d.endpoints.NetworkCert()
-		client, err := cluster.Connect(address, cert, false)
+		client, err := cluster.Connect(address, cert, true)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -1162,7 +1162,7 @@ func internalClusterPostRebalance(d *Daemon, r *http.Request) response.Response 
 	}
 
 	cert := d.endpoints.NetworkCert()
-	client, err := cluster.Connect(address, cert, false)
+	client, err := cluster.Connect(address, cert, true)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/container_post.go
+++ b/lxd/container_post.go
@@ -297,7 +297,7 @@ func containerPostClusteringMigrate(d *Daemon, c instance.Instance, oldName, new
 
 	run := func(*operations.Operation) error {
 		// Connect to the source host, i.e. ourselves (the node the container is running on).
-		source, err := cluster.Connect(sourceAddress, cert, false)
+		source, err := cluster.Connect(sourceAddress, cert, true)
 		if err != nil {
 			return errors.Wrap(err, "Failed to connect to source server")
 		}

--- a/lxd/images.go
+++ b/lxd/images.go
@@ -1925,6 +1925,7 @@ func imageExport(d *Daemon, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(err)
 		}
+
 		return response.ForwardedResponse(client, r)
 	}
 
@@ -2217,12 +2218,14 @@ func imageSyncBetweenNodes(d *Daemon, project string, fingerprint string) error 
 	if err != nil {
 		return errors.Wrap(err, "Failed to fetch the leader node address")
 	}
+
 	var targetNodeAddress string
 	if shared.StringInSlice(leader, addresses) {
 		targetNodeAddress = leader
 	} else {
 		targetNodeAddress = addresses[0]
 	}
+
 	client, err := cluster.Connect(targetNodeAddress, d.endpoints.NetworkCert(), true)
 	if err != nil {
 		return errors.Wrap(err, "Failed to connect node for image synchronization")

--- a/lxd/networks.go
+++ b/lxd/networks.go
@@ -2316,7 +2316,7 @@ func (n *network) refreshForkdnsServerAddresses(heartbeatData *cluster.APIHeartb
 			continue
 		}
 
-		client, err := cluster.Connect(node.Address, cert, false)
+		client, err := cluster.Connect(node.Address, cert, true)
 		if err != nil {
 			return err
 		}

--- a/lxd/operations.go
+++ b/lxd/operations.go
@@ -16,7 +16,6 @@ import (
 	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
-	"github.com/lxc/lxd/shared/logger"
 )
 
 var operationCmd = APIEndpoint{
@@ -82,12 +81,7 @@ func operationGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	body, _, err = client.GetOperation(id)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	return response.SyncResponse(true, body)
+	return response.ForwardedResponse(client, r)
 }
 
 func operationDelete(d *Daemon, r *http.Request) response.Response {
@@ -136,12 +130,7 @@ func operationDelete(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = client.DeleteOperation(id)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	return response.EmptySyncResponse
+	return response.ForwardedResponse(client, r)
 }
 
 func operationsGet(d *Daemon, r *http.Request) response.Response {
@@ -361,12 +350,7 @@ func operationWaitGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	apiOp, _, err := client.GetOperationWait(id, timeout)
-	if err != nil {
-		return response.SmartError(err)
-	}
-
-	return response.SyncResponse(true, apiOp)
+	return response.ForwardedResponse(client, r)
 }
 
 type operationWebSocket struct {
@@ -447,7 +431,6 @@ func operationWebsocketGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	logger.Debugf("Forward operation websocket from node %s", address)
 	source, err := client.GetOperationWebsocket(id, secret)
 	if err != nil {
 		return response.SmartError(err)

--- a/lxd/response/response.go
+++ b/lxd/response/response.go
@@ -139,6 +139,7 @@ func Conflict(err error) Response {
 	if err != nil {
 		message = err.Error()
 	}
+
 	return &errorResponse{http.StatusConflict, message}
 }
 
@@ -148,6 +149,7 @@ func Forbidden(err error) Response {
 	if err != nil {
 		message = err.Error()
 	}
+
 	return &errorResponse{http.StatusForbidden, message}
 }
 
@@ -162,6 +164,7 @@ func NotFound(err error) Response {
 	if err != nil {
 		message = err.Error()
 	}
+
 	return &errorResponse{http.StatusNotFound, message}
 }
 
@@ -171,6 +174,7 @@ func NotImplemented(err error) Response {
 	if err != nil {
 		message = err.Error()
 	}
+
 	return &errorResponse{http.StatusNotImplemented, message}
 }
 
@@ -186,6 +190,7 @@ func Unavailable(err error) Response {
 	if err != nil {
 		message = err.Error()
 	}
+
 	return &errorResponse{http.StatusServiceUnavailable, message}
 }
 
@@ -308,6 +313,7 @@ func (r *fileResponse) Render(w http.ResponseWriter) error {
 				return err
 			}
 			defer fd.Close()
+
 			rd = fd
 		} else {
 			rd = bytes.NewReader(entry.Buffer)
@@ -361,6 +367,7 @@ func (r *forwardedResponse) Render(w http.ResponseWriter) error {
 	if err != nil {
 		return err
 	}
+
 	for key := range r.request.Header {
 		forwarded.Header.Set(key, r.request.Header.Get(key))
 	}
@@ -369,6 +376,7 @@ func (r *forwardedResponse) Render(w http.ResponseWriter) error {
 	if err != nil {
 		return err
 	}
+
 	response, err := httpClient.Do(forwarded)
 	if err != nil {
 		return err


### PR DESCRIPTION
With this change, connections to other cluster nodes for non-notify operations will now be held until a working event connection is established with the target.

This should avoid race conditions where we forward a request to another node but then fail to forward operation updates due to not being connected to that node's events stream yet.