### PR TITLE
Multi architecture clustering

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -889,3 +889,7 @@ Add virtual machine support.
 
 ## image\_profiles
 Allows a list of profiles to be applied to an image when launching a new container. 
+
+## multi\_architecture\_clustering
+This adds a new `architecture` attribute to cluster entries which indicates a cluster 
+node's architecture.

--- a/lxc/cluster.go
+++ b/lxc/cluster.go
@@ -117,7 +117,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		if member.Database {
 			database = "YES"
 		}
-		line := []string{member.ServerName, member.URL, database, strings.ToUpper(member.Status), member.Message}
+		line := []string{member.ServerName, member.URL, database, strings.ToUpper(member.Status), member.Message, member.Architecture}
 		data = append(data, line)
 	}
 	sort.Sort(byName(data))
@@ -128,6 +128,7 @@ func (c *cmdClusterList) Run(cmd *cobra.Command, args []string) error {
 		i18n.G("DATABASE"),
 		i18n.G("STATE"),
 		i18n.G("MESSAGE"),
+		i18n.G("ARCHITECTURE"),
 	}
 
 	return utils.RenderTable(c.flagFormat, header, data, members)

--- a/lxd/cluster/heartbeat_test.go
+++ b/lxd/cluster/heartbeat_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -144,7 +145,7 @@ func (f *heartbeatFixture) Grow() *cluster.Gateway {
 	name := address
 
 	nodes, err := cluster.Accept(
-		targetState, target, name, address, cluster.SchemaVersion, len(version.APIExtensions))
+		targetState, target, name, address, cluster.SchemaVersion, len(version.APIExtensions), osarch.ARCH_64BIT_INTEL_X86)
 	require.NoError(f.t, err)
 
 	err = cluster.Join(state, gateway, target.Cert(), name, nodes)

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -156,7 +156,7 @@ func Bootstrap(state *state.State, gateway *Gateway, name string) error {
 //
 // Return an updated list raft database nodes (possibly including the newly
 // accepted node).
-func Accept(state *state.State, gateway *Gateway, name, address string, schema, api int) ([]db.RaftNode, error) {
+func Accept(state *state.State, gateway *Gateway, name, address string, schema, api, arch int) ([]db.RaftNode, error) {
 	// Check parameters
 	if name == "" {
 		return nil, fmt.Errorf("node name must not be empty")
@@ -169,13 +169,6 @@ func Accept(state *state.State, gateway *Gateway, name, address string, schema, 
 	err := state.Cluster.Transaction(func(tx *db.ClusterTx) error {
 		// Check that the node can be accepted with these parameters.
 		err := membershipCheckClusterStateForAccept(tx, name, address, schema, api)
-		if err != nil {
-			return err
-		}
-
-		// TODO: when fixing #6380 this should be replaced with the
-		// actual architecture of the foreign node.
-		arch, err := osarch.ArchitectureGetLocalID()
 		if err != nil {
 			return err
 		}
@@ -818,6 +811,11 @@ func List(state *state.State) ([]api.ClusterMember, error) {
 		result[i].URL = fmt.Sprintf("https://%s", node.Address)
 		result[i].Database = shared.StringInSlice(string(db.ClusterRoleDatabase), node.Roles)
 		result[i].Roles = node.Roles
+		result[i].Architecture, err = osarch.ArchitectureName(node.Architecture)
+		if err != nil {
+			return nil, err
+		}
+
 		if node.IsOffline(offlineThreshold) {
 			result[i].Status = "Offline"
 			result[i].Message = fmt.Sprintf(

--- a/lxd/cluster/membership_test.go
+++ b/lxd/cluster/membership_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/state"
 	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/osarch"
 	"github.com/lxc/lxd/shared/version"
 	"github.com/mpvl/subtest"
 	"github.com/stretchr/testify/assert"
@@ -204,7 +205,7 @@ func TestAccept_UnmetPreconditions(t *testing.T) {
 
 			c.setup(&membershipFixtures{t: t, state: state})
 
-			_, err := cluster.Accept(state, gateway, c.name, c.address, c.schema, c.api)
+			_, err := cluster.Accept(state, gateway, c.name, c.address, c.schema, c.api, osarch.ARCH_64BIT_INTEL_X86)
 			assert.EqualError(t, err, c.error)
 		})
 	}
@@ -224,7 +225,7 @@ func TestAccept(t *testing.T) {
 	f.ClusterNode("1.2.3.4:666")
 
 	nodes, err := cluster.Accept(
-		state, gateway, "buzz", "5.6.7.8:666", cluster.SchemaVersion, len(version.APIExtensions))
+		state, gateway, "buzz", "5.6.7.8:666", cluster.SchemaVersion, len(version.APIExtensions), osarch.ARCH_64BIT_INTEL_X86)
 	assert.NoError(t, err)
 	assert.Len(t, nodes, 2)
 	assert.Equal(t, int64(1), nodes[0].ID)
@@ -306,7 +307,7 @@ func TestJoin(t *testing.T) {
 
 	// Accept the joining node.
 	raftNodes, err := cluster.Accept(
-		targetState, targetGateway, "rusp", address, cluster.SchemaVersion, len(version.APIExtensions))
+		targetState, targetGateway, "rusp", address, cluster.SchemaVersion, len(version.APIExtensions), osarch.ARCH_64BIT_INTEL_X86)
 	require.NoError(t, err)
 
 	// Actually join the cluster.

--- a/lxd/db/node.go
+++ b/lxd/db/node.go
@@ -37,6 +37,7 @@ type NodeInfo struct {
 	APIExtensions int       // Number of API extensions of the LXD code running on the node
 	Heartbeat     time.Time // Timestamp of the last heartbeat
 	Roles         []string  // List of cluster roles
+	Architecture  int       // Node architecture
 }
 
 // IsOffline returns true if the last successful heartbeat time of the node is
@@ -270,6 +271,7 @@ func (c *ClusterTx) nodes(pending bool, where string, args ...interface{}) ([]No
 			&nodes[i].Schema,
 			&nodes[i].APIExtensions,
 			&nodes[i].Heartbeat,
+			&nodes[i].Architecture,
 		}
 	}
 	if pending {
@@ -279,7 +281,7 @@ func (c *ClusterTx) nodes(pending bool, where string, args ...interface{}) ([]No
 	}
 
 	// Get the node entries
-	sql = "SELECT id, name, address, description, schema, api_extensions, heartbeat FROM nodes WHERE pending=?"
+	sql = "SELECT id, name, address, description, schema, api_extensions, heartbeat, arch FROM nodes WHERE pending=?"
 	if where != "" {
 		sql += fmt.Sprintf("AND %s ", where)
 	}
@@ -584,6 +586,7 @@ func (c *ClusterTx) NodeWithLeastContainers() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get offline threshold")
 	}
+
 	nodes, err := c.Nodes()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get current nodes")

--- a/shared/api/cluster.go
+++ b/shared/api/cluster.go
@@ -60,4 +60,7 @@ type ClusterMember struct {
 
 	// API extension: clustering_roles
 	Roles []string `json:"roles" yaml:"roles"`
+
+	// API extension: multi_architecture_clustering
+	Architecture string `json:"architecture" yaml:"architecture"`
 }

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -180,6 +180,7 @@ var APIExtensions = []string{
 	"container_disk_ceph",
 	"virtual-machines",
 	"image_profiles",
+	"multi_architecture_clustering",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
For #6380
Registering the native architecture of each server in the nodes database table and updating the generated /1.0 output