### PR TITLE
Storage migration volume pre-filler

### DIFF
--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -220,7 +220,7 @@ func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
 
 // CreateVolume creates an empty volume and can optionally fill it by executing the supplied
 // filler function.
-func (d *dir) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error {
+func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error {
 	volPath := vol.MountPath()
 	err := vol.CreateMountPath()
 	if err != nil {
@@ -258,8 +258,9 @@ func (d *dir) CreateVolume(vol Volume, filler func(mountPath, rootBlockPath stri
 	}
 
 	// Run the volume filler function if supplied.
-	if filler != nil {
-		err = filler(volPath, rootBlockPath)
+	if filler != nil && filler.Fill != nil {
+		d.logger.Debug("Running filler function")
+		err = filler.Fill(volPath, rootBlockPath)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -1,0 +1,21 @@
+package drivers
+
+// Info represents information about a storage driver.
+type Info struct {
+	Name                  string
+	Version               string
+	VolumeTypes           []VolumeType // Supported volume types.
+	Remote                bool         // Whether the driver uses a remote backing store.
+	OptimizedImages       bool         // Whether driver stores images as separate volume.
+	PreservesInodes       bool         // Whether driver preserves inodes when volumes are moved hosts.
+	BlockBacking          bool         // Whether driver uses block devices as backing store.
+	RunningQuotaResize    bool         // Whether quota resize is supported whilst instance running.
+	RunningSnapshotFreeze bool         // Whether instance should be frozen during snapshot if running.
+}
+
+// VolumeFiller provides a struct for filling a volume.
+type VolumeFiller struct {
+	Fill func(mountPath, rootBlockPath string) error // Function to fill the volume.
+
+	Fingerprint string // If the Filler will unpack an image, it should be this fingerprint.
+}

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -34,7 +34,7 @@ type Driver interface {
 
 	// Volumes.
 	ValidateVolume(vol Volume, removeUnknownKeys bool) error
-	CreateVolume(vol Volume, filler func(mountPath, rootBlockPath string) error, op *operations.Operation) error
+	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
 	CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, op *operations.Operation) error
 	RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, op *operations.Operation) error
 	DeleteVolume(volType VolumeType, volName string, op *operations.Operation) error
@@ -69,7 +69,7 @@ type Driver interface {
 	// Migration.
 	MigrationTypes(contentType ContentType) []migration.Type
 	MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs migration.VolumeSourceArgs, op *operations.Operation) error
-	CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, op *operations.Operation) error
+	CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, volTargetArgs migration.VolumeTargetArgs, preFiller *VolumeFiller, op *operations.Operation) error
 
 	// Backup.
 	BackupVolume(vol Volume, targetPath string, optimized bool, snapshots bool, op *operations.Operation) error

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -27,19 +27,6 @@ func Load(state *state.State, driverName string, name string, config map[string]
 	return d, nil
 }
 
-// Info represents information about a storage driver.
-type Info struct {
-	Name                  string
-	Version               string
-	VolumeTypes           []VolumeType // Supported volume types.
-	Remote                bool         // Whether the driver uses a remote backing store.
-	OptimizedImages       bool         // Whether driver stores images as separate volume.
-	PreservesInodes       bool         // Whether driver preserves inodes when volumes are moved hosts.
-	BlockBacking          bool         // Whether driver uses block devices as backing store.
-	RunningQuotaResize    bool         // Whether quota resize is supported whilst instance running.
-	RunningSnapshotFreeze bool         // Whether instance should be frozen during snapshot if running.
-}
-
 // SupportedDrivers returns a list of supported storage drivers.
 func SupportedDrivers() []Info {
 	supportedDrivers := []Info{}


### PR DESCRIPTION
Adds a new type called `VolumeFiller` which contains a filler function and an optional image fingerprint string.

This is then used by `CreateVolume` for volume filling, but also specifically `CreateVolumeFromMigration` to support a pre-filler optimisation when using Rsync and `dir` driver for migration. If the base image exists on the target, the new volume will be pre-filled from the image before performing the rsync in an attempt to reduce the amount of data needing to be transferred over the network.

By supplying the image fingerprint in the VolumeFiller as well, other storage drivers that use optimised volumes can check if the volume exists first and then just create a volume from that existing volume.