### PR TITLE
Storage instance mount read-only and LXD_SHIFTFS_DISABLE

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -28,3 +28,4 @@ Name                            | Description
 `LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off
 `LXD_UNPRIVILEGED_ONLY`         | If set to `true`, enforces that only unprivileged containers can be created. Note that any privileged containers that have been created before setting LXD_UNPRIVILEGED_ONLY will continue to be privileged. To use this option effectively it should be set when the LXD daemon is first setup.
 `LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
+`LXD_SHIFTFS_DISABLE`           | Disable shiftfs support (useful when testing traditional UID shifting)

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -63,6 +63,7 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 	}
 	defer os.RemoveAll(tmpPath)
 
+	// Check if we can load new storage layer for pool driver type.
 	pool, err := storagePools.GetPoolByInstance(s, sourceInst)
 	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented {
 		if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -620,11 +620,16 @@ func (d *Daemon) init() error {
 		logger.Infof(" - unprivileged file capabilities: no")
 	}
 
-	if util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil {
-		d.os.Shiftfs = true
-		logger.Infof(" - shiftfs support: yes")
+	// Detect shiftfs support.
+	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
+		logger.Infof(" - shiftfs support: disabled")
 	} else {
-		logger.Infof(" - shiftfs support: no")
+		if util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil {
+			d.os.Shiftfs = true
+			logger.Infof(" - shiftfs support: yes")
+		} else {
+			logger.Infof(" - shiftfs support: no")
+		}
 	}
 
 	// Detect LXC features

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1178,6 +1178,24 @@ func (b *lxdBackend) MountInstance(inst instance.Instance, op *operations.Operat
 	return b.driver.MountVolume(volType, volStorageName, op)
 }
 
+// MountInstanceReadOnly mounts the instance's root volume read-only.
+func (b *lxdBackend) MountInstanceReadOnly(inst instance.Instance, op *operations.Operation) (bool, error) {
+	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name()})
+	logger.Debug("MountInstanceReadOnly started")
+	defer logger.Debug("MountInstanceReadOnly finished")
+
+	// Check we can convert the instance to the volume type needed.
+	volType, err := InstanceTypeToVolumeType(inst.Type())
+	if err != nil {
+		return false, err
+	}
+
+	// Get the volume name on storage.
+	volStorageName := project.Prefix(inst.Project(), inst.Name())
+
+	return b.driver.MountVolumeReadOnly(volType, volStorageName, op)
+}
+
 // UnmountInstance unmounts the instance's root volume.
 func (b *lxdBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
 	logger := logging.AddContext(b.logger, log.Ctx{"project": inst.Project(), "instance": inst.Name()})

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -108,6 +108,10 @@ func (b *mockBackend) MountInstance(inst instance.Instance, op *operations.Opera
 	return true, nil
 }
 
+func (b *mockBackend) MountInstanceReadOnly(inst instance.Instance, op *operations.Operation) (bool, error) {
+	return true, nil
+}
+
 func (b *mockBackend) UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error) {
 	return true, nil
 }

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -621,6 +621,10 @@ func (d *cephfs) MountVolume(volType VolumeType, volName string, op *operations.
 	return false, nil
 }
 
+func (d *cephfs) MountVolumeReadOnly(volType VolumeType, volName string, op *operations.Operation) (bool, error) {
+	return false, ErrNotImplemented
+}
+
 func (d *cephfs) MountVolumeSnapshot(volType VolumeType, VolName, snapshotName string, op *operations.Operation) (bool, error) {
 	if volType != VolumeTypeCustom {
 		return false, fmt.Errorf("Volume type not supported")

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -45,8 +45,9 @@ type Driver interface {
 	GetVolumeDiskPath(volType VolumeType, volName string) (string, error)
 
 	// MountVolume mounts a storage volume, returns true if we caused a new mount, false if
-	// already mounted.
+	// already mounted or doesn't need to be unmounted.
 	MountVolume(volType VolumeType, volName string, op *operations.Operation) (bool, error)
+	MountVolumeReadOnly(volType VolumeType, volName string, op *operations.Operation) (bool, error)
 
 	// MountVolumeSnapshot mounts a storage volume snapshot as readonly, returns true if we
 	// caused a new mount, false if already mounted.

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -41,6 +41,7 @@ type Pool interface {
 	SetInstanceQuota(inst instance.Instance, size string, op *operations.Operation) error
 
 	MountInstance(inst instance.Instance, op *operations.Operation) (bool, error)
+	MountInstanceReadOnly(inst instance.Instance, op *operations.Operation) (bool, error)
 	UnmountInstance(inst instance.Instance, op *operations.Operation) (bool, error)
 	GetInstanceDisk(inst instance.Instance) (string, error)
 


### PR DESCRIPTION
Adds `MountInstanceReadOnly` functionality to backendLXD as a forthcoming requirement for the storage publish functionality.

Also added support for disabling shiftfs at runtime using `LXD_SHIFTFS_DISABLE` environment variable, which will be useful when testing publish shifting,