### PR TITLE
Storage adds LXD_SHIFTFS_DISABLE env var to disable shiftfs at runtime

### DIFF
--- a/doc/environment.md
+++ b/doc/environment.md
@@ -28,3 +28,4 @@ Name                            | Description
 `LXD_SECURITY_APPARMOR`         | If set to `false`, forces AppArmor off
 `LXD_UNPRIVILEGED_ONLY`         | If set to `true`, enforces that only unprivileged containers can be created. Note that any privileged containers that have been created before setting LXD_UNPRIVILEGED_ONLY will continue to be privileged. To use this option effectively it should be set when the LXD daemon is first setup.
 `LXD_OVMF_PATH`                 | Path to an OVMF build including `OVMF_CODE.fd` and `OVMF_VARS.ms.fd`
+`LXD_SHIFTFS_DISABLE`           | Disable shiftfs support (useful when testing traditional UID shifting)

--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -63,6 +63,7 @@ func backupCreate(s *state.State, args db.InstanceBackupArgs, sourceInst instanc
 	}
 	defer os.RemoveAll(tmpPath)
 
+	// Check if we can load new storage layer for pool driver type.
 	pool, err := storagePools.GetPoolByInstance(s, sourceInst)
 	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented {
 		if err != nil {

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -620,11 +620,16 @@ func (d *Daemon) init() error {
 		logger.Infof(" - unprivileged file capabilities: no")
 	}
 
-	if util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil {
-		d.os.Shiftfs = true
-		logger.Infof(" - shiftfs support: yes")
+	// Detect shiftfs support.
+	if shared.IsTrue(os.Getenv("LXD_SHIFTFS_DISABLE")) {
+		logger.Infof(" - shiftfs support: disabled")
 	} else {
-		logger.Infof(" - shiftfs support: no")
+		if util.HasFilesystem("shiftfs") || util.LoadModule("shiftfs") == nil {
+			d.os.Shiftfs = true
+			logger.Infof(" - shiftfs support: yes")
+		} else {
+			logger.Infof(" - shiftfs support: no")
+		}
 	}
 
 	// Detect LXC features


### PR DESCRIPTION
Adds `LXD_SHIFTFS_DISABLE` env var to allow shiftfs to be disabled at runtime to allow testing of traditional UID shifting on kernels with shiftfs support.