### PR TITLE
lxd/vm: Remove default GPU

### DIFF
--- a/lxd/vm_qemu.go
+++ b/lxd/vm_qemu.go
@@ -1052,10 +1052,6 @@ driver = "virtio-scsi-pci"
 bus = "qemu_pcie1"
 addr = "0x0"
 
-# Graphics card
-[device]
-driver = "virtio-gpu"
-
 # Balloon driver
 [device "qemu_pcie2"]
 driver = "pcie-root-port"


### PR DESCRIPTION
The GPU isn't really useful in most cases and when it is useful, some
flexibility around the type of GPU being passed would be good.

So I think we should instead implement the "gpu" device type rather than
have one by default.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>