### PR TITLE
cgroups: pre-mount on pure-cgroup2 systems with cgroup namespaces

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -781,8 +781,13 @@ func (c *containerLXC) initLXC(config bool) error {
 		mounts = append(mounts, "sys:rw")
 	}
 
-	if !shared.PathExists("/proc/self/ns/cgroup") {
-		mounts = append(mounts, "cgroup:mixed")
+	cgInfo := cgroup.GetInfo()
+	if cgInfo.Namespacing {
+		if cgInfo.Layout == cgroup.CgroupsUnified {
+			mounts = append(mounts, "cgroup:rw:force")
+		} else {
+			mounts = append(mounts, "cgroup:mixed")
+		}
 	}
 
 	err = lxcSetConfigItem(cc, "lxc.mount.auto", strings.Join(mounts, " "))


### PR DESCRIPTION
We only do force-premounting if we are on a cgroup2-only system.
While it's paranoid to check for both since cgroup2-only should imply cgroupns
but let's not rely on that.

Closes #6587.
Signed-off-by: Christian Brauner <christian.brauner@ubuntu.com>