### PR TITLE
lxd/db: Rename ContainerNames to InstanceNames

### DIFF
--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -876,7 +876,7 @@ func containersPost(d *Daemon, r *http.Request) response.Response {
 		var names []string
 		err := d.cluster.Transaction(func(tx *db.ClusterTx) error {
 			var err error
-			names, err = tx.ContainerNames(project)
+			names, err = tx.InstanceNames(project)
 			return err
 		})
 		if err != nil {
@@ -892,9 +892,10 @@ func containersPost(d *Daemon, r *http.Request) response.Response {
 			}
 
 			if i > 100 {
-				return response.InternalError(fmt.Errorf("couldn't generate a new unique name after 100 tries"))
+				return response.InternalError(fmt.Errorf("Couldn't generate a new unique name after 100 tries"))
 			}
 		}
+
 		logger.Debugf("No name provided, creating %s", req.Name)
 	}
 

--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -170,14 +170,14 @@ type InstanceBackupArgs struct {
 	CompressionAlgorithm string
 }
 
-// ContainerNames returns the names of all containers the given project.
-func (c *ClusterTx) ContainerNames(project string) ([]string, error) {
+// InstanceNames returns the names of all containers the given project.
+func (c *ClusterTx) InstanceNames(project string) ([]string, error) {
 	stmt := `
 SELECT instances.name FROM instances
   JOIN projects ON projects.id = instances.project_id
   WHERE projects.name = ? AND instances.type = ?
 `
-	return query.SelectStrings(c.tx, stmt, project, instancetype.Container)
+	return query.SelectStrings(c.tx, stmt, project, instancetype.Any)
 }
 
 // ContainerNodeAddress returns the address of the node hosting the container


### PR DESCRIPTION
We're dealing with a single namespace for both containers and VMs, so we
need to extract the combined list.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>