### PR TITLE
VM: Add no-user-config and chroot to start flags

### DIFF
--- a/lxd/instance/qemu/vm_qemu.go
+++ b/lxd/instance/qemu/vm_qemu.go
@@ -628,6 +628,7 @@ func (vm *Qemu) Start(stateful bool) error {
 		"-serial", "chardev:console",
 		"-nodefaults",
 		"-no-reboot",
+		"-no-user-config",
 		"-readconfig", confFile,
 		"-pidfile", vm.pidFilePath(),
 	}

--- a/lxd/instance/qemu/vm_qemu.go
+++ b/lxd/instance/qemu/vm_qemu.go
@@ -631,7 +631,9 @@ func (vm *Qemu) Start(stateful bool) error {
 		"-no-user-config",
 		"-readconfig", confFile,
 		"-pidfile", vm.pidFilePath(),
+		"-chroot", vm.Path(),
 	}
+
 	if shared.IsTrue(vm.expandedConfig["limits.memory.hugepages"]) {
 		args = append(args, "-mem-path", "/dev/hugepages/", "-mem-prealloc")
 	}


### PR DESCRIPTION
Starts VMs with `-no-user-config` and `-chroot` flags.