### PR TITLE
Storage support updating pool config during create

### DIFF
--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -23,7 +23,7 @@ type Driver interface {
 	// Internal.
 	Config() map[string]string
 	Info() Info
-	HasVolume(volType VolumeType, volName string) bool
+	HasVolume(vol Volume) bool
 
 	// Pool.
 	Create() error
@@ -39,33 +39,33 @@ type Driver interface {
 	CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Operation) error
 	CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool, op *operations.Operation) error
 	RefreshVolume(vol Volume, srcVol Volume, srcSnapshots []Volume, op *operations.Operation) error
-	DeleteVolume(volType VolumeType, volName string, op *operations.Operation) error
-	RenameVolume(volType VolumeType, volName string, newName string, op *operations.Operation) error
+	DeleteVolume(vol Volume, op *operations.Operation) error
+	RenameVolume(vol Volume, newName string, op *operations.Operation) error
 	UpdateVolume(vol Volume, changedConfig map[string]string) error
-	GetVolumeUsage(volType VolumeType, volName string) (int64, error)
-	SetVolumeQuota(volType VolumeType, volName, size string, op *operations.Operation) error
-	GetVolumeDiskPath(volType VolumeType, volName string) (string, error)
+	GetVolumeUsage(vol Volume) (int64, error)
+	SetVolumeQuota(vol Volume, size string, op *operations.Operation) error
+	GetVolumeDiskPath(vol Volume) (string, error)
 
 	// MountVolume mounts a storage volume, returns true if we caused a new mount, false if
 	// already mounted.
-	MountVolume(volType VolumeType, volName string, op *operations.Operation) (bool, error)
+	MountVolume(vol Volume, op *operations.Operation) (bool, error)
 
 	// MountVolumeSnapshot mounts a storage volume snapshot as readonly, returns true if we
 	// caused a new mount, false if already mounted.
-	MountVolumeSnapshot(volType VolumeType, volName, snapshotName string, op *operations.Operation) (bool, error)
+	MountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
 
 	// UnmountVolume unmounts a storage volume, returns true if unmounted, false if was not
 	// mounted.
-	UnmountVolume(volType VolumeType, volName string, op *operations.Operation) (bool, error)
+	UnmountVolume(vol Volume, op *operations.Operation) (bool, error)
 
 	// UnmountVolume unmounts a storage volume snapshot, returns true if unmounted, false if was
 	// not mounted.
-	UnmountVolumeSnapshot(VolumeType VolumeType, volName, snapshotName string, op *operations.Operation) (bool, error)
+	UnmountVolumeSnapshot(snapVol Volume, op *operations.Operation) (bool, error)
 
-	CreateVolumeSnapshot(volType VolumeType, volName string, newSnapshotName string, op *operations.Operation) error
-	DeleteVolumeSnapshot(volType VolumeType, volName string, snapshotName string, op *operations.Operation) error
-	RenameVolumeSnapshot(volType VolumeType, volName string, snapshotName string, newSnapshotName string, op *operations.Operation) error
-	VolumeSnapshots(volType VolumeType, volName string, op *operations.Operation) ([]string, error)
+	CreateVolumeSnapshot(snapVol Volume, op *operations.Operation) error
+	DeleteVolumeSnapshot(snapVol Volume, op *operations.Operation) error
+	RenameVolumeSnapshot(snapVol Volume, newSnapshotName string, op *operations.Operation) error
+	VolumeSnapshots(vol Volume, op *operations.Operation) ([]string, error)
 	RestoreVolume(vol Volume, snapshotName string, op *operations.Operation) error
 
 	// Migration.

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -28,7 +28,12 @@ type Driver interface {
 	// Pool.
 	Create() error
 	Delete(op *operations.Operation) error
+	// Mount mounts a storage pool if needed, returns true if we caused a new mount, false if
+	// already mounted.
 	Mount() (bool, error)
+
+	// Unmount unmounts a storage pool if needed, returns true if unmounted, false if was not
+	// mounted.
 	Unmount() (bool, error)
 	GetResources() (*api.ResourcesStoragePool, error)
 	Validate(config map[string]string) error

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -99,12 +99,13 @@ func CreatePool(state *state.State, poolID int64, dbPool *api.StoragePoolsPost, 
 		Name:           dbPool.Name,
 		Driver:         dbPool.Driver,
 	}
+
 	pool.name = dbPool.Name
 	pool.state = state
 	pool.logger = logger
 
 	// Create the pool itself on the storage device..
-	err = pool.create(dbPool, localOnly, op)
+	err = pool.create(localOnly, op)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using loopback images the pool's config is updated after the driver create function has run to record the newly created loopback image location.

Adds generic support for updating config during create.

Includes https://github.com/lxc/lxd/pull/6605