### PR TITLE
Storage update validation

### DIFF
--- a/lxd/db/storage_pools.go
+++ b/lxd/db/storage_pools.go
@@ -871,16 +871,15 @@ func (c *Cluster) StoragePoolNodeVolumeGetTypeByProject(project, volumeName stri
 	return c.StoragePoolVolumeGetType(project, volumeName, volumeType, poolID, c.nodeID)
 }
 
-// StoragePoolVolumeUpdate updates the storage volume attached to a given storage
-// pool.
-func (c *Cluster) StoragePoolVolumeUpdate(volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
-	volumeID, _, err := c.StoragePoolNodeVolumeGetType(volumeName, volumeType, poolID)
+// StoragePoolVolumeUpdateByProject updates the storage volume attached to a given storage pool.
+func (c *Cluster) StoragePoolVolumeUpdateByProject(project, volumeName string, volumeType int, poolID int64, volumeDescription string, volumeConfig map[string]string) error {
+	volumeID, _, err := c.StoragePoolNodeVolumeGetTypeByProject(project, volumeName, volumeType, poolID)
 	if err != nil {
 		return err
 	}
 
 	err = c.Transaction(func(tx *ClusterTx) error {
-		err = storagePoolVolumeReplicateIfCeph(tx.tx, volumeID, "default", volumeName, volumeType, poolID, func(volumeID int64) error {
+		err = storagePoolVolumeReplicateIfCeph(tx.tx, volumeID, project, volumeName, volumeType, poolID, func(volumeID int64) error {
 			err = StorageVolumeConfigClear(tx.tx, volumeID)
 			if err != nil {
 				return err

--- a/lxd/db/storage_pools_test.go
+++ b/lxd/db/storage_pools_test.go
@@ -184,7 +184,7 @@ func TestStoragePoolVolume_Ceph(t *testing.T) {
 
 	// Update the volume
 	config["k"] = "v2"
-	err = cluster.StoragePoolVolumeUpdate("v1", 1, poolID, "volume 1", config)
+	err = cluster.StoragePoolVolumeUpdateByProject("default", "v1", 1, poolID, "volume 1", config)
 	require.NoError(t, err)
 	for _, nodeID := range []int64{1, 2} {
 		_, volume, err := cluster.StoragePoolVolumeGetType("default", "v1", 1, poolID, nodeID)

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -480,7 +480,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
-			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -568,7 +568,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
-				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
@@ -649,7 +649,7 @@ func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string,
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
-			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -767,7 +767,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
-			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -884,7 +884,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the snapshot")
-			err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -914,7 +914,7 @@ func upgradeFromStorageTypeDir(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
-			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -1076,7 +1076,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
-			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -1231,7 +1231,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
-				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
@@ -1402,7 +1402,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
-			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -1594,7 +1594,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(ct, storagePoolVolumeTypeContainer, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the container")
-			err := d.cluster.StoragePoolVolumeUpdate(ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", ct, storagePoolVolumeTypeContainer, poolID, "", containerPoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -1680,7 +1680,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(cs, storagePoolVolumeTypeContainer, poolID)
 			if err == nil {
 				logger.Warnf("Storage volumes database already contains an entry for the snapshot")
-				err := d.cluster.StoragePoolVolumeUpdate(cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
+				err := d.cluster.StoragePoolVolumeUpdateByProject("default", cs, storagePoolVolumeTypeContainer, poolID, "", snapshotPoolVolumeConfig)
 				if err != nil {
 					return err
 				}
@@ -1736,7 +1736,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 		_, err = d.cluster.StoragePoolNodeVolumeGetTypeID(img, storagePoolVolumeTypeImage, poolID)
 		if err == nil {
 			logger.Warnf("Storage volumes database already contains an entry for the image")
-			err := d.cluster.StoragePoolVolumeUpdate(img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
+			err := d.cluster.StoragePoolVolumeUpdateByProject("default", img, storagePoolVolumeTypeImage, poolID, "", imagePoolVolumeConfig)
 			if err != nil {
 				return err
 			}
@@ -2290,7 +2290,7 @@ func patchStorageApiUpdateStorageConfigs(name string, d *Daemon) error {
 			// exist in the db, so it's safe to ignore the error.
 			volumeType, _ := driver.VolumeTypeNameToType(volume.Type)
 			// Update the volume config.
-			err = d.cluster.StoragePoolVolumeUpdate(volume.Name, volumeType, poolID, volume.Description, volume.Config)
+			err = d.cluster.StoragePoolVolumeUpdateByProject("default", volume.Name, volumeType, poolID, volume.Description, volume.Config)
 			if err != nil {
 				return err
 			}
@@ -2438,7 +2438,7 @@ func patchStorageApiDetectLVSize(name string, d *Daemon) error {
 			// exist in the db, so it's safe to ignore the error.
 			volumeType, _ := driver.VolumeTypeNameToType(volume.Type)
 			// Update the volume config.
-			err = d.cluster.StoragePoolVolumeUpdate(volume.Name, volumeType, poolID, volume.Description, volume.Config)
+			err = d.cluster.StoragePoolVolumeUpdateByProject("default", volume.Name, volumeType, poolID, volume.Description, volume.Config)
 			if err != nil {
 				return err
 			}
@@ -2568,7 +2568,7 @@ func patchStorageZFSVolumeSize(name string, d *Daemon) error {
 			// exist in the db, so it's safe to ignore the error.
 			volumeType, _ := driver.VolumeTypeNameToType(volume.Type)
 			// Update the volume config.
-			err = d.cluster.StoragePoolVolumeUpdate(volume.Name,
+			err = d.cluster.StoragePoolVolumeUpdateByProject("default", volume.Name,
 				volumeType, poolID, volume.Description,
 				volume.Config)
 			if err != nil {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -566,7 +566,7 @@ func storagePoolVolumeAttachPrepare(s *state.State, poolName string, volumeName 
 	// Update last idmap
 	poolVolumePut.Config["volatile.idmap.last"] = jsonIdmap
 
-	err = s.Cluster.StoragePoolVolumeUpdate(volumeName, volumeType, poolID, poolVolumePut.Description, poolVolumePut.Config)
+	err = s.Cluster.StoragePoolVolumeUpdateByProject("default", volumeName, volumeType, poolID, poolVolumePut.Description, poolVolumePut.Config)
 	if err != nil {
 		return err
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2255,7 +2255,7 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 
 	// Update the database if something changed.
 	if len(changedConfig) != 0 || newDesc != curVol.Description {
-		err = b.state.Cluster.StoragePoolVolumeUpdate(volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, newConfig)
+		err = b.state.Cluster.StoragePoolVolumeUpdateByProject("default", volName, db.StoragePoolVolumeTypeCustom, b.ID(), newDesc, newConfig)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -59,8 +59,8 @@ func (b *lxdBackend) MigrationTypes(contentType drivers.ContentType, refresh boo
 
 // create creates the storage pool layout on the storage device.
 // localOnly is used for clustering where only a single node should do remote storage setup.
-func (b *lxdBackend) create(dbPool *api.StoragePoolsPost, localOnly bool, op *operations.Operation) error {
-	logger := logging.AddContext(b.logger, log.Ctx{"args": dbPool})
+func (b *lxdBackend) create(localOnly bool, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"config": b.db.Config, "description": b.db.Description, "localOnly": localOnly})
 	logger.Debug("create started")
 	defer logger.Debug("created finished")
 

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -142,27 +142,7 @@ func (b *lxdBackend) Update(driverOnly bool, newDesc string, newConfig map[strin
 	}
 
 	// Diff the configurations.
-	changedConfig := make(map[string]string)
-	userOnly := true
-	for key := range b.db.Config {
-		if b.db.Config[key] != newConfig[key] {
-			if !strings.HasPrefix(key, "user.") {
-				userOnly = false
-			}
-
-			changedConfig[key] = newConfig[key] // Will be empty string on deleted keys.
-		}
-	}
-
-	for key := range newConfig {
-		if b.db.Config[key] != newConfig[key] {
-			if !strings.HasPrefix(key, "user.") {
-				userOnly = false
-			}
-
-			changedConfig[key] = newConfig[key]
-		}
-	}
+	changedConfig, userOnly := b.detectChangedConfig(b.db.Config, newConfig)
 
 	// Apply config changes if there are any.
 	if len(changedConfig) != 0 {

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -120,6 +120,7 @@ func (b *lxdBackend) newVolume(volType drivers.VolumeType, contentType drivers.C
 	return drivers.NewVolume(b.driver, b.name, volType, contentType, volName, volConfig)
 }
 
+// GetResources returns utilisation information about the pool.
 func (b *lxdBackend) GetResources() (*api.ResourcesStoragePool, error) {
 	logger := logging.AddContext(b.logger, nil)
 	logger.Debug("GetResources started")

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2301,6 +2301,20 @@ func (b *lxdBackend) UpdateCustomVolume(volName, newDesc string, newConfig map[s
 	return nil
 }
 
+// UpdateCustomVolumeSnapshot updates the description of a custom volume snapshot.
+// Volume config is not allowd to be updated and will return an error.
+func (b *lxdBackend) UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "newDesc": newDesc, "newConfig": newConfig})
+	logger.Debug("UpdateCustomVolumeSnapshot started")
+	defer logger.Debug("UpdateCustomVolumeSnapshot finished")
+
+	if !shared.IsSnapshot(volName) {
+		return fmt.Errorf("Volume must be a snapshot")
+	}
+
+	return b.updateVolumeDescriptionOnly("default", volName, db.StoragePoolVolumeTypeCustom, newDesc, newConfig)
+}
+
 // DeleteCustomVolume removes a custom volume and its snapshots.
 func (b *lxdBackend) DeleteCustomVolume(volName string, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName})

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1798,6 +1798,15 @@ func (b *lxdBackend) DeleteImage(fingerprint string, op *operations.Operation) e
 	return nil
 }
 
+// UpdateImage updates image config.
+func (b *lxdBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	logger := logging.AddContext(b.logger, log.Ctx{"fingerprint": fingerprint, "newDesc": newDesc, "newConfig": newConfig})
+	logger.Debug("UpdateImage started")
+	defer logger.Debug("UpdateImage finished")
+
+	return b.updateVolumeDescriptionOnly("default", fingerprint, db.StoragePoolVolumeTypeImage, newDesc, newConfig)
+}
+
 // CreateCustomVolume creates an empty custom volume.
 func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error {
 	logger := logging.AddContext(b.logger, log.Ctx{"volName": volName, "desc": desc, "config": config})

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -88,6 +88,10 @@ func (b *mockBackend) DeleteInstance(inst instance.Instance, op *operations.Oper
 	return nil
 }
 
+func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	return nil
+}
+
 func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }
@@ -144,11 +148,19 @@ func (b *mockBackend) UnmountInstanceSnapshot(inst instance.Instance, op *operat
 	return true, nil
 }
 
+func (b *mockBackend) UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error {
+	return nil
+}
+
 func (b *mockBackend) EnsureImage(fingerprint string, op *operations.Operation) error {
 	return nil
 }
 
 func (b *mockBackend) DeleteImage(fingerprint string, op *operations.Operation) error {
+	return nil
+}
+
+func (b *mockBackend) UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 
@@ -201,6 +213,10 @@ func (b *mockBackend) RenameCustomVolumeSnapshot(volName string, newName string,
 }
 
 func (b *mockBackend) DeleteCustomVolumeSnapshot(volName string, op *operations.Operation) error {
+	return nil
+}
+
+func (b *mockBackend) UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error {
 	return nil
 }
 

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -76,6 +76,11 @@ func (d *common) validateVolume(vol Volume, driverRules map[string]func(value st
 		}
 	}
 
+	// If volume type is not custom, don't allow "size" property.
+	if vol.volType != VolumeTypeCustom && vol.config["size"] != "" {
+		return fmt.Errorf("Volume 'size' property is only valid for custom volume types")
+	}
+
 	return nil
 }
 

--- a/lxd/storage/load.go
+++ b/lxd/storage/load.go
@@ -104,7 +104,7 @@ func CreatePool(state *state.State, poolID int64, dbPool *api.StoragePoolsPost, 
 	pool.logger = logger
 
 	// Create the pool itself on the storage device..
-	err = pool.create(dbPool, localOnly, op)
+	err = pool.create(localOnly, op)
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -33,6 +33,7 @@ type Pool interface {
 	CreateInstanceFromMigration(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeTargetArgs, op *operations.Operation) error
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
+	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error
@@ -52,10 +53,12 @@ type Pool interface {
 	RestoreInstanceSnapshot(inst instance.Instance, src instance.Instance, op *operations.Operation) error
 	MountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error)
 	UnmountInstanceSnapshot(inst instance.Instance, op *operations.Operation) (bool, error)
+	UpdateInstanceSnapshot(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Images.
 	EnsureImage(fingerprint string, op *operations.Operation) error
 	DeleteImage(fingerprint string, op *operations.Operation) error
+	UpdateImage(fingerprint, newDesc string, newConfig map[string]string, op *operations.Operation) error
 
 	// Custom volumes.
 	CreateCustomVolume(volName, desc string, config map[string]string, op *operations.Operation) error
@@ -71,6 +74,7 @@ type Pool interface {
 	CreateCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error
 	RenameCustomVolumeSnapshot(volName string, newSnapshotName string, op *operations.Operation) error
 	DeleteCustomVolumeSnapshot(volName string, op *operations.Operation) error
+	UpdateCustomVolumeSnapshot(volName, newDesc string, newConfig map[string]string, op *operations.Operation) error
 	RestoreCustomVolume(volName string, snapshotName string, op *operations.Operation) error
 
 	// Custom volume migration.

--- a/lxd/storage_ceph.go
+++ b/lxd/storage_ceph.go
@@ -2443,7 +2443,8 @@ func (s *storageCeph) StorageEntitySetQuota(volumeType int, size int64, data int
 
 	// Update the database
 	s.volume.Config["size"] = units.GetByteSizeString(size, 0)
-	err = s.s.Cluster.StoragePoolVolumeUpdate(
+	err = s.s.Cluster.StoragePoolVolumeUpdateByProject(
+		"default",
 		s.volume.Name,
 		volumeType,
 		s.poolID,

--- a/lxd/storage_lvm.go
+++ b/lxd/storage_lvm.go
@@ -2122,7 +2122,8 @@ func (s *storageLvm) StorageEntitySetQuota(volumeType int, size int64, data inte
 
 	// Update the database
 	s.volume.Config["size"] = units.GetByteSizeString(size, 0)
-	err = s.s.Cluster.StoragePoolVolumeUpdate(
+	err = s.s.Cluster.StoragePoolVolumeUpdateByProject(
+		"default",
 		s.volume.Name,
 		volumeType,
 		s.poolID,

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -873,7 +873,7 @@ func storagePoolVolumeTypeGet(d *Daemon, r *http.Request, volumeTypeName string)
 	}
 
 	// Get the storage volume.
-	_, volume, err := d.cluster.StoragePoolNodeVolumeGetType(volumeName, volumeType, poolID)
+	_, volume, err := d.cluster.StoragePoolNodeVolumeGetTypeByProject(project, volumeName, volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/lxd/storage_volumes.go
+++ b/lxd/storage_volumes.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
 	"github.com/lxc/lxd/lxd/db"
+	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/operations"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/lxd/state"
@@ -908,6 +909,8 @@ func storagePoolVolumeTypeImageGet(d *Daemon, r *http.Request) response.Response
 // This function does allow limited functionality for non-custom volume types, specifically you
 // can modify the volume's description only.
 func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string) response.Response {
+	project := projectParam(r)
+
 	// Get the name of the storage volume.
 	volumeName, err := storageGetVolumeNameFromURL(r)
 	if err != nil {
@@ -945,7 +948,7 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string)
 	}
 
 	// Get the existing storage volume.
-	_, vol, err := d.cluster.StoragePoolNodeVolumeGetType(volumeName, volumeType, poolID)
+	_, vol, err := d.cluster.StoragePoolNodeVolumeGetTypeByProject(project, volumeName, volumeType, poolID)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -981,31 +984,42 @@ func storagePoolVolumeTypePut(d *Daemon, r *http.Request, volumeTypeName string)
 				}
 			}
 
-			// Handle update requests.
+			// Handle custom volume update requests.
 			err = pool.UpdateCustomVolume(vol.Name, req.Description, req.Config, nil)
 			if err != nil {
 				return response.SmartError(err)
 			}
-		} else {
-			// You are only allowed to modify the description for non-custom volumes.
-			// This is a special case because the rootfs devices do not provide a way
-			// to update a non-custom volume's description.
-			if len(req.Config) > 0 {
-				return response.BadRequest(fmt.Errorf("Only description can be modified for volume type %s", volumeTypeName))
+		} else if volumeType == db.StoragePoolVolumeTypeContainer || volumeType == db.StoragePoolVolumeTypeVM {
+			inst, err := instance.LoadByProjectAndName(d.State(), project, vol.Name)
+			if err != nil {
+				return response.NotFound(err)
 			}
 
 			// There is a bug in the lxc client (lxc/storage_volume.go#L829-L865) which
-			// means that modifying a snapshot's description gets routed here rather
-			// than the dedicated snapshot editing route. So need to handle snapshot
-			// volumes here too.
-
-			// Update the database if description changed.
-			if req.Description != vol.Description {
-				err = d.cluster.StoragePoolVolumeUpdate(vol.Name, volumeType, poolID, req.Description, vol.Config)
+			// means that modifying an instance snapshot's description gets routed here
+			// rather than the dedicated snapshot editing route. So need to handle
+			// snapshot volumes here too.
+			if inst.IsSnapshot() {
+				// Handle instance snapshot volume update requests.
+				err = pool.UpdateInstanceSnapshot(inst, req.Description, req.Config, nil)
 				if err != nil {
-					response.SmartError(err)
+					return response.SmartError(err)
+				}
+			} else {
+				// Handle instance volume update requests.
+				err = pool.UpdateInstance(inst, req.Description, req.Config, nil)
+				if err != nil {
+					return response.SmartError(err)
 				}
 			}
+		} else if volumeType == db.StoragePoolVolumeTypeImage {
+			// Handle image update requests.
+			err = pool.UpdateImage(vol.Name, req.Description, req.Config, nil)
+			if err != nil {
+				return response.SmartError(err)
+			}
+		} else {
+			return response.SmartError(fmt.Errorf("Invalid volume type"))
 		}
 	} else {
 

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -461,7 +461,7 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	do := func(op *operations.Operation) error {
 		// Update the database if description changed.
 		if req.Description != vol.Description {
-			err = d.cluster.StoragePoolVolumeUpdate(vol.Name, volumeType, poolID, req.Description, vol.Config)
+			err = d.cluster.StoragePoolVolumeUpdateByProject("default", vol.Name, volumeType, poolID, req.Description, vol.Config)
 			if err != nil {
 				return err
 			}

--- a/lxd/storage_volumes_snapshot.go
+++ b/lxd/storage_volumes_snapshot.go
@@ -459,11 +459,25 @@ func storagePoolVolumeSnapshotTypePut(d *Daemon, r *http.Request) response.Respo
 	}
 
 	do := func(op *operations.Operation) error {
-		// Update the database if description changed.
-		if req.Description != vol.Description {
-			err = d.cluster.StoragePoolVolumeUpdateByProject("default", vol.Name, volumeType, poolID, req.Description, vol.Config)
+		// Check if we can load new storage layer for pool driver type.
+		pool, err := storagePools.GetPoolByName(d.State(), poolName)
+		if err != storageDrivers.ErrUnknownDriver {
 			if err != nil {
 				return err
+			}
+
+			// Handle custom volume update requests.
+			err = pool.UpdateCustomVolumeSnapshot(vol.Name, req.Description, nil, op)
+			if err != nil {
+				return err
+			}
+		} else {
+			// Update the database if description changed. Use current config.
+			if req.Description != vol.Description {
+				err = d.cluster.StoragePoolVolumeUpdateByProject("default", vol.Name, volumeType, poolID, req.Description, vol.Config)
+				if err != nil {
+					return err
+				}
 			}
 		}
 

--- a/lxd/storage_volumes_utils.go
+++ b/lxd/storage_volumes_utils.go
@@ -202,7 +202,7 @@ func storagePoolVolumeUpdate(state *state.State, poolName string, volumeName str
 
 	// Update the database if something changed
 	if len(changedConfig) != 0 || newDescription != oldDescription {
-		err = state.Cluster.StoragePoolVolumeUpdate(volumeName, volumeType, poolID, newDescription, newConfig)
+		err = state.Cluster.StoragePoolVolumeUpdateByProject("default", volumeName, volumeType, poolID, newDescription, newConfig)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
- Enforces that "size" volume property can only be updated on custom volume types.
- Adds UpdateInstance and UpdateImage functions that can be used to add driver specific update rules.
- Removes `dbPool` argument from storage pool `create` function, as same data is available via `b.db`