### PR TITLE
Storage loader fix

### DIFF
--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -28,7 +28,7 @@ func (d *cephfs) load() error {
 	}
 
 	// Validate the required binaries.
-	for _, tool := range []string{"ceph", "rdb"} {
+	for _, tool := range []string{"ceph", "rbd"} {
 		_, err := exec.LookPath(tool)
 		if err != nil {
 			return fmt.Errorf("Required tool '%s' is missing", tool)

--- a/lxd/storage/drivers/driver_common.go
+++ b/lxd/storage/drivers/driver_common.go
@@ -24,15 +24,13 @@ type common struct {
 	logger               logger.Logger
 }
 
-func (d *common) init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonVolRulesFunc func(vol Volume) map[string]func(string) error) error {
+func (d *common) init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonVolRulesFunc func(vol Volume) map[string]func(string) error) {
 	d.name = name
 	d.config = config
 	d.getVolID = volIDFunc
 	d.getCommonVolumeRules = commonVolRulesFunc
 	d.state = state
 	d.logger = logger
-
-	return d.load()
 }
 
 func (d *common) load() error {

--- a/lxd/storage/drivers/interface.go
+++ b/lxd/storage/drivers/interface.go
@@ -14,7 +14,7 @@ import (
 type driver interface {
 	Driver
 
-	init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonRulesFunc func(vol Volume) map[string]func(string) error) error
+	init(state *state.State, name string, config map[string]string, logger logger.Logger, volIDFunc func(volType VolumeType, volName string) (int64, error), commonRulesFunc func(vol Volume) map[string]func(string) error)
 	load() error
 }
 

--- a/lxd/storage/drivers/load.go
+++ b/lxd/storage/drivers/load.go
@@ -19,7 +19,9 @@ func Load(state *state.State, driverName string, name string, config map[string]
 	}
 
 	d := driverFunc()
-	err := d.init(state, name, config, logger, volIDFunc, commonVolRulesFunc)
+	d.init(state, name, config, logger, volIDFunc, commonVolRulesFunc)
+
+	err := d.load()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When `init` was modified to call `d.load()` back in https://github.com/lxc/lxd/commit/de19b81a3a53379e5d2bcb4a255c1bbd2e8506cc the intention was that if a driver needed to define it's own `load()` function then it would override the common one.

However this isn't working as designed, and instead, because inside `driverCommon.load()` `d` is always of type `driverCommon` it is always calling the common `load` function which does nothing.

This change pushes the call to the driver specific `load` function to the main driver `Load()` function where the type of the driver is the interface rather than the common driver.

This will allow the cephfs `load()` and future driver's to work correctly.