### PR TITLE
Storage mount tweaks

### DIFF
--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -20,6 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/instance"
 	"github.com/lxc/lxd/lxd/rsync"
 	driver "github.com/lxc/lxd/lxd/storage"
+	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 	log "github.com/lxc/lxd/shared/log15"
 	"github.com/lxc/lxd/shared/logger"
@@ -1095,7 +1096,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		// Unmount the logical volume.
 		oldContainerMntPoint := shared.VarPath("containers", ct)
 		if shared.IsMountPoint(oldContainerMntPoint) {
-			err := driver.TryUnmount(oldContainerMntPoint, unix.MNT_DETACH)
+			err := storageDrivers.TryUnmount(oldContainerMntPoint, unix.MNT_DETACH)
 			if err != nil {
 				logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s", oldContainerMntPoint, err)
 				return err
@@ -1270,7 +1271,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 				if shared.PathExists(oldLvDevPath) {
 					// Unmount the logical volume.
 					if shared.IsMountPoint(oldSnapshotMntPoint) {
-						err := driver.TryUnmount(oldSnapshotMntPoint, unix.MNT_DETACH)
+						err := storageDrivers.TryUnmount(oldSnapshotMntPoint, unix.MNT_DETACH)
 						if err != nil {
 							logger.Errorf("Failed to unmount LVM logical volume \"%s\": %s", oldSnapshotMntPoint, err)
 							return err
@@ -1373,7 +1374,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		}
 
 		if !shared.IsMountPoint(newContainerMntPoint) {
-			err := driver.TryMount(containerLvDevPath, newContainerMntPoint, lvFsType, 0, mountOptions)
+			err := storageDrivers.TryMount(containerLvDevPath, newContainerMntPoint, lvFsType, 0, mountOptions)
 			if err != nil {
 				logger.Errorf("Failed to mount LVM logical \"%s\" onto \"%s\" : %s", containerLvDevPath, newContainerMntPoint, err)
 				return err
@@ -1421,7 +1422,7 @@ func upgradeFromStorageTypeLvm(name string, d *Daemon, defaultPoolName string, d
 		// Unmount the logical volume.
 		oldImageMntPoint := shared.VarPath("images", img+".lv")
 		if shared.IsMountPoint(oldImageMntPoint) {
-			err := driver.TryUnmount(oldImageMntPoint, unix.MNT_DETACH)
+			err := storageDrivers.TryUnmount(oldImageMntPoint, unix.MNT_DETACH)
 			if err != nil {
 				return err
 			}
@@ -1621,7 +1622,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			_, err := shared.TryRunCommand("zfs", "unmount", "-f", ctDataset)
 			if err != nil {
 				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount, trying lazy umount (MNT_DETACH)...")
-				err := driver.TryUnmount(oldContainerMntPoint, unix.MNT_DETACH)
+				err := storageDrivers.TryUnmount(oldContainerMntPoint, unix.MNT_DETACH)
 				if err != nil {
 					failedUpgradeEntities = append(failedUpgradeEntities, fmt.Sprintf("containers/%s: Failed to umount zfs filesystem.", ct))
 					continue
@@ -1769,7 +1770,7 @@ func upgradeFromStorageTypeZfs(name string, d *Daemon, defaultPoolName string, d
 			_, err := shared.TryRunCommand("zfs", "unmount", "-f", imageDataset)
 			if err != nil {
 				logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount, trying lazy umount (MNT_DETACH)...")
-				err := driver.TryUnmount(oldImageMntPoint, unix.MNT_DETACH)
+				err := storageDrivers.TryUnmount(oldImageMntPoint, unix.MNT_DETACH)
 				if err != nil {
 					logger.Warnf("Failed to unmount ZFS filesystem: %s", err)
 				}

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -127,7 +127,7 @@ func (d *cephfs) Create() error {
 
 	// Mount the pool.
 	uri := fmt.Sprintf("%s:6789:/", strings.Join(monAddresses, ","))
-	err = tryMount(uri, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(uri, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
 	if err != nil {
 		return err
 	}
@@ -184,7 +184,7 @@ func (d *cephfs) Delete(op *operations.Operation) error {
 
 	// Mount the pool.
 	uri := fmt.Sprintf("%s:6789:/", strings.Join(monAddresses, ","))
-	err = tryMount(uri, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(uri, mountPoint, "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
 	if err != nil {
 		return err
 	}
@@ -249,7 +249,7 @@ func (d *cephfs) Mount() (bool, error) {
 
 	// Mount the pool.
 	uri := fmt.Sprintf("%s:6789:/%s", strings.Join(monAddresses, ","), fsPath)
-	err = tryMount(uri, GetPoolMountPath(d.name), "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
+	err = TryMount(uri, GetPoolMountPath(d.name), "ceph", 0, fmt.Sprintf("name=%v,secret=%v,mds_namespace=%v", d.config["cephfs.user.name"], userSecret, fsName))
 	if err != nil {
 		return false, err
 	}

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -104,7 +104,7 @@ func (d *dir) Mount() (bool, error) {
 	}
 
 	// Setup the bind-mount.
-	err := tryMount(d.config["source"], path, "none", unix.MS_BIND, "")
+	err := TryMount(d.config["source"], path, "none", unix.MS_BIND, "")
 	if err != nil {
 		return false, err
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -5,9 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
-
-	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/db"
 	"github.com/lxc/lxd/lxd/instance"
@@ -25,83 +22,6 @@ import (
 
 // VolumeUsedByInstancesWithProfiles returns a slice containing the names of instances using a volume.
 var VolumeUsedByInstancesWithProfiles func(s *state.State, poolName string, volumeName string, volumeTypeName string, runningOnly bool) ([]string, error)
-
-// Export the mount options map since we might find it useful in other parts of
-// LXD.
-type mountOptions struct {
-	capture bool
-	flag    uintptr
-}
-
-// MountOptions represents a list of possible mount options.
-var MountOptions = map[string]mountOptions{
-	"async":         {false, unix.MS_SYNCHRONOUS},
-	"atime":         {false, unix.MS_NOATIME},
-	"bind":          {true, unix.MS_BIND},
-	"defaults":      {true, 0},
-	"dev":           {false, unix.MS_NODEV},
-	"diratime":      {false, unix.MS_NODIRATIME},
-	"dirsync":       {true, unix.MS_DIRSYNC},
-	"exec":          {false, unix.MS_NOEXEC},
-	"lazytime":      {true, unix.MS_LAZYTIME},
-	"mand":          {true, unix.MS_MANDLOCK},
-	"noatime":       {true, unix.MS_NOATIME},
-	"nodev":         {true, unix.MS_NODEV},
-	"nodiratime":    {true, unix.MS_NODIRATIME},
-	"noexec":        {true, unix.MS_NOEXEC},
-	"nomand":        {false, unix.MS_MANDLOCK},
-	"norelatime":    {false, unix.MS_RELATIME},
-	"nostrictatime": {false, unix.MS_STRICTATIME},
-	"nosuid":        {true, unix.MS_NOSUID},
-	"rbind":         {true, unix.MS_BIND | unix.MS_REC},
-	"relatime":      {true, unix.MS_RELATIME},
-	"remount":       {true, unix.MS_REMOUNT},
-	"ro":            {true, unix.MS_RDONLY},
-	"rw":            {false, unix.MS_RDONLY},
-	"strictatime":   {true, unix.MS_STRICTATIME},
-	"suid":          {false, unix.MS_NOSUID},
-	"sync":          {true, unix.MS_SYNCHRONOUS},
-}
-
-// TryMount tries mounting a filesystem multiple times. This is useful for unreliable backends.
-func TryMount(src string, dst string, fs string, flags uintptr, options string) error {
-	var err error
-
-	for i := 0; i < 20; i++ {
-		err = unix.Mount(src, dst, fs, flags, options)
-		if err == nil {
-			break
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// TryUnmount tries unmounting a filesystem multiple times. This is useful for unreliable backends.
-func TryUnmount(path string, flags int) error {
-	var err error
-
-	for i := 0; i < 20; i++ {
-		err = unix.Unmount(path, flags)
-		if err == nil {
-			break
-		}
-
-		time.Sleep(500 * time.Millisecond)
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
 
 // ValidName validates the provided name, and returns an error if it's not a valid storage name.
 func ValidName(value string) error {

--- a/lxd/storage_btrfs.go
+++ b/lxd/storage_btrfs.go
@@ -163,7 +163,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 			return fmt.Errorf("Failed to create sparse file %s: %s", source, err)
 		}
 
-		output, err := drivers.MakeFSType(source, "btrfs", &drivers.MkfsOptions{Label: s.pool.Name})
+		output, err := makeFSType(source, "btrfs", &mkfsOptions{Label: s.pool.Name})
 		if err != nil {
 			return fmt.Errorf("Failed to create the BTRFS pool: %v (%s)", err, output)
 		}
@@ -174,7 +174,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 		if filepath.IsAbs(source) {
 			isBlockDev = shared.IsBlockdevPath(source)
 			if isBlockDev {
-				output, err := drivers.MakeFSType(source, "btrfs", &drivers.MkfsOptions{Label: s.pool.Name})
+				output, err := makeFSType(source, "btrfs", &mkfsOptions{Label: s.pool.Name})
 				if err != nil {
 					return fmt.Errorf("Failed to create the BTRFS pool: %v (%s)", err, output)
 				}
@@ -222,7 +222,7 @@ func (s *storageBtrfs) StoragePoolCreate() error {
 
 	var err1 error
 	var devUUID string
-	mountFlags, mountOptions := drivers.ResolveMountOptions(s.getBtrfsMountOptions())
+	mountFlags, mountOptions := resolveMountOptions(s.getBtrfsMountOptions())
 	mountFlags |= s.remount
 	if isBlockDev && filepath.IsAbs(source) {
 		devUUID, _ = shared.LookupUUIDByBlockDevPath(source)
@@ -415,7 +415,7 @@ func (s *storageBtrfs) StoragePoolMount() (bool, error) {
 		return false, nil
 	}
 
-	mountFlags, mountOptions := drivers.ResolveMountOptions(s.getBtrfsMountOptions())
+	mountFlags, mountOptions := resolveMountOptions(s.getBtrfsMountOptions())
 	mountSource := source
 	isBlockDev := shared.IsBlockdevPath(source)
 	if filepath.IsAbs(source) {

--- a/lxd/storage_ceph_utils.go
+++ b/lxd/storage_ceph_utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/rsync"
 	driver "github.com/lxc/lxd/lxd/storage"
-	"github.com/lxc/lxd/lxd/storage/drivers"
+	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -1685,14 +1685,14 @@ func (s *storageCeph) cephRBDVolumeBackupCreate(tmpPath string, backup backup.Ba
 	}
 
 	// Mount the volume
-	mountFlags, mountOptions := drivers.ResolveMountOptions(s.getRBDMountOptions())
-	err = driver.TryMount(RBDDevPath, tmpContainerMntPoint, RBDFilesystem, mountFlags, mountOptions)
+	mountFlags, mountOptions := resolveMountOptions(s.getRBDMountOptions())
+	err = storageDrivers.TryMount(RBDDevPath, tmpContainerMntPoint, RBDFilesystem, mountFlags, mountOptions)
 	if err != nil {
 		logger.Errorf("Failed to mount RBD device %s onto %s: %s", RBDDevPath, tmpContainerMntPoint, err)
 		return err
 	}
 	logger.Debugf("Mounted RBD device %s onto %s", RBDDevPath, tmpContainerMntPoint)
-	defer driver.TryUnmount(tmpContainerMntPoint, unix.MNT_DETACH)
+	defer storageDrivers.TryUnmount(tmpContainerMntPoint, unix.MNT_DETACH)
 
 	// Figure out the target name
 	targetName := sourceContainerName
@@ -1772,7 +1772,7 @@ func (s *storageCeph) doContainerCreate(projectName, name string, privileged boo
 
 	// get filesystem
 	RBDFilesystem := s.getRBDFilesystem()
-	output, err := drivers.MakeFSType(RBDDevPath, RBDFilesystem, nil)
+	output, err := makeFSType(RBDDevPath, RBDFilesystem, nil)
 	if err != nil {
 		logger.Errorf(`Failed to create filesystem type "%s" on device path "%s" for RBD storage volume for container "%s" on storage pool "%s": %v (%s)`, RBDFilesystem, RBDDevPath, name, s.pool.Name, err, output)
 		return err
@@ -1839,8 +1839,8 @@ func (s *storageCeph) doContainerMount(projectName string, name string) (bool, e
 			s.OSDPoolName, storagePoolVolumeTypeNameContainer,
 			volumeName, true, s.UserName)
 		if ret >= 0 {
-			mountFlags, mountOptions := drivers.ResolveMountOptions(s.getRBDMountOptions())
-			mounterr = driver.TryMount(RBDDevPath, containerMntPoint,
+			mountFlags, mountOptions := resolveMountOptions(s.getRBDMountOptions())
+			mounterr = storageDrivers.TryMount(RBDDevPath, containerMntPoint,
 				RBDFilesystem, mountFlags, mountOptions)
 			ourMount = true
 		}

--- a/lxd/storage_lvm_utils.go
+++ b/lxd/storage_lvm_utils.go
@@ -17,7 +17,6 @@ import (
 	"github.com/lxc/lxd/lxd/rsync"
 	"github.com/lxc/lxd/lxd/state"
 	driver "github.com/lxc/lxd/lxd/storage"
-	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
 	"github.com/lxc/lxd/shared/logger"
@@ -857,7 +856,7 @@ func lvmCreateLv(projectName, vgName string, thinPoolName string, lvName string,
 
 	fsPath := getLvmDevPath(projectName, vgName, volumeType, lvName)
 
-	output, err = storageDrivers.MakeFSType(fsPath, lvFsType, nil)
+	output, err = makeFSType(fsPath, lvFsType, nil)
 	if err != nil {
 		logger.Errorf("Filesystem creation failed: %v (%s)", err, output)
 		return fmt.Errorf("Error making filesystem on image LV: %v (%s)", err, output)

--- a/lxd/storage_utils.go
+++ b/lxd/storage_utils.go
@@ -2,9 +2,13 @@ package main
 
 import (
 	"fmt"
+	"strings"
+
+	"golang.org/x/sys/unix"
 
 	"github.com/lxc/lxd/lxd/instance"
 	driver "github.com/lxc/lxd/lxd/storage"
+	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
 
@@ -47,4 +51,98 @@ func shrinkVolumeFilesystem(s storage, volumeType int, fsType string, devPath st
 
 	err := driver.ShrinkFileSystem(fsType, devPath, mntpoint, byteSize)
 	return cleanupFunc, err
+}
+
+// MkfsOptions represents options for filesystem creation.
+type mkfsOptions struct {
+	Label string
+}
+
+// MakeFSType creates the provided filesystem.
+func makeFSType(path string, fsType string, options *mkfsOptions) (string, error) {
+	var err error
+	var msg string
+
+	fsOptions := options
+	if fsOptions == nil {
+		fsOptions = &mkfsOptions{}
+	}
+
+	cmd := []string{fmt.Sprintf("mkfs.%s", fsType), path}
+	if fsOptions.Label != "" {
+		cmd = append(cmd, "-L", fsOptions.Label)
+	}
+
+	if fsType == "ext4" {
+		cmd = append(cmd, "-E", "nodiscard,lazy_itable_init=0,lazy_journal_init=0")
+	}
+
+	msg, err = shared.TryRunCommand(cmd[0], cmd[1:]...)
+	if err != nil {
+		return msg, err
+	}
+
+	return "", nil
+}
+
+// mountOption represents an individual mount option.
+type mountOption struct {
+	capture bool
+	flag    uintptr
+}
+
+// mountOptions represents a list of possible mount options.
+var mountOptions = map[string]mountOption{
+	"async":         {false, unix.MS_SYNCHRONOUS},
+	"atime":         {false, unix.MS_NOATIME},
+	"bind":          {true, unix.MS_BIND},
+	"defaults":      {true, 0},
+	"dev":           {false, unix.MS_NODEV},
+	"diratime":      {false, unix.MS_NODIRATIME},
+	"dirsync":       {true, unix.MS_DIRSYNC},
+	"exec":          {false, unix.MS_NOEXEC},
+	"lazytime":      {true, unix.MS_LAZYTIME},
+	"mand":          {true, unix.MS_MANDLOCK},
+	"noatime":       {true, unix.MS_NOATIME},
+	"nodev":         {true, unix.MS_NODEV},
+	"nodiratime":    {true, unix.MS_NODIRATIME},
+	"noexec":        {true, unix.MS_NOEXEC},
+	"nomand":        {false, unix.MS_MANDLOCK},
+	"norelatime":    {false, unix.MS_RELATIME},
+	"nostrictatime": {false, unix.MS_STRICTATIME},
+	"nosuid":        {true, unix.MS_NOSUID},
+	"rbind":         {true, unix.MS_BIND | unix.MS_REC},
+	"relatime":      {true, unix.MS_RELATIME},
+	"remount":       {true, unix.MS_REMOUNT},
+	"ro":            {true, unix.MS_RDONLY},
+	"rw":            {false, unix.MS_RDONLY},
+	"strictatime":   {true, unix.MS_STRICTATIME},
+	"suid":          {false, unix.MS_NOSUID},
+	"sync":          {true, unix.MS_SYNCHRONOUS},
+}
+
+// resolveMountOptions resolves the provided mount options.
+func resolveMountOptions(options string) (uintptr, string) {
+	mountFlags := uintptr(0)
+	tmp := strings.SplitN(options, ",", -1)
+	for i := 0; i < len(tmp); i++ {
+		opt := tmp[i]
+		do, ok := mountOptions[opt]
+		if !ok {
+			continue
+		}
+
+		if do.capture {
+			mountFlags |= do.flag
+		} else {
+			mountFlags &= ^do.flag
+		}
+
+		copy(tmp[i:], tmp[i+1:])
+		tmp[len(tmp)-1] = ""
+		tmp = tmp[:len(tmp)-1]
+		i--
+	}
+
+	return mountFlags, strings.Join(tmp, ",")
 }

--- a/lxd/storage_zfs_utils.go
+++ b/lxd/storage_zfs_utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/lxc/lxd/lxd/project"
 	driver "github.com/lxc/lxd/lxd/storage"
+	storageDrivers "github.com/lxc/lxd/lxd/storage/drivers"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/logger"
 )
@@ -522,7 +523,7 @@ func zfsUmount(poolName string, path string, mountpoint string) error {
 		fmt.Sprintf("%s/%s", poolName, path))
 	if err != nil {
 		logger.Warnf("Failed to unmount ZFS filesystem via zfs unmount: %s. Trying lazy umount (MNT_DETACH)...", output)
-		err := driver.TryUnmount(mountpoint, unix.MNT_DETACH)
+		err := storageDrivers.TryUnmount(mountpoint, unix.MNT_DETACH)
 		if err != nil {
 			logger.Warnf("Failed to unmount ZFS filesystem via lazy umount (MNT_DETACH)...")
 			return err
@@ -685,7 +686,7 @@ func (s *storageZfs) doContainerMount(projectName, name string, privileged bool)
 	if !shared.IsMountPoint(containerPoolVolumeMntPoint) {
 		source := fmt.Sprintf("%s/%s", s.getOnDiskPoolName(), fs)
 		zfsMountOptions := fmt.Sprintf("rw,zfsutil,mntpoint=%s", containerPoolVolumeMntPoint)
-		mounterr := driver.TryMount(source, containerPoolVolumeMntPoint, "zfs", 0, zfsMountOptions)
+		mounterr := storageDrivers.TryMount(source, containerPoolVolumeMntPoint, "zfs", 0, zfsMountOptions)
 		if mounterr != nil {
 			if mounterr != unix.EBUSY {
 				logger.Errorf("Failed to mount ZFS dataset \"%s\" onto \"%s\": %v", source, containerPoolVolumeMntPoint, mounterr)


### PR DESCRIPTION
- Removes mount helper functions that were in the `storage` package and copies them into both `main` and `storage/drivers` packages as unexported functions.
- This was needed as the new `storage/drivers` drivers need access to these functions, but we do not want to export them when the only external users is the old storage layer.
- The exception to this is `TryMount` and `TryUnmount` which is used from the patches.go file and will need to remain after the old storage layer is removed, so these are left as exported in `storage/drivers` pkg.
