### PR TITLE
Storage pool loader instance type checks

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -121,7 +121,7 @@ func backupCreateTarball(s *state.State, path string, b backup.Backup, c instanc
 	}
 
 	pool, err := storagePools.GetPoolByInstance(s, c)
-	if err != storageDrivers.ErrUnknownDriver && err != db.ErrNoSuchObject {
+	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented && err != db.ErrNoSuchObject {
 		if err != nil {
 			return err
 		}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -240,8 +240,8 @@ func containerLXCCreate(s *state.State, args db.InstanceArgs) (instance.Instance
 
 	// Initialize the container storage
 	// Check if we can load new storage layer for pool driver type.
-	pool, err := storagePools.GetPoolByName(c.state, storagePool)
-	if err != storageDrivers.ErrUnknownDriver {
+	pool, err := storagePools.GetPoolByInstance(c.state, c)
+	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented {
 		if err != nil {
 			return nil, err
 		}
@@ -3426,7 +3426,7 @@ func (c *containerLXC) Delete() error {
 
 	// Check if we can load new storage layer for pool driver type.
 	pool, err := storagePools.GetPoolByInstance(c.state, c)
-	if err != storageDrivers.ErrUnknownDriver && err != db.ErrNoSuchObject {
+	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented && err != db.ErrNoSuchObject {
 		if err != nil {
 			return err
 		}
@@ -3474,7 +3474,7 @@ func (c *containerLXC) Delete() error {
 				}
 			}
 		}
-	} else if err == storageDrivers.ErrUnknownDriver {
+	} else if err != db.ErrNoSuchObject {
 		// Attempt to initialize storage interface for the container.
 		err := c.initStorage()
 		if err != nil {
@@ -5802,8 +5802,8 @@ func (c *containerLXC) diskState() map[string]api.InstanceStateDisk {
 		var usage int64
 
 		// Check if we can load new storage layer for pool driver type.
-		pool, err := storagePools.GetPoolByName(c.state, dev.Config["pool"])
-		if err != storageDrivers.ErrUnknownDriver {
+		pool, err := storagePools.GetPoolByInstance(c.state, c)
+		if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented {
 			if err != nil {
 				logger.Error("Error loading storage pool", log.Ctx{"project": c.Project(), "instance": c.Name(), "err": err})
 				continue

--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -345,7 +345,7 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 
 	// Check if we can load new storage layer for pool driver type.
 	pool, err := storagePools.GetPoolByInstance(state, s.instance)
-	if err != storageDrivers.ErrUnknownDriver && err != db.ErrNoSuchObject {
+	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented && err != db.ErrNoSuchObject {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
When loading the new storage pool package we check that the underlying driver supports the instance type. This allows for deploying partially supported new drivers that only implement custom volumes.

As part of my testing for the new LVM driver I found some areas where this instance type check was not happening.