### PR TITLE
Revert helper

### DIFF
--- a/lxd/revert/revert.go
+++ b/lxd/revert/revert.go
@@ -1,0 +1,33 @@
+package revert
+
+// Reverter is a helper type to manage revert functions.
+type Reverter struct {
+	revertFuncs []func()
+}
+
+// New returns a new Reverter.
+func New() *Reverter {
+	return &Reverter{}
+}
+
+// Add adds a revert function to the list to be run when Revert() is called.
+func (r *Reverter) Add(f func()) {
+	r.revertFuncs = append(r.revertFuncs, f)
+}
+
+// Fail runs any revert functions in the reverse order they were added.
+// Should be used with defer or when a task has encountered an error and needs to be reverted.
+func (r *Reverter) Fail() {
+	funcCount := len(r.revertFuncs)
+	for k := range r.revertFuncs {
+		// Run the revert functions in reverse order.
+		k = funcCount - 1 - k
+		r.revertFuncs[k]()
+	}
+}
+
+// Success clears the revert functions previously added.
+// Should be called on successful completion of a task to prevent revert functions from being run.
+func (r *Reverter) Success() {
+	r.revertFuncs = nil
+}

--- a/lxd/revert/revert_test.go
+++ b/lxd/revert/revert_test.go
@@ -1,0 +1,31 @@
+package revert_test
+
+import (
+	"fmt"
+
+	"github.com/lxc/lxd/lxd/revert"
+)
+
+func ExampleReverter_fail() {
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { fmt.Println("1st step") })
+	revert.Add(func() { fmt.Println("2nd step") })
+
+	return // Revert functions are run in reverse order on return.
+	// Output: 2nd step
+	// 1st step
+}
+
+func ExampleReverter_success() {
+	revert := revert.New()
+	defer revert.Fail()
+
+	revert.Add(func() { fmt.Println("1st step") })
+	revert.Add(func() { fmt.Println("2nd step") })
+
+	revert.Success() // Revert functions added are not run on return.
+	return
+	// Output:
+}


### PR DESCRIPTION
As I've been working on the new storage layer I've found myself using a revert pattern that worked well but had a fair amount of boiler plate, so this package removes some of the duplication and makes it clearer to read.

Original pattern

```go
func main() {
        revertFuncs := []func{}
        defer func()  {
                range _, f := revertFuncs {
                        f()
                }
        }

        // Do step 1
        revertFuncs := append(revertFuncs, func() {
             //something that undoes step 1
        })

        // Do step 2

        revertFuncs = nil
        return
}
```

This also has the disadvantage that the revert steps are not run in reverse order.

This PR introduces the `revert` package which reduces boiler plate and runs revert steps in reverse order:

```go
func main() {
        revert := revert.New()
        defer revert.Fail()

        // Do step 1
        revert.Add( func() {
             //something that undoes step 1
        }) 

        // Do step 2

        revert.Success()
        return
}
```