### PR TITLE
Storage config expansion tweaks

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2149,13 +2149,14 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 	}()
 
 	// Check the supplied config and remove any fields not relevant for destination pool type.
-	err := b.driver.ValidateVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, args.Config), true)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, args.Config)
+	err := b.driver.ValidateVolume(vol, true)
 	if err != nil {
 		return err
 	}
 
 	// Create database entry for new storage volume.
-	err = VolumeDBCreate(b.state, "default", b.name, args.Name, args.Description, db.StoragePoolVolumeTypeNameCustom, false, args.Config)
+	err = VolumeDBCreate(b.state, "default", b.name, args.Name, args.Description, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 	if err != nil {
 		return err
 	}
@@ -2167,7 +2168,7 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 			newSnapshotName := drivers.GetSnapshotVolumeName(args.Name, snapName)
 
 			// Create database entry for new storage volume snapshot.
-			err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, args.Description, db.StoragePoolVolumeTypeNameCustom, true, args.Config)
+			err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, args.Description, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
 			if err != nil {
 				return err
 			}
@@ -2176,7 +2177,6 @@ func (b *lxdBackend) CreateCustomVolumeFromMigration(conn io.ReadWriteCloser, ar
 		}
 	}
 
-	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, args.Name, args.Config)
 	err = b.driver.CreateVolumeFromMigration(vol, conn, args, nil, op)
 	if err != nil {
 		conn.Close()

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1911,13 +1911,14 @@ func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]
 	defer logger.Debug("CreateCustomVolume finished")
 
 	// Validate config.
-	err := b.driver.ValidateVolume(b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config), false)
+	vol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config)
+	err := b.driver.ValidateVolume(vol, false)
 	if err != nil {
 		return err
 	}
 
 	// Create database entry for new storage volume.
-	err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, config)
+	err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 	if err != nil {
 		return err
 	}
@@ -1930,8 +1931,7 @@ func (b *lxdBackend) CreateCustomVolume(volName, desc string, config map[string]
 	}()
 
 	// Create the empty custom volume on the storage device.
-	newVol := b.newVolume(drivers.VolumeTypeCustom, drivers.ContentTypeFS, volName, config)
-	err = b.driver.CreateVolume(newVol, nil, op)
+	err = b.driver.CreateVolume(vol, nil, op)
 	if err != nil {
 		return err
 	}
@@ -2025,7 +2025,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 		}
 
 		// Create database entry for new storage volume.
-		err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, config)
+		err = VolumeDBCreate(b.state, "default", b.name, volName, desc, db.StoragePoolVolumeTypeNameCustom, false, vol.Config())
 		if err != nil {
 			return err
 		}
@@ -2037,7 +2037,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 				newSnapshotName := drivers.GetSnapshotVolumeName(volName, snapName)
 
 				// Create database entry for new storage volume snapshot.
-				err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, desc, db.StoragePoolVolumeTypeNameCustom, true, config)
+				err = VolumeDBCreate(b.state, "default", b.name, newSnapshotName, desc, db.StoragePoolVolumeTypeNameCustom, true, vol.Config())
 				if err != nil {
 					return err
 				}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -116,30 +116,21 @@ func (b *lxdBackend) create(localOnly bool, op *operations.Operation) error {
 	return nil
 }
 
-// newVolume returns a new Volume instance.
+// newVolume returns a new Volume instance containing copies of the supplied volume config and the pools config,
 func (b *lxdBackend) newVolume(volType drivers.VolumeType, contentType drivers.ContentType, volName string, volConfig map[string]string) drivers.Volume {
-	// Copy the config map.
+	// Copy the config map to avoid internal modifications affecting external state.
 	newConfig := map[string]string{}
 	for k, v := range volConfig {
 		newConfig[k] = v
 	}
 
-	// And now expand it with the pool data.
+	// Copy the pool config map to avoid internal modifications affecting external state.
+	newPoolConfig := map[string]string{}
 	for k, v := range b.db.Config {
-		if !strings.HasPrefix(k, "volume.") {
-			continue
-		}
-
-		fields := strings.SplitN(k, "volume.", 2)
-		name := fields[1]
-
-		_, ok := newConfig[name]
-		if !ok {
-			newConfig[name] = v
-		}
+		newPoolConfig[k] = v
 	}
 
-	return drivers.NewVolume(b.driver, b.name, volType, contentType, volName, newConfig)
+	return drivers.NewVolume(b.driver, b.name, volType, contentType, volName, newConfig, newPoolConfig)
 }
 
 // GetResources returns utilisation information about the pool.

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -94,7 +94,7 @@ func (d *btrfs) CreateVolumeFromBackup(vol Volume, snapshots []string, srcData i
 	revertHook := func() {
 		for _, snapName := range snapshots {
 			fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapshotName, vol.config)
+			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
 

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -267,7 +267,7 @@ func (d *cephfs) HasVolume(vol Volume) bool {
 	return d.vfsHasVolume(vol)
 }
 
-// ValidateVolume validates the supplied volume config.
+// ValidateVolume validates the supplied volume config. Optionally removes invalid keys from the volume's config.
 func (d *cephfs) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	return d.validateVolume(vol, nil, removeUnknownKeys)
 }

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -80,7 +80,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 		for _, snapName := range revertSnaps {
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
 
-			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config)
+			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
 
@@ -161,7 +161,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, 
 		// Remove any paths created if we are reverting.
 		for _, snapName := range revertSnaps {
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config)
+			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
@@ -187,7 +187,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, 
 			}
 
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config)
+			snapVol := NewVolume(d, d.name, vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 
 			// Create the snapshot itself.
 			err = d.CreateVolumeSnapshot(snapVol, op)

--- a/lxd/storage/drivers/driver_cephfs_volumes.go
+++ b/lxd/storage/drivers/driver_cephfs_volumes.go
@@ -119,7 +119,7 @@ func (d *cephfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots b
 		}
 
 		// Apply the volume quota if specified.
-		err = d.SetVolumeQuota(vol, vol.config["size"], op)
+		err = d.SetVolumeQuota(vol, vol.ExpandedConfig("size"), op)
 		if err != nil {
 			return err
 		}
@@ -200,7 +200,7 @@ func (d *cephfs) CreateVolumeFromMigration(vol Volume, conn io.ReadWriteCloser, 
 		}
 
 		// Apply the volume quota if specified.
-		err = d.SetVolumeQuota(vol, vol.config["size"], op)
+		err = d.SetVolumeQuota(vol, vol.ExpandedConfig("size"), op)
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -44,7 +44,7 @@ func (d *dir) setupInitialQuota(vol Volume) (func(), error) {
 	revert.Add(revertFunc)
 
 	// Set the quota.
-	err = d.setQuota(volPath, volID, vol.config["size"])
+	err = d.setQuota(volPath, volID, vol.ExpandedConfig("size"))
 	if err != nil {
 		return nil, err
 	}

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -185,7 +185,7 @@ func (d *dir) HasVolume(vol Volume) bool {
 	return d.vfsHasVolume(vol)
 }
 
-// ValidateVolume validates the supplied volume config.
+// ValidateVolume validates the supplied volume config. Optionally removes invalid keys from the volume's config.
 func (d *dir) ValidateVolume(vol Volume, removeUnknownKeys bool) error {
 	return d.validateVolume(vol, nil, removeUnknownKeys)
 }

--- a/lxd/storage/drivers/generic.go
+++ b/lxd/storage/drivers/generic.go
@@ -39,7 +39,7 @@ func genericCopyVolume(d Driver, applyQuota func(vol Volume) (func(), error), vo
 		// Remove any paths created if we are reverting.
 		for _, snapName := range revertSnaps {
 			fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config)
+			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
 
@@ -61,7 +61,7 @@ func genericCopyVolume(d Driver, applyQuota func(vol Volume) (func(), error), vo
 				}, op)
 
 				fullSnapName := GetSnapshotVolumeName(vol.name, snapName)
-				snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config)
+				snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 
 				// Create the snapshot itself.
 				err = d.CreateVolumeSnapshot(snapVol, op)
@@ -116,7 +116,7 @@ func genericCreateVolumeFromMigration(d Driver, applyQuota func(vol Volume) (fun
 		// Remove any paths created if we are reverting.
 		for _, snapName := range revertSnaps {
 			fullSnapName := GetSnapshotVolumeName(vol.Name(), snapName)
-			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config)
+			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapName, vol.config, vol.poolConfig)
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
 
@@ -143,7 +143,7 @@ func genericCreateVolumeFromMigration(d Driver, applyQuota func(vol Volume) (fun
 
 			// Create the snapshot itself.
 			fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config)
+			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
 
 			err = d.CreateVolumeSnapshot(snapVol, op)
 			if err != nil {
@@ -207,7 +207,7 @@ func genericBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.Re
 	revertHook := func() {
 		for _, snapName := range snapshots {
 			fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
-			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config)
+			snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
 			d.DeleteVolumeSnapshot(snapVol, op)
 		}
 
@@ -257,7 +257,7 @@ func genericBackupUnpack(d Driver, vol Volume, snapshots []string, srcData io.Re
 		}
 
 		fullSnapshotName := GetSnapshotVolumeName(vol.name, snapName)
-		snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config)
+		snapVol := NewVolume(d, d.Name(), vol.volType, vol.contentType, fullSnapshotName, vol.config, vol.poolConfig)
 		err = d.CreateVolumeSnapshot(snapVol, op)
 		if err != nil {
 			return nil, nil, err

--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -280,7 +280,7 @@ func createSparseFile(filePath string, sizeBytes int64) error {
 
 // ensureVolumeBlockFile creates or resizes the raw block file for a volume.
 func ensureVolumeBlockFile(vol Volume, path string) error {
-	blockSize := vol.config["size"]
+	blockSize := vol.ExpandedConfig("size")
 	if blockSize == "" {
 		blockSize = defaultBlockSize
 	}

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -394,7 +394,7 @@ func VolumeValidateConfig(s *state.State, name string, config map[string]string,
 	if err != drivers.ErrUnknownDriver {
 		// Note: This legacy validation function doesn't have the concept of validating
 		// different volumes types, so the types are hard coded as Custom and FS.
-		return driver.ValidateVolume(drivers.NewVolume(driver, parentPool.Name, drivers.VolumeTypeCustom, drivers.ContentTypeFS, name, config), false)
+		return driver.ValidateVolume(drivers.NewVolume(driver, parentPool.Name, drivers.VolumeTypeCustom, drivers.ContentTypeFS, name, config, parentPool.Config), false)
 	}
 
 	// Otherwise fallback to doing legacy validation.


### PR DESCRIPTION
Includes https://github.com/lxc/lxd/pull/6647

Back in https://github.com/lxc/lxd/pull/6641 @stgraber modified `lxdBackend.newVolume()` to merge the pool's `volume.*` keys into the volume's config (stripping the `volume.` prefix).

In order to do this safely the PR also copies the supplied `volConfig` so that any modifications do not affecting the external config map passed in.

Unfortunately this has had 2 negative side effects:

1. In `CreateVolumeFromMigration` the incoming config is validated and if some keys are not suitable for the target storage pool the validation process removed them. However the change to copy the supplied config when creating a new volume struct prevented this from bubbling up to the function that creates the database row (luckily the DB row create function itself also does validation and detected this issue).

2. We don't want to store merged config from the pool into the new volume DB row, so we need a way to differentiate between pool config and volume config after validation modifications, yet still be able to merge the two when retrieving specific keys (so that pool's volume config is applied when not overridden in volume config).

This PR fixes this by making the following changes:


- Removes pool config expansion from  `lxdBackend.newVolume()`.
- Instead stores a copy of pool config inside the `Volume` struct.
- Keeps the copying of supplied `volConfig` inside `Volume struct`.
- Adds `Volume.Config()` to allow external access to the current (unexpanded) volume config which may have been modified during validation.
- Adds `Volume.ExpandedConfig(key)` function to allow access to an expanded view of a single config key which will then apply the pool's volume config if a key is not defined in the volume config itself.
- Updates use of `vol.config["key"]` to `vol.ExpandedConfig("key")` where appropriate.