### PR TITLE
Storage misc changes

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2079,7 +2079,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 	offerHeader := migration.TypesToHeader(offeredTypes...)
 	migrationType, err := migration.MatchTypes(offerHeader, migration.MigrationFSType_RSYNC, b.MigrationTypes(drivers.ContentTypeFS, false))
 	if err != nil {
-		return fmt.Errorf("Failed to neogotiate copy migration type: %v", err)
+		return fmt.Errorf("Failed to negotiate copy migration type: %v", err)
 	}
 
 	// Run sender and receiver in separate go routines to prevent deadlocks.

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -2114,6 +2114,7 @@ func (b *lxdBackend) CreateCustomVolumeFromCopy(volName, desc string, config map
 	errs := []error{}
 	aEndErr := <-aEndErrCh
 	if aEndErr != nil {
+		aEnd.Close()
 		errs = append(errs, aEndErr)
 	}
 

--- a/lxd/storage/memorypipe/memory_pipe.go
+++ b/lxd/storage/memorypipe/memory_pipe.go
@@ -4,6 +4,8 @@ import (
 	"io"
 )
 
+const bufferSize = 10
+
 // msg represents an internal structure sent between the pipes.
 type msg struct {
 	data []byte
@@ -59,11 +61,11 @@ func (p *pipe) Close() error {
 // indicate to the other end that the session has ended.
 func NewPipePair() (io.ReadWriteCloser, io.ReadWriteCloser) {
 	aEnd := &pipe{
-		ch: make(chan msg, 1),
+		ch: make(chan msg, bufferSize),
 	}
 
 	bEnd := &pipe{
-		ch: make(chan msg, 1),
+		ch: make(chan msg, bufferSize),
 	}
 
 	aEnd.otherEnd = bEnd

--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -575,7 +575,7 @@ func validateVolumeCommonRules(vol drivers.Volume) map[string]func(string) error
 // Container Format B: Combined tarball containing metadata files and root squashfs.
 //	- Unpack combined tarball into mountPath.
 // VM Format A: Separate metadata tarball and root qcow2 file.
-// 	- Unpack metadata tarball into mountPath (if file exists, convert to raw, if not just copy).
+// 	- Unpack metadata tarball into mountPath.
 //	- Check rootBlockPath is a file and convert qcow2 file into raw format in rootBlockPath.
 func ImageUnpack(imageFile, destPath, destBlockFile string, blockBackend, runningInUserns bool, tracker *ioprogress.ProgressTracker) error {
 	// For all formats, first unpack the metadata (or combined) tarball into destPath.


### PR DESCRIPTION
Biggest change here is to increase `memorypipe` buffer so that if sender fails before sending anything, we can close the sender side and still allow the recv side to send a close signal even if they have already sent opening message.