### PR TITLE
lxd/instances: Export FillNetworkDevice

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -1288,7 +1288,7 @@ func (c *containerLXC) deviceLoad(deviceName string, rawConfig deviceConfig.Devi
 
 	// Create copy of config and load some fields from volatile if device is nic or infiniband.
 	if shared.StringInSlice(rawConfig["type"], []string{"nic", "infiniband"}) {
-		configCopy, err = c.fillNetworkDevice(deviceName, rawConfig)
+		configCopy, err = c.FillNetworkDevice(deviceName, rawConfig)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -6326,9 +6326,9 @@ func (c *containerLXC) removeUnixDevices() error {
 	return nil
 }
 
-// fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
+// FillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
 // generated name and hwaddr properties if these are missing from the device.
-func (c *containerLXC) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
+func (c *containerLXC) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
 	var err error
 	newDevice := m.Clone()
 
@@ -6822,7 +6822,7 @@ func (c *containerLXC) maasInterfaces(devices map[string]map[string]string) ([]m
 			continue
 		}
 
-		m, err := c.fillNetworkDevice(k, m)
+		m, err := c.FillNetworkDevice(k, m)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -85,6 +85,7 @@ type Instance interface {
 	InitPID() int
 	State() string
 	ExpiryDate() time.Time
+	FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error)
 
 	// Paths
 	Path() string
@@ -100,7 +101,6 @@ type Instance interface {
 	StoragePool() (string, error)
 
 	// Progress reporting
-
 	SetOperation(op *operations.Operation)
 
 	// FIXME: Those should be internal functions

--- a/lxd/instance/qemu/vm_qemu.go
+++ b/lxd/instance/qemu/vm_qemu.go
@@ -787,7 +787,7 @@ func (vm *Qemu) deviceLoad(deviceName string, rawConfig deviceConfig.Device) (de
 
 	// Create copy of config and load some fields from volatile if device is nic or infiniband.
 	if shared.StringInSlice(rawConfig["type"], []string{"nic", "infiniband"}) {
-		configCopy, err = vm.fillNetworkDevice(deviceName, rawConfig)
+		configCopy, err = vm.FillNetworkDevice(deviceName, rawConfig)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -2729,7 +2729,7 @@ func (vm *Qemu) RenderState() (*api.InstanceState, error) {
 				}
 
 				// Fill the MAC address.
-				m, err := vm.fillNetworkDevice(k, m)
+				m, err := vm.FillNetworkDevice(k, m)
 				if err != nil {
 					return nil, err
 				}
@@ -3095,9 +3095,9 @@ func (vm *Qemu) DaemonState() *state.State {
 	return vm.state
 }
 
-// fillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
+// FillNetworkDevice takes a nic or infiniband device type and enriches it with automatically
 // generated name and hwaddr properties if these are missing from the device.
-func (vm *Qemu) fillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
+func (vm *Qemu) FillNetworkDevice(name string, m deviceConfig.Device) (deviceConfig.Device, error) {
 	var err error
 
 	newDevice := m.Clone()
@@ -3173,7 +3173,7 @@ func (vm *Qemu) maasInterfaces(devices map[string]map[string]string) ([]maas.Con
 			continue
 		}
 
-		m, err := vm.fillNetworkDevice(k, m)
+		m, err := vm.FillNetworkDevice(k, m)
 		if err != nil {
 			return nil, err
 		}

--- a/lxd/networks_utils.go
+++ b/lxd/networks_utils.go
@@ -655,12 +655,10 @@ func networkUpdateStatic(s *state.State, networkName string) error {
 				continue
 			}
 
-			if inst.Type() == instancetype.Container {
-				// Fill in the hwaddr from volatile
-				d, err = inst.(*containerLXC).fillNetworkDevice(k, d)
-				if err != nil {
-					continue
-				}
+			// Fill in the hwaddr from volatile
+			d, err = inst.FillNetworkDevice(k, d)
+			if err != nil {
+				continue
 			}
 
 			// Add the new host entries


### PR DESCRIPTION
This lets us fix the lack of MAC expension in the dnsmasq lease handling logic.

Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>