### PR TITLE
Storage Instance Backup Config

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -730,7 +730,7 @@ func instanceCreateAsSnapshot(s *state.State, args db.InstanceArgs, sourceInstan
 	}
 
 	// Attempt to update backup.yaml for instance.
-	err = instance.WriteBackupFile(s, sourceInstance)
+	err = sourceInstance.UpdateBackupFile()
 	if err != nil {
 		return nil, err
 	}
@@ -1035,7 +1035,7 @@ func instanceConfigureInternal(state *state.State, c instance.Instance) error {
 		return fmt.Errorf("Instance type not supported")
 	}
 
-	err = instance.WriteBackupFile(state, c)
+	err = c.UpdateBackupFile()
 	if err != nil {
 		return err
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -7032,3 +7032,19 @@ func (rw *lxcCgroupReadWriter) Set(version cgroup.Backend, controller string, ke
 
 	return rw.cc.SetCgroupItem(key, value)
 }
+
+// UpdateBackupFile writes the instance's backup.yaml file to storage.
+func (c *containerLXC) UpdateBackupFile() error {
+	// Check if we can load new storage layer for pool driver type.
+	pool, err := c.getStoragePool()
+	if err != storageDrivers.ErrUnknownDriver && err != storageDrivers.ErrNotImplemented {
+		if err != nil {
+			return err
+		}
+
+		return pool.UpdateInstanceBackupFile(c, nil)
+	}
+
+	// Fallback to legacy backup function for old storage drivers.
+	return instance.WriteBackupFile(c.state, c)
+}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2225,7 +2225,7 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 	}
 
 	// Update the backup.yaml file
-	err = instance.WriteBackupFile(c.state, c)
+	err = c.UpdateBackupFile()
 	if err != nil {
 		if ourStart {
 			c.unmount()
@@ -3331,7 +3331,7 @@ func (c *containerLXC) Restore(sourceContainer instance.Instance, stateful bool)
 
 	// The old backup file may be out of date (e.g. it doesn't have all the current snapshots of
 	// the container listed); let's write a new one to be safe.
-	err = instance.WriteBackupFile(c.state, c)
+	err = c.UpdateBackupFile()
 	if err != nil {
 		return err
 	}
@@ -4511,7 +4511,7 @@ func (c *containerLXC) Update(args db.InstanceArgs, userRequested bool) error {
 
 	// Only update the backup file if it already exists (indicating the instance is mounted).
 	if shared.PathExists(filepath.Join(c.Path(), "backup.yaml")) {
-		err := instance.WriteBackupFile(c.state, c)
+		err := c.UpdateBackupFile()
 		if err != nil && !os.IsNotExist(err) {
 			return errors.Wrap(err, "Failed to write backup file")
 		}

--- a/lxd/containers_post.go
+++ b/lxd/containers_post.go
@@ -724,8 +724,8 @@ func createFromBackup(d *Daemon, project string, data io.Reader, pool string) re
 			return errors.Wrap(err, "Load instance")
 		}
 
-		// Run the storage post hook to perform any final actions now that the instance
-		// has been created in the database.
+		// Run the storage post hook to perform any final actions now that the instance has been created
+		// in the database (this normally includes unmounting volumes that were mounted).
 		if postHook != nil {
 			err = postHook(c)
 			if err != nil {

--- a/lxd/instance/instance_interface.go
+++ b/lxd/instance/instance_interface.go
@@ -29,6 +29,7 @@ type Instance interface {
 	Restore(source Instance, stateful bool) error
 	Snapshots() ([]Instance, error)
 	Backups() ([]backup.Backup, error)
+	UpdateBackupFile() error
 
 	// Config handling
 	Rename(newName string) error

--- a/lxd/instance/instance_utils.go
+++ b/lxd/instance/instance_utils.go
@@ -451,7 +451,7 @@ func LoadByProjectAndName(s *state.State, project, name string) (Instance, error
 	return inst, nil
 }
 
-// WriteBackupFile writes instance's config to a file.
+// WriteBackupFile writes instance's config to a file. Deprecated, use inst.UpdateBackupFile().
 func WriteBackupFile(state *state.State, inst Instance) error {
 	// We only write backup files out for actual instances.
 	if inst.IsSnapshot() {

--- a/lxd/instance/qemu/vm_qemu.go
+++ b/lxd/instance/qemu/vm_qemu.go
@@ -3296,3 +3296,13 @@ func (vm *Qemu) maasUpdate(oldDevices map[string]map[string]string) error {
 
 	return vm.state.MAAS.CreateContainer(project.Prefix(vm.project, vm.name), interfaces)
 }
+
+// UpdateBackupFile writes the instance's backup.yaml file to storage.
+func (vm *Qemu) UpdateBackupFile() error {
+	pool, err := vm.getStoragePool()
+	if err != nil {
+		return err
+	}
+
+	return pool.UpdateInstanceBackupFile(vm, nil)
+}

--- a/lxd/instance/qemu/vm_qemu.go
+++ b/lxd/instance/qemu/vm_qemu.go
@@ -1861,7 +1861,7 @@ func (vm *Qemu) Update(args db.InstanceArgs, userRequested bool) error {
 		return errors.Wrap(err, "Failed to update database")
 	}
 
-	err = instance.WriteBackupFile(vm.state, vm)
+	err = vm.UpdateBackupFile()
 	if err != nil && !os.IsNotExist(err) {
 		return errors.Wrap(err, "Failed to write backup file")
 	}

--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -470,9 +470,12 @@ func (b *lxdBackend) CreateInstanceFromBackup(srcBackup backup.Info, srcData io.
 	}
 
 	// Update pool information in the backup.yaml file.
-	vol.MountTask(func(mountPath string, op *operations.Operation) error {
+	err = vol.MountTask(func(mountPath string, op *operations.Operation) error {
 		return backup.UpdateInstanceConfigStoragePool(b.state.Cluster, srcBackup, mountPath)
 	}, op)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	var postHook func(instance.Instance) error
 	if volPostHook != nil {

--- a/lxd/storage/backend_mock.go
+++ b/lxd/storage/backend_mock.go
@@ -92,6 +92,10 @@ func (b *mockBackend) UpdateInstance(inst instance.Instance, newDesc string, new
 	return nil
 }
 
+func (b *mockBackend) UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error {
+	return nil
+}
+
 func (b *mockBackend) MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeSourceArgs, op *operations.Operation) error {
 	return nil
 }

--- a/lxd/storage/pool_interface.go
+++ b/lxd/storage/pool_interface.go
@@ -34,6 +34,7 @@ type Pool interface {
 	RenameInstance(inst instance.Instance, newName string, op *operations.Operation) error
 	DeleteInstance(inst instance.Instance, op *operations.Operation) error
 	UpdateInstance(inst instance.Instance, newDesc string, newConfig map[string]string, op *operations.Operation) error
+	UpdateInstanceBackupFile(inst instance.Instance, op *operations.Operation) error
 
 	MigrateInstance(inst instance.Instance, conn io.ReadWriteCloser, args migration.VolumeSourceArgs, op *operations.Operation) error
 	RefreshInstance(inst instance.Instance, src instance.Instance, srcSnapshots []instance.Instance, op *operations.Operation) error


### PR DESCRIPTION
Includes https://github.com/lxc/lxd/pull/6675

This PR adds a new function to the storage pool interface: `BackupInstanceConfig()` that will ultimately replace the existing `instance.WriteBackupYaml()` function.

The reason for this is that writing the backup config yaml file is inherently dependent on the storage layer and for drivers where the volume needs to be mounted, ensuring that the volume was mounted in all occurrences that the backup yaml file needed writing was becoming error prone to track.

Instead this moves the yaml generation and writing into the backendLXD, where it can directly mount the volume if needed.

The remaining changes then expose a new function on `Instance` called `BackupConfig()` that then selectively uses the new storage function or the legacy one based on the storage driver available. 