### PR TITLE
Storage: Support non-default project in storagePoolDelete

### DIFF
--- a/lxd/storage_pools.go
+++ b/lxd/storage_pools.go
@@ -574,7 +574,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		// Only delete images if locally stored or running on initial member.
 		if !isClusterNotification(r) || !pool.Driver().Info().Remote {
 			for _, volume := range volumeNames {
-				_, imgInfo, err := d.cluster.ImageGet("default", volume, false, false)
+				_, imgInfo, err := d.cluster.ImageGet(projectParam(r), volume, false, false)
 				if err != nil {
 					return response.InternalError(err)
 				}
@@ -613,7 +613,7 @@ func storagePoolDelete(d *Daemon, r *http.Request) response.Response {
 		}
 
 		for _, volume := range volumeNames {
-			_, imgInfo, err := d.cluster.ImageGet("default", volume, false, false)
+			_, imgInfo, err := d.cluster.ImageGet(projectParam(r), volume, false, false)
 			if err != nil {
 				return response.InternalError(err)
 			}


### PR DESCRIPTION
This allows storage pools that have *all* volumes in a non-default project to be deleted.

Note: This still does not allow storage pools that have a mixture of volumes from different projects to be deleted.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>