### PR TITLE
[Makefiles] Whitelist ldflags in libcap pkgconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ deps:
 	@echo "export CGO_CFLAGS=\"-I$(GOPATH)/deps/sqlite/ -I$(GOPATH)/deps/libco/ -I$(GOPATH)/deps/raft/include/ -I$(GOPATH)/deps/dqlite/include/\""
 	@echo "export CGO_LDFLAGS=\"-L$(GOPATH)/deps/sqlite/.libs/ -L$(GOPATH)/deps/libco/ -L$(GOPATH)/deps/raft/.libs -L$(GOPATH)/deps/dqlite/.libs/\""
 	@echo "export LD_LIBRARY_PATH=\"$(GOPATH)/deps/sqlite/.libs/:$(GOPATH)/deps/libco/:$(GOPATH)/deps/raft/.libs/:$(GOPATH)/deps/dqlite/.libs/\""
+	@echo "export CGO_LDFLAGS_ALLOW=\"-Wl,-wrap,pthread_create\""
+
 
 .PHONY: update
 update:

--- a/doc/index.md
+++ b/doc/index.md
@@ -119,6 +119,7 @@ make deps
 export CGO_CFLAGS="${CGO_CFLAGS} -I${GOPATH}/deps/sqlite/ -I${GOPATH}/deps/dqlite/include/ -I${GOPATH}/deps/raft/include/ -I${GOPATH}/deps/libco/"
 export CGO_LDFLAGS="${CGO_LDFLAGS} -L${GOPATH}/deps/sqlite/.libs/ -L${GOPATH}/deps/dqlite/.libs/ -L${GOPATH}/deps/raft/.libs -L${GOPATH}/deps/libco/"
 export LD_LIBRARY_PATH="${GOPATH}/deps/sqlite/.libs/:${GOPATH}/deps/dqlite/.libs/:${GOPATH}/deps/raft/.libs:${GOPATH}/deps/libco/:${LD_LIBRARY_PATH}"
+export CGO_LDFLAGS_ALLOW="-Wl,-wrap,pthread_create"
 make
 ```
 


### PR DESCRIPTION
libcap 1.29 was extended to support go, in turn adding some extensions
to the distributed pkgconfig files [1]. By default for security reasons,
the cgo compiler only allows -D, -I, and -l however allows us to extend
this by adding a regex filter to CGO_ALLOW_LDFLAGS [2].

It should be noted that libcap implement the same in their build systems
[3], but use a more relaxed ALLOW regex. Restrict ours as it probably
shouldn't be too wide.

Fixes: #6727

[1]: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=1a61e6f395f2d2784365920872c14d9f69ff8cf1
[2]: https://golang.org/cmd/cgo/
[3]: https://git.kernel.org/pub/scm/libs/libcap/libcap.git/commit/?id=b2b267ef1c83f1f3d3105a4bb84f8bebbc130dec

Signed-off-by: Morten Linderud <morten@linderud.pw>