### PR TITLE
VM: Block boundary size

### DIFF
--- a/lxd/storage/drivers/driver_lvm_utils.go
+++ b/lxd/storage/drivers/driver_lvm_utils.go
@@ -316,12 +316,14 @@ func (d *lvm) roundedSizeBytesString(size string) (int64, error) {
 		return 0, err
 	}
 
-	if sizeBytes < 512 {
-		sizeBytes = 512
+	// LVM tools require sizes in multiples of 512 bytes.
+	const minSizeBytes = 512
+	if sizeBytes < minSizeBytes {
+		sizeBytes = minSizeBytes
 	}
 
-	// Round the size to closest 512 bytes as LVM tools require sizes in multiples of 512 bytes.
-	sizeBytes = int64(sizeBytes/512) * 512
+	// Round the size to closest minSizeBytes bytes.
+	sizeBytes = int64(sizeBytes/minSizeBytes) * minSizeBytes
 
 	return sizeBytes, nil
 }


### PR DESCRIPTION
Ensures that VM image files created use an 8K block boundary size, even if the volume size specified by the user is in metric units. This is to work around a qemu bug when volume size is not a standard block boundary multiple.