### PR TITLE
VM: boot priority

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -899,3 +899,6 @@ Add a new device\_id field in the disk entries on the resources API.
 
 ## storage\_lvm\_stripes
 This adds the ability to use LVM stripes on normal volumes and thin pool volumes.
+
+## vm\_boot\_priority
+Adds a `boot.priority` property on nic and disk devices to control the boot order.

--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -895,7 +895,7 @@ This adds a new `architecture` attribute to cluster members which indicates a cl
 member's architecture.
 
 ## resources\_disk\_id
-Add a new device_id field in the disk entries on the resources API.
+Add a new device\_id field in the disk entries on the resources API.
 
 ## storage\_lvm\_stripes
 This adds the ability to use LVM stripes on normal volumes and thin pool volumes.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -272,6 +272,7 @@ hwaddr                  | string    | randomly assigned | no        | The MAC ad
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 maas.subnet.ipv4        | string    | -                 | no        | MAAS IPv4 subnet to register the instance in
 maas.subnet.ipv6        | string    | -                 | no        | MAAS IPv6 subnet to register the instance in
+boot.priority           | integer   | -                 | no        | Boot priority for VMs (higher boots first)
 
 #### nictype: bridged
 Uses an existing bridge on the host and creates a virtual device pair to connect the host bridge to the instance.
@@ -297,6 +298,7 @@ security.ipv4\_filtering | boolean   | false             | no        | Prevent t
 security.ipv6\_filtering | boolean   | false             | no        | Prevent the instance from spoofing another's IPv6 address (enables mac\_filtering)
 maas.subnet.ipv4         | string    | -                 | no        | MAAS IPv4 subnet to register the instance in
 maas.subnet.ipv6         | string    | -                 | no        | MAAS IPv6 subnet to register the instance in
+boot.priority            | integer   | -                 | no        | Boot priority for VMs (higher boots first)
 
 #### nictype: macvlan
 Sets up a new network device based on an existing one but using a different MAC address.
@@ -312,6 +314,7 @@ hwaddr                  | string    | randomly assigned | no        | The MAC ad
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 maas.subnet.ipv4        | string    | -                 | no        | MAAS IPv4 subnet to register the instance in
 maas.subnet.ipv6        | string    | -                 | no        | MAAS IPv6 subnet to register the instance in
+boot.priority           | integer   | -                 | no        | Boot priority for VMs (higher boots first)
 
 #### nictype: ipvlan
 Sets up a new network device based on an existing one using the same MAC address but a different IP.
@@ -365,6 +368,7 @@ limits.egress           | string    | -                 | no        | I/O limit 
 limits.max              | string    | -                 | no        | Same as modifying both limits.ingress and limits.egress
 ipv4.routes             | string    | -                 | no        | Comma delimited list of IPv4 static routes to add on host to nic
 ipv6.routes             | string    | -                 | no        | Comma delimited list of IPv6 static routes to add on host to nic
+boot.priority           | integer   | -                 | no        | Boot priority for VMs (higher boots first)
 
 #### nictype: sriov
 Passes a virtual function of an SR-IOV enabled physical network device into the instance.
@@ -381,6 +385,7 @@ security.mac\_filtering | boolean   | false             | no        | Prevent th
 vlan                    | integer   | -                 | no        | The VLAN ID to attach to
 maas.subnet.ipv4        | string    | -                 | no        | MAAS IPv4 subnet to register the instance in
 maas.subnet.ipv6        | string    | -                 | no        | MAAS IPv6 subnet to register the instance in
+boot.priority           | integer   | -                 | no        | Boot priority for VMs (higher boots first)
 
 #### nictype: routed
 This NIC type is similar in operation to IPVLAN, in that it allows an instance to join an external network without needing to configure a bridge and shares the host's MAC address.
@@ -572,6 +577,7 @@ shift               | boolean   | false     | no        | Setup a shifting overl
 raw.mount.options   | string    | -         | no        | Filesystem specific mount options
 ceph.user\_name     | string    | admin     | no        | If source is ceph or cephfs then ceph user\_name must be specified by user for proper mount
 ceph.cluster\_name  | string    | admin     | no        | If source is ceph or cephfs then ceph cluster\_name must be specified by user for proper mount
+boot.priority       | integer   | -         | no        | Boot priority for VMs (higher boots first)
 
 ### Type: unix-char
 Unix character device entries simply make the requested character device

--- a/lxd/container_logs.go
+++ b/lxd/container_logs.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gorilla/mux"
 
+	"github.com/lxc/lxd/lxd/project"
 	"github.com/lxc/lxd/lxd/response"
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/version"
@@ -103,11 +104,11 @@ func containerLogGet(d *Daemon, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	project := projectParam(r)
+	projectName := projectParam(r)
 	name := mux.Vars(r)["name"]
 
 	// Handle requests targeted to a container on a different node
-	resp, err := ForwardedResponseIfContainerIsRemote(d, r, project, name, instanceType)
+	resp, err := ForwardedResponseIfContainerIsRemote(d, r, projectName, name, instanceType)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -126,7 +127,7 @@ func containerLogGet(d *Daemon, r *http.Request) response.Response {
 	}
 
 	ent := response.FileResponseEntry{
-		Path:     shared.LogPath(name, file),
+		Path:     shared.LogPath(project.Prefix(projectName, name), file),
 		Filename: file,
 	}
 

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2172,6 +2172,10 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 			}
 
 			for _, nicItem := range runConf.NetworkInterface {
+				if nicItem.Key == "devName" {
+					// Skip internal device name key, not used by liblxc.
+					continue
+				}
 				err = lxcSetConfigItem(c.c, fmt.Sprintf("%s.%d.%s", networkKeyPrefix, nicID, nicItem.Key), nicItem.Value)
 				if err != nil {
 					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device network interface '%s'", dev.Name)

--- a/lxd/device/config/device_runconfig.go
+++ b/lxd/device/config/device_runconfig.go
@@ -17,6 +17,7 @@ type RunConfigItem struct {
 
 // MountEntryItem represents a single mount entry item.
 type MountEntryItem struct {
+	DevName    string   // The internal name for the device.
 	DevPath    string   // Describes the block special device or remote filesystem to be mounted.
 	TargetPath string   // Describes the mount point (target) for the filesystem.
 	FSType     string   // Describes the type of the filesystem.

--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -82,6 +82,7 @@ func (d *disk) validateConfig() error {
 		"raw.mount.options": shared.IsAny,
 		"ceph.cluster_name": shared.IsAny,
 		"ceph.user_name":    shared.IsAny,
+		"boot.priority":     shared.IsUint32,
 	}
 
 	// VMs don't use the "path" property, but containers need it, so if we are validating a profile that can

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -116,6 +116,7 @@ func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -138,6 +138,7 @@ func (d *infinibandSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -47,6 +47,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 		"ipv6.address":            NetworkValidAddressV6,
 		"ipv4.routes":             NetworkValidNetworkV4List,
 		"ipv6.routes":             NetworkValidNetworkV6List,
+		"boot.priority":           shared.IsUint32,
 	}
 
 	validators := map[string]func(value string) error{}

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -176,6 +176,7 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -71,6 +71,7 @@ func (d *nicBridged) validateConfig() error {
 		"security.ipv6_filtering",
 		"maas.subnet.ipv4",
 		"maas.subnet.ipv6",
+		"boot.priority",
 	}
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -19,7 +19,7 @@ func (d *nicMACVLAN) validateConfig() error {
 	}
 
 	requiredFields := []string{"parent"}
-	optionalFields := []string{"name", "mtu", "hwaddr", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6"}
+	optionalFields := []string{"name", "mtu", "hwaddr", "vlan", "maas.subnet.ipv4", "maas.subnet.ipv6", "boot.priority"}
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {
 		return err

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -106,6 +106,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -85,6 +85,7 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -26,6 +26,7 @@ func (d *nicPhysical) validateConfig() error {
 		"vlan",
 		"maas.subnet.ipv4",
 		"maas.subnet.ipv6",
+		"boot.priority",
 	}
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -111,6 +111,7 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -37,6 +37,7 @@ func (d *nicSRIOV) validateConfig() error {
 		"security.mac_filtering",
 		"maas.subnet.ipv4",
 		"maas.subnet.ipv6",
+		"boot.priority",
 	}
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -113,6 +113,7 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
+		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/scripts/bash/lxd-client
+++ b/scripts/bash/lxd-client
@@ -114,7 +114,8 @@ _have lxc && {
       security.ipv4_filtering security.ipv6_filtering vlan limits.read \
       limits.write path source optional readonly size recursive pool \
       propagation shift major minor uid gid mode required vendorid productid \
-      pci id listen connect bind nat proxy_protocol security.uid security.gid"
+      pci id listen connect bind nat proxy_protocol security.uid security.gid \
+      boot.priority"
 
     networks_keys="bridge.driver bridge.external_interfaces bridge.mode \
       bridge.mtu bridge.hwaddr dns.domain dns.mode fan.overlay_subnet fan.type \

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -183,6 +183,7 @@ var APIExtensions = []string{
 	"clustering_architecture",
 	"resources_disk_id",
 	"storage_lvm_stripes",
+	"vm_boot_priority",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
- Adds support for Disk and NIC device `boot.priority` setting.
- Unifies root disk and other disk qemu config creation.
- Makes root disk default `boot.priority` 1 and other devices default `boot.priority` 0.
- Uses boot index for SCSI ID.