### PR TITLE
Use a light TCP/TLS connection attempt instead of a client request

### DIFF
--- a/lxd/cluster/connect.go
+++ b/lxd/cluster/connect.go
@@ -1,9 +1,11 @@
 package cluster
 
 import (
+	"crypto/tls"
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/pkg/errors"
@@ -164,4 +166,21 @@ func SetupTrust(cert, targetAddress, targetCert, targetPassword string) error {
 	}
 
 	return nil
+}
+
+// Probe network connectivity to the member with the given address.
+func hasConnectivity(cert *shared.CertInfo, address string) bool {
+	config, err := tlsClientConfig(cert)
+	if err != nil {
+		return false
+	}
+
+	var conn net.Conn
+	dialer := &net.Dialer{Timeout: time.Second}
+	conn, err = tls.DialWithDialer(dialer, "tcp", address, config)
+	if err == nil {
+		conn.Close()
+		return true
+	}
+	return false
 }

--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -367,7 +367,7 @@ func (g *Gateway) DialFunc() client.DialFunc {
 // Dial function for establishing raft connections.
 func (g *Gateway) raftDial() client.DialFunc {
 	return func(ctx context.Context, address string) (net.Conn, error) {
-		if address == "0" {
+		if address == "1" {
 			addr, err := g.raftAddress(1)
 			if err != nil {
 				return nil, err

--- a/lxd/cluster/membership.go
+++ b/lxd/cluster/membership.go
@@ -867,21 +867,20 @@ func isMemberOnline(state *state.State, cert *shared.CertInfo, address string) (
 			return err
 		}
 		if node.IsOffline(offlineThreshold) {
-			// Even the heartbeat timestamp is not recent enough,
-			// let's try to connect to the node, just in case the
-			// heartbeat is lagging behind for some reason and the
-			// node is actually up.
-			client, err := Connect(node.Address, cert, true)
-			if err == nil {
-				_, _, err = client.GetServer()
-			}
-			online = err == nil
+			online = false
 		}
 		return nil
 	})
 	if err != nil {
 		return false, err
 	}
+	// Even if the heartbeat timestamp is not recent enough, let's try to
+	// connect to the node, just in case the heartbeat is lagging behind
+	// for some reason and the node is actually up.
+	if !online && hasConnectivity(cert, address) {
+		online = true
+	}
+
 	return online, nil
 }
 


### PR DESCRIPTION
This avoids deadlocks, since client.GetServer() might connect but not return
since it waits for the daemon to be fully up.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>