### PR TITLE
VM: Switch to unsafe async I/O mode on ZFS pools backed by files

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -52,6 +52,9 @@ import (
 	"github.com/lxc/lxd/shared/units"
 )
 
+// qemuAsyncIO is used to indicate disk should use unsafe cache I/O.
+const qemuUnsafeIO = "unsafeio"
+
 var errQemuAgentOffline = fmt.Errorf("LXD VM agent isn't currently running")
 
 var vmConsole = map[int]bool{}
@@ -1512,12 +1515,42 @@ func (vm *qemu) addRootDriveConfig(sb *strings.Builder, bootIndexes map[string]i
 		DevPath: rootDrivePath,
 	}
 
+	// If the storage pool is on ZFS and backed by a loop file and we can't use DirectIO, then resort to
+	// unsafe async I/O to avoid kernel hangs when running ZFS storage pools in an image file on another FS.
+	driverInfo := pool.Driver().Info()
+	driverConf := pool.Driver().Config()
+	if driverInfo.Name == "zfs" && !driverInfo.DirectIO && shared.PathExists(driverConf["source"]) && !shared.IsBlockdevPath(driverConf["source"]) {
+		driveConf.Opts = append(driveConf.Opts, qemuUnsafeIO)
+	}
+
 	return vm.addDriveConfig(sb, bootIndexes, driveConf)
 }
 
 // addDriveConfig adds the qemu config required for adding a supplementary drive.
 func (vm *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, driveConf deviceConfig.MountEntryItem) error {
-	devName := fmt.Sprintf(driveConf.DevName)
+	// Use native kernel async IO and O_DIRECT by default.
+	aioMode := "native"
+	cacheMode := "none" // Bypass host cache, use O_DIRECT semantics.
+
+	// If drive config indicates we need to use unsafe I/O then use it.
+	if shared.StringInSlice(qemuUnsafeIO, driveConf.Opts) {
+		logger.Warnf("Using unsafe cache I/O with %s", driveConf.DevPath)
+		aioMode = "threads"
+		cacheMode = "unsafe" // Use host cache, but ignore all sync requests from guest.
+	} else if shared.PathExists(driveConf.DevPath) && !shared.IsBlockdevPath(driveConf.DevPath) {
+		// Disk dev path is a file, check whether it is located on a ZFS filesystem.
+		fsType, err := util.FilesystemDetect(driveConf.DevPath)
+		if err != nil {
+			return errors.Wrapf(err, "Failed detecting filesystem type of %q", driveConf.DevPath)
+		}
+
+		// If FS is ZFS, avoid using direct I/O and use host page cache only.
+		if fsType == "zfs" {
+			logger.Warnf("Using writeback cache I/O with %s", driveConf.DevPath)
+			aioMode = "threads"
+			cacheMode = "writeback" // Use host cache, with neither O_DSYNC nor O_DIRECT semantics.
+		}
+	}
 
 	// Devices use "lxd_" prefix indicating that this is a user named device.
 	t := template.Must(template.New("").Parse(`
@@ -1526,8 +1559,8 @@ func (vm *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, 
 file = "{{.devPath}}"
 format = "raw"
 if = "none"
-cache = "none"
-aio = "native"
+cache = "{{.cacheMode}}"
+aio = "{{.aioMode}}"
 
 [device "dev-lxd_{{.devName}}"]
 driver = "scsi-hd"
@@ -1540,9 +1573,11 @@ bootindex = "{{.bootIndex}}"
 `))
 
 	m := map[string]interface{}{
-		"devName":   devName,
+		"devName":   driveConf.DevName,
 		"devPath":   driveConf.DevPath,
-		"bootIndex": bootIndexes[devName],
+		"bootIndex": bootIndexes[driveConf.DevName],
+		"cacheMode": cacheMode,
+		"aioMode":   aioMode,
 	}
 	return t.Execute(sb, m)
 }

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -742,17 +742,18 @@ func SetupStorageDriver(s *state.State, forceCheck bool) error {
 	}
 
 	for _, poolName := range pools {
-		logger.Debugf("Initializing and checking storage pool \"%s\"", poolName)
+		logger.Debugf("Initializing and checking storage pool %q", poolName)
+		errPrefix := fmt.Sprintf("Failed initializing storage pool %q", poolName)
 
 		pool, err := storagePools.GetPoolByName(s, poolName)
 		if err != storageDrivers.ErrUnknownDriver {
 			if err != nil {
-				return err
+				return errors.Wrap(err, errPrefix)
 			}
 
 			_, err = pool.Mount()
 			if err != nil {
-				return err
+				return errors.Wrap(err, errPrefix)
 			}
 		} else {
 			s, err := storagePoolInit(s, poolName)
@@ -763,7 +764,7 @@ func SetupStorageDriver(s *state.State, forceCheck bool) error {
 
 			err = s.StoragePoolCheck()
 			if err != nil {
-				return err
+				return errors.Wrap(err, errPrefix)
 			}
 		}
 	}

--- a/lxd/storage/drivers/driver_btrfs.go
+++ b/lxd/storage/drivers/driver_btrfs.go
@@ -74,6 +74,7 @@ func (d *btrfs) Info() Info {
 		BlockBacking:          false,
 		RunningQuotaResize:    true,
 		RunningSnapshotFreeze: false,
+		DirectIO:              true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_cephfs.go
+++ b/lxd/storage/drivers/driver_cephfs.go
@@ -69,6 +69,7 @@ func (d *cephfs) Info() Info {
 		BlockBacking:          false,
 		RunningQuotaResize:    true,
 		RunningSnapshotFreeze: false,
+		DirectIO:              true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_dir.go
+++ b/lxd/storage/drivers/driver_dir.go
@@ -38,6 +38,7 @@ func (d *dir) Info() Info {
 		BlockBacking:          false,
 		RunningQuotaResize:    true,
 		RunningSnapshotFreeze: true,
+		DirectIO:              true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -90,6 +90,7 @@ func (d *lvm) Info() Info {
 		BlockBacking:          true,
 		RunningQuotaResize:    false,
 		RunningSnapshotFreeze: false,
+		DirectIO:              true,
 	}
 }
 

--- a/lxd/storage/drivers/driver_types.go
+++ b/lxd/storage/drivers/driver_types.go
@@ -11,6 +11,7 @@ type Info struct {
 	BlockBacking          bool         // Whether driver uses block devices as backing store.
 	RunningQuotaResize    bool         // Whether quota resize is supported whilst instance running.
 	RunningSnapshotFreeze bool         // Whether instance should be frozen during snapshot if running.
+	DirectIO              bool         // Whether the driver supports direct I/O.
 }
 
 // VolumeFiller provides a struct for filling a volume.

--- a/shared/version/version.go
+++ b/shared/version/version.go
@@ -16,7 +16,7 @@ type DottedVersion struct {
 
 // NewDottedVersion returns a new Version.
 func NewDottedVersion(versionString string) (*DottedVersion, error) {
-	formatError := fmt.Errorf("Invalid version format: %s", versionString)
+	formatError := fmt.Errorf("Invalid version format: %q", versionString)
 	split := strings.Split(versionString, ".")
 	if len(split) < 2 {
 		return nil, formatError


### PR DESCRIPTION
Detects if the storage root disk is running on a ZFS pool backed by a loop file and switches to use unsafe cached I/O when using old ZFS version to avoid kernel hangs.

Additionally if a raw disk is attached to a VM that is hosted on a ZFS filesystem we switch to using writeback cached I/O and disable O_DIRECT semantics as this is not supported.

Based on reports of ZFS issues from https://discuss.linuxcontainers.org/t/testing-out-lxd-3-19-candidate/6531/37

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>