### PR TITLE
storage: Fix xfs_growfs command for older versions

### DIFF
--- a/lxd/storage/utils.go
+++ b/lxd/storage/utils.go
@@ -168,7 +168,7 @@ func GrowFileSystem(fsType string, devPath string, mntpoint string) error {
 	case "ext4":
 		msg, err = shared.TryRunCommand("resize2fs", devPath)
 	case "xfs":
-		msg, err = shared.TryRunCommand("xfs_growfs", devPath)
+		msg, err = shared.TryRunCommand("xfs_growfs", mntpoint)
 	case "btrfs":
 		msg, err = shared.TryRunCommand("btrfs", "filesystem", "resize", "max", mntpoint)
 	default:


### PR DESCRIPTION
On debian 9.9 xfs_growfs version, the binary does not accept the block
device as an argument, but the mount point. Since this behavior is also
supported on later versions, I've replaced the command from the block
device to the mount point, in order not to crash older versions of XFS.

Signed-off-by: Louis Solofrizzo <lsolofrizzo@online.net>