### PR TITLE
VM: Physical PCI passthrough

### DIFF
--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2171,10 +2171,6 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 			}
 
 			for _, nicItem := range runConf.NetworkInterface {
-				if nicItem.Key == "devName" {
-					// Skip internal device name key, not used by liblxc.
-					continue
-				}
 				err = lxcSetConfigItem(c.c, fmt.Sprintf("%s.%d.%s", networkKeyPrefix, nicID, nicItem.Key), nicItem.Value)
 				if err != nil {
 					return "", postStartHooks, errors.Wrapf(err, "Failed to setup device network interface '%s'", dev.Name)

--- a/lxd/device/device_utils_network.go
+++ b/lxd/device/device_utils_network.go
@@ -139,8 +139,8 @@ func NetworkRemoveInterface(nic string) error {
 	return err
 }
 
-// NetworkRemoveInterfaceIfNeeded removes a network interface by name but only if no other instance is using it.
-func NetworkRemoveInterfaceIfNeeded(state *state.State, nic string, current instance.Instance, parent string, vlanID string) error {
+// networkRemoveInterfaceIfNeeded removes a network interface by name but only if no other instance is using it.
+func networkRemoveInterfaceIfNeeded(state *state.State, nic string, current instance.Instance, parent string, vlanID string) error {
 	// Check if it's used by another instance.
 	instances, err := InstanceLoadNodeAll(state)
 	if err != nil {

--- a/lxd/device/infiniband_physical.go
+++ b/lxd/device/infiniband_physical.go
@@ -116,11 +116,17 @@ func (d *infinibandPhysical) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: saveData["host_name"]},
+	}
+
+	if d.inst.Type() == instancetype.VM {
+		runConf.NetworkInterface = append(runConf.NetworkInterface,
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+			}...)
 	}
 
 	return &runConf, nil

--- a/lxd/device/infiniband_sriov.go
+++ b/lxd/device/infiniband_sriov.go
@@ -138,7 +138,6 @@ func (d *infinibandSRIOV) Start() (*deviceConfig.RunConfig, error) {
 	}
 
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/device/nic_bridged.go
+++ b/lxd/device/nic_bridged.go
@@ -176,7 +176,6 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -185,8 +184,10 @@ func (d *nicBridged) Start() (*deviceConfig.RunConfig, error) {
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
-			deviceConfig.RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
-		)
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+				{Key: "hwaddr", Value: d.config["hwaddr"]},
+			}...)
 	}
 
 	return &runConf, nil

--- a/lxd/device/nic_ipvlan.go
+++ b/lxd/device/nic_ipvlan.go
@@ -232,7 +232,7 @@ func (d *nicIPVLAN) postStop() error {
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {
 		parentName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
-		err := NetworkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
+		err := networkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
 		if err != nil {
 			return err
 		}

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -134,7 +134,6 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -143,8 +142,10 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
-			deviceConfig.RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
-		)
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+				{Key: "hwaddr", Value: d.config["hwaddr"]},
+			}...)
 	}
 
 	revert.Success()

--- a/lxd/device/nic_macvlan.go
+++ b/lxd/device/nic_macvlan.go
@@ -83,7 +83,7 @@ func (d *nicMACVLAN) Start() (*deviceConfig.RunConfig, error) {
 
 	if shared.IsTrue(saveData["last_state.created"]) {
 		revert.Add(func() {
-			NetworkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
+			networkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
 		})
 	}
 
@@ -188,7 +188,7 @@ func (d *nicMACVLAN) postStop() error {
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {
 		actualParentName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
-		err := NetworkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
+		err := networkRemoveInterfaceIfNeeded(d.state, actualParentName, d.inst, d.config["parent"], d.config["vlan"])
 		if err != nil {
 			errs = append(errs, err)
 		}

--- a/lxd/device/nic_p2p.go
+++ b/lxd/device/nic_p2p.go
@@ -97,7 +97,6 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
@@ -106,8 +105,10 @@ func (d *nicP2P) Start() (*deviceConfig.RunConfig, error) {
 
 	if d.inst.Type() == instancetype.VM {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
-			deviceConfig.RunConfigItem{Key: "hwaddr", Value: d.config["hwaddr"]},
-		)
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+				{Key: "hwaddr", Value: d.config["hwaddr"]},
+			}...)
 	}
 
 	return &runConf, nil

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -111,11 +111,17 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},
 		{Key: "link", Value: saveData["host_name"]},
+	}
+
+	if d.inst.Type() == instancetype.VM {
+		runConf.NetworkInterface = append(runConf.NetworkInterface,
+			[]deviceConfig.RunConfigItem{
+				{Key: "devName", Value: d.name},
+			}...)
 	}
 
 	return &runConf, nil

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -3,9 +3,12 @@ package device
 import (
 	"fmt"
 
+	"github.com/pkg/errors"
+
 	deviceConfig "github.com/lxc/lxd/lxd/device/config"
 	"github.com/lxc/lxd/lxd/instance/instancetype"
 	"github.com/lxc/lxd/lxd/revert"
+	"github.com/lxc/lxd/lxd/util"
 	"github.com/lxc/lxd/shared"
 )
 
@@ -15,20 +18,22 @@ type nicPhysical struct {
 
 // validateConfig checks the supplied config for correctness.
 func (d *nicPhysical) validateConfig() error {
-	if d.inst.Type() != instancetype.Container {
+	if d.inst.Type() != instancetype.Container && d.inst.Type() != instancetype.VM {
 		return ErrUnsupportedDevType
 	}
 
 	requiredFields := []string{"parent"}
 	optionalFields := []string{
 		"name",
-		"mtu",
-		"hwaddr",
-		"vlan",
 		"maas.subnet.ipv4",
 		"maas.subnet.ipv6",
 		"boot.priority",
 	}
+
+	if d.inst.Type() == instancetype.Container {
+		optionalFields = append(optionalFields, "mtu", "hwaddr", "vlan")
+	}
+
 	err := d.config.Validate(nicValidationRules(requiredFields, optionalFields))
 	if err != nil {
 		return err
@@ -66,45 +71,97 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 	revert := revert.New()
 	defer revert.Fail()
 
+	// pciSlotName, used for VM physical passthrough.
+	var pciSlotName string
+
+	// If VM, then try and load the vfio-pci module first.
+	if d.inst.Type() == instancetype.VM {
+		err = util.LoadModule("vfio-pci")
+		if err != nil {
+			return nil, errors.Wrapf(err, "Error loading %q module", "vfio-pci")
+		}
+	}
+
 	// Record the host_name device used for restoration later.
 	saveData["host_name"] = NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
-	statusDev, err := NetworkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], saveData["host_name"], d.config["vlan"])
-	if err != nil {
-		return nil, err
-	}
 
-	// Record whether we created this device or not so it can be removed on stop.
-	saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
-
-	if shared.IsTrue(saveData["last_state.created"]) {
-		revert.Add(func() {
-			NetworkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
-		})
-	}
-
-	// If we didn't create the device we should track various properties so we can restore them when the
-	// instance is stopped or the device is detached.
-	if !shared.IsTrue(saveData["last_state.created"]) {
-		err = networkSnapshotPhysicalNic(saveData["host_name"], saveData)
+	if d.inst.Type() == instancetype.Container {
+		statusDev, err := NetworkCreateVlanDeviceIfNeeded(d.state, d.config["parent"], saveData["host_name"], d.config["vlan"])
 		if err != nil {
 			return nil, err
 		}
-	}
 
-	// Set the MAC address.
-	if d.config["hwaddr"] != "" {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "address", d.config["hwaddr"])
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set the MAC address: %s", err)
-		}
-	}
+		// Record whether we created this device or not so it can be removed on stop.
+		saveData["last_state.created"] = fmt.Sprintf("%t", statusDev != "existing")
 
-	// Set the MTU.
-	if d.config["mtu"] != "" {
-		_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
-		if err != nil {
-			return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+		if shared.IsTrue(saveData["last_state.created"]) {
+			revert.Add(func() {
+				NetworkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
+			})
 		}
+
+		// If we didn't create the device we should track various properties so we can restore them when the
+		// instance is stopped or the device is detached.
+		if !shared.IsTrue(saveData["last_state.created"]) {
+			err = networkSnapshotPhysicalNic(saveData["host_name"], saveData)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// Set the MAC address.
+		if d.config["hwaddr"] != "" {
+			_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "address", d.config["hwaddr"])
+			if err != nil {
+				return nil, fmt.Errorf("Failed to set the MAC address: %s", err)
+			}
+		}
+
+		// Set the MTU.
+		if d.config["mtu"] != "" {
+			_, err := shared.RunCommand("ip", "link", "set", "dev", saveData["host_name"], "mtu", d.config["mtu"])
+			if err != nil {
+				return nil, fmt.Errorf("Failed to set the MTU: %s", err)
+			}
+		}
+	} else if d.inst.Type() == instancetype.VM {
+		// Get PCI information about the network interface.
+		ueventPath := fmt.Sprintf("/sys/class/net/%s/device/uevent", saveData["host_name"])
+		pciDev, err := networkGetDevicePCIDevice(ueventPath)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Failed to get PCI device info for %q", saveData["host_name"])
+		}
+
+		saveData["last_state.pci.slot.name"] = pciDev.SlotName
+		saveData["last_state.pci.driver"] = pciDev.Driver
+
+		// Unbind the interface from the host.
+		err = networkDeviceUnbind(pciDev)
+		if err != nil {
+			return nil, err
+		}
+
+		revert.Add(func() { networkDeviceBind(pciDev) })
+
+		// Register the device with the vfio-pci module.
+		err = networkVFIOPCIRegister(pciDev)
+		if err != nil {
+			return nil, err
+		}
+
+		vfioDev := pciDevice{
+			Driver:   "vfio-pci",
+			SlotName: pciDev.SlotName,
+		}
+
+		revert.Add(func() { networkDeviceUnbind(vfioDev) })
+
+		err = networkDeviceBindWait(vfioDev)
+		if err != nil {
+			return nil, err
+		}
+
+		pciSlotName = saveData["last_state.pci.slot.name"]
 	}
 
 	err = d.volatileSet(saveData)
@@ -124,6 +181,7 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 		runConf.NetworkInterface = append(runConf.NetworkInterface,
 			[]deviceConfig.RunConfigItem{
 				{Key: "devName", Value: d.name},
+				{Key: "pciSlotName", Value: pciSlotName},
 			}...)
 	}
 
@@ -147,25 +205,51 @@ func (d *nicPhysical) Stop() (*deviceConfig.RunConfig, error) {
 // postStop is run after the device is removed from the instance.
 func (d *nicPhysical) postStop() error {
 	defer d.volatileSet(map[string]string{
-		"host_name":          "",
-		"last_state.hwaddr":  "",
-		"last_state.mtu":     "",
-		"last_state.created": "",
+		"host_name":                "",
+		"last_state.hwaddr":        "",
+		"last_state.mtu":           "",
+		"last_state.created":       "",
+		"last_state.pci.slot.name": "",
+		"last_state.pci.driver":    "",
 	})
 
 	v := d.volatileGet()
-	hostName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
 
-	// This will delete the parent interface if we created it for VLAN parent.
-	if shared.IsTrue(v["last_state.created"]) {
-		err := NetworkRemoveInterfaceIfNeeded(d.state, hostName, d.inst, d.config["parent"], d.config["vlan"])
+	// If VM physical pass through, unbind from vfio-pci and bind back to host driver.
+	if d.inst.Type() == instancetype.VM && v["last_state.pci.slot.name"] != "" {
+		vfioDev := pciDevice{
+			Driver:   "vfio-pci",
+			SlotName: v["last_state.pci.slot.name"],
+		}
+
+		err := networkDeviceUnbind(vfioDev)
 		if err != nil {
 			return err
 		}
-	} else {
-		err := networkRestorePhysicalNic(hostName, v)
+
+		hostDev := pciDevice{
+			Driver:   v["last_state.pci.driver"],
+			SlotName: v["last_state.pci.slot.name"],
+		}
+
+		err = networkDeviceBind(hostDev)
 		if err != nil {
 			return err
+		}
+	} else if d.inst.Type() == instancetype.Container {
+		hostName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
+
+		// This will delete the parent interface if we created it for VLAN parent.
+		if shared.IsTrue(v["last_state.created"]) {
+			err := NetworkRemoveInterfaceIfNeeded(d.state, hostName, d.inst, d.config["parent"], d.config["vlan"])
+			if err != nil {
+				return err
+			}
+		} else if v["last_state.pci.slot.name"] == "" {
+			err := networkRestorePhysicalNic(hostName, v)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/device/nic_physical.go
+++ b/lxd/device/nic_physical.go
@@ -96,7 +96,7 @@ func (d *nicPhysical) Start() (*deviceConfig.RunConfig, error) {
 
 		if shared.IsTrue(saveData["last_state.created"]) {
 			revert.Add(func() {
-				NetworkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
+				networkRemoveInterfaceIfNeeded(d.state, saveData["host_name"], d.inst, d.config["parent"], d.config["vlan"])
 			})
 		}
 
@@ -241,7 +241,7 @@ func (d *nicPhysical) postStop() error {
 
 		// This will delete the parent interface if we created it for VLAN parent.
 		if shared.IsTrue(v["last_state.created"]) {
-			err := NetworkRemoveInterfaceIfNeeded(d.state, hostName, d.inst, d.config["parent"], d.config["vlan"])
+			err := networkRemoveInterfaceIfNeeded(d.state, hostName, d.inst, d.config["parent"], d.config["vlan"])
 			if err != nil {
 				return err
 			}

--- a/lxd/device/nic_routed.go
+++ b/lxd/device/nic_routed.go
@@ -310,7 +310,7 @@ func (d *nicRouted) postStop() error {
 	// This will delete the parent interface if we created it for VLAN parent.
 	if shared.IsTrue(v["last_state.created"]) {
 		parentName := NetworkGetHostDevice(d.config["parent"], d.config["vlan"])
-		err := NetworkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
+		err := networkRemoveInterfaceIfNeeded(d.state, parentName, d.inst, d.config["parent"], d.config["vlan"])
 		if err != nil {
 			return err
 		}

--- a/lxd/device/nic_sriov.go
+++ b/lxd/device/nic_sriov.go
@@ -113,7 +113,6 @@ func (d *nicSRIOV) Start() (*deviceConfig.RunConfig, error) {
 
 	runConf := deviceConfig.RunConfig{}
 	runConf.NetworkInterface = []deviceConfig.RunConfigItem{
-		{Key: "devName", Value: d.name},
 		{Key: "name", Value: d.config["name"]},
 		{Key: "type", Value: "phys"},
 		{Key: "flags", Value: "up"},

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1457,7 +1457,7 @@ func (vm *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, 
 
 // addNetDevConfig adds the qemu config required for adding a network device.
 func (vm *qemu) addNetDevConfig(sb *strings.Builder, nicIndex int, bootIndexes map[string]int, nicConfig []deviceConfig.RunConfigItem, fdFiles *[]string) error {
-	var devName, nicName, devHwaddr string
+	var devName, nicName, devHwaddr, pciSlotName string
 	for _, nicItem := range nicConfig {
 		if nicItem.Key == "devName" {
 			devName = nicItem.Value
@@ -1465,6 +1465,8 @@ func (vm *qemu) addNetDevConfig(sb *strings.Builder, nicIndex int, bootIndexes m
 			nicName = nicItem.Value
 		} else if nicItem.Key == "hwaddr" {
 			devHwaddr = nicItem.Value
+		} else if nicItem.Key == "pciSlotName" {
+			pciSlotName = nicItem.Value
 		}
 	}
 
@@ -1499,6 +1501,10 @@ func (vm *qemu) addNetDevConfig(sb *strings.Builder, nicIndex int, bootIndexes m
 		// Detect TAP (via TUN driver) device.
 		tplFields["ifName"] = nicName
 		tpl = qemuNetDevTapTun
+	} else if pciSlotName != "" {
+		// Detect physical passthrough device.
+		tplFields["pciSlotName"] = pciSlotName
+		tpl = qemuNetdevPhysical
 	}
 
 	if tpl != nil {

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -220,6 +220,6 @@ var qemuNetdevPhysical = template.Must(template.New("qemuNetdevPhysical").Parse(
 # Network card ("{{.devName}}" device)
 [device "dev-lxd_{{.devName}}"]
 driver = "vfio-pci"
-host = "{{.host}}"
+host = "{{.pciSlotName}}"
 bootindex = "{{.bootIndex}}"
 `))

--- a/shared/instance.go
+++ b/shared/instance.go
@@ -418,6 +418,10 @@ func ConfigKeyChecker(key string) (func(value string) error, error) {
 		if strings.HasSuffix(key, ".ceph_rbd") {
 			return IsAny, nil
 		}
+
+		if strings.HasSuffix(key, ".driver") {
+			return IsAny, nil
+		}
 	}
 
 	if strings.HasPrefix(key, "environment.") {


### PR DESCRIPTION
This PR add support for passing through a physical network device into a VM:

Usage:

```
lxc config device add v1 eth1 nic nictype=physical parent=enp4s0f1
```

Note: At this time you may need to increase the ulimits for MEMLOCK, e.g.

/etc/security/limits.conf
```
*       soft    memlock unlimited
*       hard    memlock unlimited
```