### PR TITLE
VM: Failed startup cleanup

### DIFF
--- a/lxd/instance/drivers/qmp/monitor.go
+++ b/lxd/instance/drivers/qmp/monitor.go
@@ -154,7 +154,9 @@ func (m *Monitor) Wait() (chan struct{}, error) {
 // Disconnect forces a disconnection from QEMU.
 func (m *Monitor) Disconnect() {
 	// Stop all go routines and disconnect from socket.
-	close(m.chDisconnect)
+	if !m.disconnected {
+		close(m.chDisconnect)
+	}
 	m.disconnected = true
 	m.qmp.Disconnect()
 


### PR DESCRIPTION
If the VM start up fails for some reason, clean up devices added on the host so we don't leave stray devices around.

Also, if failure occurs after VM process is launched, then actively kill VM process if `Start()` still fails to complete cleanly.