### PR TITLE
Storage: Only detect volume.block.filesystem changes on block backed pool FS volumes

### DIFF
--- a/lxd/storage/backend_lxd.go
+++ b/lxd/storage/backend_lxd.go
@@ -1937,7 +1937,7 @@ func (b *lxdBackend) EnsureImage(fingerprint string, op *operations.Operation) e
 	// If an existing DB row was found, check if filesystem is the same as the current pool's filesystem.
 	// If not we need to delete the existing cached image volume and re-create using new filesystem.
 	if imgDBVol != nil && contentType == drivers.ContentTypeFS {
-		if imgDBVol.Config["block.filesystem"] != b.poolBlockFilesystem() {
+		if b.Driver().Info().BlockBacking && imgDBVol.Config["block.filesystem"] != b.poolBlockFilesystem() {
 			logger.Debug("Filesystem of pool has changed since cached image volume created, regenerating image volume")
 			err = b.DeleteImage(fingerprint, op)
 			if err != nil {


### PR DESCRIPTION
Fixes https://discuss.linuxcontainers.org/t/high-load-when-launching-container/6603/6

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>