### PR TITLE
Migration: Adds support for pre-bidirectional negotiation targets

### DIFF
--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -128,6 +128,12 @@ func MatchTypes(offer MigrationHeader, fallbackType MigrationFSType, ourTypes []
 				offeredFeatures = offer.GetZfsFeaturesSlice()
 			} else if offerFSType == MigrationFSType_RSYNC {
 				offeredFeatures = offer.GetRsyncFeaturesSlice()
+				if !shared.StringInSlice("bidirectional", offeredFeatures) {
+					// If no bi-directional support, this means we are getting a response from
+					// an old LXD server that doesn't support bidirectional negotiation, so
+					// assume LXD 3.7 level. NOTE: Do NOT extend this list of arguments.
+					offeredFeatures = []string{"xattrs", "delete", "compress"}
+				}
 			}
 
 			// Find common features in both our type and offered type.


### PR DESCRIPTION
Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>