### PR TITLE
Improve a first impression error message

### DIFF
--- a/lxd/container.go
+++ b/lxd/container.go
@@ -61,7 +61,7 @@ func containerValidName(name string) error {
 	}
 
 	if !shared.ValidHostname(name) {
-		return fmt.Errorf("Container name isn't a valid hostname")
+		return fmt.Errorf("Container name isn't a valid DNS hostname. Names may not contain dots.")
 	}
 
 	return nil


### PR DESCRIPTION
The first thing a new user might try to do is create a new container named after a distro: "ubuntu-18.04".

This fails with an error that the name is not valid, but wasn't clear about the problem. 

This clarifies that the container name is supposed to be a valid *DNS* hostname. Since dots seem like a common problem in potential container names, those are called out specifically as a problem.