### PR TITLE
lxd/storage/drivers: Pass mountPath to xfs_growfs

### DIFF
--- a/lxd/storage/drivers/utils.go
+++ b/lxd/storage/drivers/utils.go
@@ -472,7 +472,7 @@ func growFileSystem(fsType string, devPath string, vol Volume) error {
 		case "ext4":
 			msg, err = shared.TryRunCommand("resize2fs", devPath)
 		case "xfs":
-			msg, err = shared.TryRunCommand("xfs_growfs", devPath)
+			msg, err = shared.TryRunCommand("xfs_growfs", mountPath)
 		case "btrfs":
 			msg, err = shared.TryRunCommand("btrfs", "filesystem", "resize", "max", mountPath)
 		default:


### PR DESCRIPTION
As the man page suggests, xfs_growfs should take the mount point, not
the dev path.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>