### PR TITLE
Storage: Fixes concurrent access race to map

### DIFF
--- a/lxd/storage/locking/lock.go
+++ b/lxd/storage/locking/lock.go
@@ -27,12 +27,12 @@ func Lock(poolName string, volType string, volName string) func() {
 		// Get exclusive access to the map and see if there is already an operation ongoing.
 		ongoingOperationMapLock.Lock()
 		waitCh, ok := ongoingOperationMap[lockID]
-		ongoingOperationMapLock.Unlock()
 
 		if !ok {
 			// No ongoing operation, create a new channel to indicate our new operation.
 			waitCh = make(chan struct{})
 			ongoingOperationMap[lockID] = waitCh
+			ongoingOperationMapLock.Unlock()
 
 			// Return a function that will complete the operation.
 			return func() {
@@ -59,6 +59,7 @@ func Lock(poolName string, volType string, volName string) func() {
 
 		// An existing operation is ongoing, lets wait for that to finish and then try
 		// to get exlusive access to create a new operation again.
+		ongoingOperationMapLock.Unlock()
 		<-waitCh
 	}
 }


### PR DESCRIPTION
There is a race modifying the lock map with a new lock channel for a named lock which causes hangs during high load benchmarks.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>