### PR TITLE
VM: forklimits

### DIFF
--- a/lxd/main.go
+++ b/lxd/main.go
@@ -131,6 +131,10 @@ func main() {
 	forkfileCmd := cmdForkfile{global: &globalCmd}
 	app.AddCommand(forkfileCmd.Command())
 
+	// forklimits sub-command
+	forklimitsCmd := cmdForklimits{global: &globalCmd}
+	app.AddCommand(forklimitsCmd.Command())
+
 	// forkmigrate sub-command
 	forkmigrateCmd := cmdForkmigrate{global: &globalCmd}
 	app.AddCommand(forkmigrateCmd.Command())

--- a/lxd/main.go
+++ b/lxd/main.go
@@ -71,6 +71,17 @@ func (c *cmdGlobal) Run(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// rawArgs returns the raw unprocessed arguments from os.Args after the command name arg is found.
+func (c *cmdGlobal) rawArgs(cmd *cobra.Command) []string {
+	for i, arg := range os.Args {
+		if arg == cmd.Name() && len(os.Args)-1 > i {
+			return os.Args[i+1:]
+		}
+	}
+
+	return []string{}
+}
+
 func main() {
 	// daemon command (main)
 	daemonCmd := cmdDaemon{}


### PR DESCRIPTION
- Adds `forklimits` command for launching a process with locally changed rlimits.
- Switches qemu process to use `forklimits` with unlimited `memlock` rlimit for PCI passthrough.