### PR TITLE
Storage: Fixes migrate refresh final sync snapshot bug

### DIFF
--- a/lxd/migrate_container.go
+++ b/lxd/migrate_container.go
@@ -754,8 +754,10 @@ func (s *migrationSourceWs) Do(state *state.State, migrateOp *operations.Operati
 	// Perform final sync if in multi sync mode.
 	if volSourceArgs.MultiSync {
 		if pool != nil {
-			// Indicate to the storage driver we are doing final sync.
+			// Indicate to the storage driver we are doing final sync and because of this don't send
+			// snapshots as they don't need to have a final sync as not being modified.
 			volSourceArgs.FinalSync = true
+			volSourceArgs.Snapshots = nil
 
 			err = pool.MigrateInstance(s.instance, &shared.WebsocketIO{Conn: s.fsConn}, volSourceArgs, migrateOp)
 			if err != nil {

--- a/lxd/migration/migration_volumes.go
+++ b/lxd/migration/migration_volumes.go
@@ -25,7 +25,7 @@ type VolumeSourceArgs struct {
 	TrackProgress bool
 	MultiSync     bool
 	FinalSync     bool
-	Data          interface{}
+	Data          interface{} // Optional store to persist storage driver state between MultiSync phases.
 }
 
 // VolumeTargetArgs represents the arguments needed to setup a volume migration sink.

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -1040,7 +1040,7 @@ func (d *zfs) MigrateVolume(vol Volume, conn io.ReadWriteCloser, volSrcArgs *mig
 				defer shared.RunCommand("zfs", "destroy", finalParent)
 				defer shared.RunCommand("zfs", "destroy", srcSnapshot)
 			} else {
-				volSrcArgs.Data = srcSnapshot
+				volSrcArgs.Data = srcSnapshot // Persist parent state for final sync.
 			}
 		} else {
 			defer shared.RunCommand("zfs", "destroy", srcSnapshot)


### PR DESCRIPTION
When a container is running, and has a new snapshot to sync during refresh mode, after the snapshot has been synced initially, it is also still sent as part of the final sync stage, which is not needed as snapshots are not being modified.

Reported from: https://discuss.linuxcontainers.org/t/snapshots-should-not-be-transferred-during-final-sync/6677

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>