### PR TITLE
Network: Adds "network" property to bridged NIC device

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -908,3 +908,7 @@ Adds support for unix char and block device hotplugging.
 
 ## api\_filtering
 Adds support for filtering the result of a GET request for instances and images.
+
+## instance\_nic\_network
+Adds support for the `network` property on a NIC device to allow a NIC to be linked to a managed network.
+This allows it to inherit some of the network's settings and allows better validation of IP settings.

--- a/doc/instances.md
+++ b/doc/instances.md
@@ -292,6 +292,7 @@ Device configuration properties:
 Key                      | Type      | Default           | Required  | Description
 :--                      | :--       | :--               | :--       | :--
 parent                   | string    | -                 | yes       | The name of the host device
+network                  | string    | -                 | yes       | The LXD network to link device to (instead of parent)
 name                     | string    | kernel assigned   | no        | The name of the interface inside the instance
 mtu                      | integer   | parent MTU        | no        | The MTU of the new interface
 hwaddr                   | string    | randomly assigned | no        | The MAC address of the new interface

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -2056,7 +2056,7 @@ func (c *containerLXC) startCommon() (string, []func() error, error) {
 		// Start the device.
 		runConf, err := c.deviceStart(dev.Name, dev.Config, false)
 		if err != nil {
-			return "", postStartHooks, errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+			return "", postStartHooks, errors.Wrapf(err, "Failed to start device %q", dev.Name)
 		}
 
 		if runConf == nil {
@@ -4627,13 +4627,13 @@ func (c *containerLXC) updateDevices(removeDevices deviceConfig.Devices, addDevi
 			if err == device.ErrUnsupportedDevType {
 				continue // No point in trying to remove device below.
 			} else if err != nil {
-				return errors.Wrapf(err, "Failed to stop device '%s'", dev.Name)
+				return errors.Wrapf(err, "Failed to stop device %q", dev.Name)
 			}
 		}
 
 		err := c.deviceRemove(dev.Name, dev.Config)
 		if err != nil && err != device.ErrUnsupportedDevType {
-			return errors.Wrapf(err, "Failed to remove device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to remove device %q", dev.Name)
 		}
 
 		// Check whether we are about to add the same device back with updated config and
@@ -4641,7 +4641,7 @@ func (c *containerLXC) updateDevices(removeDevices deviceConfig.Devices, addDevi
 		// this device (as its an actual removal or a device type change).
 		err = c.deviceResetVolatile(dev.Name, dev.Config, addDevices[dev.Name])
 		if err != nil {
-			return errors.Wrapf(err, "Failed to reset volatile data for device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to reset volatile data for device %q", dev.Name)
 		}
 	}
 
@@ -4651,13 +4651,13 @@ func (c *containerLXC) updateDevices(removeDevices deviceConfig.Devices, addDevi
 		if err == device.ErrUnsupportedDevType {
 			continue // No point in trying to start device below.
 		} else if err != nil {
-			return errors.Wrapf(err, "Failed to add device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to add device %q", dev.Name)
 		}
 
 		if isRunning {
 			_, err := c.deviceStart(dev.Name, dev.Config, isRunning)
 			if err != nil && err != device.ErrUnsupportedDevType {
-				return errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+				return errors.Wrapf(err, "Failed to start device %q", dev.Name)
 			}
 		}
 	}
@@ -4665,7 +4665,7 @@ func (c *containerLXC) updateDevices(removeDevices deviceConfig.Devices, addDevi
 	for _, dev := range updateDevices.Sorted() {
 		err := c.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices, isRunning)
 		if err != nil && err != device.ErrUnsupportedDevType {
-			return errors.Wrapf(err, "Failed to update device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to update device %q", dev.Name)
 		}
 	}
 

--- a/lxd/device/nic.go
+++ b/lxd/device/nic.go
@@ -31,6 +31,7 @@ func nicValidationRules(requiredFields []string, optionalFields []string) map[st
 	defaultValidators := map[string]func(value string) error{
 		"name":                    shared.IsAny,
 		"parent":                  shared.IsAny,
+		"network":                 shared.IsAny,
 		"mtu":                     shared.IsAny,
 		"vlan":                    shared.IsAny,
 		"hwaddr":                  networkValidMAC,

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -655,7 +655,7 @@ func (vm *qemu) Start(stateful bool) error {
 		runConf, err := vm.deviceStart(dev.Name, dev.Config, false)
 		if err != nil {
 			op.Done(err)
-			return errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to start device %q", dev.Name)
 		}
 
 		if runConf == nil {
@@ -667,7 +667,7 @@ func (vm *qemu) Start(stateful bool) error {
 			revert.Add(func() {
 				err := vm.deviceStop(localDev.Name, localDev.Config)
 				if err != nil {
-					logger.Errorf("Failed to cleanup device '%s': %v", localDev.Name, err)
+					logger.Errorf("Failed to cleanup device %q: %v", localDev.Name, err)
 				}
 			})
 		}(dev)
@@ -2303,13 +2303,13 @@ func (vm *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices dev
 			if err == device.ErrUnsupportedDevType {
 				continue // No point in trying to remove device below.
 			} else if err != nil {
-				return errors.Wrapf(err, "Failed to stop device '%s'", dev.Name)
+				return errors.Wrapf(err, "Failed to stop device %q", dev.Name)
 			}
 		}
 
 		err := vm.deviceRemove(dev.Name, dev.Config)
 		if err != nil && err != device.ErrUnsupportedDevType {
-			return errors.Wrapf(err, "Failed to remove device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to remove device %q", dev.Name)
 		}
 
 		// Check whether we are about to add the same device back with updated config and
@@ -2317,7 +2317,7 @@ func (vm *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices dev
 		// this device (as its an actual removal or a device type change).
 		err = vm.deviceResetVolatile(dev.Name, dev.Config, addDevices[dev.Name])
 		if err != nil {
-			return errors.Wrapf(err, "Failed to reset volatile data for device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to reset volatile data for device %q", dev.Name)
 		}
 	}
 
@@ -2327,13 +2327,13 @@ func (vm *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices dev
 		if err == device.ErrUnsupportedDevType {
 			continue // No point in trying to start device below.
 		} else if err != nil {
-			return errors.Wrapf(err, "Failed to add device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to add device %q", dev.Name)
 		}
 
 		if isRunning {
 			_, err := vm.deviceStart(dev.Name, dev.Config, isRunning)
 			if err != nil && err != device.ErrUnsupportedDevType {
-				return errors.Wrapf(err, "Failed to start device '%s'", dev.Name)
+				return errors.Wrapf(err, "Failed to start device %q", dev.Name)
 			}
 		}
 	}
@@ -2341,7 +2341,7 @@ func (vm *qemu) updateDevices(removeDevices deviceConfig.Devices, addDevices dev
 	for _, dev := range updateDevices.Sorted() {
 		err := vm.deviceUpdate(dev.Name, dev.Config, oldExpandedDevices, isRunning)
 		if err != nil && err != device.ErrUnsupportedDevType {
-			return errors.Wrapf(err, "Failed to update device '%s'", dev.Name)
+			return errors.Wrapf(err, "Failed to update device %q", dev.Name)
 		}
 	}
 

--- a/lxd/network/network.go
+++ b/lxd/network/network.go
@@ -543,7 +543,7 @@ func (n *Network) setup(oldConfig map[string]string) error {
 
 		// Update the dnsmasq config
 		dnsmasqCmd = append(dnsmasqCmd, []string{fmt.Sprintf("--listen-address=%s", ip.String()), "--enable-ra"}...)
-		if n.config["ipv6.dhcp"] == "" || shared.IsTrue(n.config["ipv6.dhcp"]) {
+		if n.HasDHCPv6() {
 			if n.config["ipv6.firewall"] == "" || shared.IsTrue(n.config["ipv6.firewall"]) {
 				// Setup basic iptables overrides for DHCP/DNS
 				n.state.Firewall.NetworkSetupIPv6DNSOverrides(n.name)
@@ -1590,7 +1590,10 @@ func (n *Network) HasDHCPv4() bool {
 	return false
 }
 
-// HasDHCPv6 indicates whether the network has DHCPv6 enabled.
+// HasDHCPv6 indicates whether the network has DHCPv6 enabled (includes stateless SLAAC router advertisement mode).
+// Technically speaking stateless SLAAC RA mode isn't DHCPv6, but for consistency with LXD's config paradigm, DHCP
+// here means "an ability to automatically allocate IPs and routes", rather than stateful DHCP with leases.
+// To check if true stateful DHCPv6 is enabled check the "ipv6.dhcp.stateful" config key.
 func (n *Network) HasDHCPv6() bool {
 	if n.config["ipv6.dhcp"] == "" || shared.IsTrue(n.config["ipv6.dhcp"]) {
 		return true

--- a/lxd/network/network.go
+++ b/lxd/network/network.go
@@ -38,6 +38,12 @@ const ForkdnsServersListFile = "servers.conf"
 
 var forkdnsServersLock sync.Mutex
 
+// DHCPRange represents a range of IPs from start to end.
+type DHCPRange struct {
+	Start net.IP
+	End   net.IP
+}
+
 // Network represents a LXD network.
 type Network struct {
 	// Properties
@@ -1600,4 +1606,44 @@ func (n *Network) HasDHCPv6() bool {
 	}
 
 	return false
+}
+
+// DHCPv4Ranges returns a parsed set of DHCPv4 ranges for this network.
+func (n *Network) DHCPv4Ranges() []DHCPRange {
+	dhcpRanges := make([]DHCPRange, 0)
+	if n.config["ipv4.dhcp.ranges"] != "" {
+		for _, r := range strings.Split(n.config["ipv4.dhcp.ranges"], ",") {
+			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
+			if len(parts) == 2 {
+				startIP := net.ParseIP(parts[0])
+				endIP := net.ParseIP(parts[1])
+				dhcpRanges = append(dhcpRanges, DHCPRange{
+					Start: startIP.To4(),
+					End:   endIP.To4(),
+				})
+			}
+		}
+	}
+
+	return dhcpRanges
+}
+
+// DHCPv6Ranges returns a parsed set of DHCPv6 ranges for this network.
+func (n *Network) DHCPv6Ranges() []DHCPRange {
+	dhcpRanges := make([]DHCPRange, 0)
+	if n.config["ipv6.dhcp.ranges"] != "" {
+		for _, r := range strings.Split(n.config["ipv6.dhcp.ranges"], ",") {
+			parts := strings.SplitN(strings.TrimSpace(r), "-", 2)
+			if len(parts) == 2 {
+				startIP := net.ParseIP(parts[0])
+				endIP := net.ParseIP(parts[1])
+				dhcpRanges = append(dhcpRanges, DHCPRange{
+					Start: startIP.To16(),
+					End:   endIP.To16(),
+				})
+			}
+		}
+	}
+
+	return dhcpRanges
 }

--- a/lxd/networks_config.go
+++ b/lxd/networks_config.go
@@ -102,6 +102,9 @@ var networkConfigKeys = map[string]func(value string) error{
 	},
 
 	"raw.dnsmasq": shared.IsAny,
+
+	"maas.subnet.ipv4": shared.IsAny,
+	"maas.subnet.ipv6": shared.IsAny,
 }
 
 func networkValidateConfig(name string, config map[string]string) error {

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -186,6 +186,7 @@ var APIExtensions = []string{
 	"vm_boot_priority",
 	"unix_hotplug_devices",
 	"api_filtering",
+	"instance_nic_network",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
Introduces the concept of a "linked network" for `bridged` NIC devices using the `network` property.

When a bridged NIC device is linked to a LXD network some of the options will go away and instead be controlled globally at the network level.

These options will be inherited from the network and *not* be configurable on the instance device:

* `parent`
* `mtu`
* `maas.subnet.ipv4`
* `maas.subnet.ipv6`

This also adds stricter enforcement of `ipv4.address` and `ipv6.address` as it uses info from the linked network to validate subnet properly and whether the options are supported by parent network (i.e. DHCP enabled).

Fixes https://github.com/lxc/lxd/issues/5890