### PR TITLE
Define MS_LAZYTIME for compatibility with older glibc

### DIFF
--- a/lxd/seccomp/seccomp.go
+++ b/lxd/seccomp/seccomp.go
@@ -248,6 +248,10 @@ static void prepare_seccomp_iovec(struct iovec *iov,
 	iov[3].iov_base = cookie;
 	iov[3].iov_len = SECCOMP_COOKIE_SIZE;
 }
+
+#ifndef MS_LAZYTIME
+#define MS_LAZYTIME (1<<25)
+#endif
 */
 import "C"
 


### PR DESCRIPTION
When trying to build >=lxd-3.19 on CentOS 7, I end up with an error that MS_LAZYTIME is not defined:

```
[...]
cd /builddir/build/BUILD/lxd-3.20/_output/src/github.com/lxc/lxd/lxd/operations
/usr/lib/golang/pkg/tool/linux_amd64/compile -o $WORK/b271/_pkg_.a -trimpath "$WORK/b271=>" -shared -p github.com/lxc/lxd/lxd/operations -complete -installsuffix shared -buildid BxjqF6JDqzJaVS_Ni7TT/BxjqF6JDqzJaVS_Ni7TT -goversion go1.13.3 -D "" -importcfg $WORK/b271/importcfg -pack ./linux.go ./operations.go ./response.go ./websocket.go      
/usr/lib/golang/pkg/tool/linux_amd64/buildid -w $WORK/b249/_pkg_.a # internal
cp $WORK/b249/_pkg_.a /builddir/.cache/go-build/a6/a6dd409adfbf0a94a35d59b7e699d3d6dfa276fd5b8beddf7652a78aa193d139-d # internal
/usr/lib/golang/pkg/tool/linux_amd64/buildid -w $WORK/b199/_pkg_.a # internal                                          
cp $WORK/b199/_pkg_.a /builddir/.cache/go-build/f6/f6169aa3398e3228634fd7555cb49d596ecb77334f6183a355258664ec482dd3-d # internal
# github.com/lxc/lxd/lxd/seccomp
_output/src/github.com/lxc/lxd/lxd/seccomp/seccomp.go:1194:40: could not determine kind of name for C.MS_LAZYTIME
```

Checking `/usr/include/sys/mount.h` (glibc-2.17) in the buildroot show that it doesn't know about this mount flag yet.

As suggested by @stgraber [here](https://discuss.linuxcontainers.org/t/lxd-3-19-on-centos-7-via-copr/6696/2), this commit defines the flag in case it's unknown.