### PR TITLE
Storage: Adds updateFromV23 DB patch to ensure lvm.vg_name

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -815,7 +815,7 @@ func (d *Daemon) init() error {
 
 	/* Read the storage pools */
 	logger.Infof("Initializing storage pools")
-	err = SetupStorageDriver(d.State(), false)
+	err = setupStorageDriver(d.State(), false)
 	if err != nil {
 		return err
 	}

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -808,41 +808,41 @@ func (d *Daemon) init() error {
 		containersRestart(s)
 	}
 
-	// Setup the user-agent
+	// Setup the user-agent.
 	if clustered {
 		version.UserAgentFeatures([]string{"cluster"})
 	}
 
-	/* Read the storage pools */
+	// Read the storage pools.
 	logger.Infof("Initializing storage pools")
 	err = setupStorageDriver(d.State(), false)
 	if err != nil {
 		return err
 	}
 
-	// Mount any daemon storage
+	// Mount any daemon storage.
 	err = daemonStorageMount(d.State())
 	if err != nil {
 		return err
 	}
 
-	/* Apply all patches */
+	// Apply all patches.
 	err = patchesApplyAll(d)
 	if err != nil {
 		return err
 	}
 
-	/* Setup the networks */
+	// Setup the networks.
 	logger.Infof("Initializing networks")
 	err = networkStartup(d.State())
 	if err != nil {
 		return err
 	}
 
-	// Cleanup leftover images
+	// Cleanup leftover images.
 	pruneLeftoverImages(d)
 
-	/* Setup the proxy handler, external authentication and MAAS */
+	// Setup the proxy handler, external authentication and MAAS.
 	candidAPIURL := ""
 	candidAPIKey := ""
 	candidDomains := ""

--- a/lxd/db/cluster/schema.go
+++ b/lxd/db/cluster/schema.go
@@ -495,5 +495,5 @@ CREATE TABLE storage_volumes_config (
     FOREIGN KEY (storage_volume_id) REFERENCES storage_volumes (id) ON DELETE CASCADE
 );
 
-INSERT INTO schema (version, updated_at) VALUES (23, strftime("%s"))
+INSERT INTO schema (version, updated_at) VALUES (24, strftime("%s"))
 `

--- a/lxd/db/cluster/update.go
+++ b/lxd/db/cluster/update.go
@@ -174,12 +174,12 @@ CREATE TABLE images_profiles (
 	FOREIGN KEY (profile_id) REFERENCES profiles (id) ON DELETE CASCADE,
 	UNIQUE (image_id, profile_id)
 );
-INSERT INTO images_profiles (image_id, profile_id) 
+INSERT INTO images_profiles (image_id, profile_id)
 	SELECT images.id, profiles.id FROM images
 	JOIN profiles ON images.project_id = profiles.project_id
 	WHERE profiles.name = 'default';
 INSERT INTO images_profiles (image_id, profile_id)
-	SELECT images.id, profiles.id FROM projects_config AS R 
+	SELECT images.id, profiles.id FROM projects_config AS R
 	JOIN projects_config AS S ON R.project_id = S.project_id
 	JOIN images ON images.project_id = R.project_id
 	JOIN profiles ON profiles.project_id = 1 AND profiles.name = "default"

--- a/lxd/patches.go
+++ b/lxd/patches.go
@@ -451,7 +451,7 @@ func patchStorageApi(name string, d *Daemon) error {
 		return err
 	}
 
-	return SetupStorageDriver(d.State(), true)
+	return setupStorageDriver(d.State(), true)
 }
 
 func upgradeFromStorageTypeBtrfs(name string, d *Daemon, defaultPoolName string, defaultStorageTypeName string, cRegular []string, cSnapshots []string, imgPublic []string, imgPrivate []string) error {

--- a/lxd/storage.go
+++ b/lxd/storage.go
@@ -711,7 +711,7 @@ func resetContainerDiskIdmap(container *containerLXC, srcIdmap *idmap.IdmapSet) 
 	return nil
 }
 
-func SetupStorageDriver(s *state.State, forceCheck bool) error {
+func setupStorageDriver(s *state.State, forceCheck bool) error {
 	pools, err := s.Cluster.StoragePoolsNotPending()
 	if err != nil {
 		if err == db.ErrNoSuchObject {

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -479,6 +479,10 @@ func (d *lvm) Update(changedConfig map[string]string) error {
 // Mount mounts the storage pool (this does nothing for external LVM pools, but for loopback image
 // LVM pools this creates a loop device).
 func (d *lvm) Mount() (bool, error) {
+	if d.config["lvm.vg_name"] == "" {
+		return false, fmt.Errorf("Cannot mount pool as %q is not specified", "lvm.vg_name")
+	}
+
 	// Open the loop file if the LVM device doesn't exist yet and the source points to a file.
 	if !shared.IsDir(fmt.Sprintf("/dev/%s", d.config["lvm.vg_name"])) && filepath.IsAbs(d.config["source"]) && !shared.IsBlockdevPath(d.config["source"]) {
 		loopFile, err := d.openLoopFile(d.config["source"])

--- a/lxd/storage/drivers/driver_lvm.go
+++ b/lxd/storage/drivers/driver_lvm.go
@@ -466,11 +466,11 @@ func (d *lvm) Update(changedConfig map[string]string) error {
 	}
 
 	if changedConfig["lvm.thinpool_name"] != "" {
-		_, err := shared.TryRunCommand("lvrename", d.config["lvm.vg_name"], d.config["lvm.thinpool_name"], changedConfig["lvm.thinpool_name"])
+		_, err := shared.TryRunCommand("lvrename", d.config["lvm.vg_name"], d.thinpoolName(), changedConfig["lvm.thinpool_name"])
 		if err != nil {
-			return errors.Wrapf(err, "Error renaming LVM thin pool from %q to %q", d.config["lvm.thinpool_name"], changedConfig["lvm.thinpool_name"])
+			return errors.Wrapf(err, "Error renaming LVM thin pool from %q to %q", d.thinpoolName(), changedConfig["lvm.thinpool_name"])
 		}
-		d.logger.Debug("Thin pool volume renamed", log.Ctx{"vg_name": d.config["lvm.vg_name"], "thinpool": d.config["lvm.thinpool_name"], "new_thinpool": changedConfig["lvm.thinpool_name"]})
+		d.logger.Debug("Thin pool volume renamed", log.Ctx{"vg_name": d.config["lvm.vg_name"], "thinpool": d.thinpoolName(), "new_thinpool": changedConfig["lvm.thinpool_name"]})
 	}
 
 	return nil

--- a/lxd/storage/drivers/driver_zfs.go
+++ b/lxd/storage/drivers/driver_zfs.go
@@ -50,7 +50,10 @@ func (d *zfs) load() error {
 	}
 
 	// Load the kernel module.
-	util.LoadModule("zfs")
+	err := util.LoadModule("zfs")
+	if err != nil {
+		return errors.Wrapf(err, "Error loading %q module", "zfs")
+	}
 
 	// Validate the needed tools are present.
 	for _, tool := range []string{"zpool", "zfs"} {


### PR DESCRIPTION
Related to https://github.com/lxc/lxd/issues/6828

Adds `updateFromV23` DB patch to ensure that older storage pools that do not have the `lvm.vg_name` config property set will have it set to the pool name.