### PR TITLE
Device: Fixes ebtables filter leak with Bridged NIC on umanaged bridge

### DIFF
--- a/test/suites/container_devices_nic_bridged_filtering.sh
+++ b/test/suites/container_devices_nic_bridged_filtering.sh
@@ -376,7 +376,12 @@ test_container_devices_nic_bridged_filtering() {
     echo "Shouldn't be able to unset IPv6 address with ipv4_filtering enabled and DHCPv6 disabled"
   fi
 
+  # Delete container and check filters are cleaned up.
   lxc delete -f "${ctPrefix}A"
+  if ebtables --concurrent -L --Lmac2 --Lx | grep -e "${ctAHost}" ; then
+      echo "ebtables filter still applied after delete"
+      false
+  fi
 
   # Test MAC filtering on unmanaged bridge.
   ip link add "${brName}2" type bridge


### PR DESCRIPTION
If using a `bridged` NIC connected to an unmanaged bridge (or one that didn't use DHCP) with static IPs assigned (just for filtering purposes not DHCP allocation) then when the device is stopped the static IPs defined in config were not considered when removing filters.

This could lead to ebtables filter rules leaks. 

Adds a test for this scenario too.

Includes https://github.com/lxc/lxd/pull/6851