### PR TITLE
Unlock when isLeader failure

### DIFF
--- a/lxd/cluster/gateway.go
+++ b/lxd/cluster/gateway.go
@@ -700,6 +700,7 @@ func (g *Gateway) waitLeadership() error {
 		g.lock.RLock()
 		isLeader, err := g.isLeader()
 		if err != nil {
+			g.lock.RUnlock()
 			return err
 		}
 		if isLeader {


### PR DESCRIPTION
The following ensures that when requesting isLeader and an error is
returned, that the code correctly unlocks, otherwise you could end up
with a lockup.

I'm unsure how often this would happen, I found this just looking over
the codebase.