### PR TITLE
Consider the default port when checking address overlap

### DIFF
--- a/lxd/util/net.go
+++ b/lxd/util/net.go
@@ -138,6 +138,9 @@ func NetworkInterfaceAddress() string {
 // address2, in the sense that they are either the same address or address2 is
 // specified using a wildcard with the same port of address1.
 func IsAddressCovered(address1, address2 string) bool {
+	address1 = CanonicalNetworkAddress(address1)
+	address2 = CanonicalNetworkAddress(address2)
+
 	if address1 == address2 {
 		return true
 	}

--- a/lxd/util/net_test.go
+++ b/lxd/util/net_test.go
@@ -71,6 +71,7 @@ func TestIsAddressCovered(t *testing.T) {
 		{"[::1]:8443", ":8443", true},
 		{":8443", "[::]:8443", true},
 		{"0.0.0.0:8443", "[::]:8443", true},
+		{"10.30.0.8:8443", "[::]", true},
 	}
 
 	// Test some localhost cases too


### PR DESCRIPTION
Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>