### PR TITLE
VM: Further attempts to fix VM exec instability

### DIFF
--- a/shared/network.go
+++ b/shared/network.go
@@ -211,7 +211,7 @@ func WebsocketRecvStream(w io.Writer, conn *websocket.Conn) chan bool {
 			}
 
 			if err != nil {
-				logger.Debugf("Got error getting next reader %s, %s", err, w)
+				logger.Debugf("Got error getting next reader %s", err)
 				break
 			}
 


### PR DESCRIPTION
- Adds ability to switch `WebsocketExecMirror` from using custom `poll` to using standard `read`.
- Closes PTYs earlier to prevent `WebsocketExecMirror` from blocking on reading of file handle.
