### PR TITLE
Revert "lxd/instance/drivers/driver/qemu: Fix go routine leak and hanging lxc clients

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -2904,14 +2904,7 @@ func (vm *qemu) Exec(req api.InstanceExecPost, stdin *os.File, stdout *os.File, 
 			return nil, err
 		}
 
-		revert.Add(func() {
-			termios.Restore(int(stdin.Fd()), oldttystate)
-
-			// Write a reset escape sequence to the console to cancel any ongoing reads to the handle
-			// and then close it.
-			stdout.Write([]byte("\x1bc"))
-			stdout.Close()
-		})
+		revert.Add(func() { termios.Restore(int(stdin.Fd()), oldttystate) })
 	}
 
 	dataDone := make(chan bool)


### PR DESCRIPTION
This reverts commit 78b4b396c8413e4b6e6c32317611d0fead72d09b.

This is because although it fixes the hanging lxc clients and leaking go routines, it also introduces a regression when using `lxc exec` without a single command that is expected to output data directly to the console.

With the escape sequence being sent, this was intermittently wiping out the output of the command.

Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>