### PR TITLE
Firewall: nftables driver

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -918,3 +918,5 @@ Support specifying a custom values for database voters and standbys.
 The new cluster.max_voters and cluster.max_standby configuration keys were introduced
 to specify to the ideal number of database voter and standbys.
 
+## firewall\_driver
+Adds the `Firewall` property to the ServerEnvironment struct indicating the firewall driver being used.

--- a/lxd/api_1.0.go
+++ b/lxd/api_1.0.go
@@ -203,6 +203,7 @@ func api10Get(d *Daemon, r *http.Request) response.Response {
 		ServerVersion:          version.Version,
 		ServerClustered:        clustered,
 		ServerName:             serverName,
+		Firewall:               fmt.Sprintf("%s", d.firewall),
 	}
 
 	env.KernelFeatures = map[string]string{

--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -784,6 +784,7 @@ func (d *Daemon) init() error {
 	}
 
 	d.firewall = firewall.New()
+	logger.Infof("Firewall loaded driver %q", d.firewall)
 
 	err = cluster.NotifyUpgradeCompleted(d.State(), certInfo)
 	if err != nil {

--- a/lxd/firewall/drivers/drivers_nftables.go
+++ b/lxd/firewall/drivers/drivers_nftables.go
@@ -1,0 +1,441 @@
+package drivers
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	"strings"
+	"text/template"
+
+	"github.com/pkg/errors"
+
+	deviceConfig "github.com/lxc/lxd/lxd/device/config"
+	"github.com/lxc/lxd/lxd/project"
+	"github.com/lxc/lxd/shared"
+	"github.com/lxc/lxd/shared/logger"
+	"github.com/lxc/lxd/shared/version"
+)
+
+const nftablesNamespace = "lxd"
+const nftablesContentTemplate = "nftablesContent"
+
+// nftablesChainSeparator The "." character is specifically chosen here so as to prevent the ability for collisions
+// between project prefix (which is empty if project is default) and device name combinations that both are allowed
+// to contain underscores (where as instance name is not).
+const nftablesChainSeparator = "."
+
+// nftablesMinVersion We need at least 0.9.1 as this was when the arp ether saddr filters were added.
+const nftablesMinVersion = "0.9.1"
+
+// Nftables is an implmentation of LXD firewall using nftables.
+type Nftables struct{}
+
+// String returns the driver name.
+func (d Nftables) String() string {
+	return "nftables"
+}
+
+// Compat returns whether the host is compatible with this driver and whether the driver backend is in use.
+func (d Nftables) Compat() (bool, bool) {
+	// Check if nftables nft command exists, if not use xtables.
+	_, err := exec.LookPath("nft")
+	if err != nil {
+		return false, false
+	}
+
+	// Get nftables version.
+	nftVersion, err := d.hostVersion()
+	if err != nil {
+		logger.Debugf("Firewall nftables failed detecting nft version: %v", err)
+		return false, false
+	}
+
+	// Check nft version meets minimum required.
+	minVer, _ := version.NewDottedVersion(nftablesMinVersion)
+	if nftVersion.Compare(minVer) < 0 {
+		logger.Debugf("Firewall nftables detected nft version %q is too low, need %q or above", nftVersion, nftablesMinVersion)
+		return false, false
+	}
+
+	// Check whether in use by parsing ruleset and looking for existing rules.
+	ruleset, err := d.nftParseRuleset()
+	if err != nil {
+		logger.Errorf("Firewall nftables unable to parse existing ruleset: %v", err)
+		return true, false
+	}
+
+	for _, item := range ruleset {
+		if item.Type == "rule" {
+			return true, true // At least one rule found indicates in use.
+		}
+	}
+
+	return true, false
+}
+
+// nftGenericItem represents some common fields amongst the different nftables types.
+type nftGenericItem struct {
+	Type   string // Type of item (table, chain or rule).
+	Family string `json:"family"` // Family of item (ip, ip6, bridge etc).
+	Table  string `json:"table"`  // Table the item belongs to (for chains and rules).
+	Chain  string `json:"chain"`  // Chain the item belongs to (for rules).
+	Name   string `json:"name"`   // Name of item (for tables and chains).
+}
+
+// nftParseRuleset parses the ruleset and returns the generic parts as a slice of items.
+func (d Nftables) nftParseRuleset() ([]nftGenericItem, error) {
+	// Dump ruleset as JSON. Use -nn flags to avoid doing DNS lookups of IPs mentioned in any rules.
+	cmd := exec.Command("nft", "list", "ruleset", "--json", "-nn")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	// This only extracts certain generic parts of the ruleset, see man libnftables-json for more info.
+	v := &struct {
+		Nftables []map[string]nftGenericItem `json:"nftables"`
+	}{}
+
+	err = json.NewDecoder(stdout).Decode(v)
+	if err != nil {
+		return nil, err
+	}
+
+	items := []nftGenericItem{}
+	for _, item := range v.Nftables {
+		if rule, found := item["rule"]; found {
+			rule.Type = "rule"
+			items = append(items, rule)
+		} else if chain, found := item["chain"]; found {
+			chain.Type = "chain"
+			items = append(items, chain)
+		} else if table, found := item["table"]; found {
+			table.Type = "table"
+			items = append(items, table)
+		}
+	}
+
+	cmd.Wait()
+	return items, nil
+}
+
+// GetVersion returns the version of dnsmasq.
+func (d Nftables) hostVersion() (*version.DottedVersion, error) {
+	output, err := shared.RunCommandCLocale("nft", "--version")
+	if err != nil {
+		return nil, errors.Wrap(err, "Failed to check nftables version")
+	}
+
+	lines := strings.Split(string(output), " ")
+	return version.NewDottedVersion(strings.TrimPrefix(lines[1], "v"))
+}
+
+// NetworkSetupForwardingPolicy allows forwarding dependent on boolean argument
+func (d Nftables) NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error {
+	action := "reject"
+	if allow {
+		action = "accept"
+	}
+
+	family, err := d.getIPFamily(ipVersion)
+	if err != nil {
+		return err
+	}
+
+	tplFields := map[string]interface{}{
+		"namespace":      nftablesNamespace,
+		"chainSeparator": nftablesChainSeparator,
+		"networkName":    networkName,
+		"family":         family,
+		"action":         action,
+	}
+
+	err = d.applyNftConfig(nftablesNetForwardingPolicy, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding forwarding policy rules for network %q (%s)", networkName, tplFields["family"])
+	}
+
+	return nil
+}
+
+// NetworkSetupOutboundNAT configures outbound NAT.
+// If srcIP is non-nil then SNAT is used with the specified address, otherwise MASQUERADE mode is used.
+// Append mode is always on and so the append argument is ignored.
+func (d Nftables) NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, _ bool) error {
+	family := "ip"
+	if subnet.IP.To4() == nil {
+		family = "ip6"
+	}
+
+	// If SNAT IP not supplied then use the IP of the outbound interface (MASQUERADE).
+	srcIPStr := ""
+	if srcIP != nil {
+		srcIPStr = srcIP.String()
+	}
+
+	tplFields := map[string]interface{}{
+		"namespace":      nftablesNamespace,
+		"chainSeparator": nftablesChainSeparator,
+		"networkName":    networkName,
+		"family":         family,
+		"subnet":         subnet.String(),
+		"srcIP":          srcIPStr,
+	}
+
+	err := d.applyNftConfig(nftablesNetOutboundNAT, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding outbound NAT rules for network %q (%s)", networkName, tplFields["family"])
+	}
+
+	return nil
+}
+
+// NetworkSetupDHCPDNSAccess sets up basic nftables overrides for DHCP/DNS.
+func (d Nftables) NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) error {
+	family, err := d.getIPFamily(ipVersion)
+	if err != nil {
+		return err
+	}
+
+	tplFields := map[string]interface{}{
+		"namespace":      nftablesNamespace,
+		"chainSeparator": nftablesChainSeparator,
+		"networkName":    networkName,
+		"family":         family,
+	}
+
+	err = d.applyNftConfig(nftablesNetDHCPDNS, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding DHCP/DNS access rules for network %q (%s)", networkName, tplFields["family"])
+	}
+
+	return nil
+}
+
+// NetworkSetupDHCPv4Checksum attempts a workaround for broken DHCP clients. No-op as not supported by nftables.
+// See https://wiki.nftables.org/wiki-nftables/index.php/Supported_features_compared_to_xtables#CHECKSUM.
+func (d Nftables) NetworkSetupDHCPv4Checksum(networkName string) error {
+	return nil
+}
+
+// NetworkClear removes the LXD network related chains.
+func (d Nftables) NetworkClear(networkName string, ipVersion uint) error {
+	family, err := d.getIPFamily(ipVersion)
+	if err != nil {
+		return err
+	}
+
+	// Remove chains created by network rules.
+	err = d.removeChains([]string{family}, networkName, "fwd", "pstrt", "in", "out")
+	if err != nil {
+		return errors.Wrapf(err, "Failed clearing nftables rules for network %q", networkName)
+	}
+
+	return nil
+}
+
+//instanceDeviceLabel returns the unique label used for instance device chains.
+func (d Nftables) instanceDeviceLabel(projectName, instanceName, deviceName string) string {
+	return fmt.Sprintf("%s%s%s", project.Prefix(projectName, instanceName), nftablesChainSeparator, deviceName)
+}
+
+// InstanceSetupBridgeFilter sets up the filter rules to apply bridged device IP filtering.
+func (d Nftables) InstanceSetupBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
+	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
+
+	mac, err := net.ParseMAC(hwAddr)
+	if err != nil {
+		return err
+	}
+
+	tplFields := map[string]interface{}{
+		"namespace":      nftablesNamespace,
+		"chainSeparator": nftablesChainSeparator,
+		"family":         "bridge",
+		"deviceLabel":    deviceLabel,
+		"parentName":     parentName,
+		"hostName":       hostName,
+		"hwAddr":         hwAddr,
+		"hwAddrHex":      fmt.Sprintf("0x%s", hex.EncodeToString(mac)),
+	}
+
+	if IPv4 != nil {
+		tplFields["ipv4Addr"] = IPv4.String()
+	}
+
+	if IPv6 != nil {
+		tplFields["ipv6Addr"] = IPv6.String()
+		tplFields["ipv6AddrHex"] = fmt.Sprintf("0x%s", hex.EncodeToString(IPv6))
+	}
+
+	err = d.applyNftConfig(nftablesInstanceBridgeFilter, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding bridge filter rules for instance device %q (%s)", deviceLabel, tplFields["family"])
+	}
+
+	return nil
+}
+
+// InstanceClearBridgeFilter removes any filter rules that were added to apply bridged device IP filtering.
+func (d Nftables) InstanceClearBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
+	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
+
+	// Remove chains created by bridge filter rules.
+	err := d.removeChains([]string{"bridge"}, deviceLabel, "in", "fwd")
+	if err != nil {
+		return errors.Wrapf(err, "Failed clearing bridge filter rules for instance device %q", deviceLabel)
+	}
+
+	return nil
+}
+
+// InstanceSetupProxyNAT creates DNAT rules for proxy devices.
+func (d Nftables) InstanceSetupProxyNAT(projectName, instanceName, deviceName string, listen, connect *deviceConfig.ProxyAddress) error {
+	connectAddrCount := len(connect.Addr)
+	if connectAddrCount < 1 {
+		return fmt.Errorf("At least 1 connect address must be supplied")
+	}
+
+	if len(listen.Addr) < 1 {
+		return fmt.Errorf("At least 1 listen address must be supplied")
+	}
+
+	if connectAddrCount > 1 && len(listen.Addr) != connectAddrCount {
+		return fmt.Errorf("More than 1 connect addresses have been supplied, but insufficient for listen addresses")
+	}
+
+	// Generate a slice of rules to add.
+	var rules []map[string]interface{}
+	for i, lAddr := range listen.Addr {
+		listenHost, listenPort, err := net.SplitHostPort(lAddr)
+		if err != nil {
+			return err
+		}
+
+		// Use the connect address that corresponds to the listen address (unless only 1 is specified).
+		connectIndex := 0
+		if connectAddrCount > 1 {
+			connectIndex = i
+		}
+
+		connectHost, connectPort, err := net.SplitHostPort(connect.Addr[connectIndex])
+		if err != nil {
+			return err
+		}
+
+		// Figure out which IP family we are using and format the destination host/port as appropriate.
+		family := "ip"
+		toDest := fmt.Sprintf("%s:%s", connectHost, connectPort)
+		connectIP := net.ParseIP(connectHost)
+		if connectIP.To4() == nil {
+			family = "ip6"
+			toDest = fmt.Sprintf("[%s]:%s", connectHost, connectPort)
+		}
+
+		rules = append(rules, map[string]interface{}{
+			"family":     family,
+			"connType":   listen.ConnType,
+			"listenHost": listenHost,
+			"listenPort": listenPort,
+			"toDest":     toDest,
+		})
+	}
+
+	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
+	tplFields := map[string]interface{}{
+		"namespace":      nftablesNamespace,
+		"chainSeparator": nftablesChainSeparator,
+		"family":         rules[0]["family"], // Family should be same for all rules, so use 1st as global.
+		"deviceLabel":    deviceLabel,
+		"rules":          rules,
+	}
+
+	err := d.applyNftConfig(nftablesNetProxyNAT, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed adding proxy rules for instance device %q", deviceLabel)
+	}
+
+	return nil
+}
+
+// InstanceClearProxyNAT remove DNAT rules for proxy devices.
+func (d Nftables) InstanceClearProxyNAT(projectName, instanceName, deviceName string) error {
+	deviceLabel := d.instanceDeviceLabel(projectName, instanceName, deviceName)
+	err := d.removeChains([]string{"ip", "ip6"}, deviceLabel, "out", "prert")
+	if err != nil {
+		return errors.Wrapf(err, "Failed clearing proxy rules for instance device %q", deviceLabel)
+	}
+
+	return nil
+}
+
+// getIPFamily converts IP version number into family name used by nftables.
+func (d Nftables) getIPFamily(ipVersion uint) (string, error) {
+	if ipVersion == 4 {
+		return "ip", nil
+	} else if ipVersion == 6 {
+		return "ip6", nil
+	}
+
+	return "", fmt.Errorf("Invalid IP version")
+}
+
+// applyNftConfig loads the specified config template and then applies it to the common template before sending to
+// the nft command to be atomically applied to the system.
+func (d Nftables) applyNftConfig(tpl *template.Template, tplFields map[string]interface{}) error {
+	// Load the specified template into the common template's parse tree under the nftableContentTemplate
+	// name so that the nftableContentTemplate template can use it with the generic name.
+	_, err := nftablesCommonTable.AddParseTree(nftablesContentTemplate, tpl.Tree)
+	if err != nil {
+		return errors.Wrapf(err, "Failed loading %q template", tpl.Name())
+	}
+
+	config := &strings.Builder{}
+	err = nftablesCommonTable.Execute(config, tplFields)
+	if err != nil {
+		return errors.Wrapf(err, "Failed running %q template", tpl.Name())
+	}
+
+	_, err = shared.RunCommand("nft", config.String())
+	if err != nil {
+		return errors.Wrapf(err, "Failed apply nftables config")
+	}
+
+	return nil
+}
+
+// removeChains removes the specified chains from the specified families.
+// If not empty, chain suffix is appended to each chain name, separated with "_".
+func (d Nftables) removeChains(families []string, chainSuffix string, chains ...string) error {
+	ruleset, err := d.nftParseRuleset()
+	if err != nil {
+		return err
+	}
+
+	fullChains := chains
+	if chainSuffix != "" {
+		fullChains = make([]string, 0, len(chains))
+		for _, chain := range chains {
+			fullChains = append(fullChains, fmt.Sprintf("%s%s%s", chain, nftablesChainSeparator, chainSuffix))
+		}
+	}
+
+	for _, family := range families {
+		for _, item := range ruleset {
+			if item.Type == "chain" && item.Family == family && item.Table == nftablesNamespace && shared.StringInSlice(item.Name, fullChains) {
+				_, err = shared.RunCommand("nft", "delete", "chain", family, nftablesNamespace, item.Name)
+				if err != nil {
+					return errors.Wrapf(err, "Failed deleting nftables chain %q (%s)", item.Name, family)
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/lxd/firewall/drivers/drivers_nftables_templates.go
+++ b/lxd/firewall/drivers/drivers_nftables_templates.go
@@ -1,0 +1,112 @@
+package drivers
+
+import (
+	"text/template"
+)
+
+var nftablesCommonTable = template.Must(template.New("nftablesCommonTable").Parse(`
+table {{.family}} {{.namespace}} {
+	{{- template "nftablesContent" . -}}
+}
+`))
+
+var nftablesNetForwardingPolicy = template.Must(template.New("nftablesNetForwardingPolicy").Parse(`
+chain fwd{{.chainSeparator}}{{.networkName}} {
+	type filter hook forward priority 0; policy accept;
+	oifname "{{.networkName}}" {{.action}}
+	iifname "{{.networkName}}" {{.action}}
+}
+`))
+
+var nftablesNetOutboundNAT = template.Must(template.New("nftablesNetOutboundNAT").Parse(`
+chain pstrt{{.chainSeparator}}{{.networkName}} {
+	type nat hook postrouting priority 100; policy accept;
+	{{if .srcIP -}}
+	{{.family}} saddr {{.subnet}} {{.family}} daddr != {{.subnet}} snat {{.srcIP}}
+	{{else -}}
+	{{.family}} saddr {{.subnet}} {{.family}} daddr != {{.subnet}} masquerade
+	{{- end}}
+}
+`))
+
+var nftablesNetDHCPDNS = template.Must(template.New("nftablesNetDHCPDNS").Parse(`
+chain in{{.chainSeparator}}{{.networkName}} {
+	type filter hook input priority 0; policy accept;
+	iifname "{{.networkName}}" tcp dport 53 accept
+	iifname "{{.networkName}}" udp dport 53 accept
+	{{if eq .family "ip" -}}
+	iifname "{{.networkName}}" udp dport 67 accept
+	{{else -}}
+	iifname "{{.networkName}}" udp dport 547 accept
+	{{- end}}
+}
+
+chain out{{.chainSeparator}}{{.networkName}} {
+	type filter hook output priority 0; policy accept;
+	oifname "{{.networkName}}" tcp sport 53 accept
+	oifname "{{.networkName}}" udp sport 53 accept
+	{{if eq .family "ip" -}}
+	oifname "{{.networkName}}" udp sport 67 accept
+	{{else -}}
+	oifname "{{.networkName}}" udp sport 547 accept
+	{{- end}}
+}
+`))
+
+var nftablesNetProxyNAT = template.Must(template.New("nftablesNetProxyNAT").Parse(`
+chain prert{{.chainSeparator}}{{.deviceLabel}} {
+	type nat hook prerouting priority -100; policy accept;
+	{{- range .rules}}
+	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.toDest}}
+	{{- end}}
+}
+
+chain out{{.chainSeparator}}{{.deviceLabel}}{
+	type nat hook output priority -100; policy accept;
+	{{- range .rules}}
+	{{.family}} daddr {{.listenHost}} {{.connType}} dport {{.listenPort}} dnat to {{.toDest}}
+	{{- end}}
+}
+`))
+
+// nftablesInstanceBridgeFilter defines the rules needed for MAC, IPv4 and IPv6 bridge security filtering.
+// To prevent instances from using IPs that are different from their assigned IPs we use ARP and NDP filtering
+// to prevent neighbour advertisements that are not allowed. However in order for DHCPv4 & DHCPv6 to work back to
+// the LXD host we need to allow DHCPv4 inbound and for IPv6 we need to allow IPv6 Router Solicitation and DHPCv6.
+// Nftables doesn't support the equivalent of "arp saddr" and "arp saddr ether" at this time so in order to filter
+// NDP advertisements that come from the genuine Ethernet MAC address but have a spoofed NDP source MAC/IP adddress
+// we need to use manual header offset extraction.
+var nftablesInstanceBridgeFilter = template.Must(template.New("nftablesInstanceBridgeFilter").Parse(`
+chain in{{.chainSeparator}}{{.deviceLabel}} {
+	type filter hook input priority -200; policy accept;
+	iifname "{{.hostName}}" ether saddr != {{.hwAddr}} drop
+	iifname "{{.hostName}}" ether type arp arp saddr ether != {{.hwAddr}} drop
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,528,48 != {{.hwAddrHex}} drop
+	{{if .ipv4Addr -}}
+	iifname "{{.hostName}}" ether type arp arp saddr ip != {{.ipv4Addr}} drop
+	iifname "{{.hostName}}" ether type ip ip saddr 0.0.0.0 ip daddr 255.255.255.255 udp dport 67 accept
+	iifname "{{.hostName}}" ether type ip ip saddr != {{.ipv4Addr}} drop
+	{{- end}}
+	{{if .ipv6Addr -}}
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::1:2 udp dport 547 accept
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr fe80::/10 ip6 daddr ff02::2 icmpv6 type 133 accept
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,128 != {{.ipv6AddrHex}} drop
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr != {{.ipv6Addr}} drop
+	{{- end}}
+}
+
+chain fwd{{.chainSeparator}}{{.deviceLabel}} {
+	type filter hook forward priority -200; policy accept;
+	iifname "{{.hostName}}" ether saddr != {{.hwAddr}} drop
+	iifname "{{.hostName}}" ether type arp arp saddr ether != {{.hwAddr}} drop
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,528,48 != {{.hwAddrHex}} drop
+	{{if .ipv4Addr -}}
+	iifname "{{.hostName}}" ether type arp arp saddr ip != {{.ipv4Addr}} drop
+	iifname "{{.hostName}}" ether type ip ip saddr != {{.ipv4Addr}} drop
+	{{- end}}
+	{{if .ipv6Addr -}}
+	iifname "{{.hostName}}" ether type ip6 ip6 saddr != {{.ipv6Addr}} drop
+	iifname "{{.hostName}}" ether type ip6 icmpv6 type 136 @nh,384,128 != {{.ipv6AddrHex}} drop
+	{{- end}}
+}
+`))

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -234,10 +234,12 @@ func (d Xtables) InstanceClearBridgeFilter(projectName, instanceName, deviceName
 // InstanceSetupProxyNAT creates DNAT rules for proxy devices.
 func (d Xtables) InstanceSetupProxyNAT(projectName, instanceName, deviceName string, listen, connect *deviceConfig.ProxyAddress) error {
 	connectAddrCount := len(connect.Addr)
-	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
-
 	if connectAddrCount < 1 {
 		return fmt.Errorf("At least 1 connect address must be supplied")
+	}
+
+	if len(listen.Addr) < 1 {
+		return fmt.Errorf("At least 1 listen address must be supplied")
 	}
 
 	if connectAddrCount > 1 && len(listen.Addr) != connectAddrCount {
@@ -247,6 +249,8 @@ func (d Xtables) InstanceSetupProxyNAT(projectName, instanceName, deviceName str
 	revert := revert.New()
 	defer revert.Fail()
 	revert.Add(func() { d.InstanceClearProxyNAT(projectName, instanceName, deviceName) })
+
+	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
 	for i, lAddr := range listen.Addr {
 		listenHost, listenPort, err := net.SplitHostPort(lAddr)

--- a/lxd/firewall/drivers/drivers_xtables.go
+++ b/lxd/firewall/drivers/drivers_xtables.go
@@ -17,16 +17,16 @@ import (
 	"github.com/lxc/lxd/shared/logger"
 )
 
-// XTables is an implmentation of LXD firewall using {ip, ip6, eb}tables
-type XTables struct{}
+// Xtables is an implmentation of LXD firewall using {ip, ip6, eb}tables
+type Xtables struct{}
 
 //networkIPTablesComment returns the iptables comment that is added to each network related rule.
-func (d XTables) networkIPTablesComment(networkName string) string {
+func (d Xtables) networkIPTablesComment(networkName string) string {
 	return fmt.Sprintf("LXD network %s", networkName)
 }
 
 // NetworkSetupForwardingPolicy allows forwarding dependent on boolean argument
-func (d XTables) NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error {
+func (d Xtables) NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error {
 	forwardType := "REJECT"
 	if allow {
 		forwardType = "ACCEPT"
@@ -49,7 +49,7 @@ func (d XTables) NetworkSetupForwardingPolicy(networkName string, ipVersion uint
 
 // NetworkSetupOutboundNAT configures outbound NAT.
 // If srcIP is non-nil then SNAT is used with the specified address, otherwise MASQUERADE mode is used.
-func (d XTables) NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, appendRule bool) error {
+func (d Xtables) NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, appendRule bool) error {
 	family := uint(4)
 	if subnet.IP.To4() == nil {
 		family = 6
@@ -86,7 +86,7 @@ func (d XTables) NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, 
 }
 
 // NetworkSetupDHCPDNSAccess sets up basic iptables overrides for DHCP/DNS.
-func (d XTables) NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) error {
+func (d Xtables) NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) error {
 	var rules [][]string
 	if ipVersion == 4 {
 		rules = [][]string{
@@ -126,13 +126,13 @@ func (d XTables) NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) e
 }
 
 // NetworkSetupDHCPv4Checksum attempts a workaround for broken DHCP clients.
-func (d XTables) NetworkSetupDHCPv4Checksum(networkName string) error {
+func (d Xtables) NetworkSetupDHCPv4Checksum(networkName string) error {
 	comment := d.networkIPTablesComment(networkName)
 	return d.iptablesPrepend(4, comment, "mangle", "POSTROUTING", "-o", networkName, "-p", "udp", "--dport", "68", "-j", "CHECKSUM", "--checksum-fill")
 }
 
 // NetworkClear removes network rules from filter, mangle and nat tables.
-func (d XTables) NetworkClear(networkName string, ipVersion uint) error {
+func (d Xtables) NetworkClear(networkName string, ipVersion uint) error {
 	err := d.iptablesClear(ipVersion, d.networkIPTablesComment(networkName), "filter", "mangle", "nat")
 	if err != nil {
 		return err
@@ -142,12 +142,12 @@ func (d XTables) NetworkClear(networkName string, ipVersion uint) error {
 }
 
 //instanceDeviceIPTablesComment returns the iptables comment that is added to each instance device related rule.
-func (d XTables) instanceDeviceIPTablesComment(projectName, instanceName, deviceName string) string {
+func (d Xtables) instanceDeviceIPTablesComment(projectName, instanceName, deviceName string) string {
 	return fmt.Sprintf("LXD container %s (%s)", project.Prefix(projectName, instanceName), deviceName)
 }
 
 // InstanceSetupBridgeFilter sets up the filter rules to apply bridged device IP filtering.
-func (d XTables) InstanceSetupBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
+func (d Xtables) InstanceSetupBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
 	rules := d.generateFilterEbtablesRules(hostName, hwAddr, IPv4, IPv6)
@@ -179,7 +179,7 @@ func (d XTables) InstanceSetupBridgeFilter(projectName, instanceName, deviceName
 }
 
 // InstanceClearBridgeFilter removes any filter rules that were added to apply bridged device IP filtering.
-func (d XTables) InstanceClearBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
+func (d Xtables) InstanceClearBridgeFilter(projectName, instanceName, deviceName, parentName, hostName, hwAddr string, IPv4, IPv6 net.IP) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
 	// Get a current list of rules active on the host.
@@ -232,7 +232,7 @@ func (d XTables) InstanceClearBridgeFilter(projectName, instanceName, deviceName
 }
 
 // InstanceSetupProxyNAT creates DNAT rules for proxy devices.
-func (d XTables) InstanceSetupProxyNAT(projectName, instanceName, deviceName string, listen, connect *deviceConfig.ProxyAddress) error {
+func (d Xtables) InstanceSetupProxyNAT(projectName, instanceName, deviceName string, listen, connect *deviceConfig.ProxyAddress) error {
 	connectAddrCount := len(connect.Addr)
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 
@@ -292,7 +292,7 @@ func (d XTables) InstanceSetupProxyNAT(projectName, instanceName, deviceName str
 }
 
 // InstanceClearProxyNAT remove DNAT rules for proxy devices.
-func (d XTables) InstanceClearProxyNAT(projectName, instanceName, deviceName string) error {
+func (d Xtables) InstanceClearProxyNAT(projectName, instanceName, deviceName string) error {
 	comment := d.instanceDeviceIPTablesComment(projectName, instanceName, deviceName)
 	errs := []error{}
 	err := d.iptablesClear(4, comment, "nat")
@@ -313,7 +313,7 @@ func (d XTables) InstanceClearProxyNAT(projectName, instanceName, deviceName str
 }
 
 // generateFilterEbtablesRules returns a customised set of ebtables filter rules based on the device.
-func (d XTables) generateFilterEbtablesRules(hostName, hwAddr string, IPv4, IPv6 net.IP) [][]string {
+func (d Xtables) generateFilterEbtablesRules(hostName, hwAddr string, IPv4, IPv6 net.IP) [][]string {
 	// MAC source filtering rules. Blocks any packet coming from instance with an incorrect Ethernet source MAC.
 	// This is required for IP filtering too.
 	rules := [][]string{
@@ -352,7 +352,7 @@ func (d XTables) generateFilterEbtablesRules(hostName, hwAddr string, IPv4, IPv6
 }
 
 // generateFilterIptablesRules returns a customised set of iptables filter rules based on the device.
-func (d XTables) generateFilterIptablesRules(projectName, instanceName, parentName, hostName, hwAddr string, _ net.IP, IPv6 net.IP) (rules [][]string, err error) {
+func (d Xtables) generateFilterIptablesRules(projectName, instanceName, parentName, hostName, hwAddr string, _ net.IP, IPv6 net.IP) (rules [][]string, err error) {
 	mac, err := net.ParseMAC(hwAddr)
 	if err != nil {
 		return
@@ -386,7 +386,7 @@ func (d XTables) generateFilterIptablesRules(projectName, instanceName, parentNa
 // matchEbtablesRule compares an active rule to a supplied match rule to see if they match.
 // If deleteMode is true then the "-A" flag in the active rule will be modified to "-D" and will
 // not be part of the equality match. This allows delete commands to be generated from dumped add commands.
-func (d XTables) matchEbtablesRule(activeRule []string, matchRule []string, deleteMode bool) bool {
+func (d Xtables) matchEbtablesRule(activeRule []string, matchRule []string, deleteMode bool) bool {
 	for i := range matchRule {
 		// Active rules will be dumped in "add" format, we need to detect
 		// this and switch it to "delete" mode if requested. If this has already been
@@ -413,7 +413,7 @@ func (d XTables) matchEbtablesRule(activeRule []string, matchRule []string, dele
 }
 
 // iptablesAdd adds an iptables rule.
-func (d XTables) iptablesConfig(ipVersion uint, comment, table, method, chain string, rule ...string) error {
+func (d Xtables) iptablesConfig(ipVersion uint, comment, table, method, chain string, rule ...string) error {
 	var cmd string
 	if ipVersion == 4 {
 		cmd = "iptables"
@@ -452,17 +452,17 @@ func (d XTables) iptablesConfig(ipVersion uint, comment, table, method, chain st
 }
 
 // iptablesAppend appends an iptables rule.
-func (d XTables) iptablesAppend(ipVersion uint, comment, table, chain string, rule ...string) error {
+func (d Xtables) iptablesAppend(ipVersion uint, comment, table, chain string, rule ...string) error {
 	return d.iptablesConfig(ipVersion, comment, table, "-A", chain, rule...)
 }
 
 // iptablesPrepend prepends an iptables rule.
-func (d XTables) iptablesPrepend(ipVersion uint, comment, table, chain string, rule ...string) error {
+func (d Xtables) iptablesPrepend(ipVersion uint, comment, table, chain string, rule ...string) error {
 	return d.iptablesConfig(ipVersion, comment, table, "-I", chain, rule...)
 }
 
 // iptablesClear clears iptables rules matching the supplied comment in the specified tables.
-func (d XTables) iptablesClear(ipVersion uint, comment string, fromTables ...string) error {
+func (d Xtables) iptablesClear(ipVersion uint, comment string, fromTables ...string) error {
 	var cmd string
 	var tablesFile string
 	if ipVersion == 4 {

--- a/lxd/firewall/firewall_interface.go
+++ b/lxd/firewall/firewall_interface.go
@@ -8,6 +8,8 @@ import (
 
 // Firewall represents an LXD firewall.
 type Firewall interface {
+	String() string
+	Compat() (bool, bool)
 	NetworkSetupForwardingPolicy(networkName string, ipVersion uint, allow bool) error
 	NetworkSetupOutboundNAT(networkName string, subnet *net.IPNet, srcIP net.IP, append bool) error
 	NetworkSetupDHCPDNSAccess(networkName string, ipVersion uint) error

--- a/lxd/firewall/firewall_load.go
+++ b/lxd/firewall/firewall_load.go
@@ -4,8 +4,35 @@ import (
 	"github.com/lxc/lxd/lxd/firewall/drivers"
 )
 
+const driverXtables = "xtables"
+const driverNftables = "nftables"
+
 // New returns an appropriate firewall implementation.
+// Uses xtables if nftables isn't compatible or isn't in use already, otherwise uses nftables.
 func New() Firewall {
-	// TODO: Issue #6223: add startup logic to choose xtables or nftables
-	return drivers.XTables{}
+	nftables := drivers.Nftables{}
+	xtables := drivers.Xtables{}
+
+	// If nftables is compatible and already in use, then we prefer to use the nftables driver irrespective of
+	// whether xtables is in use or not.
+	nftablesCompat, nftablesInUse := nftables.Compat()
+	if nftablesCompat && nftablesInUse {
+		return nftables
+	} else if !nftablesCompat {
+		// Note: If nftables isn't compatible, we fallback to xtables without considering whether xtables
+		// is itself compatible. This continues the existing behaviour of allowing LXD to start with
+		// potentially an incomplete firewall backend, so that only networks and instances using those
+		// features will fail to start later.
+		return xtables
+	}
+
+	// If xtables is compatible and already in use, then we prefer to stick with the xtables driver rather than
+	// mix the use of firewall drivers on the system.
+	xtablesCompat, xtablesInUse := xtables.Compat()
+	if xtablesCompat && xtablesInUse {
+		return xtables
+	}
+
+	// Otherwise prefer nftables as default.
+	return nftables
 }

--- a/lxd/network/network.go
+++ b/lxd/network/network.go
@@ -350,12 +350,18 @@ func (n *Network) setup(oldConfig map[string]string) error {
 	if n.config["bridge.mode"] == "fan" || !shared.StringInSlice(n.config["ipv4.address"], []string{"", "none"}) {
 		if n.HasDHCPv4() && n.HasIPv4Firewall() {
 			// Setup basic iptables overrides for DHCP/DNS
-			n.state.Firewall.NetworkSetupDHCPDNSAccess(n.name, 4)
+			err = n.state.Firewall.NetworkSetupDHCPDNSAccess(n.name, 4)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Attempt a workaround for broken DHCP clients
 		if n.HasIPv4Firewall() {
-			n.state.Firewall.NetworkSetupDHCPv4Checksum(n.name)
+			err = n.state.Firewall.NetworkSetupDHCPv4Checksum(n.name)
+			if err != nil {
+				return err
+			}
 		}
 
 		// Allow forwarding
@@ -532,7 +538,10 @@ func (n *Network) setup(oldConfig map[string]string) error {
 		if n.HasDHCPv6() {
 			if n.config["ipv6.firewall"] == "" || shared.IsTrue(n.config["ipv6.firewall"]) {
 				// Setup basic iptables overrides for DHCP/DNS
-				n.state.Firewall.NetworkSetupDHCPDNSAccess(n.name, 6)
+				err = n.state.Firewall.NetworkSetupDHCPDNSAccess(n.name, 6)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Build DHCP configuration

--- a/shared/api/server.go
+++ b/shared/api/server.go
@@ -32,6 +32,7 @@ type ServerEnvironment struct {
 	ServerVersion  string `json:"server_version" yaml:"server_version"`
 	Storage        string `json:"storage" yaml:"storage"`
 	StorageVersion string `json:"storage_version" yaml:"storage_version"`
+	Firewall       string `json:"firewall" yaml:"firewall"`
 }
 
 // ServerPut represents the modifiable fields of a LXD server configuration

--- a/shared/version/api.go
+++ b/shared/version/api.go
@@ -188,6 +188,7 @@ var APIExtensions = []string{
 	"api_filtering",
 	"instance_nic_network",
 	"clustering_sizing",
+	"firewall_driver",
 }
 
 // APIExtensionsCount returns the number of available API extensions.


### PR DESCRIPTION
This is a WIP that adds initial nftables support to the `firewall` package.

- [x] Network rules
- [x] Proxy NAT rules
- [x] Instance filtering rules
- [x] Loading logic
- [x] Update tests

One way that nftables is quite different to iptables is that there are no built in tables or chains.
Additionally `tables` in nftables are just namespaces (or containers) for chains and their rules, they have no inherent meaning to nftables itself.

Chains are added to tables, and so-called "base chains" hook themselves into the netfilter subsystem at the required point. Only then will these chains actually handle packets. Chains hook themselves into the netfilter system using a priority. I've used the same priorities as iptables does when hooking into netfilter as documented https://wiki.nftables.org/wiki-nftables/index.php/Configuring_chains#Base_chain_priority.

From from my research, if multiple chains are added to the same hook point with the same priority, netfilter processes them in the order they were added.

This means the user must come up with a suitable set of tables and chains for their purposes.

I have gone with the approach of using a single top-level table called `lxd` for each IP family (`ip` and `ip6`, and there will likely be another for bridge filtering). 

Inside the `lxd` tables several chains are created for each LXD managed network (prefixed with `in`, `fwd` and `pr` for each netfilter hook type of `input`, `forward` and `postrouting` respectively, followed by the network name). A chain's name appears to have maximum length limit of 254 chars, so this should comfortably accommodate the network device name.

Each logical function (such as forward policy, outbound NAT and DHCP/DNS access) is implemented as a separate nftables config template in the same format as is generated from `nft list ruleset`, this means that it includes the table, chain and multiple rules in a single config definition, which is then applied atomically using a single command.

I've checked and if the table/chain exists already, the config is merged into it, rather than replacing it.

Because each managed network has its own chains, cleaning up the network is simply a case of removing those chains if they exist. I've not been able to figure out a way of listing chains in a table. In later versions of `nft`it is possible to dump the ruleset for an entire table in JSON, which would allow one to get a list of chains. However the version of `nft` in ubuntu 18.04 doesn't have this option, and the native dump format is non-trivial to parse. So I have resorted to attempting to list the rules in a specific chain and if that command fails then using that as an indication the chain doesn't exist and so doesn't need removing.

The `NetworkSetupOutboundNAT` function definition has an `append` boolean which indicates whether to add the rule at the start or the end of the chain in iptables. However with nftables, using our own chains, this doesn't make a lot of sense, and so I have ignored it.

However I do intend to do further testing to see how the default policies of other non-LXD chains may impact this (from looking at the nftables documentation, if a packet is accepted by one chain, it is still offered to other chains for the possibility of dropping it later).

The `NetworkSetupDHCPv4Checksum` always returns `nil` as this is not supported by nftables, and was only ever needed for older DHCP clients, so hopefully this isn't an issue anymore.

Example network rules config:

```
table ip lxd {
	chain in_lxdbr0 {
		type filter hook input priority 0; policy accept;
		iifname "lxdbr0" tcp dport domain accept
		iifname "lxdbr0" udp dport domain accept
		iifname "lxdbr0" udp dport bootps accept
	}

	chain fwd_lxdbr0 {
		type filter hook forward priority 0; policy accept;
		oifname "lxdbr0" accept
		iifname "lxdbr0" accept
	}

	chain pr_lxdbr0 {
		type nat hook postrouting priority 100; policy accept;
		ip saddr 10.16.75.0/24 ip daddr != 10.16.75.0/24 masquerade
	}
}
table ip6 lxd {
	chain in_lxdbr0 {
		type filter hook input priority 0; policy accept;
		iifname "lxdbr0" tcp dport domain accept
		iifname "lxdbr0" udp dport domain accept
		iifname "lxdbr0" udp dport bootps accept
	}

	chain fwd_lxdbr0 {
		type filter hook forward priority 0; policy accept;
		oifname "lxdbr0" accept
		iifname "lxdbr0" accept
	}

	chain pr_lxdbr0 {
		type nat hook postrouting priority 100; policy accept;
		ip6 saddr fd42:6792:c25a:f818::/64 ip6 daddr != fd42:6792:c25a:f818::/64 masquerade
	}
}
```
