### PR TITLE
VM: CPU topology

### DIFF
--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1437,6 +1437,9 @@ func (vm *qemu) addCPUConfig(sb *strings.Builder) error {
 	return qemuCPU.Execute(sb, map[string]interface{}{
 		"architecture": vm.architectureName,
 		"cpuCount":     cpuCount,
+		"cpuSockets":   1,
+		"cpuCores":     cpuCount,
+		"cpuThreads":   1,
 	})
 }
 

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -150,6 +150,9 @@ var qemuCPU = template.Must(template.New("qemuCPU").Parse(`
 # CPU
 [smp-opts]
 cpus = "{{.cpuCount}}"
+sockets = "{{.cpuSockets}}"
+cores = "{{.cpuCores}}"
+threads = "{{.cpuThreads}}"
 `))
 
 var qemuControlSocket = template.Must(template.New("qemuControlSocket").Parse(`

--- a/shared/util.go
+++ b/shared/util.go
@@ -586,6 +586,15 @@ func Int64InSlice(key int64, list []int64) bool {
 	return false
 }
 
+func Uint64InSlice(key uint64, list []uint64) bool {
+	for _, entry := range list {
+		if entry == key {
+			return true
+		}
+	}
+	return false
+}
+
 func IsTrue(value string) bool {
 	if StringInSlice(strings.ToLower(value), []string{"true", "1", "yes", "on"}) {
 		return true


### PR DESCRIPTION
This adds support for comparing the requested CPU pin with physical hardware layout and if consistent, configures qemu to mimic the setup (sockets, cores, threads) and pin the resulting threads on the matching cores.

The logic also sorts the provided pinning data by hardware order (socket, core, thread) which matches what qemu itself uses and is how the pin is lined up with qemu threads later on.