### PR TITLE
Storage: Fixes container import bugs when using projects

### DIFF
--- a/lxd/api.go
+++ b/lxd/api.go
@@ -120,7 +120,7 @@ func isClusterNotification(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == "lxd-cluster-notifier"
 }
 
-// Extract the project query parameter from the given request.
+// projectParam returns the project query parameter from the given request or "default" if parameter is not set.
 func projectParam(request *http.Request) string {
 	project := queryParam(request, "project")
 	if project == "" {

--- a/lxd/api_internal.go
+++ b/lxd/api_internal.go
@@ -850,7 +850,8 @@ func internalImport(d *Daemon, r *http.Request) response.Response {
 	rootDev["pool"] = containerPoolName
 
 	// Mark the filesystem as going through an import
-	fd, err := os.Create(filepath.Join(containerMntPoint, ".importing"))
+	importingFilePath := storagePools.InstanceImportingFilePath(instancetype.Container, containerPoolName, projectName, req.Name)
+	fd, err := os.Create(importingFilePath)
 	if err != nil {
 		return response.InternalError(err)
 	}

--- a/lxd/container_lxc.go
+++ b/lxd/container_lxc.go
@@ -3454,16 +3454,10 @@ func (c *containerLXC) Delete() error {
 		// the creation of the instance and we are now being asked to delete the instance,
 		// we should not remove the storage volumes themselves as this would cause data loss.
 		isImport := false
-		poolName := pool.Name()
-		if c.IsSnapshot() {
-			cName, _, _ := shared.InstanceGetParentAndSnapshotName(c.name)
-			if shared.PathExists(shared.VarPath("storage-pools", poolName, "containers", cName, ".importing")) {
-				isImport = true
-			}
-		} else {
-			if shared.PathExists(shared.VarPath("storage-pools", poolName, "containers", c.name, ".importing")) {
-				isImport = true
-			}
+		cName, _, _ := shared.InstanceGetParentAndSnapshotName(c.Name())
+		importingFilePath := storagePools.InstanceImportingFilePath(c.Type(), pool.Name(), c.Project(), cName)
+		if shared.PathExists(importingFilePath) {
+			isImport = true
 		}
 
 		if c.IsSnapshot() {
@@ -3508,15 +3502,10 @@ func (c *containerLXC) Delete() error {
 		// the creation of the instance and we are now being asked to delete the instance,
 		// we should not remove the storage volumes themselves as this would cause data loss.
 		isImport := false
-		if c.IsSnapshot() {
-			cName, _, _ := shared.InstanceGetParentAndSnapshotName(c.name)
-			if shared.PathExists(shared.VarPath("storage-pools", poolName, "containers", cName, ".importing")) {
-				isImport = true
-			}
-		} else {
-			if shared.PathExists(shared.VarPath("storage-pools", poolName, "containers", c.name, ".importing")) {
-				isImport = true
-			}
+		cName, _, _ := shared.InstanceGetParentAndSnapshotName(c.Name())
+		importingFilePath := storagePools.InstanceImportingFilePath(c.Type(), poolName, c.Project(), cName)
+		if shared.PathExists(importingFilePath) {
+			isImport = true
 		}
 
 		if c.IsSnapshot() {

--- a/lxd/storage/storage.go
+++ b/lxd/storage/storage.go
@@ -26,6 +26,21 @@ func InstancePath(instanceType instancetype.Type, projectName, instanceName stri
 	return shared.VarPath("containers", fullName)
 }
 
+// InstanceImportingFilePath returns the file path used to indicate an instance import is in progress.
+// This marker file is created when using `lxd import` to import an instance that exists on the storage device
+// but does not exist in the LXD database. The presence of this file causes the instance not to be removed from
+// the storage device if the import should fail for some reason.
+func InstanceImportingFilePath(instanceType instancetype.Type, poolName, projectName, instanceName string) string {
+	fullName := project.Prefix(projectName, instanceName)
+
+	typeDir := "containers"
+	if instanceType == instancetype.VM {
+		typeDir = "virtual-machines"
+	}
+
+	return shared.VarPath("storage-pools", poolName, typeDir, fullName, ".importing")
+}
+
 // GetStoragePoolMountPoint returns the mountpoint of the given pool.
 // {LXD_DIR}/storage-pools/<pool>
 // Deprecated, use GetPoolMountPath in storage/drivers package.


### PR DESCRIPTION
- The check for ".importing" file wasn't project aware, could cause the container on storage device to be incorrectly removed.
- When using `--force` flag, the old DB volume records removal code was not project aware, preventing the container from being imported.