### PR TITLE
Storage: Allow LVM pool to be backed by existing non-empty volume group

### DIFF
--- a/doc/api-extensions.md
+++ b/doc/api-extensions.md
@@ -920,3 +920,9 @@ to specify to the ideal number of database voter and standbys.
 
 ## firewall\_driver
 Adds the `Firewall` property to the ServerEnvironment struct indicating the firewall driver being used.
+
+## storage\_lvm\_vg\_force\_reuse
+Introduces the ability to create a storage pool from an existing non-empty volume group.
+This option should be used with care, as LXD can then not guarantee that volume name conflicts won't occur
+with non-LXD created volumes in the same volume group.
+This could also potentially lead to LXD deleting a non-LXD volume should name conflicts occur.

--- a/doc/storage.md
+++ b/doc/storage.md
@@ -23,6 +23,7 @@ cephfs.user.name                | string    | cephfs driver                     
 lvm.thinpool\_name              | string    | lvm driver                        | LXDThinPool                | storage                            | Thin pool where volumes are created.
 lvm.use\_thinpool               | bool      | lvm driver                        | true                       | storage\_lvm\_use\_thinpool        | Whether the storage pool uses a thinpool for logical volumes.
 lvm.vg\_name                    | string    | lvm driver                        | name of the pool           | storage                            | Name of the volume group to create.
+lvm.vg.force\_reuse             | bool      | lvm driver                        | false                      | storage\_lvm\_vg\_force\_reuse     | Force using an existing non-empty volume group.
 volume.lvm.stripes              | string    | lvm driver                        | -                          | storage\_lvm\_stripes              | Number of stripes to use for new volumes (or thin pool volume).
 volume.lvm.stripes.size         | string    | lvm driver                        | -                          | storage\_lvm\_stripes              | Size of stripes to use (at least 4096 bytes and multiple of 512bytes).
 rsync.bwlimit                   | string    | -                                 | 0 (no limit)               | storage\_rsync\_bwlimit            | Specifies the upper limit to be placed on the socket I/O whenever rsync has to be used to transfer storage entities.

--- a/lxd/storage_pools_config.go
+++ b/lxd/storage_pools_config.go
@@ -81,6 +81,7 @@ var storagePoolConfigKeys = map[string]func(value string) error{
 	"lvm.vg_name":             shared.IsAny,
 	"volume.lvm.stripes":      shared.IsUint32,
 	"volume.lvm.stripes.size": shared.IsSize,
+	"lvm.vg.force_reuse":      shared.IsBool,
 
 	// valid drivers: btrfs, lvm, zfs
 	"size": shared.IsSize,


### PR DESCRIPTION
A bug that was fixed in 3.19 that allowed existing non-empty volume groups to be used for new storage pools has caused issues with some users depending on that behaviour.

This PR introduces the `lvm.vg.force_reuse` pool config option to allow an existing non-empty volume group to be used for new storage pools.

Related discussion: https://discuss.linuxcontainers.org/t/error-when-trying-to-use-an-existing-lvm-pool-with-a-new-installation/6809