### PR TITLE
Increase timeout of standalone SQL statements

### DIFF
--- a/lxd/daemon.go
+++ b/lxd/daemon.go
@@ -740,7 +740,7 @@ func (d *Daemon) init() error {
 
 		store := d.gateway.NodeStore()
 
-		contextTimeout := 5 * time.Second
+		contextTimeout := 30 * time.Second
 		if !clustered {
 			// FIXME: this is a workaround for #5234. We set a very
 			// high timeout when we're not clustered, since there's


### PR DESCRIPTION
If the hardware is slow or loaded spurious timeouts can kick in.

Should help with #6439.

Signed-off-by: Free Ekanayaka <free.ekanayaka@canonical.com>