### PR TITLE
lxd/backup: Have tar not transform symlink targets

### DIFF
--- a/lxd/backup.go
+++ b/lxd/backup.go
@@ -181,7 +181,7 @@ func backupCreateTarball(s *state.State, path string, b backup.Backup, c instanc
 		os.RemoveAll(backupPath)
 	}()
 
-	args := []string{"-cf", backupPath, "--numeric-owner", "--xattrs", "-C", path, "--transform", "s,^./,backup/,", "."}
+	args := []string{"-cf", backupPath, "--numeric-owner", "--xattrs", "-C", path, "--transform", "s,^./,backup/,S", "."}
 	_, err = shared.RunCommand("tar", args...)
 	if err != nil {
 		return err


### PR DESCRIPTION
This adds the 'S' flag to tar's transformation. It tells tar to not
apply transformation to symbolic link targets.

Signed-off-by: Thomas Hipp <thomas.hipp@canonical.com>