### PR TITLE
Storage:  Fixes GPT alternative header not being at the end of the VM block device

### DIFF
--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -412,9 +412,9 @@ func (d *btrfs) SetVolumeQuota(vol Volume, size string, op *operations.Operation
 			return err
 		}
 
-		// If size not specified in volume config, then use pool's default volume.size setting.
+		// If size not specified in volume config, then use pool's default block size.
 		if size == "" || size == "0" {
-			size = d.config["volume.size"]
+			size = defaultBlockSize
 		}
 
 		resized, err := genericVFSResizeBlockFile(rootBlockPath, size)

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -65,7 +65,7 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 	// If we are creating a block volume, resize it to the requested size or the default.
 	// We expect the filler function to have converted the qcow2 image to raw into the rootBlockPath.
 	if vol.contentType == ContentTypeBlock {
-		err := ensureVolumeBlockFile(vol, rootBlockPath)
+		err := ensureVolumeBlockFile(rootBlockPath, vol.ExpandedConfig("size"))
 		if err != nil {
 			return err
 		}

--- a/lxd/storage/drivers/driver_btrfs_volumes.go
+++ b/lxd/storage/drivers/driver_btrfs_volumes.go
@@ -52,6 +52,14 @@ func (d *btrfs) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Op
 		if err != nil {
 			return err
 		}
+
+		// Move the GPT alt header to end of disk if needed.
+		if vol.IsVMBlock() {
+			err = d.moveGPTAltHeader(rootBlockPath)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// If we are creating a block volume, resize it to the requested size or the default.

--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -136,6 +136,14 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 				return err
 			}
 
+			// Move the GPT alt header to end of disk if needed.
+			if vol.IsVMBlock() {
+				err = d.moveGPTAltHeader(devPath)
+				if err != nil {
+					return err
+				}
+			}
+
 			return err
 		}, op)
 		if err != nil {

--- a/lxd/storage/drivers/driver_dir_utils.go
+++ b/lxd/storage/drivers/driver_dir_utils.go
@@ -129,9 +129,9 @@ func (d *dir) setQuota(path string, volID int64, size string) error {
 		return fmt.Errorf("Missing volume ID")
 	}
 
-	// If size not specified in volume config, then use pool's default volume.size setting.
+	// If size not specified in volume config, then use pool's default size setting.
 	if size == "" || size == "0" {
-		size = d.config["volume.size"]
+		size = defaultBlockSize
 	}
 
 	sizeBytes, err := units.ParseByteSizeString(size)

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -57,6 +57,14 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		if err != nil {
 			return err
 		}
+
+		// Move the GPT alt header to end of disk if needed.
+		if vol.IsVMBlock() {
+			err = d.moveGPTAltHeader(rootBlockPath)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	// If we are creating a block volume, resize it to the requested size or the default.

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -252,9 +252,9 @@ func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 			return err
 		}
 
-		// If size not specified in volume config, then use pool's default volume.size setting.
+		// If size not specified in volume config, then use pool's default block size.
 		if size == "" || size == "0" {
-			size = d.config["volume.size"]
+			size = defaultBlockSize
 		}
 
 		resized, err := genericVFSResizeBlockFile(rootBlockPath, size)

--- a/lxd/storage/drivers/driver_dir_volumes.go
+++ b/lxd/storage/drivers/driver_dir_volumes.go
@@ -40,6 +40,7 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 			return err
 		}
 	} else {
+		// Filesystem quotas only used with non-block volume types.
 		revertFunc, err := d.setupInitialQuota(vol)
 		if err != nil {
 			return err
@@ -57,22 +58,22 @@ func (d *dir) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 		if err != nil {
 			return err
 		}
-
-		// Move the GPT alt header to end of disk if needed.
-		if vol.IsVMBlock() {
-			err = d.moveGPTAltHeader(rootBlockPath)
-			if err != nil {
-				return err
-			}
-		}
 	}
 
 	// If we are creating a block volume, resize it to the requested size or the default.
 	// We expect the filler function to have converted the qcow2 image to raw into the rootBlockPath.
 	if vol.contentType == ContentTypeBlock {
-		err := ensureVolumeBlockFile(vol, rootBlockPath)
+		err := ensureVolumeBlockFile(rootBlockPath, vol.ExpandedConfig("size"))
 		if err != nil {
 			return err
+		}
+
+		// Move the GPT alt header to end of disk if needed and if filler specified.
+		if vol.IsVMBlock() && filler != nil && filler.Fill != nil {
+			err = d.moveGPTAltHeader(rootBlockPath)
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -244,14 +245,41 @@ func (d *dir) GetVolumeUsage(vol Volume) (int64, error) {
 
 // SetVolumeQuota sets the quota on the volume.
 func (d *dir) SetVolumeQuota(vol Volume, size string, op *operations.Operation) error {
-	volPath := vol.MountPath()
+	// For VM block files, resize the file if needed.
+	if vol.contentType == ContentTypeBlock {
+		rootBlockPath, err := d.GetVolumeDiskPath(vol)
+		if err != nil {
+			return err
+		}
 
+		// If size not specified in volume config, then use pool's default volume.size setting.
+		if size == "" || size == "0" {
+			size = d.config["volume.size"]
+		}
+
+		resized, err := genericVFSResizeBlockFile(rootBlockPath, size)
+		if err != nil {
+			return err
+		}
+
+		// Move the GPT alt header to end of disk if needed and resize has taken place.
+		if vol.IsVMBlock() && resized {
+			err = d.moveGPTAltHeader(rootBlockPath)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+
+	// For non-VM block volumes, set filesystem quota.
 	volID, err := d.getVolID(vol.volType, vol.name)
 	if err != nil {
 		return err
 	}
 
-	return d.setQuota(volPath, volID, size)
+	return d.setQuota(vol.MountPath(), volID, size)
 }
 
 // GetVolumeDiskPath returns the location of a disk volume.

--- a/lxd/storage/drivers/driver_lvm_volumes.go
+++ b/lxd/storage/drivers/driver_lvm_volumes.go
@@ -71,6 +71,14 @@ func (d *lvm) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Oper
 				if err != nil {
 					return err
 				}
+
+				// Move the GPT alt header to end of disk if needed.
+				if vol.IsVMBlock() {
+					err = d.moveGPTAltHeader(devPath)
+					if err != nil {
+						return err
+					}
+				}
 			}
 		}
 
@@ -380,6 +388,14 @@ func (d *lvm) SetVolumeQuota(vol Volume, size string, op *operations.Operation) 
 		if err != nil {
 			return err
 
+		}
+
+		// Move the GPT alt header to end of disk if needed.
+		if vol.IsVMBlock() {
+			err = d.moveGPTAltHeader(volDevPath)
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/lxd/storage/drivers/driver_zfs_volumes.go
+++ b/lxd/storage/drivers/driver_zfs_volumes.go
@@ -485,6 +485,12 @@ func (d *zfs) CreateVolumeFromCopy(vol Volume, srcVol Volume, copySnapshots bool
 		}
 	}
 
+	// Resize the new volume and filesystem to the correct size.
+	err := d.SetVolumeQuota(vol, vol.ExpandedConfig("size"), nil)
+	if err != nil {
+		return err
+	}
+
 	// All done.
 	revert.Success()
 


### PR DESCRIPTION
Addresses issue https://github.com/lxc/lxd/issues/6929

There are 2 issues here:

1. We need to move the GPT alternative header to the end of the disk after unpacking a VM image to a disk file. This is what the GPT standard requires so it knows where to find the backup header. This change needs to be added to each VM capable driver:

- [x] ZFS
- [x] LVM
- [x] DIR
- [x] BTRFS
- [x] CEPH

2. When cloning a ZFS volume from a snapshot, because snapshots don't have the `volmode` property, the property is instead inherited from parent (which LXD currently doesn't modify from default), and so when the new volume is created ZFS then probes the partitions on the disk and creates a device for each partition. This probing causes the host kernel to detect the the problem GPT header and logs warnings to the kernel log.

There is also potentially a bug in ZFS itself, because specifying `volmode=none` on the `zfs clone` command is not respected and instead it still uses the parent setting, even though `zfs get volmode` will show the correct setting on the cloned volume.

Although fixing the first issue will fix the second issue, it is an indication of a wider problem in that we do not want the partitions of the VM image to be presented on the host.