### PR TITLE
Honor "features.profiles" when expanding instance configs

### DIFF
--- a/lxd/db/containers.go
+++ b/lxd/db/containers.go
@@ -332,9 +332,9 @@ SELECT instances.name, nodes.id, nodes.address, nodes.heartbeat
 	return result, nil
 }
 
-// ContainerListExpanded loads all containers across all projects and expands
-// their config and devices using the profiles they are associated to.
-func (c *ClusterTx) ContainerListExpanded() ([]Instance, error) {
+// Load all instances across all projects and expands their config and devices
+// using the profiles they are associated to.
+func (c *ClusterTx) instanceListExpanded() ([]Instance, error) {
 	instances, err := c.InstanceList(InstanceFilter{})
 	if err != nil {
 		return nil, errors.Wrap(err, "Load containers")

--- a/lxd/db/containers_export_test.go
+++ b/lxd/db/containers_export_test.go
@@ -1,0 +1,5 @@
+package db
+
+func (c *ClusterTx) InstanceListExpanded() ([]Instance, error) {
+	return c.instanceListExpanded()
+}

--- a/lxd/db/containers_test.go
+++ b/lxd/db/containers_test.go
@@ -187,7 +187,7 @@ func TestInstanceListExpanded(t *testing.T) {
 	_, err = tx.InstanceCreate(container)
 	require.NoError(t, err)
 
-	containers, err := tx.ContainerListExpanded()
+	containers, err := tx.InstanceListExpanded()
 	require.NoError(t, err)
 
 	assert.Len(t, containers, 1)

--- a/lxd/db/storage_volumes.go
+++ b/lxd/db/storage_volumes.go
@@ -228,7 +228,7 @@ func (c *Cluster) StorageVolumeIsAvailable(pool, volume string) (bool, error) {
 			return errors.Wrapf(err, "Fetch node name")
 		}
 
-		containers, err := tx.ContainerListExpanded()
+		containers, err := tx.instanceListExpanded()
 		if err != nil {
 			return errors.Wrapf(err, "Fetch containers")
 		}


### PR DESCRIPTION
The code in ```ContainerListExpanded``` did not honor the ```features.profiles``` project configuration when expanding instance configs.

This code path is hit only when checking if a Ceph storage volume is attachable, and is such a corner case that it probably went unnoticed so far.