### PR TITLE
Storage: Don't format ceph block volumes with a filesystem

### DIFF
--- a/lxd/storage/drivers/driver_ceph_volumes.go
+++ b/lxd/storage/drivers/driver_ceph_volumes.go
@@ -102,9 +102,12 @@ func (d *ceph) CreateVolume(vol Volume, filler *VolumeFiller, op *operations.Ope
 
 	// Get filesystem.
 	RBDFilesystem := d.getRBDFilesystem(vol)
-	_, err = makeFSType(RBDDevPath, RBDFilesystem, nil)
-	if err != nil {
-		return err
+
+	if vol.contentType == ContentTypeFS {
+		_, err = makeFSType(RBDDevPath, RBDFilesystem, nil)
+		if err != nil {
+			return err
+		}
 	}
 
 	// For VMs, also create the filesystem volume.


### PR DESCRIPTION


Signed-off-by: Thomas Parrott <thomas.parrott@canonical.com>