### PR TITLE
lxd/vm: Set gic-version on arm64

### DIFF
--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -14,6 +14,7 @@ type = "q35"
 {{end -}}
 {{if eq .architecture "aarch64" -}}
 type = "virt"
+gic-version = "host"
 {{end -}}
 {{if eq .architecture "ppc64le" -}}
 type = "pseries"


### PR DESCRIPTION
Signed-off-by: Stéphane Graber <stgraber@ubuntu.com>