### PR TITLE
VM: 9p disk device shares

### DIFF
--- a/lxd/device/disk.go
+++ b/lxd/device/disk.go
@@ -105,19 +105,19 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	if d.config["required"] != "" && d.config["optional"] != "" {
-		return fmt.Errorf("Cannot use both \"required\" and deprecated \"optional\" properties at the same time")
+		return fmt.Errorf(`Cannot use both "required" and deprecated "optional" properties at the same time`)
 	}
 
 	if d.config["source"] == "" && d.config["path"] != "/" {
-		return fmt.Errorf("Disk entry is missing the required \"source\" property")
+		return fmt.Errorf(`Disk entry is missing the required "source" property`)
 	}
 
 	if d.config["path"] == "/" && d.config["source"] != "" {
-		return fmt.Errorf("Root disk entry may not have a \"source\" property set")
+		return fmt.Errorf(`Root disk entry may not have a "source" property set`)
 	}
 
 	if d.config["path"] == "/" && d.config["pool"] == "" {
-		return fmt.Errorf("Root disk entry must have a \"pool\" property set")
+		return fmt.Errorf(`Root disk entry must have a "pool" property set`)
 	}
 
 	if d.config["size"] != "" && d.config["path"] != "/" {
@@ -129,7 +129,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 	}
 
 	if !(strings.HasPrefix(d.config["source"], "ceph:") || strings.HasPrefix(d.config["source"], "cephfs:")) && (d.config["ceph.cluster_name"] != "" || d.config["ceph.user_name"] != "") {
-		return fmt.Errorf("Invalid options ceph.cluster_name/ceph.user_name for source: %s", d.config["source"])
+		return fmt.Errorf("Invalid options ceph.cluster_name/ceph.user_name for source %q", d.config["source"])
 	}
 
 	// Check no other devices also have the same path as us. Use LocalDevices for this check so
@@ -153,12 +153,12 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 	// for the existence of "source" when "pool" is empty.
 	if d.config["pool"] == "" && d.config["source"] != "" && d.config["source"] != diskSourceCloudInit && d.isRequired(d.config) && !shared.PathExists(shared.HostPath(d.config["source"])) &&
 		!strings.HasPrefix(d.config["source"], "ceph:") && !strings.HasPrefix(d.config["source"], "cephfs:") {
-		return fmt.Errorf("Missing source '%s' for disk '%s'", d.config["source"], d.name)
+		return fmt.Errorf("Missing source %q for disk %q", d.config["source"], d.name)
 	}
 
 	if d.config["pool"] != "" {
 		if d.config["shift"] != "" {
-			return fmt.Errorf("The \"shift\" property cannot be used with custom storage volumes")
+			return fmt.Errorf(`The "shift" property cannot be used with custom storage volumes`)
 		}
 
 		if filepath.IsAbs(d.config["source"]) {
@@ -167,7 +167,7 @@ func (d *disk) validateConfig(instConf instance.ConfigReader) error {
 
 		_, err := d.state.Cluster.StoragePoolGetID(d.config["pool"])
 		if err != nil {
-			return fmt.Errorf("The \"%s\" storage pool doesn't exist", d.config["pool"])
+			return fmt.Errorf("The %q storage pool doesn't exist", d.config["pool"])
 		}
 
 		// Only check storate volume is available if we are validating an instance device and not a profile

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -927,6 +927,21 @@ func (vm *qemu) Start(stateful bool) error {
 	return nil
 }
 
+// openUnixSocket connects to a UNIX socket and returns the connection.
+func (vm *qemu) openUnixSocket(sockPath string) (*net.UnixConn, error) {
+	addr, err := net.ResolveUnixAddr("unix", sockPath)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := net.DialUnix("unix", nil, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
 func (vm *qemu) setupNvram() error {
 	// No UEFI nvram for ppc64le.
 	if vm.architecture == osarch.ARCH_64BIT_POWERPC_LITTLE_ENDIAN {

--- a/lxd/instance/drivers/driver_qemu.go
+++ b/lxd/instance/drivers/driver_qemu.go
@@ -1699,12 +1699,11 @@ func (vm *qemu) addDriveConfig(sb *strings.Builder, bootIndexes map[string]int, 
 	}
 
 	return qemuDrive.Execute(sb, map[string]interface{}{
-		"architecture": vm.architectureName,
-		"devName":      driveConf.DevName,
-		"devPath":      driveConf.DevPath,
-		"bootIndex":    bootIndexes[driveConf.DevName],
-		"cacheMode":    cacheMode,
-		"aioMode":      aioMode,
+		"devName":   driveConf.DevName,
+		"devPath":   driveConf.DevPath,
+		"bootIndex": bootIndexes[driveConf.DevName],
+		"cacheMode": cacheMode,
+		"aioMode":   aioMode,
 	})
 }
 

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -51,7 +51,7 @@ backend = "ringbuf"
 size = "{{.ringbufSizeBytes}}B"
 
 # SCSI controller
-{{if ne .architecture "ppc64le" -}}
+{{- if ne .architecture "ppc64le"}}
 [device "qemu_pcie1"]
 driver = "pcie-root-port"
 port = "0x10"
@@ -63,15 +63,15 @@ addr = "0x2"
 
 [device "qemu_scsi"]
 driver = "virtio-scsi-pci"
-{{if eq .architecture "ppc64le" -}}
+{{- if eq .architecture "ppc64le"}}
 bus = "pci.0"
-{{else -}}
+{{- else}}
 bus = "qemu_pcie1"
 addr = "0x0"
-{{end -}}
+{{- end}}
 
 # Balloon driver
-{{if ne .architecture "ppc64le" -}}
+{{- if ne .architecture "ppc64le"}}
 [device "qemu_pcie2"]
 driver = "pcie-root-port"
 port = "0x11"
@@ -82,12 +82,12 @@ addr = "0x2.0x1"
 
 [device "qemu_ballon"]
 driver = "virtio-balloon-pci"
-{{if eq .architecture "ppc64le" -}}
+{{- if eq .architecture "ppc64le"}}
 bus = "pci.0"
-{{else -}}
+{{- else}}
 bus = "qemu_pcie2"
 addr = "0x0"
-{{end -}}
+{{- end}}
 
 # Random number generator
 [object "qemu_rng"]
@@ -106,12 +106,12 @@ addr = "0x2.0x2"
 [device "dev-qemu_rng"]
 driver = "virtio-rng-pci"
 rng = "qemu_rng"
-{{if eq .architecture "ppc64le" -}}
+{{- if eq .architecture "ppc64le"}}
 bus = "pci.0"
-{{else -}}
+{{- else}}
 bus = "qemu_pcie3"
 addr = "0x0"
-{{end -}}
+{{- end}}
 
 # Console
 [chardev "console"]

--- a/lxd/instance/drivers/driver_qemu_templates.go
+++ b/lxd/instance/drivers/driver_qemu_templates.go
@@ -200,6 +200,27 @@ fsdev = "qemu_config"
 mount_tag = "config"
 `))
 
+// Devices use "lxd_" prefix indicating that this is a internally named device.
+var qemuDriveDir = template.Must(template.New("qemuDriveDir").Parse(`
+# {{.devName}} drive
+[fsdev "lxd_{{.devName}}"]
+{{- if .readonly}}
+readonly = "on"
+fsdriver = "local"
+security_model = "none"
+path = "{{.path}}"
+{{- else}}
+readonly = "off"
+fsdriver = "proxy"
+sock_fd = "{{.proxyFD}}"
+{{- end}}
+
+[device "dev-lxd_{{.devName}}"]
+driver = "virtio-9p-pci"
+fsdev = "lxd_{{.devName}}"
+mount_tag = "{{.mountTag}}"
+`))
+
 // Devices use "lxd_" prefix indicating that this is a user named device.
 var qemuDrive = template.Must(template.New("qemuDrive").Parse(`
 # {{.devName}} drive

--- a/lxd/instance/instancetype/instance_vmagentmount.go
+++ b/lxd/instance/instancetype/instance_vmagentmount.go
@@ -1,0 +1,9 @@
+package instancetype
+
+// VMAgentMount defines mounts to perform inside VM via agent.
+type VMAgentMount struct {
+	Source     string
+	TargetPath string
+	FSType     string
+	Opts       []string
+}


### PR DESCRIPTION
Adds the ability to share directories from the host into the VM guest using the 9p protocol.

Requires that the `lxd-agent` is running inside the VM.

Example usage:

```
lxc config device add v1 test disk source=/some/host/dir path=/some/vm/dir
```

The `readonly` property is supported.