### PR TITLE
Missing bootstrap error check

### DIFF
--- a/lxd/api_cluster.go
+++ b/lxd/api_cluster.go
@@ -234,7 +234,7 @@ func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
 
 	// If there's no cluster.https_address set, but core.https_address is,
 	// let's default to it.
-	d.db.Transaction(func(tx *db.NodeTx) error {
+	err := d.db.Transaction(func(tx *db.NodeTx) error {
 		config, err := node.ConfigLoad(tx)
 		if err != nil {
 			return errors.Wrap(err, "Failed to fetch member configuration")
@@ -256,6 +256,9 @@ func clusterPutBootstrap(d *Daemon, req api.ClusterPut) response.Response {
 
 		return nil
 	})
+	if err != nil {
+		return response.SmartError(err)
+	}
 
 	op, err := operations.OperationCreate(d.State(), "", operations.OperationClassTask, db.OperationClusterBootstrap, resources, nil, run, nil, nil)
 	if err != nil {


### PR DESCRIPTION
Attempting to patch the cluster.http_address if it's not set isn't
being checked if there is an error loading the configuration or
patching the value.

Signed-off-by: Simon Richardson <simon.richardson@canonical.com>